### PR TITLE
feat: add virtual scrolling to file viewer for large files

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^2.2.0",
         "@tanstack/react-query": "^5.64.0",
         "@tanstack/react-router": "^1.95.0",
+        "@tanstack/react-virtual": "^3.13.9",
         "clsx": "^2.1.0",
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "@headlessui/react": "^2.2.0",
     "@tanstack/react-query": "^5.64.0",
     "@tanstack/react-router": "^1.95.0",
+    "@tanstack/react-virtual": "^3.13.9",
     "clsx": "^2.1.0",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.5",


### PR DESCRIPTION
Use @tanstack/react-virtual to only render visible lines, preventing browser freezes on 100K+ line files. Disable syntax highlighting above 5,000 lines and use memoized row components to minimize re-renders.