### PR TITLE
feat: add local directory and local tarball support for EEST fixtures source

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -97,6 +97,23 @@ benchmark:
   #     #   # fixtures_artifact_run_id: "12345678901"
   #     #   # genesis_artifact_run_id: "12345678901"
   #     #   # fixtures_subdir also works with artifacts
+  #
+  #     # Option 3c: EEST fixtures from local directories.
+  #     # Points directly at already-extracted fixtures and genesis directories.
+  #     # No downloading or caching — useful for local development with locally-built EEST fixtures.
+  #     # eest_fixtures:
+  #     #   local_fixtures_dir: /home/user/eest-output/fixtures
+  #     #   local_genesis_dir: /home/user/eest-output/genesis
+  #     #   # fixtures_subdir also works with local directories
+  #     #   # fixtures_subdir: fixtures/blockchain_tests_engine_x  # default
+  #
+  #     # Option 3d: EEST fixtures from local .tar.gz tarballs.
+  #     # Extracts tarballs to a cache directory (keyed by content hash, re-extraction skipped
+  #     # if already cached). Useful when you have locally-built tarballs but haven't extracted them.
+  #     # eest_fixtures:
+  #     #   local_fixtures_tarball: /home/user/eest-output/fixtures_benchmark.tar.gz
+  #     #   local_genesis_tarball: /home/user/eest-output/benchmark_genesis.tar.gz
+  #     #   # fixtures_subdir also works with local tarballs
 
 client:
   config:


### PR DESCRIPTION

Allow eest_fixtures to consume locally-built fixtures without requiring a GitHub round-trip. Two new mutually-exclusive modes are added alongside the existing release and artifact modes:

- local_fixtures_dir / local_genesis_dir: point at already-extracted directories; no downloading or caching is performed.
- local_fixtures_tarball / local_genesis_tarball: extract .tar.gz files to a cache directory keyed by a hash of the tarball paths.

github_repo is no longer required for local modes. Validation enforces that exactly one of the four modes (release, artifact, local_dir, local_tarball) is specified.