### PR TITLE
feat(ui): display blkio_config in run configuration panel

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -146,11 +146,24 @@ export interface DataDirConfig {
   method?: string
 }
 
+export interface ThrottleDeviceConfig {
+  path: string
+  rate: number
+}
+
+export interface BlkioConfig {
+  device_read_bps?: ThrottleDeviceConfig[]
+  device_read_iops?: ThrottleDeviceConfig[]
+  device_write_bps?: ThrottleDeviceConfig[]
+  device_write_iops?: ThrottleDeviceConfig[]
+}
+
 export interface ResourceLimitsConfig {
   cpuset_cpus?: string
   memory?: string
   memory_bytes?: number
   swap_disabled?: boolean
+  blkio_config?: BlkioConfig
 }
 
 export interface InstanceConfig {

--- a/ui/src/components/run-detail/RunConfiguration.tsx
+++ b/ui/src/components/run-detail/RunConfiguration.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import clsx from 'clsx'
 import type { InstanceConfig, SystemInfo } from '@/api/types'
+import { formatBytes } from '@/utils/format'
 
 interface RunConfigurationProps {
   instance: InstanceConfig
@@ -285,6 +286,65 @@ export function RunConfiguration({ instance, system }: RunConfigurationProps) {
                     <InfoItem label="Swap Disabled" value={instance.resource_limits.swap_disabled ? 'Yes' : 'No'} />
                   )}
                 </dl>
+
+                {/* Block I/O Limits */}
+                {instance.resource_limits.blkio_config && (
+                  <div className="mt-4">
+                    <h6 className="mb-2 text-xs/5 font-medium text-gray-500 dark:text-gray-400">Block I/O Limits</h6>
+                    <div className="overflow-x-auto rounded-sm bg-gray-100 p-3 dark:bg-gray-900">
+                      <div className="flex flex-col gap-3 font-mono text-xs/5 text-gray-900 dark:text-gray-100">
+                        {instance.resource_limits.blkio_config.device_read_bps &&
+                          instance.resource_limits.blkio_config.device_read_bps.length > 0 && (
+                            <div>
+                              <span className="text-gray-500 dark:text-gray-400">Read BPS: </span>
+                              {instance.resource_limits.blkio_config.device_read_bps.map((dev, i) => (
+                                <span key={i}>
+                                  {i > 0 && ', '}
+                                  {dev.path} @ {formatBytes(dev.rate)}/s
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        {instance.resource_limits.blkio_config.device_write_bps &&
+                          instance.resource_limits.blkio_config.device_write_bps.length > 0 && (
+                            <div>
+                              <span className="text-gray-500 dark:text-gray-400">Write BPS: </span>
+                              {instance.resource_limits.blkio_config.device_write_bps.map((dev, i) => (
+                                <span key={i}>
+                                  {i > 0 && ', '}
+                                  {dev.path} @ {formatBytes(dev.rate)}/s
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        {instance.resource_limits.blkio_config.device_read_iops &&
+                          instance.resource_limits.blkio_config.device_read_iops.length > 0 && (
+                            <div>
+                              <span className="text-gray-500 dark:text-gray-400">Read IOPS: </span>
+                              {instance.resource_limits.blkio_config.device_read_iops.map((dev, i) => (
+                                <span key={i}>
+                                  {i > 0 && ', '}
+                                  {dev.path} @ {dev.rate.toLocaleString()}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        {instance.resource_limits.blkio_config.device_write_iops &&
+                          instance.resource_limits.blkio_config.device_write_iops.length > 0 && (
+                            <div>
+                              <span className="text-gray-500 dark:text-gray-400">Write IOPS: </span>
+                              {instance.resource_limits.blkio_config.device_write_iops.map((dev, i) => (
+                                <span key={i}>
+                                  {i > 0 && ', '}
+                                  {dev.path} @ {dev.rate.toLocaleString()}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                      </div>
+                    </div>
+                  </div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
Add block I/O limits display to the run details Configuration section. When blkio_config is present in resource_limits, shows:
- Read/Write bandwidth limits (formatted as bytes/s)
- Read/Write IOPS limits (formatted as numbers)

Each device entry displays its path and configured rate limit.