### PR TITLE
feat: add CPU usage % and memory usage MB charts

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -842,6 +842,7 @@ func (e *executor) executeRPC(
 			if statsDelta != nil {
 				delta = &ResourceDelta{
 					MemoryDelta:    statsDelta.MemoryDelta,
+					MemoryAbsBytes: afterStats.Memory,
 					CPUDeltaUsec:   statsDelta.CPUDeltaUsec,
 					DiskReadBytes:  statsDelta.DiskReadBytes,
 					DiskWriteBytes: statsDelta.DiskWriteBytes,

--- a/pkg/executor/index.go
+++ b/pkg/executor/index.go
@@ -176,6 +176,10 @@ func buildIndexEntry(runDir, runID string) (*IndexEntry, error) {
 						setupResources.DiskWriteBytes += agg.ResourceTotals.DiskWriteBytes
 						setupResources.DiskReadIOPS += agg.ResourceTotals.DiskReadIOPS
 						setupResources.DiskWriteIOPS += agg.ResourceTotals.DiskWriteIOPS
+
+						if agg.ResourceTotals.MemoryBytes > setupResources.MemoryBytes {
+							setupResources.MemoryBytes = agg.ResourceTotals.MemoryBytes
+						}
 					}
 				}
 
@@ -196,6 +200,10 @@ func buildIndexEntry(runDir, runID string) (*IndexEntry, error) {
 						testResources.DiskWriteBytes += agg.ResourceTotals.DiskWriteBytes
 						testResources.DiskReadIOPS += agg.ResourceTotals.DiskReadIOPS
 						testResources.DiskWriteIOPS += agg.ResourceTotals.DiskWriteIOPS
+
+						if agg.ResourceTotals.MemoryBytes > testResources.MemoryBytes {
+							testResources.MemoryBytes = agg.ResourceTotals.MemoryBytes
+						}
 					}
 				}
 
@@ -216,6 +224,10 @@ func buildIndexEntry(runDir, runID string) (*IndexEntry, error) {
 						cleanupResources.DiskWriteBytes += agg.ResourceTotals.DiskWriteBytes
 						cleanupResources.DiskReadIOPS += agg.ResourceTotals.DiskReadIOPS
 						cleanupResources.DiskWriteIOPS += agg.ResourceTotals.DiskWriteIOPS
+
+						if agg.ResourceTotals.MemoryBytes > cleanupResources.MemoryBytes {
+							cleanupResources.MemoryBytes = agg.ResourceTotals.MemoryBytes
+						}
 					}
 				}
 			}

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -237,6 +237,7 @@ export interface TestEntry {
 export interface ResourceTotals {
   cpu_usec: number
   memory_delta_bytes: number
+  memory_bytes?: number
   disk_read_bytes: number
   disk_write_bytes: number
   disk_read_iops: number
@@ -284,6 +285,7 @@ export interface MethodStatsFloat {
 // Resource delta for a single RPC call
 export interface ResourceDelta {
   memory_delta_bytes: number
+  memory_abs_bytes?: number
   cpu_delta_usec: number
   disk_read_bytes: number
   disk_write_bytes: number

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -594,6 +594,9 @@ export function RunDetailPage() {
             tests={result.tests}
             onTestClick={handleTestModalChange}
             resourceCollectionMethod={config.system_resource_collection_method}
+            cpuCores={config.instance.resource_limits?.cpuset_cpus
+              ? config.instance.resource_limits.cpuset_cpus.split(',').length
+              : config.system.cpu_cores}
           />
 
           {result.pre_run_steps && Object.keys(result.pre_run_steps).length > 0 && (


### PR DESCRIPTION
Store absolute memory reading (memory_abs_bytes) in ResourceDelta and propagate it as memory_bytes in ResourceTotals. Derive CPU usage percentage from existing cpu_usec and time_total fields on the frontend.

New charts:
- CPU Usage % with optional reference line at allocated core count
- Memory Usage (MB) showing absolute RAM usage trajectory (only shown for new runs that include memory_abs_bytes data)

Existing CPU chart renamed to "CPU Time" for clarity. Summary stat cards expanded with "Avg CPU %" and "Memory" entries.