### PR TITLE
feat(ui): add rollback_strategy to index and runs UI

### DIFF
--- a/pkg/executor/index.go
+++ b/pkg/executor/index.go
@@ -35,9 +35,10 @@ type IndexEntry struct {
 
 // IndexInstance contains the client instance information for the index.
 type IndexInstance struct {
-	ID     string `json:"id"`
-	Client string `json:"client"`
-	Image  string `json:"image"`
+	ID               string `json:"id"`
+	Client           string `json:"client"`
+	Image            string `json:"image"`
+	RollbackStrategy string `json:"rollback_strategy,omitempty"`
 }
 
 // IndexTestStats contains aggregated test statistics for the index.
@@ -73,9 +74,10 @@ type runConfigJSON struct {
 	Status            string `json:"status,omitempty"`
 	TerminationReason string `json:"termination_reason,omitempty"`
 	Instance          struct {
-		ID     string `json:"id"`
-		Client string `json:"client"`
-		Image  string `json:"image"`
+		ID               string `json:"id"`
+		Client           string `json:"client"`
+		Image            string `json:"image"`
+		RollbackStrategy string `json:"rollback_strategy,omitempty"`
 	} `json:"instance"`
 	TestCounts *struct {
 		Total  int `json:"total"`
@@ -374,9 +376,10 @@ func buildIndexEntryFromData(
 		Status:            runConfig.Status,
 		TerminationReason: runConfig.TerminationReason,
 		Instance: &IndexInstance{
-			ID:     runConfig.Instance.ID,
-			Client: runConfig.Instance.Client,
-			Image:  runConfig.Instance.Image,
+			ID:               runConfig.Instance.ID,
+			Client:           runConfig.Instance.Client,
+			Image:            runConfig.Instance.Image,
+			RollbackStrategy: runConfig.Instance.RollbackStrategy,
 		},
 		Tests: testStats,
 	}, nil

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -16,6 +16,7 @@ export interface IndexEntry {
     id: string
     client: string
     image: string
+    rollback_strategy?: string
   }
   tests: {
     tests_total: number

--- a/ui/src/components/runs/RunFilters.tsx
+++ b/ui/src/components/runs/RunFilters.tsx
@@ -16,6 +16,9 @@ interface RunFiltersProps {
   suites?: { hash: string; name?: string }[]
   selectedSuite?: string | undefined
   onSuiteChange?: (suite: string | undefined) => void
+  strategies?: string[]
+  selectedStrategy?: string | undefined
+  onStrategyChange?: (strategy: string | undefined) => void
 }
 
 function ChevronIcon() {
@@ -102,6 +105,9 @@ export function RunFilters({
   suites,
   selectedSuite,
   onSuiteChange,
+  strategies,
+  selectedStrategy,
+  onStrategyChange,
 }: RunFiltersProps) {
   const clientOptions = [{ value: '' as const, label: 'All clients' }, ...clients.map((c) => ({ value: c, label: c }))]
   const imageOptions = [{ value: '' as const, label: 'All images' }, ...images.map((i) => ({ value: i, label: i }))]
@@ -111,6 +117,7 @@ export function RunFilters({
     { value: 'failing', label: 'Has failures' },
   ]
   const suiteOptions = suites ? [{ value: '' as const, label: 'All suites' }, ...suites.map((s) => ({ value: s.hash, label: s.name ? `${s.name} (${s.hash.slice(0, 4)})` : s.hash, icon: <JDenticon value={s.hash} size={16} /> }))] : []
+  const strategyOptions = strategies ? [{ value: '' as const, label: 'All strategies' }, ...strategies.map((s) => ({ value: s, label: s }))] : []
 
   return (
     <div className="flex flex-wrap items-center gap-4">
@@ -137,6 +144,16 @@ export function RunFilters({
           options={suiteOptions}
           allLabel="All suites"
           width="w-44"
+        />
+      )}
+      {strategies && strategies.length > 0 && onStrategyChange && (
+        <FilterDropdown
+          label="Strategy"
+          value={selectedStrategy ?? ''}
+          onChange={(v) => onStrategyChange(v || undefined)}
+          options={strategyOptions}
+          allLabel="All strategies"
+          width="w-52"
         />
       )}
       <FilterDropdown

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -6,6 +6,7 @@ import { ClientBadge } from '@/components/shared/ClientBadge'
 import { Badge } from '@/components/shared/Badge'
 import { Duration } from '@/components/shared/Duration'
 import { JDenticon } from '@/components/shared/JDenticon'
+import { StrategyIcon } from '@/components/shared/StrategyIcon'
 import { formatTimestamp, formatRelativeTime } from '@/utils/date'
 import { formatDuration, formatNumber } from '@/utils/format'
 import { type SortColumn, type SortDirection } from './sortEntries'
@@ -146,7 +147,10 @@ export function RunsTable({
                 <span title={formatRelativeTime(entry.timestamp)}>{formatTimestamp(entry.timestamp)}</span>
               </td>
               <td className="whitespace-nowrap px-6 py-4">
-                <ClientBadge client={entry.instance.client} />
+                <div className="flex items-center gap-2">
+                  <ClientBadge client={entry.instance.client} />
+                  <StrategyIcon strategy={entry.instance.rollback_strategy} />
+                </div>
               </td>
               <td className="max-w-xs truncate px-6 py-4 font-mono text-sm/6 text-gray-500 dark:text-gray-400">
                 <span title={entry.instance.image}>{entry.instance.image}</span>

--- a/ui/src/components/runs/sortEntries.ts
+++ b/ui/src/components/runs/sortEntries.ts
@@ -1,6 +1,6 @@
 import { type IndexEntry, type IndexStepType, getIndexAggregatedStats } from '@/api/types'
 
-export type SortColumn = 'timestamp' | 'client' | 'image' | 'suite' | 'duration' | 'mgas' | 'failed' | 'passed' | 'total'
+export type SortColumn = 'timestamp' | 'client' | 'image' | 'strategy' | 'suite' | 'duration' | 'mgas' | 'failed' | 'passed' | 'total'
 export type SortDirection = 'asc' | 'desc'
 
 // Calculates MGas/s from gas_used and gas_used_duration
@@ -28,6 +28,9 @@ export function sortIndexEntries(
         break
       case 'image':
         comparison = a.instance.image.localeCompare(b.instance.image)
+        break
+      case 'strategy':
+        comparison = (a.instance.rollback_strategy ?? '').localeCompare(b.instance.rollback_strategy ?? '')
         break
       case 'suite':
         comparison = (a.suite_hash ?? '').localeCompare(b.suite_hash ?? '')

--- a/ui/src/components/shared/ClientStat.tsx
+++ b/ui/src/components/shared/ClientStat.tsx
@@ -1,9 +1,11 @@
 import clsx from 'clsx'
 import { getClientColors } from '@/utils/client-colors'
+import { StrategyIcon } from '@/components/shared/StrategyIcon'
 
 interface ClientStatProps {
   client: string
   runId: string
+  rollbackStrategy?: string
 }
 
 function capitalizeFirst(str: string): string {
@@ -11,7 +13,7 @@ function capitalizeFirst(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
-export function ClientStat({ client, runId }: ClientStatProps) {
+export function ClientStat({ client, runId, rollbackStrategy }: ClientStatProps) {
   const colors = getClientColors(client)
   const logoPath = `/img/clients/${client}.jpg`
 
@@ -33,13 +35,16 @@ export function ClientStat({ client, runId }: ClientStatProps) {
           {capitalizeFirst(client)}
         </span>
       </div>
-      <div>
-        <p className={clsx('text-xs/5', colors.text, colors.darkText, 'opacity-70')}>
-          Run id
-        </p>
-        <p className={clsx('text-xs/5', colors.text, colors.darkText)}>
-          {runId}
-        </p>
+      <div className="flex items-end justify-between">
+        <div>
+          <p className={clsx('text-xs/5', colors.text, colors.darkText, 'opacity-70')}>
+            Run id
+          </p>
+          <p className={clsx('text-xs/5', colors.text, colors.darkText)}>
+            {runId}
+          </p>
+        </div>
+        <StrategyIcon strategy={rollbackStrategy} className={clsx(colors.text, colors.darkText, 'size-5 opacity-70')} />
       </div>
     </div>
   )

--- a/ui/src/components/shared/StrategyIcon.tsx
+++ b/ui/src/components/shared/StrategyIcon.tsx
@@ -1,0 +1,55 @@
+import clsx from 'clsx'
+
+const STRATEGY_TOOLTIPS: Record<string, string> = {
+  'none': 'No rollback: state is not reset between tests',
+  'rpc-debug-setHead': 'RPC rollback: rewinds chain head via debug_setHead after each test',
+  'container-recreate': 'Container recreate: stops and removes the container after each test, restarts from the same datadir',
+  'container-checkpoint-restore': 'Checkpoint/restore: uses CRIU to snapshot and instantly restore the container between tests',
+}
+
+export function StrategyIcon({ strategy, className }: { strategy?: string; className?: string }) {
+  const iconClass = clsx('size-4 text-gray-500 dark:text-gray-400', className)
+  const tooltip = strategy ? STRATEGY_TOOLTIPS[strategy] ?? strategy : undefined
+
+  switch (strategy) {
+    case 'none':
+      return (
+        <svg className={iconClass} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <title>{tooltip}</title>
+          <circle cx="8" cy="8" r="6" />
+          <line x1="3.75" y1="12.25" x2="12.25" y2="3.75" />
+        </svg>
+      )
+    case 'rpc-debug-setHead':
+      return (
+        <svg className={iconClass} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <title>{tooltip}</title>
+          <path d="M4 7l-2 2 2 2" />
+          <path d="M2 9h8a4 4 0 0 0 0-8H6" />
+        </svg>
+      )
+    case 'container-recreate':
+      return (
+        <svg className={iconClass} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <title>{tooltip}</title>
+          <path d="M13.5 6.5A5.5 5.5 0 0 0 3.08 4.5" />
+          <path d="M2.5 9.5A5.5 5.5 0 0 0 12.92 11.5" />
+          <path d="M3.08 4.5L1 3" />
+          <path d="M3.08 4.5L5 3" />
+          <path d="M12.92 11.5L15 13" />
+          <path d="M12.92 11.5L11 13" />
+        </svg>
+      )
+    case 'container-checkpoint-restore':
+      return (
+        <svg className={iconClass} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <title>{tooltip}</title>
+          <rect x="2" y="3" width="12" height="10" rx="1.5" />
+          <circle cx="8" cy="8" r="2.5" />
+          <circle cx="8" cy="8" r="0.75" fill="currentColor" stroke="none" />
+        </svg>
+      )
+    default:
+      return null
+  }
+}

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -381,7 +381,7 @@ export function RunDetailPage() {
       />
 
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
-        <ClientStat client={config.instance.client} runId={config.instance.id} />
+        <ClientStat client={config.instance.client} runId={config.instance.id} rollbackStrategy={config.instance.rollback_strategy} />
         {(config.test_counts || result) ? (
           <>
             <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">

--- a/ui/src/pages/RunsPage.tsx
+++ b/ui/src/pages/RunsPage.tsx
@@ -24,12 +24,13 @@ export function RunsPage() {
     client?: string
     image?: string
     suite?: string
+    strategy?: string
     status?: TestStatusFilter
     sortBy?: SortColumn
     sortDir?: SortDirection
     steps?: string
   }
-  const { page = 1, pageSize = DEFAULT_PAGE_SIZE, client, image, suite, status = 'all', sortBy = 'timestamp', sortDir = 'desc', steps } = search
+  const { page = 1, pageSize = DEFAULT_PAGE_SIZE, client, image, suite, strategy, status = 'all', sortBy = 'timestamp', sortDir = 'desc', steps } = search
 
   // Parse step filter from URL
   const parseStepFilter = (stepsParam: string | undefined): IndexStepType[] => {
@@ -63,6 +64,12 @@ export function RunsPage() {
     return Array.from(imageSet).sort()
   }, [index])
 
+  const strategies = useMemo(() => {
+    if (!index) return []
+    const strategySet = new Set(index.entries.map((e) => e.instance.rollback_strategy).filter((s): s is string => !!s))
+    return Array.from(strategySet).sort()
+  }, [index])
+
   const suiteHashes = useMemo(() => {
     if (!index) return []
     const suiteSet = new Set(index.entries.map((e) => e.suite_hash).filter((s): s is string => !!s))
@@ -93,11 +100,12 @@ export function RunsPage() {
       if (client && e.instance.client !== client) return false
       if (image && e.instance.image !== image) return false
       if (suite && e.suite_hash !== suite) return false
+      if (strategy && e.instance.rollback_strategy !== strategy) return false
       if (status === 'passing' && e.tests.tests_total - e.tests.tests_passed > 0) return false
       if (status === 'failing' && e.tests.tests_total - e.tests.tests_passed === 0) return false
       return true
     })
-  }, [index, client, image, suite, status])
+  }, [index, client, image, suite, strategy, status])
 
   const sortedEntries = useMemo(() => sortIndexEntries(filteredEntries, sortBy, sortDir, stepFilter), [filteredEntries, sortBy, sortDir, stepFilter])
   const totalPages = Math.ceil(sortedEntries.length / localPageSize)
@@ -105,44 +113,49 @@ export function RunsPage() {
 
   const handlePageChange = (newPage: number) => {
     setLocalPage(newPage)
-    navigate({ to: '/runs', search: { page: newPage, pageSize: localPageSize, client, image, suite, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: newPage, pageSize: localPageSize, client, image, suite, strategy, status, sortBy, sortDir, steps } })
   }
 
   const handlePageSizeChange = (newSize: number) => {
     setLocalPageSize(newSize)
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: newSize, client, image, suite, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: newSize, client, image, suite, strategy, status, sortBy, sortDir, steps } })
   }
 
   const handleClientChange = (newClient: string | undefined) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client: newClient, image, suite, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client: newClient, image, suite, strategy, status, sortBy, sortDir, steps } })
   }
 
   const handleImageChange = (newImage: string | undefined) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image: newImage, suite, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image: newImage, suite, strategy, status, sortBy, sortDir, steps } })
   }
 
   const handleSuiteChange = (newSuite: string | undefined) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite: newSuite, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite: newSuite, strategy, status, sortBy, sortDir, steps } })
+  }
+
+  const handleStrategyChange = (newStrategy: string | undefined) => {
+    setLocalPage(1)
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy: newStrategy, status, sortBy, sortDir, steps } })
   }
 
   const handleStatusChange = (newStatus: TestStatusFilter) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, status: newStatus, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status: newStatus, sortBy, sortDir, steps } })
   }
 
   const handleSortChange = (newSortBy: SortColumn, newSortDir: SortDirection) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, status, sortBy: newSortBy, sortDir: newSortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status, sortBy: newSortBy, sortDir: newSortDir, steps } })
   }
 
   const handleStepFilterChange = (newFilter: IndexStepType[]) => {
     const stepsParam = newFilter.length === ALL_INDEX_STEP_TYPES.length ? undefined : newFilter.join(',')
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, status, sortBy, sortDir, steps: stepsParam } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status, sortBy, sortDir, steps: stepsParam } })
   }
 
   if (isLoading) {
@@ -198,6 +211,9 @@ export function RunsPage() {
               suites={suites}
               selectedSuite={suite}
               onSuiteChange={handleSuiteChange}
+              strategies={strategies}
+              selectedStrategy={strategy}
+              onStrategyChange={handleStrategyChange}
               selectedStatus={status}
               onStatusChange={handleStatusChange}
             />


### PR DESCRIPTION
Pass rollback_strategy from config.json through to index.json and surface it in the UI with per-strategy SVG icons, sorting, filtering, and display in the run detail client card.