### PR TITLE
feat(config): make genesis files optional

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,8 @@ global:
 
 benchmark:
   results_dir: ${RESULTS_DIR:-./results}
+  # Optional: Set ownership (user:group) for results files. Useful when running as root.
+  # results_owner: "1000:1000"
   # Optional: Enable/disable system resource collection (cgroups/Docker Stats API).
   # When disabled, no CPU/memory/disk metrics will be collected during tests.
   # Useful when running in environments without cgroup access. Default: true

--- a/pkg/client/besu.go
+++ b/pkg/client/besu.go
@@ -21,7 +21,6 @@ func (s *besuSpec) DefaultImage() string {
 func (s *besuSpec) DefaultCommand() []string {
 	return []string{
 		"--data-path=/data",
-		"--genesis-file=/tmp/genesis.json",
 		"--bonsai-historical-block-limit=10000",
 		"--bonsai-limit-trie-logs-enabled=false",
 		"--metrics-enabled=true",
@@ -43,6 +42,10 @@ func (s *besuSpec) DefaultCommand() []string {
 		"--max-peers=0",
 		"--discovery-enabled=false",
 	}
+}
+
+func (s *besuSpec) GenesisFlag() string {
+	return "--genesis-file="
 }
 
 func (s *besuSpec) RequiresInit() bool {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,6 +28,10 @@ type Spec interface {
 	// DefaultCommand returns the default command arguments.
 	DefaultCommand() []string
 
+	// GenesisFlag returns the genesis flag format (e.g., "--genesis-file=").
+	// Returns empty string if client doesn't use a genesis flag (e.g., Erigon uses init container).
+	GenesisFlag() string
+
 	// RequiresInit returns true if client needs init container.
 	RequiresInit() bool
 

--- a/pkg/client/erigon.go
+++ b/pkg/client/erigon.go
@@ -44,6 +44,10 @@ func (s *erigonSpec) DefaultCommand() []string {
 	}
 }
 
+func (s *erigonSpec) GenesisFlag() string {
+	return "" // Erigon uses init container for genesis, not a command flag.
+}
+
 func (s *erigonSpec) RequiresInit() bool {
 	return true
 }

--- a/pkg/client/geth.go
+++ b/pkg/client/geth.go
@@ -21,7 +21,6 @@ func (s *gethSpec) DefaultImage() string {
 func (s *gethSpec) DefaultCommand() []string {
 	return []string{
 		"--datadir=/data",
-		"--override.genesis=/tmp/genesis.json",
 		"--syncmode=full",
 		"--gcmode=archive",
 		"--snapshot=false",
@@ -48,6 +47,10 @@ func (s *gethSpec) DefaultCommand() []string {
 		"--metrics.port=8008",
 		"--verbosity=3",
 	}
+}
+
+func (s *gethSpec) GenesisFlag() string {
+	return "--override.genesis="
 }
 
 func (s *gethSpec) RequiresInit() bool {

--- a/pkg/client/nethermind.go
+++ b/pkg/client/nethermind.go
@@ -21,7 +21,6 @@ func (s *nethermindSpec) DefaultImage() string {
 func (s *nethermindSpec) DefaultCommand() []string {
 	return []string{
 		"--datadir=/data",
-		"--Init.ChainSpecPath=/tmp/genesis.json",
 		"--config=none",
 		"--JsonRpc.Enabled=true",
 		"--JsonRpc.Host=0.0.0.0",
@@ -41,6 +40,10 @@ func (s *nethermindSpec) DefaultCommand() []string {
 		"--Merge.TerminalTotalDifficulty=0",
 		"--Blocks.CachePrecompilesOnBlockProcessing=false",
 	}
+}
+
+func (s *nethermindSpec) GenesisFlag() string {
+	return "--Init.ChainSpecPath="
 }
 
 func (s *nethermindSpec) RequiresInit() bool {

--- a/pkg/client/nimbus.go
+++ b/pkg/client/nimbus.go
@@ -20,7 +20,6 @@ func (s *nimbusSpec) DefaultImage() string {
 
 func (s *nimbusSpec) DefaultCommand() []string {
 	return []string{
-		"--custom-network=/tmp/genesis.json",
 		"--data-dir=/data",
 		"--metrics=true",
 		"--metrics-address=0.0.0.0",
@@ -35,6 +34,10 @@ func (s *nimbusSpec) DefaultCommand() []string {
 		"--http-address=0.0.0.0",
 		"--http-port=8545",
 	}
+}
+
+func (s *nimbusSpec) GenesisFlag() string {
+	return "--custom-network="
 }
 
 func (s *nimbusSpec) RequiresInit() bool {

--- a/pkg/client/reth.go
+++ b/pkg/client/reth.go
@@ -22,7 +22,6 @@ func (s *rethSpec) DefaultCommand() []string {
 	return []string{
 		"node",
 		"--datadir=/var/lib/reth",
-		"--chain=/tmp/genesis.json",
 		"--full",
 		"--http",
 		"--http.addr=0.0.0.0",
@@ -37,6 +36,10 @@ func (s *rethSpec) DefaultCommand() []string {
 		"--authrpc.port=8551",
 		"--engine.disable-precompile-cache",
 	}
+}
+
+func (s *rethSpec) GenesisFlag() string {
+	return "--chain="
 }
 
 func (s *rethSpec) RequiresInit() bool {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -331,16 +331,6 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("instance %q: unknown client type %q", instance.ID, instance.Client)
 		}
 
-		if instance.Genesis == "" {
-			if _, ok := c.Client.Config.Genesis[instance.Client]; !ok {
-				return fmt.Errorf(
-					"instance %q: no genesis URL configured for client %q",
-					instance.ID,
-					instance.Client,
-				)
-			}
-		}
-
 		// Validate instance-level datadir.
 		if instance.DataDir != nil {
 			if err := instance.DataDir.Validate(fmt.Sprintf("instance %q datadir", instance.ID)); err != nil {


### PR DESCRIPTION
Add GenesisFlag() method to client Spec interface to decouple genesis flag handling from default commands. Genesis is now conditionally loaded, mounted, and added to the command only when configured.

- Add GenesisFlag() to Spec interface returning flag prefix per client
- Remove hardcoded genesis flags from each client's DefaultCommand()
- Remove genesis validation requirement from config validation
- Make genesis loading, file writing, and mounting conditional
- Skip init container when no genesis is configured (e.g., Erigon)
- Add genesis flag to command dynamically when genesis is provided
- Fail run if neither genesis nor datadir is configured
- Add results_owner example to config.example.yaml