### PR TITLE
feat: add generate-markdown-summary command for run directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,12 +34,13 @@ tmp/
 *.log
 .ai_plans
 config.yaml
+summary-*.md
+/data/
+/fixtures/
+/config/
+
 
 # Root level npm (should only be in ui/)
 /node_modules/
 /package.json
 /package-lock.json
-
-/data/
-/fixtures/
-/config/

--- a/cmd/benchmarkoor/markdown_summary.go
+++ b/cmd/benchmarkoor/markdown_summary.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/executor"
+	"github.com/spf13/cobra"
+)
+
+var generateMarkdownSummaryCmd = &cobra.Command{
+	Use:   "generate-markdown-summary",
+	Short: "Generate a markdown summary from a benchmark run directory",
+	Long:  `Reads config.json and result.json from a run directory and produces a markdown summary file.`,
+	RunE:  runGenerateMarkdownSummary,
+}
+
+var (
+	runToMdRunDir string
+	runToMdOutput string
+)
+
+const maxMarkdownChars = 65000
+
+func init() {
+	rootCmd.AddCommand(generateMarkdownSummaryCmd)
+	generateMarkdownSummaryCmd.Flags().StringVar(&runToMdRunDir, "run-dir", "",
+		"Path to the benchmark run directory")
+	generateMarkdownSummaryCmd.Flags().StringVar(&runToMdOutput, "output", "",
+		"Output file path (default: summary-<run_id>.md)")
+
+	if err := generateMarkdownSummaryCmd.MarkFlagRequired("run-dir"); err != nil {
+		panic(err)
+	}
+}
+
+func runGenerateMarkdownSummary(_ *cobra.Command, _ []string) error {
+	runID := filepath.Base(runToMdRunDir)
+
+	log.WithField("run_dir", runToMdRunDir).
+		Info("Generating markdown summary")
+
+	md, err := executor.GenerateRunMarkdown(
+		runToMdRunDir, runID, maxMarkdownChars,
+	)
+	if err != nil {
+		return fmt.Errorf("generating markdown: %w", err)
+	}
+
+	output := runToMdOutput
+	if output == "" {
+		output = fmt.Sprintf("summary-%s.md", runID)
+	}
+
+	if err := os.WriteFile(output, []byte(md), 0644); err != nil {
+		return fmt.Errorf("writing output file: %w", err)
+	}
+
+	log.WithField("output", output).
+		Info("Markdown summary generated successfully")
+
+	return nil
+}

