### PR TITLE
feat: add run metadata labels to config.json

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,11 @@ type Config struct {
 	Client    ClientConfig    `yaml:"client" mapstructure:"client"`
 }
 
+// MetadataConfig contains arbitrary metadata labels for a benchmark run.
+type MetadataConfig struct {
+	Labels map[string]string `yaml:"labels,omitempty" mapstructure:"labels" json:"labels,omitempty"`
+}
+
 // GlobalConfig contains global application settings.
 type GlobalConfig struct {
 	LogLevel           string            `yaml:"log_level" mapstructure:"log_level"`
@@ -67,6 +72,7 @@ type GlobalConfig struct {
 	Directories        DirectoriesConfig `yaml:"directories,omitempty" mapstructure:"directories"`
 	DropCachesPath     string            `yaml:"drop_caches_path,omitempty" mapstructure:"drop_caches_path"`
 	GitHubToken        string            `yaml:"github_token,omitempty" mapstructure:"github_token"`
+	Metadata           MetadataConfig    `yaml:"metadata,omitempty" mapstructure:"metadata"`
 }
 
 // DirectoriesConfig contains directory path configurations.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1100,6 +1100,78 @@ client:
 	})
 }
 
+func TestLoad_MetadataLabels(t *testing.T) {
+	t.Run("parses labels from yaml", func(t *testing.T) {
+		configContent := `
+global:
+  metadata:
+    labels:
+      env: production
+      team: platform
+client:
+  config:
+    genesis:
+      geth: http://example.com/genesis.json
+  instances:
+    - id: test-instance
+      client: geth
+`
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o644))
+
+		cfg, err := Load(configPath)
+		require.NoError(t, err)
+
+		require.Len(t, cfg.Global.Metadata.Labels, 2)
+		assert.Equal(t, "production", cfg.Global.Metadata.Labels["env"])
+		assert.Equal(t, "platform", cfg.Global.Metadata.Labels["team"])
+	})
+
+	t.Run("empty metadata produces no errors", func(t *testing.T) {
+		configContent := `
+client:
+  config:
+    genesis:
+      geth: http://example.com/genesis.json
+  instances:
+    - id: test-instance
+      client: geth
+`
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o644))
+
+		cfg, err := Load(configPath)
+		require.NoError(t, err)
+
+		assert.Nil(t, cfg.Global.Metadata.Labels)
+	})
+
+	t.Run("empty labels map produces no errors", func(t *testing.T) {
+		configContent := `
+global:
+  metadata:
+    labels: {}
+client:
+  config:
+    genesis:
+      geth: http://example.com/genesis.json
+  instances:
+    - id: test-instance
+      client: geth
+`
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o644))
+
+		cfg, err := Load(configPath)
+		require.NoError(t, err)
+
+		assert.Empty(t, cfg.Global.Metadata.Labels)
+	})
+}
+
 // createTestTarball creates a minimal .tar.gz file at the given path for testing.
 func createTestTarball(t *testing.T, path string) {
 	t.Helper()

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -89,18 +89,19 @@ type StartBlock struct {
 
 // RunConfig contains configuration for a single test run.
 type RunConfig struct {
-	Timestamp                      int64             `json:"timestamp"`
-	TimestampEnd                   int64             `json:"timestamp_end,omitempty"`
-	SuiteHash                      string            `json:"suite_hash,omitempty"`
-	SystemResourceCollectionMethod string            `json:"system_resource_collection_method,omitempty"`
-	System                         *SystemInfo       `json:"system"`
-	Instance                       *ResolvedInstance `json:"instance"`
-	StartBlock                     *StartBlock       `json:"start_block,omitempty"`
-	TestCounts                     *TestCounts       `json:"test_counts,omitempty"`
-	Status                         string            `json:"status,omitempty"`
-	TerminationReason              string            `json:"termination_reason,omitempty"`
-	ContainerExitCode              *int64            `json:"container_exit_code,omitempty"`
-	ContainerOOMKilled             *bool             `json:"container_oom_killed,omitempty"`
+	Timestamp                      int64                  `json:"timestamp"`
+	TimestampEnd                   int64                  `json:"timestamp_end,omitempty"`
+	SuiteHash                      string                 `json:"suite_hash,omitempty"`
+	SystemResourceCollectionMethod string                 `json:"system_resource_collection_method,omitempty"`
+	System                         *SystemInfo            `json:"system"`
+	Instance                       *ResolvedInstance      `json:"instance"`
+	Metadata                       *config.MetadataConfig `json:"metadata,omitempty"`
+	StartBlock                     *StartBlock            `json:"start_block,omitempty"`
+	TestCounts                     *TestCounts            `json:"test_counts,omitempty"`
+	Status                         string                 `json:"status,omitempty"`
+	TerminationReason              string                 `json:"termination_reason,omitempty"`
+	ContainerExitCode              *int64                 `json:"container_exit_code,omitempty"`
+	ContainerOOMKilled             *bool                  `json:"container_oom_killed,omitempty"`
 }
 
 // Run status constants.
@@ -908,6 +909,11 @@ func (r *runner) runContainerLifecycle(
 				return nil
 			}(),
 		},
+	}
+
+	// Attach metadata labels if configured.
+	if r.cfg.FullConfig != nil && len(r.cfg.FullConfig.Global.Metadata.Labels) > 0 {
+		runConfig.Metadata = &r.cfg.FullConfig.Global.Metadata
 	}
 
 	if len(params.GenesisGroups) > 0 {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -140,6 +140,9 @@ export interface RunConfig {
   termination_reason?: string
   container_exit_code?: number
   container_oom_killed?: boolean
+  metadata?: {
+    labels?: Record<string, string>
+  }
 }
 
 export interface SystemInfo {

--- a/ui/src/components/run-detail/RunConfiguration.tsx
+++ b/ui/src/components/run-detail/RunConfiguration.tsx
@@ -8,6 +8,9 @@ interface RunConfigurationProps {
   instance: InstanceConfig
   system: SystemInfo
   startBlock?: StartBlock
+  metadata?: {
+    labels?: Record<string, string>
+  }
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -42,7 +45,7 @@ function InfoItem({ label, value }: { label: string; value: string | number }) {
   )
 }
 
-export function RunConfiguration({ instance, system, startBlock }: RunConfigurationProps) {
+export function RunConfiguration({ instance, system, startBlock, metadata }: RunConfigurationProps) {
   const [expanded, setExpanded] = useState(false)
 
   const shortImage = instance.image.includes('/') ? instance.image.split('/').pop()! : instance.image
@@ -370,6 +373,7 @@ export function RunConfiguration({ instance, system, startBlock }: RunConfigurat
                   </dd>
                 </div>
               )}
+
             </div>
           </div>
 
@@ -486,6 +490,26 @@ export function RunConfiguration({ instance, system, startBlock }: RunConfigurat
                     </div>
                   </div>
                 )}
+              </div>
+            )}
+
+            {/* Metadata Labels */}
+            {metadata?.labels && Object.keys(metadata.labels).length > 0 && (
+              <div className="mt-6 border-t border-gray-200 pt-6 dark:border-gray-700">
+                <h4 className="mb-3 text-sm/6 font-medium text-gray-900 dark:text-gray-100">Metadata Labels</h4>
+                <div className="overflow-x-auto rounded-xs bg-gray-100 p-2 dark:bg-gray-900">
+                  <div className="flex flex-col gap-1 font-mono text-xs/5 text-gray-900 dark:text-gray-100">
+                    {Object.entries(metadata.labels).map(([key, value]) => (
+                      <div key={key} className="flex items-start gap-2">
+                        <span className="break-all">
+                          <span className="text-gray-500 dark:text-gray-400">{key}=</span>
+                          {value}
+                        </span>
+                        <CopyButton text={`${key}=${value}`} />
+                      </div>
+                    ))}
+                  </div>
+                </div>
               </div>
             )}
           </div>

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -519,7 +519,7 @@ export function RunDetailPage() {
         )}
       </div>
 
-      <RunConfiguration instance={config.instance} system={config.system} startBlock={config.start_block} />
+      <RunConfiguration instance={config.instance} system={config.system} startBlock={config.start_block} metadata={config.metadata} />
 
       <FilesPanel
         runId={runId}


### PR DESCRIPTION
Add support for arbitrary key-value labels as metadata on benchmark runs. Labels can be set via YAML config (global.metadata.labels) and/or CLI flags (--metadata.label=key=value). CLI labels merge with config labels, with CLI taking precedence on conflicts.