### PR TITLE
fix(ui): resolve presigned S3 URLs for file download buttons

### DIFF
--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -90,6 +90,15 @@ func (s *server) handlePresignedURL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// When redirect=true, issue a 302 redirect to the presigned URL.
+	// This allows <a href="...?redirect=true"> and curl -L to download
+	// files directly without the client needing to parse JSON.
+	if r.URL.Query().Get("redirect") == "true" {
+		http.Redirect(w, r, url, http.StatusFound)
+
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]string{"url": url})
 }
 

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -99,7 +99,10 @@ export async function fetchHead(path: string): Promise<HeadResult> {
           return { exists: false, size: null, url }
         }
         const contentLength = response.headers.get('content-length')
-        return { exists: true, size: contentLength ? parseInt(contentLength, 10) : null, url }
+        // Return the API URL with ?redirect=true so <a href> triggers a 302
+        // redirect to the presigned S3 URL, enabling direct file downloads.
+        const downloadUrl = `${url}${url.includes('?') ? '&' : '?'}redirect=true`
+        return { exists: true, size: contentLength ? parseInt(contentLength, 10) : null, url: downloadUrl }
       }
 
       const response = await fetch(url, { method: 'HEAD' })

--- a/ui/src/components/run-detail/FilesPanel.tsx
+++ b/ui/src/components/run-detail/FilesPanel.tsx
@@ -7,7 +7,7 @@ import { FolderOpen, Folder, Check, Copy, Download, List, ChevronDown, ChevronRi
 import type { PostTestRPCCallConfig, TestEntry } from '@/api/types'
 import { fetchHead, type HeadResult } from '@/api/client'
 import { formatBytes } from '@/utils/format'
-import { getDataUrl, loadRuntimeConfig, toAbsoluteUrl } from '@/config/runtime'
+import { getDataUrl, isS3Mode, loadRuntimeConfig, toAbsoluteUrl } from '@/config/runtime'
 import { Modal } from '@/components/shared/Modal'
 
 type DownloadListFormat = 'urls' | 'curl'
@@ -585,8 +585,10 @@ export function FilesPanel({ runId, tests, postTestRPCCalls, showDownloadList, d
 
   const downloadListText = useMemo(() => {
     if (!runtimeConfig || downloadEntries.length === 0) return ''
+    const s3 = isS3Mode(runtimeConfig)
     return downloadEntries.map((e) => {
-      const url = getDataUrl(e.path, runtimeConfig)
+      let url = getDataUrl(e.path, runtimeConfig)
+      if (s3) url += `${url.includes('?') ? '&' : '?'}redirect=true`
       return downloadFormat === 'urls'
         ? toAbsoluteUrl(url)
         : `curl -fsSL --create-dirs -o '${e.outputPath}' '${toAbsoluteUrl(url)}'`


### PR DESCRIPTION
Download buttons used the API endpoint URL which returns JSON instead of the actual file. Add ?redirect=true support to the presigned URL handler so it responds with a 302 redirect to S3, and use this in fetchHead and the download list generator for S3 mode.