--- a/pkg/executor/markdown.go
+++ b/pkg/executor/markdown.go
@@ -1,0 +1,557 @@
+package executor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// markdownRunConfig mirrors runner.RunConfig fields needed for markdown
+// generation. The executor package cannot import runner, so we define
+// local types for JSON unmarshaling.
+type markdownRunConfig struct {
+	Timestamp                      int64               `json:"timestamp"`
+	TimestampEnd                   int64               `json:"timestamp_end,omitempty"`
+	SuiteHash                      string              `json:"suite_hash,omitempty"`
+	SystemResourceCollectionMethod string              `json:"system_resource_collection_method,omitempty"`
+	System                         *markdownSystemInfo `json:"system,omitempty"`
+	Instance                       *markdownInstance   `json:"instance"`
+	Metadata                       *markdownMetadata   `json:"metadata,omitempty"`
+	StartBlock                     *markdownStartBlock `json:"start_block,omitempty"`
+	TestCounts                     *markdownTestCounts `json:"test_counts,omitempty"`
+	Status                         string              `json:"status,omitempty"`
+	TerminationReason              string              `json:"termination_reason,omitempty"`
+	ContainerExitCode              *int64              `json:"container_exit_code,omitempty"`
+	ContainerOOMKilled             *bool               `json:"container_oom_killed,omitempty"`
+}
+
+type markdownSystemInfo struct {
+	Hostname           string  `json:"hostname"`
+	OS                 string  `json:"os"`
+	Platform           string  `json:"platform"`
+	PlatformVersion    string  `json:"platform_version"`
+	KernelVersion      string  `json:"kernel_version"`
+	Arch               string  `json:"arch"`
+	Virtualization     string  `json:"virtualization,omitempty"`
+	VirtualizationRole string  `json:"virtualization_role,omitempty"`
+	CPUVendor          string  `json:"cpu_vendor"`
+	CPUModel           string  `json:"cpu_model"`
+	CPUCores           int     `json:"cpu_cores"`
+	CPUMhz             float64 `json:"cpu_mhz"`
+	CPUCacheKB         int     `json:"cpu_cache_kb"`
+	MemoryTotalGB      float64 `json:"memory_total_gb"`
+}
+
+type markdownInstance struct {
+	ID             string                  `json:"id"`
+	Client         string                  `json:"client"`
+	Image          string                  `json:"image"`
+	ClientVersion  string                  `json:"client_version,omitempty"`
+	ResourceLimits *markdownResourceLimits `json:"resource_limits,omitempty"`
+}
+
+type markdownResourceLimits struct {
+	CpusetCpus    string  `json:"cpuset_cpus,omitempty"`
+	Memory        string  `json:"memory,omitempty"`
+	MemoryBytes   int64   `json:"memory_bytes,omitempty"`
+	CPUFreqKHz    *uint64 `json:"cpu_freq_khz,omitempty"`
+	CPUTurboBoost *bool   `json:"cpu_turboboost,omitempty"`
+	CPUGovernor   string  `json:"cpu_freq_governor,omitempty"`
+}
+
+type markdownMetadata struct {
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+type markdownStartBlock struct {
+	Number    uint64 `json:"number"`
+	Hash      string `json:"hash"`
+	StateRoot string `json:"state_root"`
+}
+
+type markdownTestCounts struct {
+	Total  int `json:"total"`
+	Passed int `json:"passed"`
+	Failed int `json:"failed"`
+}
+
+// failedTestInfo holds information about a single failed test.
+type failedTestInfo struct {
+	Name        string
+	FailedSteps []string
+}
+
+// GenerateRunMarkdown generates a markdown summary for a single benchmark
+// run directory. The output is capped at maxChars characters.
+func GenerateRunMarkdown(
+	runDir, runID string,
+	maxChars int,
+) (string, error) {
+	// Parse config.json (required).
+	configPath := filepath.Join(runDir, "config.json")
+
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", fmt.Errorf("reading config.json: %w", err)
+	}
+
+	var cfg markdownRunConfig
+	if err := json.Unmarshal(configData, &cfg); err != nil {
+		return "", fmt.Errorf("parsing config.json: %w", err)
+	}
+
+	// Parse result.json (optional — may not exist for crashed runs).
+	var result *RunResult
+
+	resultPath := filepath.Join(runDir, "result.json")
+
+	resultData, readErr := os.ReadFile(resultPath)
+	if readErr == nil {
+		var rr RunResult
+		if err := json.Unmarshal(resultData, &rr); err == nil {
+			result = &rr
+		}
+	}
+
+	// Aggregate step stats and test counts.
+	var (
+		steps       *IndexStepsStats
+		testsPassed int
+		testsFailed int
+		testsTotal  int
+	)
+
+	if result != nil {
+		steps, testsPassed, testsFailed = AggregateStepStats(result)
+		testsTotal = len(result.Tests)
+	}
+
+	// Override with config test_counts when available.
+	if cfg.TestCounts != nil {
+		testsTotal = cfg.TestCounts.Total
+		testsPassed = cfg.TestCounts.Passed
+		testsFailed = cfg.TestCounts.Failed
+	}
+
+	// Build markdown.
+	var sb strings.Builder
+
+	sb.Grow(4096)
+
+	writeTitle(&sb, runID)
+	writeOverview(&sb, &cfg)
+	writeSystem(&sb, cfg.System)
+	writeResourceLimits(&sb, cfg.Instance)
+	writeMetadata(&sb, cfg.Metadata)
+	writeStartBlock(&sb, cfg.StartBlock)
+	writeTestResults(&sb, testsTotal, testsPassed, testsFailed)
+	writeStepStats(&sb, steps)
+
+	// Failed tests section is last — it gets truncated if needed.
+	failed := collectFailedTests(result)
+	writeFailedTests(&sb, failed, maxChars)
+
+	return sb.String(), nil
+}
+
+func writeTitle(sb *strings.Builder, runID string) {
+	fmt.Fprintf(sb, "# Benchmark Run: %s\n\n", runID)
+}
+
+func writeOverview(sb *strings.Builder, cfg *markdownRunConfig) {
+	sb.WriteString("## Overview\n\n")
+	sb.WriteString("| Field | Value |\n")
+	sb.WriteString("|---|---|\n")
+
+	if cfg.Status != "" {
+		fmt.Fprintf(sb, "| Status | %s |\n", cfg.Status)
+	}
+
+	if cfg.TerminationReason != "" {
+		fmt.Fprintf(sb, "| Termination Reason | %s |\n",
+			cfg.TerminationReason)
+	}
+
+	if cfg.ContainerExitCode != nil {
+		fmt.Fprintf(sb, "| Container Exit Code | %d |\n",
+			*cfg.ContainerExitCode)
+	}
+
+	if cfg.ContainerOOMKilled != nil && *cfg.ContainerOOMKilled {
+		sb.WriteString("| Container OOM Killed | yes |\n")
+	}
+
+	if cfg.Instance != nil {
+		fmt.Fprintf(sb, "| Client | %s |\n", cfg.Instance.Client)
+		fmt.Fprintf(sb, "| Image | `%s` |\n", cfg.Instance.Image)
+
+		if cfg.Instance.ClientVersion != "" {
+			fmt.Fprintf(sb, "| Client Version | %s |\n",
+				cfg.Instance.ClientVersion)
+		}
+	}
+
+	if cfg.Timestamp > 0 {
+		t := time.Unix(cfg.Timestamp, 0).UTC()
+		fmt.Fprintf(sb, "| Started | %s |\n",
+			t.Format("2006-01-02 15:04:05 UTC"))
+	}
+
+	if cfg.TimestampEnd > 0 && cfg.Timestamp > 0 {
+		dur := time.Duration(cfg.TimestampEnd-cfg.Timestamp) * time.Second
+		fmt.Fprintf(sb, "| Duration | %s |\n", formatDuration(dur))
+	}
+
+	if cfg.SuiteHash != "" {
+		fmt.Fprintf(sb, "| Suite Hash | `%s` |\n", cfg.SuiteHash)
+	}
+
+	sb.WriteByte('\n')
+}
+
+func writeSystem(sb *strings.Builder, sys *markdownSystemInfo) {
+	if sys == nil {
+		return
+	}
+
+	sb.WriteString("## System\n\n")
+	sb.WriteString("| Field | Value |\n")
+	sb.WriteString("|---|---|\n")
+
+	if sys.Hostname != "" {
+		fmt.Fprintf(sb, "| Hostname | %s |\n", sys.Hostname)
+	}
+
+	if sys.CPUModel != "" {
+		fmt.Fprintf(sb, "| CPU | %s |\n", sys.CPUModel)
+	}
+
+	if sys.CPUCores > 0 {
+		fmt.Fprintf(sb, "| Cores | %d |\n", sys.CPUCores)
+	}
+
+	if sys.CPUMhz > 0 {
+		fmt.Fprintf(sb, "| CPU MHz | %.1f |\n", sys.CPUMhz)
+	}
+
+	if sys.MemoryTotalGB > 0 {
+		fmt.Fprintf(sb, "| Memory | %.1f GB |\n", sys.MemoryTotalGB)
+	}
+
+	if sys.OS != "" {
+		fmt.Fprintf(sb, "| OS | %s |\n", sys.OS)
+	}
+
+	if sys.Platform != "" {
+		platform := sys.Platform
+		if sys.PlatformVersion != "" {
+			platform += " " + sys.PlatformVersion
+		}
+
+		fmt.Fprintf(sb, "| Platform | %s |\n", platform)
+	}
+
+	if sys.Arch != "" {
+		fmt.Fprintf(sb, "| Arch | %s |\n", sys.Arch)
+	}
+
+	if sys.KernelVersion != "" {
+		fmt.Fprintf(sb, "| Kernel | %s |\n", sys.KernelVersion)
+	}
+
+	sb.WriteByte('\n')
+}
+
+func writeResourceLimits(sb *strings.Builder, inst *markdownInstance) {
+	if inst == nil || inst.ResourceLimits == nil {
+		return
+	}
+
+	rl := inst.ResourceLimits
+
+	// Check if there's anything to show.
+	if rl.CpusetCpus == "" && rl.Memory == "" &&
+		rl.CPUFreqKHz == nil && rl.CPUTurboBoost == nil &&
+		rl.CPUGovernor == "" {
+		return
+	}
+
+	sb.WriteString("## Resource Limits\n\n")
+	sb.WriteString("| Field | Value |\n")
+	sb.WriteString("|---|---|\n")
+
+	if rl.CpusetCpus != "" {
+		fmt.Fprintf(sb, "| CPU Set | %s |\n", rl.CpusetCpus)
+	}
+
+	if rl.Memory != "" {
+		fmt.Fprintf(sb, "| Memory | %s |\n", rl.Memory)
+	}
+
+	if rl.CPUFreqKHz != nil {
+		mhz := float64(*rl.CPUFreqKHz) / 1000.0
+		fmt.Fprintf(sb, "| CPU Frequency | %.1f MHz |\n", mhz)
+	}
+
+	if rl.CPUTurboBoost != nil {
+		val := "disabled"
+		if *rl.CPUTurboBoost {
+			val = "enabled"
+		}
+
+		fmt.Fprintf(sb, "| Turbo Boost | %s |\n", val)
+	}
+
+	if rl.CPUGovernor != "" {
+		fmt.Fprintf(sb, "| CPU Governor | %s |\n", rl.CPUGovernor)
+	}
+
+	sb.WriteByte('\n')
+}
+
+func writeMetadata(sb *strings.Builder, md *markdownMetadata) {
+	if md == nil || len(md.Labels) == 0 {
+		return
+	}
+
+	sb.WriteString("## Metadata\n\n")
+	sb.WriteString("| Label | Value |\n")
+	sb.WriteString("|---|---|\n")
+
+	// Sort keys for deterministic output.
+	keys := make([]string, 0, len(md.Labels))
+	for k := range md.Labels {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		fmt.Fprintf(sb, "| %s | %s |\n", k, md.Labels[k])
+	}
+
+	sb.WriteByte('\n')
+}
+
+func writeStartBlock(sb *strings.Builder, block *markdownStartBlock) {
+	if block == nil {
+		return
+	}
+
+	sb.WriteString("## Start Block\n\n")
+	sb.WriteString("| Field | Value |\n")
+	sb.WriteString("|---|---|\n")
+	fmt.Fprintf(sb, "| Number | %d |\n", block.Number)
+
+	if block.Hash != "" {
+		fmt.Fprintf(sb, "| Hash | `%s` |\n", block.Hash)
+	}
+
+	if block.StateRoot != "" {
+		fmt.Fprintf(sb, "| State Root | `%s` |\n", block.StateRoot)
+	}
+
+	sb.WriteByte('\n')
+}
+
+func writeTestResults(
+	sb *strings.Builder,
+	total, passed, failed int,
+) {
+	sb.WriteString("## Test Results\n\n")
+	sb.WriteString("| Total | Passed | Failed |\n")
+	sb.WriteString("|---|---|---|\n")
+	fmt.Fprintf(sb, "| %d | %d | %d |\n\n", total, passed, failed)
+}
+
+func writeStepStats(sb *strings.Builder, steps *IndexStepsStats) {
+	if steps == nil {
+		return
+	}
+
+	// Check if there's any data to show.
+	if steps.Setup == nil && steps.Test == nil && steps.Cleanup == nil {
+		return
+	}
+
+	sb.WriteString("## Aggregated Step Stats\n\n")
+	sb.WriteString("| Step | Duration | Gas Used | MGas/s " +
+		"| Success | Fail |\n")
+	sb.WriteString("|---|---|---|---|---|---|\n")
+
+	writeStepRow(sb, "Setup", steps.Setup)
+	writeStepRow(sb, "Test", steps.Test)
+	writeStepRow(sb, "Cleanup", steps.Cleanup)
+
+	sb.WriteByte('\n')
+}
+
+func writeStepRow(sb *strings.Builder, name string, s *IndexStepStats) {
+	if s == nil {
+		return
+	}
+
+	fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d |\n",
+		name,
+		formatDurationNs(s.Duration),
+		formatGas(s.GasUsed),
+		formatMGasPerSec(s.GasUsed, s.GasUsedDuration),
+		s.Success,
+		s.Fail,
+	)
+}
+
+func writeFailedTests(
+	sb *strings.Builder,
+	failed []failedTestInfo,
+	maxChars int,
+) {
+	if len(failed) == 0 {
+		return
+	}
+
+	sb.WriteString("## Failed Tests\n\n")
+	sb.WriteString("| Test | Failed Steps |\n")
+	sb.WriteString("|---|---|\n")
+
+	// Reserve space for the truncation message.
+	const reserveChars = 100
+
+	for i, ft := range failed {
+		row := fmt.Sprintf("| %s | %s |\n",
+			ft.Name, strings.Join(ft.FailedSteps, ", "))
+
+		// Check if adding this row would exceed maxChars.
+		if maxChars > 0 && sb.Len()+len(row)+reserveChars > maxChars {
+			remaining := len(failed) - i
+			fmt.Fprintf(sb,
+				"\n*%d more failed test(s) not shown "+
+					"(output truncated at %d chars)*\n",
+				remaining, maxChars)
+
+			return
+		}
+
+		sb.WriteString(row)
+	}
+}
+
+// collectFailedTests iterates the result and returns a sorted list of
+// tests that have at least one failed step.
+func collectFailedTests(result *RunResult) []failedTestInfo {
+	if result == nil {
+		return nil
+	}
+
+	failed := make([]failedTestInfo, 0)
+
+	for name, test := range result.Tests {
+		if test.Steps == nil {
+			continue
+		}
+
+		var failedSteps []string
+
+		if test.Steps.Setup != nil &&
+			test.Steps.Setup.Aggregated != nil &&
+			test.Steps.Setup.Aggregated.Failed > 0 {
+			failedSteps = append(failedSteps, "setup")
+		}
+
+		if test.Steps.Test != nil &&
+			test.Steps.Test.Aggregated != nil &&
+			test.Steps.Test.Aggregated.Failed > 0 {
+			failedSteps = append(failedSteps, "test")
+		}
+
+		if test.Steps.Cleanup != nil &&
+			test.Steps.Cleanup.Aggregated != nil &&
+			test.Steps.Cleanup.Aggregated.Failed > 0 {
+			failedSteps = append(failedSteps, "cleanup")
+		}
+
+		if len(failedSteps) > 0 {
+			failed = append(failed, failedTestInfo{
+				Name:        name,
+				FailedSteps: failedSteps,
+			})
+		}
+	}
+
+	sort.Slice(failed, func(i, j int) bool {
+		return failed[i].Name < failed[j].Name
+	})
+
+	return failed
+}
+
+// formatDuration formats a time.Duration as a human-readable string.
+func formatDuration(d time.Duration) string {
+	if d < time.Second {
+		return d.String()
+	}
+
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	seconds := int(d.Seconds()) % 60
+
+	if hours > 0 {
+		return fmt.Sprintf("%dh %dm %ds", hours, minutes, seconds)
+	}
+
+	if minutes > 0 {
+		return fmt.Sprintf("%dm %ds", minutes, seconds)
+	}
+
+	return fmt.Sprintf("%ds", seconds)
+}
+
+// formatDurationNs formats nanoseconds as a human-readable duration.
+func formatDurationNs(ns int64) string {
+	return formatDuration(time.Duration(ns))
+}
+
+// formatGas formats a gas value with comma separators.
+func formatGas(gas uint64) string {
+	if gas == 0 {
+		return "0"
+	}
+
+	s := fmt.Sprintf("%d", gas)
+	n := len(s)
+
+	if n <= 3 {
+		return s
+	}
+
+	// Insert commas from the right.
+	var b strings.Builder
+
+	b.Grow(n + (n-1)/3)
+
+	for i, ch := range s {
+		if i > 0 && (n-i)%3 == 0 {
+			b.WriteByte(',')
+		}
+
+		b.WriteRune(ch)
+	}
+
+	return b.String()
+}
+
+// formatMGasPerSec computes and formats MGas/s from gas and duration in ns.
+func formatMGasPerSec(gas uint64, durationNs int64) string {
+	if gas == 0 || durationNs <= 0 {
+		return "-"
+	}
+
+	mgasPerSec := float64(gas) / 1_000_000.0 /
+		(float64(durationNs) / 1_000_000_000.0)
+
+	return fmt.Sprintf("%.2f", mgasPerSec)
+}

