### PR TITLE
feat: allow setting custom data dirs on clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ config.yaml
 /node_modules/
 /package.json
 /package-lock.json
+
+/data/

--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -122,6 +122,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		JWT:                cfg.Client.Config.JWT,
 		GenesisURLs:        cfg.Client.Config.Genesis,
 		DataDirs:           cfg.Client.DataDirs,
+		TmpDataDir:         cfg.Global.Directories.TmpDataDir,
 		TestFilter:         cfg.Benchmark.Tests.Filter,
 	}
 

--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -121,6 +121,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		DockerNetwork:      cfg.Global.DockerNetwork,
 		JWT:                cfg.Client.Config.JWT,
 		GenesisURLs:        cfg.Client.Config.Genesis,
+		DataDirs:           cfg.Client.DataDirs,
 		TestFilter:         cfg.Benchmark.Tests.Filter,
 	}
 

--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -88,9 +88,14 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 	var exec executor.Executor
 
 	if cfg.Benchmark.Tests.Source.IsConfigured() {
-		cacheDir, err := getExecutorCacheDir()
-		if err != nil {
-			return fmt.Errorf("getting cache directory: %w", err)
+		cacheDir := cfg.Global.Directories.TmpCacheDir
+		if cacheDir == "" {
+			var err error
+
+			cacheDir, err = getExecutorCacheDir()
+			if err != nil {
+				return fmt.Errorf("getting cache directory: %w", err)
+			}
 		}
 
 		execCfg := &executor.Config{

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,6 +47,18 @@ client:
   #   nimbus-el:  statusim/nimbus-eth1:performance
   #   reth:       ethpandaops/reth:performance
 
+  # Optional: Pre-populated data directories per client type.
+  # When configured, the source directory is copied and mounted into the container,
+  # and the init container is skipped (data is already initialized).
+  # datadirs:
+  #   geth:
+  #     source_dir: ./data/snapshots/geth
+  #     container_dir: /data  # default, can be omitted
+  #     method: copy  # default, only option for now
+  #   reth:
+  #     source_dir: ./data/snapshots/reth
+  #     container_dir: /root/.local/share/reth
+
   instances:
     - id: geth-latest
       client: geth
@@ -61,6 +73,9 @@ client:
       # environment:
       #   SOME_VAR: value
       # genesis: <override-url>
+      # datadir:  # Instance-level datadir (overrides global datadirs)
+      #   source_dir: ./data/custom-snapshot
+      #   container_dir: /data
 
     # Example: running multiple clients
     # - id: nethermind-latest

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,6 +3,10 @@ global:
   client_logs_to_stdout: true
   docker_network: benchmarkoor
   cleanup_on_start: false
+  # Optional directory configurations.
+  # directories:
+  #   # Directory for temporary datadir copies (defaults to system temp).
+  #   tmp_datadir: /tmp/benchmarkoor
 
 benchmark:
   results_dir: ./results

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,6 +7,8 @@ global:
   # directories:
   #   # Directory for temporary datadir copies (defaults to system temp).
   #   tmp_datadir: /tmp/benchmarkoor
+  #   # Directory for executor cache - git clones, etc (defaults to ~/.cache/benchmarkoor).
+  #   tmp_cachedir: /tmp/benchmarkoor-cache
 
 benchmark:
   results_dir: ./results

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,10 +34,18 @@ type Config struct {
 
 // GlobalConfig contains global application settings.
 type GlobalConfig struct {
-	LogLevel           string `yaml:"log_level"`
-	ClientLogsToStdout bool   `yaml:"client_logs_to_stdout"`
-	DockerNetwork      string `yaml:"docker_network"`
-	CleanupOnStart     bool   `yaml:"cleanup_on_start"`
+	LogLevel           string            `yaml:"log_level"`
+	ClientLogsToStdout bool              `yaml:"client_logs_to_stdout"`
+	DockerNetwork      string            `yaml:"docker_network"`
+	CleanupOnStart     bool              `yaml:"cleanup_on_start"`
+	Directories        DirectoriesConfig `yaml:"directories,omitempty"`
+}
+
+// DirectoriesConfig contains directory path configurations.
+type DirectoriesConfig struct {
+	// TmpDataDir is the directory for temporary datadir copies.
+	// If empty, uses the system default temp directory.
+	TmpDataDir string `yaml:"tmp_datadir,omitempty"`
 }
 
 // BenchmarkConfig contains benchmark-specific settings.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,9 +92,9 @@ const DefaultContainerDir = "/data"
 
 // DataDirConfig configures a pre-populated data directory for a client.
 type DataDirConfig struct {
-	SourceDir    string `yaml:"source_dir"`
-	ContainerDir string `yaml:"container_dir,omitempty"` // default: "/data"
-	Method       string `yaml:"method,omitempty"`        // default: "copy"
+	SourceDir    string `yaml:"source_dir" json:"source_dir"`
+	ContainerDir string `yaml:"container_dir,omitempty" json:"container_dir,omitempty"`
+	Method       string `yaml:"method,omitempty" json:"method,omitempty"`
 }
 
 // Validate checks the datadir configuration for errors.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,6 +46,9 @@ type DirectoriesConfig struct {
 	// TmpDataDir is the directory for temporary datadir copies.
 	// If empty, uses the system default temp directory.
 	TmpDataDir string `yaml:"tmp_datadir,omitempty"`
+	// TmpCacheDir is the directory for executor cache (git clones, etc).
+	// If empty, uses ~/.cache/benchmarkoor.
+	TmpCacheDir string `yaml:"tmp_cachedir,omitempty"`
 }
 
 // BenchmarkConfig contains benchmark-specific settings.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,10 +76,47 @@ func (s *SourceConfig) IsConfigured() bool {
 	return s.TestsLocalDir != "" || s.TestsGit != nil
 }
 
+// DefaultContainerDir is the default container mount path for data directories.
+const DefaultContainerDir = "/data"
+
+// DataDirConfig configures a pre-populated data directory for a client.
+type DataDirConfig struct {
+	SourceDir    string `yaml:"source_dir"`
+	ContainerDir string `yaml:"container_dir,omitempty"` // default: "/data"
+	Method       string `yaml:"method,omitempty"`        // default: "copy"
+}
+
+// Validate checks the datadir configuration for errors.
+func (d *DataDirConfig) Validate(prefix string) error {
+	if d.SourceDir == "" {
+		return fmt.Errorf("%s: source_dir is required", prefix)
+	}
+
+	info, err := os.Stat(d.SourceDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%s: source_dir %q does not exist", prefix, d.SourceDir)
+		}
+
+		return fmt.Errorf("%s: checking source_dir: %w", prefix, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%s: source_dir %q is not a directory", prefix, d.SourceDir)
+	}
+
+	if d.Method != "" && d.Method != "copy" {
+		return fmt.Errorf("%s: invalid method %q, must be \"copy\"", prefix, d.Method)
+	}
+
+	return nil
+}
+
 // ClientConfig contains client configuration settings.
 type ClientConfig struct {
-	Config    ClientDefaults   `yaml:"config"`
-	Instances []ClientInstance `yaml:"instances"`
+	Config    ClientDefaults            `yaml:"config"`
+	DataDirs  map[string]*DataDirConfig `yaml:"datadirs,omitempty"`
+	Instances []ClientInstance          `yaml:"instances"`
 }
 
 // ClientDefaults contains default settings for all clients.
@@ -100,6 +137,7 @@ type ClientInstance struct {
 	Restart     string            `yaml:"restart,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty"`
 	Genesis     string            `yaml:"genesis,omitempty"`
+	DataDir     *DataDirConfig    `yaml:"datadir,omitempty"`
 }
 
 // Load reads and parses a configuration file from the given path.
@@ -141,9 +179,33 @@ func (c *Config) applyDefaults() {
 		c.Client.Config.Genesis = make(map[string]string, 6)
 	}
 
+	// Apply defaults to global datadirs.
+	for _, dd := range c.Client.DataDirs {
+		if dd != nil {
+			if dd.Method == "" {
+				dd.Method = "copy"
+			}
+
+			if dd.ContainerDir == "" {
+				dd.ContainerDir = DefaultContainerDir
+			}
+		}
+	}
+
 	for i := range c.Client.Instances {
 		if c.Client.Instances[i].PullPolicy == "" {
 			c.Client.Instances[i].PullPolicy = DefaultPullPolicy
+		}
+
+		// Apply defaults to instance-level datadir.
+		if c.Client.Instances[i].DataDir != nil {
+			if c.Client.Instances[i].DataDir.Method == "" {
+				c.Client.Instances[i].DataDir.Method = "copy"
+			}
+
+			if c.Client.Instances[i].DataDir.ContainerDir == "" {
+				c.Client.Instances[i].DataDir.ContainerDir = DefaultContainerDir
+			}
 		}
 	}
 }
@@ -182,6 +244,22 @@ func (c *Config) Validate() error {
 					instance.ID,
 					instance.Client,
 				)
+			}
+		}
+
+		// Validate instance-level datadir.
+		if instance.DataDir != nil {
+			if err := instance.DataDir.Validate(fmt.Sprintf("instance %q datadir", instance.ID)); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Validate global datadirs.
+	for client, dd := range c.Client.DataDirs {
+		if dd != nil {
+			if err := dd.Validate(fmt.Sprintf("client.datadirs.%s", client)); err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/datadir/datadir.go
+++ b/pkg/datadir/datadir.go
@@ -1,0 +1,283 @@
+package datadir
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Copier copies data directories with progress reporting.
+type Copier interface {
+	// Copy copies the source directory to the destination with progress reporting.
+	Copy(ctx context.Context, src, dst string) error
+}
+
+// NewCopier creates a new directory copier.
+func NewCopier(log logrus.FieldLogger) Copier {
+	return &copier{
+		log: log.WithField("component", "datadir-copier"),
+	}
+}
+
+type copier struct {
+	log logrus.FieldLogger
+}
+
+// Ensure interface compliance.
+var _ Copier = (*copier)(nil)
+
+// Copy copies the source directory to the destination with progress reporting.
+func (c *copier) Copy(ctx context.Context, src, dst string) error {
+	// Calculate total size for progress reporting.
+	totalSize, err := c.calculateSize(src)
+	if err != nil {
+		return fmt.Errorf("calculating source size: %w", err)
+	}
+
+	c.log.WithFields(logrus.Fields{
+		"src":        src,
+		"dst":        dst,
+		"total_size": formatBytes(totalSize),
+	}).Info("Starting directory copy")
+
+	// Track progress.
+	var copiedBytes atomic.Int64
+	var currentFile atomic.Value
+
+	currentFile.Store("")
+
+	// Start progress reporter.
+	progressCtx, cancelProgress := context.WithCancel(ctx)
+	defer cancelProgress()
+
+	progressDone := make(chan struct{})
+
+	go func() {
+		defer close(progressDone)
+		c.reportProgress(progressCtx, totalSize, &copiedBytes, &currentFile)
+	}()
+
+	// Perform the copy.
+	if err := c.copyDir(ctx, src, dst, &copiedBytes, &currentFile); err != nil {
+		cancelProgress()
+		<-progressDone
+
+		return fmt.Errorf("copying directory: %w", err)
+	}
+
+	// Stop progress reporter and wait for it to finish.
+	cancelProgress()
+	<-progressDone
+
+	c.log.WithFields(logrus.Fields{
+		"copied": formatBytes(copiedBytes.Load()),
+	}).Info("Directory copy completed")
+
+	return nil
+}
+
+// calculateSize recursively calculates the total size of a directory.
+func (c *copier) calculateSize(path string) (int64, error) {
+	var size int64
+
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			size += info.Size()
+		}
+
+		return nil
+	})
+
+	return size, err
+}
+
+// reportProgress logs copy progress every second.
+func (c *copier) reportProgress(
+	ctx context.Context,
+	totalSize int64,
+	copiedBytes *atomic.Int64,
+	currentFile *atomic.Value,
+) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			copied := copiedBytes.Load()
+			file := currentFile.Load().(string)
+
+			var percent float64
+			if totalSize > 0 {
+				percent = float64(copied) / float64(totalSize) * 100
+			}
+
+			c.log.WithFields(logrus.Fields{
+				"progress":     fmt.Sprintf("%.1f%%", percent),
+				"copied":       formatBytes(copied),
+				"total":        formatBytes(totalSize),
+				"current_file": filepath.Base(file),
+			}).Info("Copy progress")
+		}
+	}
+}
+
+// copyDir recursively copies a directory.
+func (c *copier) copyDir(
+	ctx context.Context,
+	src, dst string,
+	copiedBytes *atomic.Int64,
+	currentFile *atomic.Value,
+) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+
+	// Create destination directory with same permissions.
+	if err := os.MkdirAll(dst, srcInfo.Mode()); err != nil {
+		return fmt.Errorf("creating destination directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("reading source directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		// Check for cancellation.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			if err := c.copyDir(ctx, srcPath, dstPath, copiedBytes, currentFile); err != nil {
+				return err
+			}
+		} else {
+			if err := c.copyFile(ctx, srcPath, dstPath, copiedBytes, currentFile); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// copyFile copies a single file preserving permissions.
+func (c *copier) copyFile(
+	ctx context.Context,
+	src, dst string,
+	copiedBytes *atomic.Int64,
+	currentFile *atomic.Value,
+) (err error) {
+	currentFile.Store(src)
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening source file: %w", err)
+	}
+
+	defer func() {
+		if closeErr := srcFile.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("closing source file: %w", closeErr)
+		}
+	}()
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("stat source file: %w", err)
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("creating destination file: %w", err)
+	}
+
+	defer func() {
+		if closeErr := dstFile.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("closing destination file: %w", closeErr)
+		}
+	}()
+
+	// Copy with progress tracking.
+	writer := &progressWriter{
+		w:           dstFile,
+		copiedBytes: copiedBytes,
+	}
+
+	// Copy in chunks to allow cancellation checks.
+	buf := make([]byte, 32*1024) // 32KB buffer
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		n, readErr := srcFile.Read(buf)
+		if n > 0 {
+			if _, writeErr := writer.Write(buf[:n]); writeErr != nil {
+				return fmt.Errorf("writing to destination: %w", writeErr)
+			}
+		}
+
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+
+			return fmt.Errorf("reading source file: %w", readErr)
+		}
+	}
+
+	return nil
+}
+
+// progressWriter wraps an io.Writer to track bytes written.
+type progressWriter struct {
+	w           io.Writer
+	copiedBytes *atomic.Int64
+}
+
+func (pw *progressWriter) Write(p []byte) (n int, err error) {
+	n, err = pw.w.Write(p)
+	pw.copiedBytes.Add(int64(n))
+
+	return n, err
+}
+
+// formatBytes formats bytes in a human-readable format.
+func formatBytes(bytes int64) string {
+	const unit = 1024
+
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+
+	return fmt.Sprintf("%.1f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -56,6 +56,7 @@ type Config struct {
 	JWT                string
 	GenesisURLs        map[string]string
 	DataDirs           map[string]*config.DataDirConfig
+	TmpDataDir         string // Directory for temporary datadir copies (empty = system default)
 	ReadyTimeout       time.Duration
 	ReadyWaitAfter     time.Duration
 	TestFilter         string
@@ -243,7 +244,8 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 		// Copy the source datadir to a temp location.
 		log.WithField("source", datadirCfg.SourceDir).Info("Using pre-populated data directory")
 
-		copiedDataDir, err := os.MkdirTemp("", "benchmarkoor-datadir-"+instance.ID+"-")
+		// Use configured temp directory or system default if empty.
+		copiedDataDir, err := os.MkdirTemp(r.cfg.TmpDataDir, "benchmarkoor-datadir-"+instance.ID+"-")
 		if err != nil {
 			return fmt.Errorf("creating temp datadir directory: %w", err)
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ethpandaops/benchmarkoor/pkg/client"
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/ethpandaops/benchmarkoor/pkg/datadir"
 	"github.com/ethpandaops/benchmarkoor/pkg/docker"
 	"github.com/ethpandaops/benchmarkoor/pkg/executor"
 	"github.com/shirou/gopsutil/v4/cpu"
@@ -54,6 +55,7 @@ type Config struct {
 	DockerNetwork      string
 	JWT                string
 	GenesisURLs        map[string]string
+	DataDirs           map[string]*config.DataDirConfig
 	ReadyTimeout       time.Duration
 	ReadyWaitAfter     time.Duration
 	TestFilter         string
@@ -87,16 +89,17 @@ type SystemInfo struct {
 
 // ResolvedInstance contains the resolved configuration for a client instance.
 type ResolvedInstance struct {
-	ID          string            `json:"id"`
-	Client      string            `json:"client"`
-	Image       string            `json:"image"`
-	Entrypoint  []string          `json:"entrypoint,omitempty"`
-	Command     []string          `json:"command,omitempty"`
-	ExtraArgs   []string          `json:"extra_args,omitempty"`
-	PullPolicy  string            `json:"pull_policy"`
-	Restart     string            `json:"restart,omitempty"`
-	Environment map[string]string `json:"environment,omitempty"`
-	Genesis     string            `json:"genesis"`
+	ID          string                `json:"id"`
+	Client      string                `json:"client"`
+	Image       string                `json:"image"`
+	Entrypoint  []string              `json:"entrypoint,omitempty"`
+	Command     []string              `json:"command,omitempty"`
+	ExtraArgs   []string              `json:"extra_args,omitempty"`
+	PullPolicy  string                `json:"pull_policy"`
+	Restart     string                `json:"restart,omitempty"`
+	Environment map[string]string     `json:"environment,omitempty"`
+	Genesis     string                `json:"genesis"`
+	DataDir     *config.DataDirConfig `json:"datadir,omitempty"`
 }
 
 // NewRunner creates a new runner instance.
@@ -121,6 +124,7 @@ func NewRunner(
 		docker:   dockerMgr,
 		registry: registry,
 		executor: exec,
+		copier:   datadir.NewCopier(log),
 		done:     make(chan struct{}),
 	}
 }
@@ -131,6 +135,7 @@ type runner struct {
 	docker   docker.Manager
 	registry client.Registry
 	executor executor.Executor
+	copier   datadir.Copier
 	done     chan struct{}
 	wg       sync.WaitGroup
 }
@@ -173,6 +178,22 @@ func (r *runner) RunAll(ctx context.Context) error {
 	return nil
 }
 
+// resolveDataDir returns the datadir config for an instance.
+// Instance-level datadir takes precedence over global datadirs.
+func (r *runner) resolveDataDir(instance *config.ClientInstance) *config.DataDirConfig {
+	// Instance-level override takes precedence.
+	if instance.DataDir != nil {
+		return instance.DataDir
+	}
+
+	// Fall back to global datadir for this client type.
+	if r.cfg.DataDirs != nil {
+		return r.cfg.DataDirs[instance.Client]
+	}
+
+	return nil
+}
+
 // RunInstance runs a single client instance through its lifecycle.
 func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstance) error {
 	// Generate a short random ID for this run.
@@ -180,28 +201,13 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 	runTimestamp := time.Now().Unix()
 
 	// Create run results directory under runs/.
-	runResultsDir := filepath.Join(r.cfg.ResultsDir, "runs", fmt.Sprintf("%d_%s_%s", runTimestamp, runID, instance.ID))
+	runResultsDir := filepath.Join(
+		r.cfg.ResultsDir, "runs",
+		fmt.Sprintf("%d_%s_%s", runTimestamp, runID, instance.ID),
+	)
 	if err := os.MkdirAll(runResultsDir, 0755); err != nil {
 		return fmt.Errorf("creating run results directory: %w", err)
 	}
-
-	// Create Docker volume for this run.
-	volumeName := fmt.Sprintf("benchmarkoor-%s-%s", runID, instance.ID)
-	volumeLabels := map[string]string{
-		"benchmarkoor.instance":   instance.ID,
-		"benchmarkoor.client":     instance.Client,
-		"benchmarkoor.run-id":     runID,
-		"benchmarkoor.managed-by": "benchmarkoor",
-	}
-	if err := r.docker.CreateVolume(ctx, volumeName, volumeLabels); err != nil {
-		return fmt.Errorf("creating volume: %w", err)
-	}
-
-	defer func() {
-		if rmErr := r.docker.RemoveVolume(context.Background(), volumeName); rmErr != nil {
-			r.log.WithError(rmErr).Warn("Failed to remove volume")
-		}
-	}()
 
 	log := r.log.WithFields(logrus.Fields{
 		"instance": instance.ID,
@@ -213,6 +219,77 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 	spec, err := r.registry.Get(client.ClientType(instance.Client))
 	if err != nil {
 		return fmt.Errorf("getting client spec: %w", err)
+	}
+
+	// Resolve datadir configuration.
+	datadirCfg := r.resolveDataDir(instance)
+	useDataDir := datadirCfg != nil
+
+	// Track cleanup functions.
+	var cleanupFuncs []func()
+
+	defer func() {
+		for _, cleanup := range cleanupFuncs {
+			cleanup()
+		}
+	}()
+
+	// Setup data directory: either Docker volume or copied datadir.
+	var dataMount docker.Mount
+
+	var volumeName string
+
+	if useDataDir {
+		// Copy the source datadir to a temp location.
+		log.WithField("source", datadirCfg.SourceDir).Info("Using pre-populated data directory")
+
+		copiedDataDir, err := os.MkdirTemp("", "benchmarkoor-datadir-"+instance.ID+"-")
+		if err != nil {
+			return fmt.Errorf("creating temp datadir directory: %w", err)
+		}
+
+		cleanupFuncs = append(cleanupFuncs, func() {
+			if rmErr := os.RemoveAll(copiedDataDir); rmErr != nil {
+				log.WithError(rmErr).Warn("Failed to remove copied datadir")
+			}
+		})
+
+		// Copy with progress reporting.
+		if err := r.copier.Copy(ctx, datadirCfg.SourceDir, copiedDataDir); err != nil {
+			return fmt.Errorf("copying datadir: %w", err)
+		}
+
+		// Use bind mount for the copied data.
+		dataMount = docker.Mount{
+			Type:   "bind",
+			Source: copiedDataDir,
+			Target: datadirCfg.ContainerDir,
+		}
+	} else {
+		// Create Docker volume for this run.
+		volumeName = fmt.Sprintf("benchmarkoor-%s-%s", runID, instance.ID)
+		volumeLabels := map[string]string{
+			"benchmarkoor.instance":   instance.ID,
+			"benchmarkoor.client":     instance.Client,
+			"benchmarkoor.run-id":     runID,
+			"benchmarkoor.managed-by": "benchmarkoor",
+		}
+
+		if err := r.docker.CreateVolume(ctx, volumeName, volumeLabels); err != nil {
+			return fmt.Errorf("creating volume: %w", err)
+		}
+
+		cleanupFuncs = append(cleanupFuncs, func() {
+			if rmErr := r.docker.RemoveVolume(context.Background(), volumeName); rmErr != nil {
+				log.WithError(rmErr).Warn("Failed to remove volume")
+			}
+		})
+
+		dataMount = docker.Mount{
+			Type:   "volume",
+			Source: volumeName,
+			Target: spec.DataDir(),
+		}
 	}
 
 	// Determine genesis source (URL or local file path).
@@ -250,7 +327,11 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 		return fmt.Errorf("creating temp directory: %w", err)
 	}
 
-	defer os.RemoveAll(tempDir)
+	cleanupFuncs = append(cleanupFuncs, func() {
+		if rmErr := os.RemoveAll(tempDir); rmErr != nil {
+			log.WithError(rmErr).Warn("Failed to remove temp directory")
+		}
+	})
 
 	genesisFile := filepath.Join(tempDir, "genesis.json")
 	if err := os.WriteFile(genesisFile, genesisContent, 0644); err != nil {
@@ -264,11 +345,7 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 
 	// Build container mounts.
 	mounts := []docker.Mount{
-		{
-			Type:   "volume",
-			Source: volumeName,
-			Target: "/data",
-		},
+		dataMount,
 		{
 			Type:     "bind",
 			Source:   genesisFile,
@@ -283,8 +360,8 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 		},
 	}
 
-	// Run init container if required.
-	if spec.RequiresInit() {
+	// Run init container if required (skip when using datadir).
+	if spec.RequiresInit() && !useDataDir {
 		log.Info("Running init container")
 
 		initSpec := &docker.ContainerSpec{
@@ -327,6 +404,8 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 		initFile.Close()
 
 		log.Info("Init container completed")
+	} else if useDataDir {
+		log.Info("Skipping init container (using pre-populated datadir)")
 	}
 
 	// Determine command.
@@ -345,6 +424,7 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 	for k, v := range spec.DefaultEnvironment() {
 		env[k] = v
 	}
+
 	for k, v := range instance.Environment {
 		env[k] = v
 	}
@@ -364,6 +444,7 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 			Restart:     instance.Restart,
 			Environment: env,
 			Genesis:     genesisSource,
+			DataDir:     datadirCfg,
 		},
 	}
 
@@ -399,13 +480,13 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 	}
 
 	// Ensure cleanup.
-	defer func() {
+	cleanupFuncs = append(cleanupFuncs, func() {
 		log.Info("Removing container")
 
 		if rmErr := r.docker.RemoveContainer(context.Background(), containerID); rmErr != nil {
 			log.WithError(rmErr).Warn("Failed to remove container")
 		}
-	}()
+	})
 
 	// Setup log streaming.
 	logCtx, logCancel := context.WithCancel(ctx)

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -6,3 +6,6 @@ dist/
 
 # TypeScript build info
 tsconfig.tsbuildinfo
+
+# Vite
+.vite/

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -45,6 +45,12 @@ export interface SystemInfo {
   memory_total_gb: number
 }
 
+export interface DataDirConfig {
+  source_dir: string
+  container_dir?: string
+  method?: string
+}
+
 export interface InstanceConfig {
   id: string
   client: string
@@ -56,6 +62,7 @@ export interface InstanceConfig {
   restart?: string
   environment?: Record<string, string>
   genesis: string
+  datadir?: DataDirConfig
 }
 
 // result.json per run

--- a/ui/src/components/run-detail/InstanceConfig.tsx
+++ b/ui/src/components/run-detail/InstanceConfig.tsx
@@ -74,6 +74,32 @@ export function InstanceConfig({ instance }: InstanceConfigProps) {
                 </dd>
               </div>
             )}
+
+            {instance.datadir && (
+              <div>
+                <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Data Directory</dt>
+                <dd className="mt-1 overflow-x-auto rounded-sm bg-gray-100 p-2 dark:bg-gray-900">
+                  <div className="flex flex-col gap-1 font-mono text-xs/5 text-gray-900 dark:text-gray-100">
+                    <div>
+                      <span className="text-gray-500 dark:text-gray-400">source: </span>
+                      {instance.datadir.source_dir}
+                    </div>
+                    {instance.datadir.container_dir && (
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">mount: </span>
+                        {instance.datadir.container_dir}
+                      </div>
+                    )}
+                    {instance.datadir.method && (
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">method: </span>
+                        {instance.datadir.method}
+                      </div>
+                    )}
+                  </div>
+                </dd>
+              </div>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
Useful when downloading a datadir snapshot and wanting to use that for stateful tests.