### PR TITLE
fix(ci): fix run-config inline heredoc never closing in action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -141,9 +141,7 @@ runs:
 
         # Write inline config if provided
         if [ -n "$INPUT_RUN_CONFIG" ]; then
-          cat <<'CONFIGEOF' > "${{ runner.temp }}/benchmarkoor-config-inline.yaml"
-        ${{ inputs.run-config }}
-        CONFIGEOF
+          echo "$INPUT_RUN_CONFIG" > "${{ runner.temp }}/benchmarkoor-config-inline.yaml"
         fi
 
         # Extract unique filesystem mount points from datadir source_dir values


### PR DESCRIPTION
The heredoc closing delimiter CONFIGEOF was indented with spaces, so bash never matched it and the inline config was silently lost. Replace with a simple echo which correctly preserves the content.