### PR TITLE
fix(ui): persist pre-run steps modal in URL

### DIFF
--- a/ui/src/components/run-detail/PreRunStepsTable.tsx
+++ b/ui/src/components/run-detail/PreRunStepsTable.tsx
@@ -17,6 +17,8 @@ interface PreRunStepsTableProps {
   suitePreRunSteps?: SuiteFile[]
   runId: string
   suiteHash?: string
+  selectedStep?: string
+  onSelectedStepChange?: (stepName: string | undefined) => void
 }
 
 function SortIcon({ direction, active }: { direction: PreRunSortDirection; active: boolean }) {
@@ -86,10 +88,11 @@ export function PreRunStepsTable({
   suitePreRunSteps,
   runId,
   suiteHash,
+  selectedStep,
+  onSelectedStepChange,
 }: PreRunStepsTableProps) {
   const [sortBy, setSortBy] = useState<PreRunSortColumn>('order')
   const [sortDir, setSortDir] = useState<PreRunSortDirection>('asc')
-  const [selectedStep, setSelectedStep] = useState<string | undefined>(undefined)
 
   const handleSort = (column: PreRunSortColumn) => {
     const newDirection = sortBy === column && sortDir === 'asc' ? 'desc' : 'asc'
@@ -169,7 +172,7 @@ export function PreRunStepsTable({
               return (
                 <tr
                   key={stepName}
-                  onClick={() => setSelectedStep(stepName)}
+                  onClick={() => onSelectedStepChange?.(stepName)}
                   className="cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
                 >
                   <td className="whitespace-nowrap px-4 py-3 text-sm/6 font-medium text-gray-500 dark:text-gray-400">
@@ -200,7 +203,7 @@ export function PreRunStepsTable({
       {selectedStep && selectedStepData && (
         <Modal
           isOpen={!!selectedStep}
-          onClose={() => setSelectedStep(undefined)}
+          onClose={() => onSelectedStepChange?.(undefined)}
           title={`Pre-Run Step #${executionOrder.get(selectedStep) ?? '?'}`}
         >
           <div className="flex flex-col gap-6">

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -118,6 +118,7 @@ export function RunDetailPage() {
     q?: string
     status?: TestStatusFilter
     testModal?: string
+    preRunModal?: string
     heatmapSort?: SortMode
     heatmapThreshold?: number
     steps?: string
@@ -130,7 +131,7 @@ export function RunDetailPage() {
   const pageSize = Number(search.pageSize) || 20
   const heatmapThreshold = search.heatmapThreshold ? Number(search.heatmapThreshold) : undefined
   const stepFilter = parseStepFilter(search.steps)
-  const { sortBy = 'order', sortDir = 'asc', q = '', status = 'all', testModal, heatmapSort, ohFs = false, blFs = false, dlModal = false, dlFmt } = search
+  const { sortBy = 'order', sortDir = 'asc', q = '', status = 'all', testModal, preRunModal, heatmapSort, ohFs = false, blFs = false, dlModal = false, dlFmt } = search
 
   const { data: config, isLoading: configLoading, error: configError, refetch: refetchConfig } = useRunConfig(runId)
   const { data: result, isLoading: resultLoading, refetch: refetchResult } = useRunResult(runId)
@@ -164,6 +165,7 @@ export function RunDetailPage() {
         q: q || undefined,
         status: status !== 'all' ? status : undefined,
         testModal,
+        preRunModal,
         heatmapSort,
         heatmapThreshold,
         steps: serializeStepFilter(stepFilter),
@@ -198,6 +200,10 @@ export function RunDetailPage() {
 
   const handleTestModalChange = (testName: string | undefined) => {
     updateSearch({ testModal: testName })
+  }
+
+  const handlePreRunModalChange = (stepName: string | undefined) => {
+    updateSearch({ preRunModal: stepName })
   }
 
   const handleHeatmapSortChange = (mode: SortMode) => {
@@ -698,6 +704,8 @@ export function RunDetailPage() {
               suitePreRunSteps={suite?.pre_run_steps}
               runId={runId}
               suiteHash={config.suite_hash}
+              selectedStep={preRunModal}
+              onSelectedStepChange={handlePreRunModalChange}
             />
           )}
 


### PR DESCRIPTION
Lift selectedStep state from PreRunStepsTable into URL search params (preRunModal), matching the existing pattern used for test modals. This preserves the open modal across page refreshes and back navigation.