### PR TITLE
feat: allow disabling system resource collection

### DIFF
--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -114,11 +114,12 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		}
 
 		execCfg := &executor.Config{
-			Source:       &cfg.Benchmark.Tests.Source,
-			Filter:       cfg.Benchmark.Tests.Filter,
-			CacheDir:     cacheDir,
-			ResultsDir:   cfg.Benchmark.ResultsDir,
-			ResultsOwner: resultsOwner,
+			Source:                          &cfg.Benchmark.Tests.Source,
+			Filter:                          cfg.Benchmark.Tests.Filter,
+			CacheDir:                        cacheDir,
+			ResultsDir:                      cfg.Benchmark.ResultsDir,
+			ResultsOwner:                    resultsOwner,
+			SystemResourceCollectionEnabled: *cfg.Benchmark.SystemResourceCollectionEnabled,
 		}
 
 		exec = executor.NewExecutor(log, execCfg)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,10 @@ global:
 
 benchmark:
   results_dir: ${RESULTS_DIR:-./results}
+  # Optional: Enable/disable system resource collection (cgroups/Docker Stats API).
+  # When disabled, no CPU/memory/disk metrics will be collected during tests.
+  # Useful when running in environments without cgroup access. Default: true
+  # system_resource_collection_enabled: true
   # Optional: Generate index.json after benchmark (aggregates all run metadata).
   # generate_results_index: true
   # Optional: Generate stats.json per suite after benchmark (aggregates test durations

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,10 @@ services:
       - BENCHMARKOOR_GLOBAL_DIRECTORIES_TMP_CACHEDIR=${PWD}/tmp/cache
       - BENCHMARKOOR_BENCHMARK_RESULTS_OWNER=${USER_UID}:${USER_GID}
     volumes:
+      # The docker socket is required to interact with docker containers
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # The cgroups path is recommended when on Linux systems to fetch system metrics
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - ./config.example.docker.yaml:/app/config.yaml:ro
       - ${PWD}/tmp:${PWD}/tmp
       - ./results:/app/results

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,11 +54,12 @@ type DirectoriesConfig struct {
 
 // BenchmarkConfig contains benchmark-specific settings.
 type BenchmarkConfig struct {
-	ResultsDir           string      `yaml:"results_dir" mapstructure:"results_dir"`
-	ResultsOwner         string      `yaml:"results_owner,omitempty" mapstructure:"results_owner"`
-	GenerateResultsIndex bool        `yaml:"generate_results_index" mapstructure:"generate_results_index"`
-	GenerateSuiteStats   bool        `yaml:"generate_suite_stats" mapstructure:"generate_suite_stats"`
-	Tests                TestsConfig `yaml:"tests,omitempty" mapstructure:"tests"`
+	ResultsDir                      string      `yaml:"results_dir" mapstructure:"results_dir"`
+	ResultsOwner                    string      `yaml:"results_owner,omitempty" mapstructure:"results_owner"`
+	SystemResourceCollectionEnabled *bool       `yaml:"system_resource_collection_enabled,omitempty" mapstructure:"system_resource_collection_enabled"`
+	GenerateResultsIndex            bool        `yaml:"generate_results_index" mapstructure:"generate_results_index"`
+	GenerateSuiteStats              bool        `yaml:"generate_suite_stats" mapstructure:"generate_suite_stats"`
+	Tests                           TestsConfig `yaml:"tests,omitempty" mapstructure:"tests"`
 }
 
 // TestsConfig contains test execution settings.
@@ -232,6 +233,7 @@ func bindEnvKeys(v *viper.Viper) {
 		// Benchmark settings
 		"benchmark.results_dir",
 		"benchmark.results_owner",
+		"benchmark.system_resource_collection_enabled",
 		"benchmark.generate_results_index",
 		"benchmark.generate_suite_stats",
 		"benchmark.tests.filter",
@@ -256,6 +258,11 @@ func (c *Config) applyDefaults() {
 
 	if c.Benchmark.ResultsDir == "" {
 		c.Benchmark.ResultsDir = DefaultResultsDir
+	}
+
+	if c.Benchmark.SystemResourceCollectionEnabled == nil {
+		enabled := true
+		c.Benchmark.SystemResourceCollectionEnabled = &enabled
 	}
 
 	if c.Client.Config.JWT == "" {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -55,11 +55,12 @@ type ExecutionResult struct {
 
 // Config for the executor.
 type Config struct {
-	Source       *config.SourceConfig
-	Filter       string
-	CacheDir     string
-	ResultsDir   string
-	ResultsOwner *fsutil.OwnerConfig // Optional file ownership for results directory
+	Source                          *config.SourceConfig
+	Filter                          string
+	CacheDir                        string
+	ResultsDir                      string
+	ResultsOwner                    *fsutil.OwnerConfig // Optional file ownership for results directory
+	SystemResourceCollectionEnabled bool                // Enable system resource collection (cgroups/Docker Stats)
 }
 
 // NewExecutor creates a new executor instance.
@@ -177,8 +178,8 @@ func (e *executor) GetSuiteHash() string {
 func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*ExecutionResult, error) {
 	startTime := time.Now()
 
-	// Create stats reader if container ID is provided.
-	if opts.ContainerID != "" {
+	// Create stats reader if container ID is provided and collection is enabled.
+	if opts.ContainerID != "" && e.cfg.SystemResourceCollectionEnabled {
 		reader, err := stats.NewReader(e.log, opts.DockerClient, opts.ContainerID)
 		if err != nil {
 			e.log.WithError(err).Warn("Failed to create stats reader, continuing without resource metrics")


### PR DESCRIPTION
If cgroups aren't available, we default to the docker api stats. 
The docker api stats is really slow compared to cgroups, so it makes the runs slower. 
The metrics aren't influenced by system stat collection, but still, during local development (e.g. on a mac) it's good to be able to disable system resource collection to just check if the benchmarks pass. 

Also added cgroup dir mount on the docker example, so that it uses cgroups. 