### PR TITLE
fix(ci): support CRIU installation on Debian runners

### DIFF
--- a/.github/actions/dependencies/action.yaml
+++ b/.github/actions/dependencies/action.yaml
@@ -102,10 +102,17 @@ runs:
         fi
 
         # Install CRIU for checkpoint-restore support.
-        # CRIU is not in Ubuntu 24.04 default repos; use the official PPA.
+        # On Ubuntu 24.04 CRIU is not in default repos; use the official PPA.
+        # On Debian, CRIU is available in the default repos.
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-          sudo add-apt-repository -y ppa:criu/ppa
-          sudo apt-get update
+          if [ -f /etc/os-release ]; then
+            . /etc/os-release
+          fi
+          if [ "${ID:-}" = "ubuntu" ]; then
+            sudo apt-get install -y software-properties-common
+            sudo add-apt-repository -y ppa:criu/ppa
+            sudo apt-get update
+          fi
           sudo apt-get install -y criu
           echo "CRIU installed: $(criu --version 2>&1 | head -1)"
         else


### PR DESCRIPTION
add-apt-repository and PPAs are Ubuntu-specific. On Debian, install CRIU directly from the default repos and only use the PPA on Ubuntu.