--- a/pkg/executor/markdown_test.go
+++ b/pkg/executor/markdown_test.go
@@ -1,0 +1,444 @@
+package executor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		{
+			name:     "sub-second",
+			duration: 500 * time.Millisecond,
+			expected: "500ms",
+		},
+		{
+			name:     "seconds only",
+			duration: 45 * time.Second,
+			expected: "45s",
+		},
+		{
+			name:     "minutes and seconds",
+			duration: 10*time.Minute + 8*time.Second,
+			expected: "10m 8s",
+		},
+		{
+			name:     "hours minutes seconds",
+			duration: 2*time.Hour + 30*time.Minute + 15*time.Second,
+			expected: "2h 30m 15s",
+		},
+		{
+			name:     "zero",
+			duration: 0,
+			expected: "0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatDuration(tt.duration))
+		})
+	}
+}
+
+func TestFormatDurationNs(t *testing.T) {
+	tests := []struct {
+		name     string
+		ns       int64
+		expected string
+	}{
+		{
+			name:     "zero",
+			ns:       0,
+			expected: "0s",
+		},
+		{
+			name:     "one second",
+			ns:       int64(time.Second),
+			expected: "1s",
+		},
+		{
+			name:     "ten minutes eight seconds",
+			ns:       int64(10*time.Minute + 8*time.Second),
+			expected: "10m 8s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatDurationNs(tt.ns))
+		})
+	}
+}
+
+func TestFormatGas(t *testing.T) {
+	tests := []struct {
+		name     string
+		gas      uint64
+		expected string
+	}{
+		{name: "zero", gas: 0, expected: "0"},
+		{name: "small", gas: 100, expected: "100"},
+		{name: "thousands", gas: 1234, expected: "1,234"},
+		{name: "millions", gas: 1234567, expected: "1,234,567"},
+		{name: "billions", gas: 1234567890, expected: "1,234,567,890"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatGas(tt.gas))
+		})
+	}
+}
+
+func TestFormatMGasPerSec(t *testing.T) {
+	tests := []struct {
+		name       string
+		gas        uint64
+		durationNs int64
+		expected   string
+	}{
+		{
+			name:       "zero gas",
+			gas:        0,
+			durationNs: int64(time.Second),
+			expected:   "-",
+		},
+		{
+			name:       "zero duration",
+			gas:        1_000_000,
+			durationNs: 0,
+			expected:   "-",
+		},
+		{
+			name:       "one mgas in one second",
+			gas:        1_000_000,
+			durationNs: int64(time.Second),
+			expected:   "1.00",
+		},
+		{
+			name:       "100 mgas in 10 seconds",
+			gas:        100_000_000,
+			durationNs: int64(10 * time.Second),
+			expected:   "10.00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected,
+				formatMGasPerSec(tt.gas, tt.durationNs))
+		})
+	}
+}
+
+func TestCollectFailedTests(t *testing.T) {
+	t.Run("nil result", func(t *testing.T) {
+		assert.Nil(t, collectFailedTests(nil))
+	})
+
+	t.Run("no failures", func(t *testing.T) {
+		result := &RunResult{
+			Tests: map[string]*TestEntry{
+				"test1": {
+					Steps: &StepsResult{
+						Test: &StepResult{
+							Aggregated: &AggregatedStats{
+								Succeeded: 1,
+								Failed:    0,
+							},
+						},
+					},
+				},
+			},
+		}
+		assert.Empty(t, collectFailedTests(result))
+	})
+
+	t.Run("with failures sorted", func(t *testing.T) {
+		result := &RunResult{
+			Tests: map[string]*TestEntry{
+				"zz_test": {
+					Steps: &StepsResult{
+						Test: &StepResult{
+							Aggregated: &AggregatedStats{Failed: 1},
+						},
+					},
+				},
+				"aa_test": {
+					Steps: &StepsResult{
+						Setup: &StepResult{
+							Aggregated: &AggregatedStats{Failed: 1},
+						},
+						Test: &StepResult{
+							Aggregated: &AggregatedStats{Failed: 2},
+						},
+					},
+				},
+			},
+		}
+
+		failed := collectFailedTests(result)
+		require.Len(t, failed, 2)
+		assert.Equal(t, "aa_test", failed[0].Name)
+		assert.Equal(t, []string{"setup", "test"}, failed[0].FailedSteps)
+		assert.Equal(t, "zz_test", failed[1].Name)
+		assert.Equal(t, []string{"test"}, failed[1].FailedSteps)
+	})
+}
+
+func TestGenerateRunMarkdown(t *testing.T) {
+	t.Run("full run with result", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFixtureConfig(t, dir)
+		writeFixtureResult(t, dir)
+
+		md, err := GenerateRunMarkdown(dir, "test_run_123", 65000)
+		require.NoError(t, err)
+
+		// Check sections are present.
+		assert.Contains(t, md, "# Benchmark Run: test_run_123")
+		assert.Contains(t, md, "## Overview")
+		assert.Contains(t, md, "| Status | completed |")
+		assert.Contains(t, md, "| Client | geth |")
+		assert.Contains(t, md, "| Image | `ethpandaops/geth:latest` |")
+		assert.Contains(t, md, "| Client Version | Geth/v1.17.0 |")
+		assert.Contains(t, md, "## System")
+		assert.Contains(t, md, "| Hostname | test-host |")
+		assert.Contains(t, md, "| CPU | AMD Ryzen 9 |")
+		assert.Contains(t, md, "## Resource Limits")
+		assert.Contains(t, md, "| CPU Set | 0-3 |")
+		assert.Contains(t, md, "## Metadata")
+		assert.Contains(t, md, "| env | staging |")
+		assert.Contains(t, md, "## Start Block")
+		assert.Contains(t, md, "| Number | 100 |")
+		assert.Contains(t, md, "## Test Results")
+		assert.Contains(t, md, "## Aggregated Step Stats")
+		assert.Contains(t, md, "| Test |")
+	})
+
+	t.Run("missing result.json", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFixtureConfig(t, dir)
+
+		md, err := GenerateRunMarkdown(dir, "crashed_run", 65000)
+		require.NoError(t, err)
+		assert.Contains(t, md, "# Benchmark Run: crashed_run")
+		assert.Contains(t, md, "## Test Results")
+		// Should still work but with zero counts.
+		assert.Contains(t, md, "| 10 | 8 | 2 |")
+	})
+
+	t.Run("missing config.json", func(t *testing.T) {
+		dir := t.TempDir()
+
+		_, err := GenerateRunMarkdown(dir, "bad_run", 65000)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reading config.json")
+	})
+
+	t.Run("no resource limits or metadata", func(t *testing.T) {
+		dir := t.TempDir()
+		writeMinimalConfig(t, dir)
+
+		md, err := GenerateRunMarkdown(dir, "minimal_run", 65000)
+		require.NoError(t, err)
+		assert.NotContains(t, md, "## Resource Limits")
+		assert.NotContains(t, md, "## Metadata")
+		assert.NotContains(t, md, "## Start Block")
+	})
+}
+
+func TestGenerateRunMarkdownCharLimit(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalConfig(t, dir)
+
+	// Create a result with many failed tests with long names.
+	result := &RunResult{
+		Tests: make(map[string]*TestEntry, 500),
+	}
+
+	for i := range 500 {
+		name := fmt.Sprintf(
+			"benchmark/compute/precompile/test_very_long_name_%04d"+
+				"_with_extra_padding_to_make_it_really_long", i)
+		result.Tests[name] = &TestEntry{
+			Steps: &StepsResult{
+				Test: &StepResult{
+					Aggregated: &AggregatedStats{Failed: 1},
+				},
+			},
+		}
+	}
+
+	resultData, err := json.MarshalIndent(result, "", "  ")
+	require.NoError(t, err)
+
+	err = os.WriteFile(
+		filepath.Join(dir, "result.json"), resultData, 0644)
+	require.NoError(t, err)
+
+	md, err := GenerateRunMarkdown(dir, "limit_run", 10000)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(md), 10000)
+	assert.Contains(t, md, "more failed test(s) not shown")
+}
+
+// writeFixtureConfig writes a comprehensive config.json for testing.
+func writeFixtureConfig(t *testing.T, dir string) {
+	t.Helper()
+
+	turbo := true
+	freqKHz := uint64(4500000)
+
+	cfg := markdownRunConfig{
+		Timestamp:    1700000000,
+		TimestampEnd: 1700000608,
+		SuiteHash:    "abc123def456",
+		Status:       "completed",
+		System: &markdownSystemInfo{
+			Hostname:      "test-host",
+			OS:            "linux",
+			Platform:      "debian",
+			KernelVersion: "6.1.0",
+			Arch:          "x86_64",
+			CPUModel:      "AMD Ryzen 9",
+			CPUCores:      16,
+			CPUMhz:        5756.0,
+			MemoryTotalGB: 64.0,
+		},
+		Instance: &markdownInstance{
+			ID:            "geth",
+			Client:        "geth",
+			Image:         "ethpandaops/geth:latest",
+			ClientVersion: "Geth/v1.17.0",
+			ResourceLimits: &markdownResourceLimits{
+				CpusetCpus:    "0-3",
+				Memory:        "16g",
+				CPUFreqKHz:    &freqKHz,
+				CPUTurboBoost: &turbo,
+			},
+		},
+		Metadata: &markdownMetadata{
+			Labels: map[string]string{
+				"env":    "staging",
+				"region": "us-east",
+			},
+		},
+		StartBlock: &markdownStartBlock{
+			Number:    100,
+			Hash:      "0xabc123",
+			StateRoot: "0xdef456",
+		},
+		TestCounts: &markdownTestCounts{
+			Total:  10,
+			Passed: 8,
+			Failed: 2,
+		},
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(dir, "config.json"), data, 0644)
+	require.NoError(t, err)
+}
+
+// writeFixtureResult writes a result.json with test data for testing.
+func writeFixtureResult(t *testing.T, dir string) {
+	t.Helper()
+
+	result := &RunResult{
+		Tests: map[string]*TestEntry{
+			"passing_test": {
+				Steps: &StepsResult{
+					Test: &StepResult{
+						Aggregated: &AggregatedStats{
+							TotalTime:        int64(5 * time.Second),
+							GasUsedTotal:     50_000_000,
+							GasUsedTimeTotal: int64(5 * time.Second),
+							Succeeded:        10,
+							Failed:           0,
+						},
+					},
+				},
+			},
+			"failing_test": {
+				Steps: &StepsResult{
+					Test: &StepResult{
+						Aggregated: &AggregatedStats{
+							TotalTime: int64(1 * time.Second),
+							Succeeded: 5,
+							Failed:    3,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(dir, "result.json"), data, 0644)
+	require.NoError(t, err)
+}
+
+// writeMinimalConfig writes a minimal config.json without optional fields.
+func writeMinimalConfig(t *testing.T, dir string) {
+	t.Helper()
+
+	cfg := markdownRunConfig{
+		Timestamp: 1700000000,
+		Status:    "completed",
+		Instance: &markdownInstance{
+			ID:     "geth",
+			Client: "geth",
+			Image:  "ethpandaops/geth:latest",
+		},
+		TestCounts: &markdownTestCounts{
+			Total:  10,
+			Passed: 8,
+			Failed: 2,
+		},
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(dir, "config.json"), data, 0644)
+	require.NoError(t, err)
+}
+
+func TestWriteFailedTestsTruncation(t *testing.T) {
+	failed := make([]failedTestInfo, 100)
+	for i := range 100 {
+		failed[i] = failedTestInfo{
+			Name:        fmt.Sprintf("very_long_test_name_%d", i),
+			FailedSteps: []string{"test"},
+		}
+	}
+
+	var sb strings.Builder
+
+	// Start with some content already in the builder.
+	sb.WriteString("# Header\n\n")
+
+	writeFailedTests(&sb, failed, 500)
+
+	output := sb.String()
+	assert.LessOrEqual(t, len(output), 500)
+	assert.Contains(t, output, "more failed test(s) not shown")
+}


### PR DESCRIPTION
Adds a CLI command that reads config.json and result.json from a benchmark run directory and produces a markdown summary with run metadata, system info, test counts, and aggregated step stats. Output is capped at 65K characters.

Also extracts AggregateStepStats from index.go for reuse.

This will be useful to generate github action summaries.