### PR TITLE
fix(ui): show empty state when index.json is missing

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1,25 +1,52 @@
 import { loadRuntimeConfig, getDataUrl } from '@/config/runtime'
 
-export async function fetchData<T>(path: string): Promise<T> {
-  const config = await loadRuntimeConfig()
-  const url = getDataUrl(path, config)
-
-  const response = await fetch(url)
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${path}: ${response.status}`)
-  }
-
-  return response.json()
+export interface FetchResult<T> {
+  data: T | null
+  status: number
 }
 
-export async function fetchText(path: string): Promise<string> {
+// Check if the content type indicates JSON
+function isJsonContentType(response: Response): boolean {
+  const contentType = response.headers.get('content-type')
+  return contentType?.includes('application/json') ?? false
+}
+
+export async function fetchData<T>(path: string): Promise<FetchResult<T>> {
   const config = await loadRuntimeConfig()
   const url = getDataUrl(path, config)
 
   const response = await fetch(url)
+
   if (!response.ok) {
-    throw new Error(`Failed to fetch ${path}: ${response.status}`)
+    return { data: null, status: response.status }
   }
 
-  return response.text()
+  // SPA servers may return 200 with HTML for missing files
+  // Treat non-JSON responses as 404
+  if (!isJsonContentType(response)) {
+    return { data: null, status: 404 }
+  }
+
+  const data = await response.json()
+  return { data, status: response.status }
+}
+
+export async function fetchText(path: string): Promise<FetchResult<string>> {
+  const config = await loadRuntimeConfig()
+  const url = getDataUrl(path, config)
+
+  const response = await fetch(url)
+
+  if (!response.ok) {
+    return { data: null, status: response.status }
+  }
+
+  // SPA servers may return 200 with HTML for missing files
+  // Check if we got HTML when expecting text data
+  const data = await response.text()
+  if (data.trimStart().startsWith('<!DOCTYPE') || data.trimStart().startsWith('<html')) {
+    return { data: null, status: 404 }
+  }
+
+  return { data, status: response.status }
 }

--- a/ui/src/api/hooks/useIndex.ts
+++ b/ui/src/api/hooks/useIndex.ts
@@ -2,9 +2,23 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchData } from '../client'
 import type { Index } from '../types'
 
+const emptyIndex: Index = { generated: 0, entries: [] }
+
 export function useIndex() {
   return useQuery({
     queryKey: ['index'],
-    queryFn: () => fetchData<Index>('runs/index.json'),
+    queryFn: async () => {
+      const { data, status } = await fetchData<Index>('runs/index.json')
+
+      if (status === 404) {
+        return emptyIndex
+      }
+
+      if (!data) {
+        throw new Error(`Failed to fetch index: ${status}`)
+      }
+
+      return data
+    },
   })
 }

--- a/ui/src/api/hooks/useRunConfig.ts
+++ b/ui/src/api/hooks/useRunConfig.ts
@@ -5,7 +5,13 @@ import type { RunConfig } from '../types'
 export function useRunConfig(runId: string) {
   return useQuery({
     queryKey: ['run', runId, 'config'],
-    queryFn: () => fetchData<RunConfig>(`runs/${runId}/config.json`),
+    queryFn: async () => {
+      const { data, status } = await fetchData<RunConfig>(`runs/${runId}/config.json`)
+      if (!data) {
+        throw new Error(`Failed to fetch run config: ${status}`)
+      }
+      return data
+    },
     enabled: !!runId,
   })
 }

--- a/ui/src/api/hooks/useRunResult.ts
+++ b/ui/src/api/hooks/useRunResult.ts
@@ -5,7 +5,13 @@ import type { RunResult } from '../types'
 export function useRunResult(runId: string) {
   return useQuery({
     queryKey: ['run', runId, 'result'],
-    queryFn: () => fetchData<RunResult>(`runs/${runId}/result.json`),
+    queryFn: async () => {
+      const { data, status } = await fetchData<RunResult>(`runs/${runId}/result.json`)
+      if (!data) {
+        throw new Error(`Failed to fetch run result: ${status}`)
+      }
+      return data
+    },
     enabled: !!runId,
   })
 }

--- a/ui/src/api/hooks/useSuite.ts
+++ b/ui/src/api/hooks/useSuite.ts
@@ -5,7 +5,13 @@ import type { SuiteInfo } from '../types'
 export function useSuite(suiteHash: string | undefined) {
   return useQuery({
     queryKey: ['suite', suiteHash],
-    queryFn: () => fetchData<SuiteInfo>(`suites/${suiteHash}/summary.json`),
+    queryFn: async () => {
+      const { data, status } = await fetchData<SuiteInfo>(`suites/${suiteHash}/summary.json`)
+      if (!data) {
+        throw new Error(`Failed to fetch suite: ${status}`)
+      }
+      return data
+    },
     enabled: !!suiteHash,
   })
 }

--- a/ui/src/api/hooks/useSuiteStats.ts
+++ b/ui/src/api/hooks/useSuiteStats.ts
@@ -5,7 +5,13 @@ import type { SuiteStats } from '../types'
 export function useSuiteStats(suiteHash: string | undefined) {
   return useQuery({
     queryKey: ['suiteStats', suiteHash],
-    queryFn: () => fetchData<SuiteStats>(`suites/${suiteHash}/stats.json`),
+    queryFn: async () => {
+      const { data, status } = await fetchData<SuiteStats>(`suites/${suiteHash}/stats.json`)
+      if (!data) {
+        throw new Error(`Failed to fetch suite stats: ${status}`)
+      }
+      return data
+    },
     enabled: !!suiteHash,
   })
 }

--- a/ui/src/api/hooks/useTestDetails.ts
+++ b/ui/src/api/hooks/useTestDetails.ts
@@ -11,7 +11,13 @@ export function useTestResultDetails(runId: string, testName: string, stepType: 
 
   return useQuery({
     queryKey: ['run', runId, 'test', testName, 'step', stepType, 'result-details'],
-    queryFn: () => fetchData<ResultDetails>(path),
+    queryFn: async () => {
+      const { data, status } = await fetchData<ResultDetails>(path)
+      if (!data) {
+        throw new Error(`Failed to fetch result details: ${status}`)
+      }
+      return data
+    },
     enabled: !!runId && !!testName,
   })
 }
@@ -23,8 +29,11 @@ export function useTestResponses(runId: string, testName: string, stepType: Step
   return useQuery({
     queryKey: ['run', runId, 'test', testName, 'step', stepType, 'responses'],
     queryFn: async () => {
-      const text = await fetchText(path)
-      return text.trim().split('\n')
+      const { data, status } = await fetchText(path)
+      if (!data) {
+        throw new Error(`Failed to fetch responses: ${status}`)
+      }
+      return data.trim().split('\n')
     },
     enabled: !!runId && !!testName,
   })
@@ -36,7 +45,13 @@ export function useTestAggregated(runId: string, testName: string, stepType: Ste
 
   return useQuery({
     queryKey: ['run', runId, 'test', testName, 'step', stepType, 'aggregated'],
-    queryFn: () => fetchData<AggregatedStats>(path),
+    queryFn: async () => {
+      const { data, status } = await fetchData<AggregatedStats>(path)
+      if (!data) {
+        throw new Error(`Failed to fetch aggregated stats: ${status}`)
+      }
+      return data
+    },
     enabled: !!runId && !!testName,
   })
 }
@@ -48,8 +63,11 @@ export function useTestRequests(suiteHash: string, testName: string, stepType: S
   return useQuery({
     queryKey: ['suite', suiteHash, 'test', testName, 'step', stepType, 'requests'],
     queryFn: async () => {
-      const text = await fetchText(path)
-      return text.trim().split('\n')
+      const { data, status } = await fetchText(path)
+      if (!data) {
+        throw new Error(`Failed to fetch requests: ${status}`)
+      }
+      return data.trim().split('\n')
     },
     enabled: !!suiteHash && !!testName,
   })

--- a/ui/src/components/suite-detail/TestFilesList.tsx
+++ b/ui/src/components/suite-detail/TestFilesList.tsx
@@ -87,7 +87,13 @@ function FileContent({
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['suite', suiteHash, stepType, testName, file.og_path],
-    queryFn: () => fetchText(path),
+    queryFn: async () => {
+      const { data, status } = await fetchText(path)
+      if (!data) {
+        throw new Error(`Failed to fetch file: ${status}`)
+      }
+      return data
+    },
   })
 
   if (isLoading) {

--- a/ui/src/pages/LogViewerPage.tsx
+++ b/ui/src/pages/LogViewerPage.tsx
@@ -344,7 +344,13 @@ export function LogViewerPage() {
     refetch,
   } = useQuery({
     queryKey: ['run', runId, 'logs', filename],
-    queryFn: () => fetchText(`runs/${runId}/${filename}`),
+    queryFn: async () => {
+      const { data, status } = await fetchText(`runs/${runId}/${filename}`)
+      if (!data) {
+        throw new Error(`Failed to fetch log: ${status}`)
+      }
+      return data
+    },
     enabled: !!runId && !!filename,
   })
 

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -125,12 +125,18 @@ export function RunDetailPage() {
   const { data: suite } = useSuite(config?.suite_hash ?? '')
   const { data: containerLog } = useQuery({
     queryKey: ['run', runId, 'container-log'],
-    queryFn: () => fetchText(`runs/${runId}/container.log`),
+    queryFn: async () => {
+      const { data } = await fetchText(`runs/${runId}/container.log`)
+      return data
+    },
     enabled: !!runId,
   })
   const { data: benchmarkoorLog } = useQuery({
     queryKey: ['run', runId, 'benchmarkoor-log'],
-    queryFn: () => fetchText(`runs/${runId}/benchmarkoor.log`),
+    queryFn: async () => {
+      const { data } = await fetchText(`runs/${runId}/benchmarkoor.log`)
+      return data
+    },
     enabled: !!runId,
   })
 


### PR DESCRIPTION
Return result objects with status from fetchData/fetchText instead of throwing errors, allowing callers to handle 404s gracefully. The index hook returns an empty index on 404, showing "No runs found" instead of an error state.

Also handles SPA servers that return 200 with HTML for missing files by checking Content-Type headers and detecting HTML responses.