### PR TITLE
feat: add end timestamp and total runtime to run config

### DIFF
--- a/pkg/executor/index.go
+++ b/pkg/executor/index.go
@@ -21,6 +21,7 @@ type Index struct {
 type IndexEntry struct {
 	RunID             string          `json:"run_id"`
 	Timestamp         int64           `json:"timestamp"`
+	TimestampEnd      int64           `json:"timestamp_end,omitempty"`
 	SuiteHash         string          `json:"suite_hash,omitempty"`
 	Instance          *IndexInstance  `json:"instance"`
 	Tests             *IndexTestStats `json:"tests"`
@@ -60,6 +61,7 @@ type IndexStepStats struct {
 // runConfigJSON is used to parse config.json files.
 type runConfigJSON struct {
 	Timestamp         int64  `json:"timestamp"`
+	TimestampEnd      int64  `json:"timestamp_end,omitempty"`
 	SuiteHash         string `json:"suite_hash,omitempty"`
 	Status            string `json:"status,omitempty"`
 	TerminationReason string `json:"termination_reason,omitempty"`
@@ -249,6 +251,7 @@ func buildIndexEntry(runDir, runID string) (*IndexEntry, error) {
 	return &IndexEntry{
 		RunID:             runID,
 		Timestamp:         runConfig.Timestamp,
+		TimestampEnd:      runConfig.TimestampEnd,
 		SuiteHash:         runConfig.SuiteHash,
 		Status:            runConfig.Status,
 		TerminationReason: runConfig.TerminationReason,

--- a/pkg/executor/suite_stats.go
+++ b/pkg/executor/suite_stats.go
@@ -25,6 +25,7 @@ type RunDuration struct {
 	GasUsed  uint64                 `json:"gas_used"`
 	Time     int64                  `json:"time_ns"`
 	RunStart int64                  `json:"run_start"`
+	RunEnd   int64                  `json:"run_end,omitempty"`
 	Steps    *RunDurationStepsStats `json:"steps,omitempty"`
 }
 
@@ -43,9 +44,10 @@ type RunDurationStepStats struct {
 
 // runInfo holds information about a run for grouping purposes.
 type runInfo struct {
-	runID     string
-	client    string
-	timestamp int64
+	runID        string
+	client       string
+	timestamp    int64
+	timestampEnd int64
 }
 
 // GenerateAllSuiteStats scans the results directory and generates stats for all suites.
@@ -93,9 +95,10 @@ func GenerateAllSuiteStats(resultsDir string) (map[string]*SuiteStats, error) {
 		}
 
 		suiteRuns[runConfig.SuiteHash] = append(suiteRuns[runConfig.SuiteHash], runInfo{
-			runID:     runID,
-			client:    runConfig.Instance.Client,
-			timestamp: runConfig.Timestamp,
+			runID:        runID,
+			client:       runConfig.Instance.Client,
+			timestamp:    runConfig.Timestamp,
+			timestampEnd: runConfig.TimestampEnd,
 		})
 	}
 
@@ -185,6 +188,7 @@ func buildSuiteStats(runsDir string, runs []runInfo) (*SuiteStats, error) {
 				GasUsed:  totalGasUsed,
 				Time:     totalGasUsedTime,
 				RunStart: run.timestamp,
+				RunEnd:   run.timestampEnd,
 				Steps:    stepsStats,
 			})
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -72,6 +72,7 @@ type Config struct {
 // RunConfig contains configuration for a single test run.
 type RunConfig struct {
 	Timestamp                      int64             `json:"timestamp"`
+	TimestampEnd                   int64             `json:"timestamp_end,omitempty"`
 	SuiteHash                      string            `json:"suite_hash,omitempty"`
 	SystemResourceCollectionMethod string            `json:"system_resource_collection_method,omitempty"`
 	System                         *SystemInfo       `json:"system"`
@@ -1088,6 +1089,7 @@ func (r *runner) runContainerLifecycle(
 				"waiting for RPC: %v", err,
 			)
 		}
+		runConfig.TimestampEnd = time.Now().Unix()
 		mu.Unlock()
 
 		if writeErr := writeRunConfig(
@@ -1267,6 +1269,9 @@ func (r *runner) runContainerLifecycle(
 		runConfig.Status = RunStatusCompleted
 	}
 	mu.Unlock()
+
+	// Record when the run ended.
+	runConfig.TimestampEnd = time.Now().Unix()
 
 	// Write final config with status.
 	if err := writeRunConfig(

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -10,6 +10,7 @@ export type RunStatus = 'completed' | 'container_died' | 'cancelled'
 export interface IndexEntry {
   run_id: string
   timestamp: number
+  timestamp_end?: number
   suite_hash?: string
   instance: {
     id: string
@@ -114,6 +115,7 @@ export function getRunDurationAggregatedStats(
 // config.json per run
 export interface RunConfig {
   timestamp: number
+  timestamp_end?: number
   suite_hash?: string
   system_resource_collection_method?: string // "cgroupv2" or "dockerstats"
   system: SystemInfo
@@ -315,6 +317,7 @@ export interface RunDuration {
   gas_used: number
   time_ns: number
   run_start: number
+  run_end?: number
   steps?: RunDurationStepsStats
 }
 

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -18,7 +18,7 @@ import { ClientStat } from '@/components/shared/ClientStat'
 import { Duration } from '@/components/shared/Duration'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { StatusAlert } from '@/components/shared/StatusBadge'
-import { formatTimestamp } from '@/utils/date'
+import { formatTimestamp, formatDurationSeconds } from '@/utils/date'
 import { formatNumber, formatBytes } from '@/utils/format'
 import { useIndex } from '@/api/hooks/useIndex'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES } from '@/api/types'
@@ -405,6 +405,12 @@ export function RunDetailPage() {
                   </>
                 )}
               </p>
+              <p className="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
+                Started at
+              </p>
+              <p className="text-xs/5 text-gray-900 dark:text-gray-100">
+                {formatTimestamp(config.timestamp)}
+              </p>
             </div>
             <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
               <div className="flex items-center justify-between">
@@ -468,12 +474,16 @@ export function RunDetailPage() {
               <p className="mt-1 text-2xl/8 font-semibold text-gray-900 dark:text-gray-100">
                 <Duration nanoseconds={totalDuration} />
               </p>
-              <p className="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
-                Started at
-              </p>
-              <p className="text-xs/5 text-gray-900 dark:text-gray-100">
-                {formatTimestamp(config.timestamp)}
-              </p>
+              {config.timestamp_end != null && config.timestamp_end > 0 && (
+                <>
+                  <p className="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
+                    Total runtime
+                  </p>
+                  <p className="text-xs/5 text-gray-900 dark:text-gray-100">
+                    {formatDurationSeconds(config.timestamp_end - config.timestamp)}
+                  </p>
+                </>
+              )}
             </div>
           </>
         ) : (
@@ -488,6 +498,16 @@ export function RunDetailPage() {
             <p className="text-xs/5 text-gray-900 dark:text-gray-100">
               {formatTimestamp(config.timestamp)}
             </p>
+            {config.timestamp_end != null && config.timestamp_end > 0 && (
+              <>
+                <p className="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                  Total runtime
+                </p>
+                <p className="text-xs/5 text-gray-900 dark:text-gray-100">
+                  {formatDurationSeconds(config.timestamp_end - config.timestamp)}
+                </p>
+              </>
+            )}
           </div>
         )}
       </div>

--- a/ui/src/utils/date.ts
+++ b/ui/src/utils/date.ts
@@ -3,6 +3,16 @@ export function formatTimestamp(timestamp: number): string {
   return date.toLocaleString()
 }
 
+export function formatDurationSeconds(totalSeconds: number): string {
+  if (totalSeconds < 0) return '0s'
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`
+  if (minutes > 0) return `${minutes}m ${seconds}s`
+  return `${seconds}s`
+}
+
 export function formatRelativeTime(timestamp: number): string {
   const now = Date.now()
   const diff = now - timestamp * 1000


### PR DESCRIPTION
Record when each run finishes (timestamp_end) alongside the existing start timestamp. Propagate through index and suite stats, and display total runtime on the run detail page.