### PR TITLE
feat: detect and display OOM kills for containers

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -121,6 +121,7 @@ export interface RunConfig {
   status?: RunStatus
   termination_reason?: string
   container_exit_code?: number
+  container_oom_killed?: boolean
 }
 
 export interface SystemInfo {

--- a/ui/src/components/shared/StatusBadge.tsx
+++ b/ui/src/components/shared/StatusBadge.tsx
@@ -71,9 +71,10 @@ interface StatusAlertProps {
   status?: RunStatus
   terminationReason?: string
   containerExitCode?: number
+  containerOOMKilled?: boolean
 }
 
-export function StatusAlert({ status, terminationReason, containerExitCode }: StatusAlertProps) {
+export function StatusAlert({ status, terminationReason, containerExitCode, containerOOMKilled }: StatusAlertProps) {
   // Only show alert for non-completed statuses
   if (!status || status === 'completed') {
     return null
@@ -109,6 +110,11 @@ export function StatusAlert({ status, terminationReason, containerExitCode }: St
         <h3 className={clsx('text-sm/6 font-medium', textClasses[status])}>{config.label}</h3>
         {terminationReason && (
           <p className={clsx('mt-1 text-sm/6', textClasses[status])}>{terminationReason}</p>
+        )}
+        {containerOOMKilled && (
+          <p className={clsx('mt-1 text-sm/6 font-semibold', textClasses[status])}>
+            Container was killed due to out of memory (OOM)
+          </p>
         )}
         {containerExitCode !== undefined && (
           <p className={clsx('mt-1 text-sm/6', textClasses[status])}>

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -385,6 +385,7 @@ export function RunDetailPage() {
         status={config.status}
         terminationReason={config.termination_reason}
         containerExitCode={config.container_exit_code}
+        containerOOMKilled={config.container_oom_killed}
       />
 
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">


### PR DESCRIPTION
Inspect container state after exit to read OOMKilled flag from Docker, propagate it through RunConfig, and surface it in the UI status alert.