### PR TITLE
fix(ui): bust browser cache for S3 presigned URL responses

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -30,7 +30,7 @@ export async function fetchViaS3(
 
   const { url: presignedUrl } = await resp.json()
 
-  return fetch(presignedUrl, init)
+  return fetch(presignedUrl, { ...init, cache: 'no-cache' })
 }
 
 export async function fetchData<T>(path: string, opts?: { cacheBustInterval?: number }): Promise<FetchResult<T>> {


### PR DESCRIPTION
Use cache: 'no-cache' on the S3 fetch so the browser revalidates with S3 via ETag/If-None-Match instead of serving stale cached responses when the underlying file changes.