### PR TITLE
feat: allow using an initial fcu to check if the "latest" block is ready

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -142,8 +142,12 @@ client:
     # Optional: Send an engine_forkchoiceUpdatedV3 call after RPC is ready to set the
     # client's chain head. Uses the latest block hash from eth_getBlockByNumber("latest").
     # Useful when starting from pre-populated data directories where the client needs an
-    # explicit FCU to recognize its chain head before test execution. Default: false
-    # bootstrap_fcu: true
+    # explicit FCU to recognize its chain head before test execution.
+    # Supports shorthand: `bootstrap_fcu: true` (defaults to max_retries: 30, backoff: 1s)
+    # bootstrap_fcu:
+    #   enabled: true
+    #   max_retries: 30
+    #   backoff: 1s
     # Optional: Container resource limits (applied to all instances by default).
     # resource_limits:
     #   # CPU pinning - use ONE of the following:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -139,10 +139,10 @@ client:
     #     dump:
     #       enabled: true
     #       filename: debug_traceBlockByHash
-    # Optional: Send an engine_forkchoiceUpdatedV3 call after RPC is ready to set the
-    # client's chain head. Uses the latest block hash from eth_getBlockByNumber("latest").
-    # Useful when starting from pre-populated data directories where the client needs an
-    # explicit FCU to recognize its chain head before test execution.
+    # Optional: Send an engine_forkchoiceUpdatedV3 call after RPC is ready.
+    # Uses the latest block hash from eth_getBlockByNumber("latest").
+    # Retries until the client accepts the FCU with VALID status, confirming
+    # it has finished internal initialization and is ready for test execution.
     # Supports shorthand: `bootstrap_fcu: true` (defaults to max_retries: 30, backoff: 1s)
     # bootstrap_fcu:
     #   enabled: true

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -139,6 +139,11 @@ client:
     #     dump:
     #       enabled: true
     #       filename: debug_traceBlockByHash
+    # Optional: Send an engine_forkchoiceUpdatedV3 call after RPC is ready to set the
+    # client's chain head. Uses the latest block hash from eth_getBlockByNumber("latest").
+    # Useful when starting from pre-populated data directories where the client needs an
+    # explicit FCU to recognize its chain head before test execution. Default: false
+    # bootstrap_fcu: true
     # Optional: Container resource limits (applied to all instances by default).
     # resource_limits:
     #   # CPU pinning - use ONE of the following:
@@ -258,6 +263,7 @@ client:
       #     dump:
       #       enabled: true
       #       filename: trace
