### PR TITLE
fix(podman): set HealthLogDestination to avoid container creation failure

### DIFF
--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -150,6 +150,7 @@ func (m *manager) CreateContainer(
 	s := &specgen.SpecGenerator{}
 	s.Name = spec.Name
 	s.Image = qualifyImageName(spec.Image)
+	s.HealthLogDestination = "local"
 	s.Entrypoint = spec.Entrypoint
 	s.Command = spec.Command
 	s.Labels = spec.Labels


### PR DESCRIPTION
Zero-initialized specgen.SpecGenerator leaves HealthLogDestination as an empty string, causing Podman to fail with "stat : no such file or directory" when creating containers with health checks. Set it to "local" to match what Podman's own CLI and NewSpecGenerator constructor do.