### PR TITLE
feat(config): add block I/O (blkio) resource limits

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -119,6 +119,24 @@ client:
     #   memory: "16g"
     #   # Disable swap for the container (sets memory-swap equal to memory and swappiness to 0)
     #   swap_disabled: true
+    #   # Block I/O throttling (optional)
+    #   blkio_config:
+    #     # Limit device read bandwidth (supports units: b, k, m, g)
+    #     device_read_bps:
+    #       - path: /dev/sdb
+    #         rate: '12mb'
+    #     # Limit device read IOPS (integer)
+    #     device_read_iops:
+    #       - path: /dev/sdb
+    #         rate: '120'
+    #     # Limit device write bandwidth
+    #     device_write_bps:
+    #       - path: /dev/sdb
+    #         rate: '1024k'
+    #     # Limit device write IOPS
+    #     device_write_iops:
+    #       - path: /dev/sdb
+    #         rate: '30'
     # Genesis file URLs per client type
     genesis:
       besu: https://github.com/nethermindeth/gas-benchmarks/raw/refs/heads/main/scripts/genesisfiles/besu/zkevmgenesis.json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -476,6 +476,19 @@ resource_limits:
   cpuset: [0, 1, 2, 3]
   memory: "16g"
   swap_disabled: true
+  blkio_config:
+    device_read_bps:
+      - path: /dev/sdb
+        rate: '12mb'
+    device_write_bps:
+      - path: /dev/sdb
+        rate: '1024k'
+    device_read_iops:
+      - path: /dev/sdb
+        rate: '120'
+    device_write_iops:
+      - path: /dev/sdb
+        rate: '30'
 ```
 
 | Option | Type | Description |
@@ -484,8 +497,27 @@ resource_limits:
 | `cpuset` | []int | Specific CPU IDs to pin to |
 | `memory` | string | Memory limit with unit: `b`, `k`, `m`, `g` (e.g., `"16g"`, `"4096m"`) |
 | `swap_disabled` | bool | Disable swap (sets memory-swap equal to memory, swappiness to 0) |
+| `blkio_config` | object | Block I/O throttling configuration (see below) |
 
 **Note:** `cpuset_count` and `cpuset` are mutually exclusive. Use one or the other.
+
+### Block I/O Configuration
+
+The `blkio_config` option allows throttling container disk I/O:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `device_read_bps` | []object | Device read bandwidth limits |
+| `device_read_iops` | []object | Device read IOPS limits |
+| `device_write_bps` | []object | Device write bandwidth limits |
+| `device_write_iops` | []object | Device write IOPS limits |
+
+Each device entry has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | Device path (e.g., `/dev/sdb`) |
+| `rate` | string | Rate limit. For `*_bps`: string with unit (`b`, `k`, `m`, `g`). For `*_iops`: integer string |
 
 ## Examples
 


### PR DESCRIPTION
Add Docker container block I/O throttling configuration to resource_limits. This allows limiting device read/write bandwidth (bps) and IOPS for containers.

New configuration options under resource_limits.blkio_config:
- device_read_bps: limit device read bandwidth
- device_write_bps: limit device write bandwidth
- device_read_iops: limit device read IOPS
- device_write_iops: limit device write IOPS

Each device entry specifies a path and rate. Bandwidth rates support units (b, k, m, g), IOPS rates are integer strings.