+      # bootstrap_fcu: true  # Instance-level override (optional)
 
     # Example: running multiple clients
     # - id: nethermind-latest

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,6 +309,7 @@ client:
 | `retry_new_payloads_syncing_state` | object | - | Retry config for SYNCING responses (see below) |
 | `resource_limits` | object | - | Container resource constraints (see [Resource Limits](#resource-limits)) |
 | `post_test_rpc_calls` | []object | - | Arbitrary RPC calls to execute after each test step (see [Post-Test RPC Calls](#post-test-rpc-calls)) |
+| `bootstrap_fcu` | bool | `false` | Send an `engine_forkchoiceUpdatedV3` after RPC is ready to set the client's chain head (see [Bootstrap FCU](#bootstrap-fcu)) |
 | `genesis` | map | - | Genesis file URLs keyed by client type |
 
 #### Drop Memory Caches
@@ -409,6 +410,24 @@ client:
 - When using pre-populated data directories where clients may need time to validate chain state
 - Combined with `wait_after_rpc_ready` for clients with complex initialization
 
+
+#### Bootstrap FCU
+
+When starting from a pre-populated data directory, some clients may not recognize their chain head until they receive an `engine_forkchoiceUpdatedV3` call. The `bootstrap_fcu` option sends this call automatically after the RPC endpoint becomes ready, using the latest block hash from `eth_getBlockByNumber("latest")`.
+
+```yaml
+client:
+  config:
+    bootstrap_fcu: true
+```
+
+The FCU call sets `headBlockHash` to the latest block, with `safeBlockHash` and `finalizedBlockHash` set to the zero hash and no payload attributes. The response must have `VALID` status — if the client rejects the FCU, the run is aborted.
+
+When using the `container-recreate` rollback strategy, the bootstrap FCU is sent after each container recreate.
+
+**When to use:**
+- When starting from pre-populated data directories where the client needs an explicit FCU to begin processing Engine API requests correctly
+- When you observe test failures due to the client not recognizing its chain head
 
 ### Data Directories
 
@@ -512,6 +531,7 @@ client:
 | `retry_new_payloads_syncing_state` | object | No | From `client.config` | Instance-specific retry config for SYNCING responses |
 | `resource_limits` | object | No | From `client.config` | Instance-specific resource limits |
 | `post_test_rpc_calls` | []object | No | From `client.config` | Instance-specific post-test RPC calls (replaces global) |
+| `bootstrap_fcu` | bool | No | From `client.config` | Instance-specific bootstrap FCU setting |
 
 ## Resource Limits
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,7 +309,7 @@ client:
 | `retry_new_payloads_syncing_state` | object | - | Retry config for SYNCING responses (see below) |
 | `resource_limits` | object | - | Container resource constraints (see [Resource Limits](#resource-limits)) |
 | `post_test_rpc_calls` | []object | - | Arbitrary RPC calls to execute after each test step (see [Post-Test RPC Calls](#post-test-rpc-calls)) |
-| `bootstrap_fcu` | bool | `false` | Send an `engine_forkchoiceUpdatedV3` after RPC is ready to set the client's chain head (see [Bootstrap FCU](#bootstrap-fcu)) |
+| `bootstrap_fcu` | bool/object | - | Send an `engine_forkchoiceUpdatedV3` after RPC is ready to set the client's chain head (see [Bootstrap FCU](#bootstrap-fcu)) |
 | `genesis` | map | - | Genesis file URLs keyed by client type |
 
 #### Drop Memory Caches
@@ -415,13 +415,32 @@ client:
 
 When starting from a pre-populated data directory, some clients may not recognize their chain head until they receive an `engine_forkchoiceUpdatedV3` call. The `bootstrap_fcu` option sends this call automatically after the RPC endpoint becomes ready, using the latest block hash from `eth_getBlockByNumber("latest")`.
 
+**Shorthand** (uses defaults: `max_retries: 30`, `backoff: 1s`):
+
 ```yaml
 client:
   config:
     bootstrap_fcu: true
 ```
 
-The FCU call sets `headBlockHash` to the latest block, with `safeBlockHash` and `finalizedBlockHash` set to the zero hash and no payload attributes. The response must have `VALID` status — if the client rejects the FCU, the run is aborted.
+**Full configuration:**
+
+```yaml
+client:
+  config:
+    bootstrap_fcu:
+      enabled: true
+      max_retries: 30
+      backoff: 1s
+```
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `enabled` | bool | Yes | - | Enable bootstrap FCU |
+| `max_retries` | int | Yes | `30` (shorthand) | Maximum number of retry attempts (must be >= 1) |
+| `backoff` | string | Yes | `1s` (shorthand) | Delay between retries (Go duration string) |
+
+The FCU call sets `headBlockHash` to the latest block, with `safeBlockHash` and `finalizedBlockHash` set to the zero hash and no payload attributes. The response must have `VALID` status. If the call fails, it is retried up to `max_retries` times with `backoff` between attempts. If all attempts fail, the run is aborted.
 
 When using the `container-recreate` rollback strategy, the bootstrap FCU is sent after each container recreate.
 
@@ -531,7 +550,7 @@ client:
 | `retry_new_payloads_syncing_state` | object | No | From `client.config` | Instance-specific retry config for SYNCING responses |
 | `resource_limits` | object | No | From `client.config` | Instance-specific resource limits |
 | `post_test_rpc_calls` | []object | No | From `client.config` | Instance-specific post-test RPC calls (replaces global) |
-| `bootstrap_fcu` | bool | No | From `client.config` | Instance-specific bootstrap FCU setting |
+| `bootstrap_fcu` | bool/object | No | From `client.config` | Instance-specific bootstrap FCU setting |
 
 ## Resource Limits
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -386,6 +386,7 @@ type ClientDefaults struct {
 	RetryNewPayloadsSyncingState *RetryNewPayloadsSyncingConfig `yaml:"retry_new_payloads_syncing_state,omitempty" mapstructure:"retry_new_payloads_syncing_state"`
 	WaitAfterRPCReady            string                         `yaml:"wait_after_rpc_ready,omitempty" mapstructure:"wait_after_rpc_ready"`
 	PostTestRPCCalls             []PostTestRPCCall              `yaml:"post_test_rpc_calls,omitempty" mapstructure:"post_test_rpc_calls"`
+	BootstrapFCU                 bool                           `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
 }
 
 // ClientInstance defines a single client instance to benchmark.
@@ -407,6 +408,7 @@ type ClientInstance struct {
 	RetryNewPayloadsSyncingState *RetryNewPayloadsSyncingConfig `yaml:"retry_new_payloads_syncing_state,omitempty" mapstructure:"retry_new_payloads_syncing_state"`
 	WaitAfterRPCReady            string                         `yaml:"wait_after_rpc_ready,omitempty" mapstructure:"wait_after_rpc_ready"`
 	PostTestRPCCalls             []PostTestRPCCall              `yaml:"post_test_rpc_calls,omitempty" mapstructure:"post_test_rpc_calls"`
+	BootstrapFCU                 *bool                          `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
 }
 
 // Load reads and parses configuration files from the given paths.
@@ -854,6 +856,16 @@ func (c *Config) GetPostTestRPCCalls(instance *ClientInstance) []PostTestRPCCall
 	}
 
 	return c.Client.Config.PostTestRPCCalls
+}
+
+// GetBootstrapFCU returns whether bootstrap FCU should be sent for an instance.
+// Instance-level setting takes precedence over global default.
+func (c *Config) GetBootstrapFCU(instance *ClientInstance) bool {
+	if instance.BootstrapFCU != nil {
+		return *instance.BootstrapFCU
+	}
+
+	return c.Client.Config.BootstrapFCU
 }
 
 // validateDropMemoryCaches validates drop_memory_caches settings and checks permissions.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -168,6 +168,13 @@ type RetryNewPayloadsSyncingConfig struct {
 	Backoff    string `yaml:"backoff" mapstructure:"backoff" json:"backoff"`
 }
 
+// BootstrapFCUConfig configures the bootstrap FCU call sent after RPC is ready.
+type BootstrapFCUConfig struct {
+	Enabled    bool   `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
+	MaxRetries int    `yaml:"max_retries" mapstructure:"max_retries" json:"max_retries"`
+	Backoff    string `yaml:"backoff" mapstructure:"backoff" json:"backoff"`
+}
+
 // PostTestRPCCall defines an arbitrary RPC call to execute after the test step.
 type PostTestRPCCall struct {
 	Method  string     `yaml:"method" mapstructure:"method" json:"method"`
@@ -386,7 +393,7 @@ type ClientDefaults struct {
 	RetryNewPayloadsSyncingState *RetryNewPayloadsSyncingConfig `yaml:"retry_new_payloads_syncing_state,omitempty" mapstructure:"retry_new_payloads_syncing_state"`
 	WaitAfterRPCReady            string                         `yaml:"wait_after_rpc_ready,omitempty" mapstructure:"wait_after_rpc_ready"`
 	PostTestRPCCalls             []PostTestRPCCall              `yaml:"post_test_rpc_calls,omitempty" mapstructure:"post_test_rpc_calls"`
-	BootstrapFCU                 bool                           `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
+	BootstrapFCU                 *BootstrapFCUConfig            `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
 }
 
 // ClientInstance defines a single client instance to benchmark.
@@ -408,7 +415,7 @@ type ClientInstance struct {
 	RetryNewPayloadsSyncingState *RetryNewPayloadsSyncingConfig `yaml:"retry_new_payloads_syncing_state,omitempty" mapstructure:"retry_new_payloads_syncing_state"`
 	WaitAfterRPCReady            string                         `yaml:"wait_after_rpc_ready,omitempty" mapstructure:"wait_after_rpc_ready"`
 	PostTestRPCCalls             []PostTestRPCCall              `yaml:"post_test_rpc_calls,omitempty" mapstructure:"post_test_rpc_calls"`
-	BootstrapFCU                 *bool                          `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
+	BootstrapFCU                 *BootstrapFCUConfig            `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
 }
 
 // Load reads and parses configuration files from the given paths.
@@ -459,6 +466,7 @@ func Load(paths ...string) (*Config, error) {
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
 			dumpConfigDecodeHook(),
+			bootstrapFCUDecodeHook(),
 		),
 	)); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
@@ -650,6 +658,11 @@ func (c *Config) Validate() error {
 
 	// Validate post_test_rpc_calls settings.
 	if err := c.validatePostTestRPCCalls(); err != nil {
+		return err
+	}
+
+	// Validate bootstrap_fcu settings.
+	if err := c.validateBootstrapFCU(); err != nil {
 		return err
 	}
 
@@ -858,11 +871,12 @@ func (c *Config) GetPostTestRPCCalls(instance *ClientInstance) []PostTestRPCCall
 	return c.Client.Config.PostTestRPCCalls
 }
 
-// GetBootstrapFCU returns whether bootstrap FCU should be sent for an instance.
-// Instance-level setting takes precedence over global default.
-func (c *Config) GetBootstrapFCU(instance *ClientInstance) bool {
+// GetBootstrapFCU returns the bootstrap FCU config for an instance.
+// Instance-level config takes precedence over global default.
+// Returns nil if not configured at either level.
+func (c *Config) GetBootstrapFCU(instance *ClientInstance) *BootstrapFCUConfig {
 	if instance.BootstrapFCU != nil {
-		return *instance.BootstrapFCU
+		return instance.BootstrapFCU
 	}
 
 	return c.Client.Config.BootstrapFCU
@@ -1090,6 +1104,33 @@ func validatePostTestRPCCall(call PostTestRPCCall, prefix string) error {
 	return nil
 }
 
+// validateBootstrapFCU validates bootstrap_fcu settings.
+func (c *Config) validateBootstrapFCU() error {
+	for _, instance := range c.Client.Instances {
+		cfg := c.GetBootstrapFCU(&instance)
+		if cfg == nil || !cfg.Enabled {
+			continue
+		}
+
+		if cfg.MaxRetries < 1 {
+			return fmt.Errorf("instance %q: bootstrap_fcu.max_retries must be at least 1",
+				instance.ID)
+		}
+
+		if cfg.Backoff == "" {
+			return fmt.Errorf("instance %q: bootstrap_fcu.backoff is required when enabled",
+				instance.ID)
+		}
+
+		if _, err := time.ParseDuration(cfg.Backoff); err != nil {
+			return fmt.Errorf("instance %q: invalid bootstrap_fcu.backoff %q: %w",
+				instance.ID, cfg.Backoff, err)
+		}
+	}
+
+	return nil
+}
+
 // dumpConfigDecodeHook returns a mapstructure decode hook that converts
 // a boolean value to DumpConfig{Enabled: bool}.
 // This allows users to write `dump: true` as shorthand for `dump: {enabled: true}`.
@@ -1101,6 +1142,31 @@ func dumpConfigDecodeHook() mapstructure.DecodeHookFuncType {
 
 		if from.Kind() == reflect.Bool {
 			return DumpConfig{Enabled: data.(bool)}, nil
+		}
+
+		return data, nil
+	}
+}
+
+// bootstrapFCUDecodeHook returns a mapstructure decode hook that converts
+// a boolean value to BootstrapFCUConfig.
+// This allows users to write `bootstrap_fcu: true` as shorthand for the full struct.
+func bootstrapFCUDecodeHook() mapstructure.DecodeHookFuncType {
+	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		if to != reflect.TypeOf(BootstrapFCUConfig{}) {
+			return data, nil
+		}
+
+		if from.Kind() == reflect.Bool {
+			if data.(bool) {
+				return BootstrapFCUConfig{
+					Enabled:    true,
+					MaxRetries: 30,
+					Backoff:    "1s",
+				}, nil
+			}
+
+			return BootstrapFCUConfig{Enabled: false}, nil
 		}
 
 		return data, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -168,7 +168,8 @@ type RetryNewPayloadsSyncingConfig struct {
 	Backoff    string `yaml:"backoff" mapstructure:"backoff" json:"backoff"`
 }
 
-// BootstrapFCUConfig configures the bootstrap FCU call sent after RPC is ready.
+// BootstrapFCUConfig configures the bootstrap FCU call used to confirm the
+// client is fully synced and ready for test execution.
 type BootstrapFCUConfig struct {
 	Enabled    bool   `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
 	MaxRetries int    `yaml:"max_retries" mapstructure:"max_retries" json:"max_retries"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -715,37 +715,35 @@ func TestSourceConfig_IsConfigured(t *testing.T) {
 }
 
 func TestGetBootstrapFCU(t *testing.T) {
-	boolPtr := func(v bool) *bool { return &v }
-
 	tests := []struct {
 		name     string
-		global   bool
-		instance *bool
-		expected bool
+		global   *BootstrapFCUConfig
+		instance *BootstrapFCUConfig
+		expected *BootstrapFCUConfig
 	}{
 		{
-			name:     "both unset defaults to false",
-			global:   false,
+			name:     "both nil returns nil",
+			global:   nil,
 			instance: nil,
-			expected: false,
+			expected: nil,
 		},
 		{
-			name:     "global true, instance nil inherits",
-			global:   true,
+			name:     "global set, instance nil inherits",
+			global:   &BootstrapFCUConfig{Enabled: true, MaxRetries: 30, Backoff: "1s"},
 			instance: nil,
-			expected: true,
+			expected: &BootstrapFCUConfig{Enabled: true, MaxRetries: 30, Backoff: "1s"},
 		},
 		{
-			name:     "instance override true",
-			global:   false,
-			instance: boolPtr(true),
-			expected: true,
+			name:     "instance overrides global",
+			global:   &BootstrapFCUConfig{Enabled: true, MaxRetries: 30, Backoff: "1s"},
+			instance: &BootstrapFCUConfig{Enabled: true, MaxRetries: 5, Backoff: "2s"},
+			expected: &BootstrapFCUConfig{Enabled: true, MaxRetries: 5, Backoff: "2s"},
 		},
 		{
-			name:     "instance override false",
-			global:   true,
-			instance: boolPtr(false),
-			expected: false,
+			name:     "instance disabled overrides global enabled",
+			global:   &BootstrapFCUConfig{Enabled: true, MaxRetries: 30, Backoff: "1s"},
+			instance: &BootstrapFCUConfig{Enabled: false},
+			expected: &BootstrapFCUConfig{Enabled: false},
 		},
 	}
 
@@ -768,7 +766,8 @@ func TestGetBootstrapFCU(t *testing.T) {
 }
 
 func TestLoad_BootstrapFCU(t *testing.T) {
-	configContent := `
+	t.Run("shorthand bool true", func(t *testing.T) {
+		configContent := `
 client:
   config:
     bootstrap_fcu: true
@@ -781,19 +780,80 @@ client:
       client: geth
       bootstrap_fcu: false
 `
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.yaml")
-	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o644))
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o644))
 
-	cfg, err := Load(configPath)
-	require.NoError(t, err)
+		cfg, err := Load(configPath)
+		require.NoError(t, err)
 
-	// Global default is true.
-	assert.True(t, cfg.Client.Config.BootstrapFCU)
+		// Global default decoded from bool shorthand.
+		require.NotNil(t, cfg.Client.Config.BootstrapFCU)
+		assert.True(t, cfg.Client.Config.BootstrapFCU.Enabled)
+		assert.Equal(t, 30, cfg.Client.Config.BootstrapFCU.MaxRetries)
+		assert.Equal(t, "1s", cfg.Client.Config.BootstrapFCU.Backoff)
 
-	// First instance inherits global true.
-	assert.True(t, cfg.GetBootstrapFCU(&cfg.Client.Instances[0]))
+		// First instance inherits global.
+		fcuCfg := cfg.GetBootstrapFCU(&cfg.Client.Instances[0])
+		require.NotNil(t, fcuCfg)
+		assert.True(t, fcuCfg.Enabled)
 
-	// Second instance overrides to false.
-	assert.False(t, cfg.GetBootstrapFCU(&cfg.Client.Instances[1]))
+		// Second instance overrides to false.
+		fcuCfg = cfg.GetBootstrapFCU(&cfg.Client.Instances[1])
+		require.NotNil(t, fcuCfg)
+		assert.False(t, fcuCfg.Enabled)
+	})
+
+	t.Run("full struct config", func(t *testing.T) {
+		configContent := `
+client:
+  config:
+    bootstrap_fcu:
+      enabled: true
+      max_retries: 10
+      backoff: 2s
+    genesis:
+      geth: http://example.com/genesis.json
+  instances:
+    - id: test-instance
+      client: geth
+`
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o644))
+
+		cfg, err := Load(configPath)
+		require.NoError(t, err)
+
+		require.NotNil(t, cfg.Client.Config.BootstrapFCU)
+		assert.True(t, cfg.Client.Config.BootstrapFCU.Enabled)
+		assert.Equal(t, 10, cfg.Client.Config.BootstrapFCU.MaxRetries)
+		assert.Equal(t, "2s", cfg.Client.Config.BootstrapFCU.Backoff)
+
+		fcuCfg := cfg.GetBootstrapFCU(&cfg.Client.Instances[0])
+		require.NotNil(t, fcuCfg)
+		assert.Equal(t, 10, fcuCfg.MaxRetries)
+		assert.Equal(t, "2s", fcuCfg.Backoff)
+	})
+
+	t.Run("not configured returns nil", func(t *testing.T) {
+		configContent := `
+client:
+  config:
+    genesis:
+      geth: http://example.com/genesis.json
+  instances:
+    - id: test-instance
+      client: geth
+`
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o644))
+
+		cfg, err := Load(configPath)
+		require.NoError(t, err)
+
+		assert.Nil(t, cfg.Client.Config.BootstrapFCU)
+		assert.Nil(t, cfg.GetBootstrapFCU(&cfg.Client.Instances[0]))
+	})
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2011,10 +2011,11 @@ func (r *runner) getLatestBlock(ctx context.Context, host string, port int) (uin
 	return blockNum, rpcResp.Result.Hash, nil
 }
 
-// sendBootstrapFCU sends an engine_forkchoiceUpdatedV3 call to set the head
-// block on the client. This is used when bootstrap_fcu is enabled to ensure
-// the client recognizes its chain head before test execution begins.
-// Retries up to cfg.MaxRetries times with cfg.Backoff between attempts.
+// sendBootstrapFCU sends an engine_forkchoiceUpdatedV3 call to confirm the
+// client is fully synced and ready for test execution. The call is retried
+// up to cfg.MaxRetries times with cfg.Backoff between attempts — some clients
+// (e.g., Erigon) may still be performing internal initialization after RPC
+// becomes available. A VALID response confirms the client is ready.
 func (r *runner) sendBootstrapFCU(
 	ctx context.Context,
 	log logrus.FieldLogger,


### PR DESCRIPTION
Erigon needs this. cause they might still be doing some initialization or internal sync. 