### PR TITLE
feat(api): add local filesystem storage backend

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -253,10 +253,11 @@ runner:
 #   #   # Only one backend (s3 or local) may be enabled at a time.
 #   #   local:
 #   #     enabled: true
-#   #     # Absolute directory paths containing benchmark results.
-#   #     # Each path should contain an index.json.
+#   #     # Named prefixes mapping URL path segments to absolute directories.
+#   #     # Each directory should contain an index.json and run/suite sub-dirs.
+#   #     # Keys become URL prefixes (e.g. /api/v1/files/results/...).
 #   #     discovery_paths:
-#   #       - /data/benchmarkoor/results
+#   #       results: /data/benchmarkoor/results
 
   client:
     config:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -249,6 +249,14 @@ runner:
 #   #     # S3 key prefixes the UI can browse. Each path should contain an index.json.
 #   #     discovery_paths:
 #   #       - results
+#   #   # Alternative: Serve files directly from local filesystem directories.
+#   #   # Only one backend (s3 or local) may be enabled at a time.
+#   #   local:
+#   #     enabled: true
+#   #     # Absolute directory paths containing benchmark results.
+#   #     # Each path should contain an index.json.
+#   #     discovery_paths:
+#   #       - /data/benchmarkoor/results
 
   client:
     config:

--- a/docs/api.md
+++ b/docs/api.md
@@ -230,20 +230,20 @@ api:
     local:
       enabled: true
       discovery_paths:
-        - /data/benchmarkoor/results
+        results: /data/benchmarkoor/results
 ```
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
 | `enabled` | bool | Yes | `false` | Enable local file serving |
-| `discovery_paths` | []string | When enabled | - | Absolute directory paths containing benchmark results. At least one is required. Must be absolute paths, must not contain `..` |
+| `discovery_paths` | map[string]string | When enabled | - | Named prefixes mapping URL path segments to absolute directories. Keys become URL prefixes (must not contain `/` or `..`). Values must be absolute paths and must not contain `..`. At least one entry is required. |
 
 **How local mode works:**
 
-1. The `GET /api/v1/config` endpoint advertises which `discovery_paths` are available and that local storage is enabled.
-2. The UI fetches `index.json` from each discovery path via the API (with auth credentials).
-3. When the UI needs a file, it requests `GET /api/v1/files/{discovery_path}/{relative_path}`.
-4. The API validates the path, iterates over configured discovery roots, resolves the file on disk, and serves it directly.
+1. The `GET /api/v1/config` endpoint advertises the discovery path names (map keys, sorted) and that local storage is enabled.
+2. The UI iterates over each discovery path name, fetching `{name}/index.json` from the API (with auth credentials) — identical to how S3 mode works.
+3. When the UI needs a file, it requests `GET /api/v1/files/{name}/{relative_path}` (e.g., `GET /api/v1/files/results/runs/abc/results.json`).
+4. The API extracts the first path segment as the prefix name, looks up the corresponding directory, resolves the file on disk, and serves it directly.
 5. No presigned URL indirection — the API streams the file content in the response.
 
 ### Path Validation
@@ -428,7 +428,7 @@ api:
     local:
       enabled: true
       discovery_paths:
-        - /data/benchmarkoor/results
+        results: /data/benchmarkoor/results
 
 # Minimal client config (required by config loader but not used by the API server).
 client:

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/api/store"
@@ -62,9 +63,18 @@ func (s *server) handleConfig(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	if s.cfg.Storage.Local != nil && s.cfg.Storage.Local.Enabled {
+		// Return just the map keys (sorted for determinism) so the UI
+		// treats local and S3 discovery paths identically.
+		keys := make([]string, 0, len(s.cfg.Storage.Local.DiscoveryPaths))
+		for k := range s.cfg.Storage.Local.DiscoveryPaths {
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
 		storageResp["local"] = map[string]any{
 			"enabled":         true,
-			"discovery_paths": s.cfg.Storage.Local.DiscoveryPaths,
+			"discovery_paths": keys,
 		}
 	}
 

--- a/pkg/api/local.go
+++ b/pkg/api/local.go
@@ -13,11 +13,12 @@ import (
 )
 
 // localFileServer serves benchmark result files directly from the local
-// filesystem. Each discovery path is an absolute directory root; incoming
-// request paths are resolved relative to these roots.
+// filesystem. Each discovery path maps a URL prefix name to an absolute
+// directory root; incoming request paths are resolved by extracting the
+// prefix and looking up the corresponding directory.
 type localFileServer struct {
 	log            logrus.FieldLogger
-	discoveryPaths []string
+	discoveryPaths map[string]string
 }
 
 // newLocalFileServer creates a new local file server from the given config.
@@ -25,9 +26,9 @@ func newLocalFileServer(
 	log logrus.FieldLogger,
 	cfg *config.APILocalStorageConfig,
 ) *localFileServer {
-	paths := make([]string, 0, len(cfg.DiscoveryPaths))
-	for _, p := range cfg.DiscoveryPaths {
-		paths = append(paths, filepath.Clean(p))
+	paths := make(map[string]string, len(cfg.DiscoveryPaths))
+	for name, dir := range cfg.DiscoveryPaths {
+		paths[name] = filepath.Clean(dir)
 	}
 
 	return &localFileServer{
@@ -36,9 +37,10 @@ func newLocalFileServer(
 	}
 }
 
-// ServeFile locates filePath under one of the discovery roots and serves
-// it via http.ServeFile. Returns an error when the path is disallowed or
-// not found under any root.
+// ServeFile locates filePath by extracting the first path segment as a
+// prefix name, looking up the directory from the map, and resolving the
+// remainder relative to that directory. Returns an error when the path is
+// disallowed, the prefix is unknown, or the file does not exist.
 func (l *localFileServer) ServeFile(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -48,28 +50,39 @@ func (l *localFileServer) ServeFile(
 		return fmt.Errorf("path %q is not allowed", filePath)
 	}
 
-	for _, root := range l.discoveryPaths {
-		full := filepath.Join(root, filePath)
+	// Split into prefix and remainder (e.g. "results/runs/abc/results.json"
+	// → prefix="results", remainder="runs/abc/results.json").
+	prefix, remainder, _ := strings.Cut(filePath, "/")
 
-		// Defense-in-depth: ensure the resolved path stays under root.
-		if !strings.HasPrefix(full, root+string(filepath.Separator)) &&
-			full != root {
-			continue
-		}
-
-		if _, err := os.Stat(full); err != nil {
-			continue
-		}
-
-		http.ServeFile(w, r, full)
-
-		return nil
+	root, ok := l.discoveryPaths[prefix]
+	if !ok {
+		return fmt.Errorf(
+			"file %q not found: unknown prefix %q", filePath, prefix,
+		)
 	}
 
-	return fmt.Errorf("file %q not found in any discovery path", filePath)
+	full := filepath.Join(root, remainder)
+
+	// Defense-in-depth: ensure the resolved path stays under root.
+	if !strings.HasPrefix(full, root+string(filepath.Separator)) &&
+		full != root {
+		return fmt.Errorf("path %q is not allowed", filePath)
+	}
+
+	if _, err := os.Stat(full); err != nil {
+		return fmt.Errorf(
+			"file %q not found in discovery path %q", filePath, prefix,
+		)
+	}
+
+	http.ServeFile(w, r, full)
+
+	return nil
 }
 
-// isAllowedPath rejects empty, absolute, unclean, or traversal request paths.
+// isAllowedPath rejects empty, absolute, unclean, or traversal request
+// paths. Also requires at least two segments (prefix + something) and
+// that the prefix exists in the map.
 func (l *localFileServer) isAllowedPath(filePath string) bool {
 	if filePath == "" {
 		return false
@@ -85,5 +98,18 @@ func (l *localFileServer) isAllowedPath(filePath string) bool {
 	}
 
 	// Ensure the path is clean (no double slashes, trailing slashes, etc.).
-	return path.Clean(filePath) == filePath
+	if path.Clean(filePath) != filePath {
+		return false
+	}
+
+	// Require at least two segments: prefix/something.
+	prefix, remainder, hasSep := strings.Cut(filePath, "/")
+	if !hasSep || remainder == "" {
+		return false
+	}
+
+	// The prefix must exist in the discovery paths map.
+	_, ok := l.discoveryPaths[prefix]
+
+	return ok
 }

--- a/pkg/api/local.go
+++ b/pkg/api/local.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+// localFileServer serves benchmark result files directly from the local
+// filesystem. Each discovery path is an absolute directory root; incoming
+// request paths are resolved relative to these roots.
+type localFileServer struct {
+	log            logrus.FieldLogger
+	discoveryPaths []string
+}
+
+// newLocalFileServer creates a new local file server from the given config.
+func newLocalFileServer(
+	log logrus.FieldLogger,
+	cfg *config.APILocalStorageConfig,
+) *localFileServer {
+	paths := make([]string, 0, len(cfg.DiscoveryPaths))
+	for _, p := range cfg.DiscoveryPaths {
+		paths = append(paths, filepath.Clean(p))
+	}
+
+	return &localFileServer{
+		log:            log.WithField("component", "local-file-server"),
+		discoveryPaths: paths,
+	}
+}
+
+// ServeFile locates filePath under one of the discovery roots and serves
+// it via http.ServeFile. Returns an error when the path is disallowed or
+// not found under any root.
+func (l *localFileServer) ServeFile(
+	w http.ResponseWriter,
+	r *http.Request,
+	filePath string,
+) error {
+	if !l.isAllowedPath(filePath) {
+		return fmt.Errorf("path %q is not allowed", filePath)
+	}
+
+	for _, root := range l.discoveryPaths {
+		full := filepath.Join(root, filePath)
+
+		// Defense-in-depth: ensure the resolved path stays under root.
+		if !strings.HasPrefix(full, root+string(filepath.Separator)) &&
+			full != root {
+			continue
+		}
+
+		if _, err := os.Stat(full); err != nil {
+			continue
+		}
+
+		http.ServeFile(w, r, full)
+
+		return nil
+	}
+
+	return fmt.Errorf("file %q not found in any discovery path", filePath)
+}
+
+// isAllowedPath rejects empty, absolute, unclean, or traversal request paths.
+func (l *localFileServer) isAllowedPath(filePath string) bool {
+	if filePath == "" {
+		return false
+	}
+
+	if strings.Contains(filePath, "..") {
+		return false
+	}
+
+	// Reject paths that start with a slash (absolute paths).
+	if filepath.IsAbs(filePath) {
+		return false
+	}
+
+	// Ensure the path is clean (no double slashes, trailing slashes, etc.).
+	return path.Clean(filePath) == filePath
+}

--- a/pkg/api/local_test.go
+++ b/pkg/api/local_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalFileServer_IsAllowedPath(t *testing.T) {
+	srv := &localFileServer{
+		log:            logrus.New(),
+		discoveryPaths: []string{"/data/results"},
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{name: "valid simple path", path: "runs/abc/results.json", expected: true},
+		{name: "valid nested path", path: "index.json", expected: true},
+		{name: "empty path", path: "", expected: false},
+		{name: "path traversal", path: "runs/../../etc/passwd", expected: false},
+		{name: "dot dot only", path: "..", expected: false},
+		{name: "absolute path", path: "/etc/passwd", expected: false},
+		{name: "trailing slash", path: "runs/abc/", expected: false},
+		{name: "double slash", path: "runs//abc", expected: false},
+		{name: "dot segment", path: "runs/./abc", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, srv.isAllowedPath(tt.path))
+		})
+	}
+}
+
+func TestLocalFileServer_ServeFile(t *testing.T) {
+	// Create temp directory structure.
+	root := t.TempDir()
+	runsDir := filepath.Join(root, "runs", "abc")
+	require.NoError(t, os.MkdirAll(runsDir, 0o755))
+	require.NoError(
+		t, os.WriteFile(
+			filepath.Join(runsDir, "results.json"),
+			[]byte(`{"ok":true}`), 0o644,
+		),
+	)
+
+	srv := newLocalFileServer(logrus.New(), &config.APILocalStorageConfig{
+		Enabled:        true,
+		DiscoveryPaths: []string{root},
+	})
+
+	t.Run("serves existing file", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/runs/abc/results.json", nil)
+		rec := httptest.NewRecorder()
+
+		err := srv.ServeFile(rec, req, "runs/abc/results.json")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), `{"ok":true}`)
+	})
+
+	t.Run("returns error for missing file", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/runs/abc/nope.json", nil)
+		rec := httptest.NewRecorder()
+
+		err := srv.ServeFile(rec, req, "runs/abc/nope.json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+		_ = rec // response not written
+	})
+
+	t.Run("rejects path traversal", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/../../etc/passwd", nil)
+		rec := httptest.NewRecorder()
+
+		err := srv.ServeFile(rec, req, "../../etc/passwd")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not allowed")
+		_ = rec
+	})
+
+	t.Run("searches multiple roots", func(t *testing.T) {
+		root2 := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root2, "archive"), 0o755))
+		require.NoError(
+			t, os.WriteFile(
+				filepath.Join(root2, "archive", "old.json"),
+				[]byte(`{"old":true}`), 0o644,
+			),
+		)
+
+		multi := newLocalFileServer(logrus.New(), &config.APILocalStorageConfig{
+			Enabled:        true,
+			DiscoveryPaths: []string{root, root2},
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/archive/old.json", nil)
+		rec := httptest.NewRecorder()
+
+		err := multi.ServeFile(rec, req, "archive/old.json")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), `{"old":true}`)
+	})
+}

--- a/pkg/api/local_test.go
+++ b/pkg/api/local_test.go
@@ -16,7 +16,7 @@ import (
 func TestLocalFileServer_IsAllowedPath(t *testing.T) {
 	srv := &localFileServer{
 		log:            logrus.New(),
-		discoveryPaths: []string{"/data/results"},
+		discoveryPaths: map[string]string{"results": "/data/results"},
 	}
 
 	tests := []struct {
@@ -24,15 +24,18 @@ func TestLocalFileServer_IsAllowedPath(t *testing.T) {
 		path     string
 		expected bool
 	}{
-		{name: "valid simple path", path: "runs/abc/results.json", expected: true},
-		{name: "valid nested path", path: "index.json", expected: true},
+		{name: "valid prefixed path", path: "results/runs/abc/results.json", expected: true},
+		{name: "valid prefixed index", path: "results/index.json", expected: true},
 		{name: "empty path", path: "", expected: false},
-		{name: "path traversal", path: "runs/../../etc/passwd", expected: false},
+		{name: "path traversal", path: "results/../../etc/passwd", expected: false},
 		{name: "dot dot only", path: "..", expected: false},
 		{name: "absolute path", path: "/etc/passwd", expected: false},
-		{name: "trailing slash", path: "runs/abc/", expected: false},
-		{name: "double slash", path: "runs//abc", expected: false},
-		{name: "dot segment", path: "runs/./abc", expected: false},
+		{name: "trailing slash", path: "results/runs/abc/", expected: false},
+		{name: "double slash", path: "results//abc", expected: false},
+		{name: "dot segment", path: "results/./abc", expected: false},
+		{name: "unknown prefix", path: "unknown/index.json", expected: false},
+		{name: "prefix only no slash", path: "results", expected: false},
+		{name: "prefix only with slash", path: "results/", expected: false},
 	}
 
 	for _, tt := range tests {
@@ -56,42 +59,66 @@ func TestLocalFileServer_ServeFile(t *testing.T) {
 
 	srv := newLocalFileServer(logrus.New(), &config.APILocalStorageConfig{
 		Enabled:        true,
-		DiscoveryPaths: []string{root},
+		DiscoveryPaths: map[string]string{"mydata": root},
 	})
 
-	t.Run("serves existing file", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/runs/abc/results.json", nil)
+	t.Run("serves existing file via prefix", func(t *testing.T) {
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/mydata/runs/abc/results.json", nil,
+		)
 		rec := httptest.NewRecorder()
 
-		err := srv.ServeFile(rec, req, "runs/abc/results.json")
+		err := srv.ServeFile(rec, req, "mydata/runs/abc/results.json")
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Contains(t, rec.Body.String(), `{"ok":true}`)
 	})
 
 	t.Run("returns error for missing file", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/runs/abc/nope.json", nil)
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/mydata/runs/abc/nope.json", nil,
+		)
 		rec := httptest.NewRecorder()
 
-		err := srv.ServeFile(rec, req, "runs/abc/nope.json")
+		err := srv.ServeFile(rec, req, "mydata/runs/abc/nope.json")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 		_ = rec // response not written
 	})
 
 	t.Run("rejects path traversal", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/../../etc/passwd", nil)
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/mydata/../../etc/passwd", nil,
+		)
 		rec := httptest.NewRecorder()
 
-		err := srv.ServeFile(rec, req, "../../etc/passwd")
+		err := srv.ServeFile(rec, req, "mydata/../../etc/passwd")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not allowed")
 		_ = rec
 	})
 
-	t.Run("searches multiple roots", func(t *testing.T) {
+	t.Run("returns error for unknown prefix", func(t *testing.T) {
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/unknown/index.json", nil,
+		)
+		rec := httptest.NewRecorder()
+
+		err := srv.ServeFile(rec, req, "unknown/index.json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not allowed")
+		_ = rec
+	})
+
+	t.Run("routes multiple prefixes to different roots", func(t *testing.T) {
 		root2 := t.TempDir()
-		require.NoError(t, os.MkdirAll(filepath.Join(root2, "archive"), 0o755))
+		require.NoError(
+			t, os.MkdirAll(filepath.Join(root2, "archive"), 0o755),
+		)
 		require.NoError(
 			t, os.WriteFile(
 				filepath.Join(root2, "archive", "old.json"),
@@ -99,17 +126,38 @@ func TestLocalFileServer_ServeFile(t *testing.T) {
 			),
 		)
 
-		multi := newLocalFileServer(logrus.New(), &config.APILocalStorageConfig{
-			Enabled:        true,
-			DiscoveryPaths: []string{root, root2},
-		})
+		multi := newLocalFileServer(
+			logrus.New(), &config.APILocalStorageConfig{
+				Enabled: true,
+				DiscoveryPaths: map[string]string{
+					"mydata":  root,
+					"archive": root2,
+				},
+			},
+		)
 
-		req := httptest.NewRequest(http.MethodGet, "/archive/old.json", nil)
+		// First prefix.
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/mydata/runs/abc/results.json", nil,
+		)
 		rec := httptest.NewRecorder()
 
-		err := multi.ServeFile(rec, req, "archive/old.json")
+		err := multi.ServeFile(rec, req, "mydata/runs/abc/results.json")
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Contains(t, rec.Body.String(), `{"old":true}`)
+		assert.Contains(t, rec.Body.String(), `{"ok":true}`)
+
+		// Second prefix.
+		req2 := httptest.NewRequest(
+			http.MethodGet,
+			"/archive/archive/old.json", nil,
+		)
+		rec2 := httptest.NewRecorder()
+
+		err = multi.ServeFile(rec2, req2, "archive/archive/old.json")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec2.Code)
+		assert.Contains(t, rec2.Body.String(), `{"old":true}`)
 	})
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -46,7 +46,7 @@ func (s *server) buildRouter() http.Handler {
 			}
 		})
 
-		// File presigning endpoints.
+		// File serving endpoints (local filesystem or S3 presigned URLs).
 		r.Route("/files", func(r chi.Router) {
 			if !s.cfg.Auth.AnonymousRead {
 				r.Use(s.requireAuth)
@@ -58,7 +58,7 @@ func (s *server) buildRouter() http.Handler {
 				))
 			}
 
-			r.Get("/*", s.handlePresignedURL)
+			r.Get("/*", s.handleFileRequest)
 		})
 
 		// Admin endpoints (require auth + admin role).

--- a/pkg/config/api.go
+++ b/pkg/config/api.go
@@ -16,11 +16,13 @@ type APIStorageConfig struct {
 }
 
 // APILocalStorageConfig serves benchmark result files directly from the
-// local filesystem. Each discovery path is an absolute directory that may
-// contain an index.json and run/suite sub-directories.
+// local filesystem. Each discovery path maps a URL prefix name to an
+// absolute directory that may contain an index.json and run/suite
+// sub-directories. The map key serves as a URL path prefix, identical
+// to how S3 discovery paths work.
 type APILocalStorageConfig struct {
-	Enabled        bool     `yaml:"enabled" mapstructure:"enabled"`
-	DiscoveryPaths []string `yaml:"discovery_paths,omitempty" mapstructure:"discovery_paths"`
+	Enabled        bool              `yaml:"enabled" mapstructure:"enabled"`
+	DiscoveryPaths map[string]string `yaml:"discovery_paths,omitempty" mapstructure:"discovery_paths"`
 }
 
 // APIS3Config contains S3 settings for presigned URL generation.

--- a/pkg/config/api.go
+++ b/pkg/config/api.go
@@ -9,8 +9,18 @@ type APIConfig struct {
 }
 
 // APIStorageConfig contains storage backend settings for serving files.
+// Only one backend (S3 or local) may be enabled at a time.
 type APIStorageConfig struct {
-	S3 *APIS3Config `yaml:"s3,omitempty" mapstructure:"s3"`
+	S3    *APIS3Config           `yaml:"s3,omitempty" mapstructure:"s3"`
+	Local *APILocalStorageConfig `yaml:"local,omitempty" mapstructure:"local"`
+}
+
+// APILocalStorageConfig serves benchmark result files directly from the
+// local filesystem. Each discovery path is an absolute directory that may
+// contain an index.json and run/suite sub-directories.
+type APILocalStorageConfig struct {
+	Enabled        bool     `yaml:"enabled" mapstructure:"enabled"`
+	DiscoveryPaths []string `yaml:"discovery_paths,omitempty" mapstructure:"discovery_paths"`
 }
 
 // APIS3Config contains S3 settings for presigned URL generation.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1969,24 +1969,47 @@ func (c *Config) validateAPILocalStorage() error {
 		)
 	}
 
-	for i, p := range localCfg.DiscoveryPaths {
-		if p == "" {
+	for name, dir := range localCfg.DiscoveryPaths {
+		// Validate the map key (URL prefix).
+		if name == "" {
 			return fmt.Errorf(
-				"api.storage.local.discovery_paths[%d]: path must not be empty", i,
+				"api.storage.local.discovery_paths: key must not be empty",
 			)
 		}
 
-		if !filepath.IsAbs(p) {
+		if strings.Contains(name, "..") {
 			return fmt.Errorf(
-				"api.storage.local.discovery_paths[%d]: path must be absolute, got %q",
-				i, p,
+				"api.storage.local.discovery_paths[%s]: "+
+					"key must not contain \"..\"", name,
 			)
 		}
 
-		if strings.Contains(p, "..") {
+		if strings.Contains(name, "/") {
 			return fmt.Errorf(
-				"api.storage.local.discovery_paths[%d]: path must not contain \"..\"",
-				i,
+				"api.storage.local.discovery_paths[%s]: "+
+					"key must not contain \"/\"", name,
+			)
+		}
+
+		// Validate the map value (absolute directory path).
+		if dir == "" {
+			return fmt.Errorf(
+				"api.storage.local.discovery_paths[%s]: "+
+					"path must not be empty", name,
+			)
+		}
+
+		if !filepath.IsAbs(dir) {
+			return fmt.Errorf(
+				"api.storage.local.discovery_paths[%s]: "+
+					"path must be absolute, got %q", name, dir,
+			)
+		}
+
+		if strings.Contains(dir, "..") {
+			return fmt.Errorf(
+				"api.storage.local.discovery_paths[%s]: "+
+					"path must not contain \"..\"", name,
 			)
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1897,10 +1897,32 @@ func (c *Config) ValidateAPI() error {
 
 // validateAPIStorage validates the API storage configuration.
 func (c *Config) validateAPIStorage() error {
-	if c.API.Storage.S3 == nil || !c.API.Storage.S3.Enabled {
-		return nil
+	s3Enabled := c.API.Storage.S3 != nil && c.API.Storage.S3.Enabled
+	localEnabled := c.API.Storage.Local != nil && c.API.Storage.Local.Enabled
+
+	if s3Enabled && localEnabled {
+		return fmt.Errorf(
+			"api.storage: only one backend (s3 or local) may be enabled at a time",
+		)
 	}
 
+	if s3Enabled {
+		if err := c.validateAPIS3Storage(); err != nil {
+			return err
+		}
+	}
+
+	if localEnabled {
+		if err := c.validateAPILocalStorage(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateAPIS3Storage validates S3 storage settings.
+func (c *Config) validateAPIS3Storage() error {
 	s3Cfg := c.API.Storage.S3
 
 	if s3Cfg.Bucket == "" {
@@ -1932,6 +1954,41 @@ func (c *Config) validateAPIStorage() error {
 			"api.storage.s3.presigned_urls.expiry: invalid duration %q: %w",
 			s3Cfg.PresignedURLs.Expiry, err,
 		)
+	}
+
+	return nil
+}
+
+// validateAPILocalStorage validates local filesystem storage settings.
+func (c *Config) validateAPILocalStorage() error {
+	localCfg := c.API.Storage.Local
+
+	if len(localCfg.DiscoveryPaths) == 0 {
+		return fmt.Errorf(
+			"api.storage.local: at least one discovery_path is required when enabled",
+		)
+	}
+
+	for i, p := range localCfg.DiscoveryPaths {
+		if p == "" {
+			return fmt.Errorf(
+				"api.storage.local.discovery_paths[%d]: path must not be empty", i,
+			)
+		}
+
+		if !filepath.IsAbs(p) {
+			return fmt.Errorf(
+				"api.storage.local.discovery_paths[%d]: path must be absolute, got %q",
+				i, p,
+			)
+		}
+
+		if strings.Contains(p, "..") {
+			return fmt.Errorf(
+				"api.storage.local.discovery_paths[%d]: path must not contain \"..\"",
+				i,
+			)
+		}
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1392,6 +1392,146 @@ func TestValidateAPIStorage(t *testing.T) {
 	}
 }
 
+func TestValidateAPILocalStorage(t *testing.T) {
+	makeConfig := func(
+		localCfg *APILocalStorageConfig,
+	) Config {
+		return Config{
+			API: &APIConfig{
+				Auth: APIAuthConfig{
+					SessionTTL: "24h",
+					Basic: BasicAuthConfig{
+						Enabled: true,
+						Users: []BasicAuthUser{
+							{Username: "admin", Password: "pass", Role: "admin"},
+						},
+					},
+				},
+				Database: APIDatabaseConfig{Driver: "sqlite"},
+				Storage:  APIStorageConfig{Local: localCfg},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		localCfg  *APILocalStorageConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:     "nil local config is valid",
+			localCfg: nil,
+			wantErr:  false,
+		},
+		{
+			name: "disabled local is valid",
+			localCfg: &APILocalStorageConfig{
+				Enabled: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid local config",
+			localCfg: &APILocalStorageConfig{
+				Enabled:        true,
+				DiscoveryPaths: []string{"/data/results"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty discovery paths",
+			localCfg: &APILocalStorageConfig{
+				Enabled:        true,
+				DiscoveryPaths: []string{},
+			},
+			wantErr:   true,
+			errSubstr: "at least one discovery_path",
+		},
+		{
+			name: "empty string in discovery paths",
+			localCfg: &APILocalStorageConfig{
+				Enabled:        true,
+				DiscoveryPaths: []string{"/data/results", ""},
+			},
+			wantErr:   true,
+			errSubstr: "must not be empty",
+		},
+		{
+			name: "relative path in discovery paths",
+			localCfg: &APILocalStorageConfig{
+				Enabled:        true,
+				DiscoveryPaths: []string{"results/data"},
+			},
+			wantErr:   true,
+			errSubstr: "must be absolute",
+		},
+		{
+			name: "path traversal in discovery paths",
+			localCfg: &APILocalStorageConfig{
+				Enabled:        true,
+				DiscoveryPaths: []string{"/data/../etc/passwd"},
+			},
+			wantErr:   true,
+			errSubstr: "must not contain \"..\"",
+		},
+		{
+			name: "multiple valid discovery paths",
+			localCfg: &APILocalStorageConfig{
+				Enabled:        true,
+				DiscoveryPaths: []string{"/data/results", "/archive/2024"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := makeConfig(tt.localCfg)
+			err := cfg.validateAPIStorage()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAPIStorageMutualExclusivity(t *testing.T) {
+	cfg := Config{
+		API: &APIConfig{
+			Auth: APIAuthConfig{
+				SessionTTL: "24h",
+				Basic: BasicAuthConfig{
+					Enabled: true,
+					Users: []BasicAuthUser{
+						{Username: "admin", Password: "pass", Role: "admin"},
+					},
+				},
+			},
+			Database: APIDatabaseConfig{Driver: "sqlite"},
+			Storage: APIStorageConfig{
+				S3: &APIS3Config{
+					Enabled:        true,
+					Bucket:         "my-bucket",
+					DiscoveryPaths: []string{"results"},
+					PresignedURLs:  APIS3PresignedURLConfig{Expiry: "1h"},
+				},
+				Local: &APILocalStorageConfig{
+					Enabled:        true,
+					DiscoveryPaths: []string{"/data/results"},
+				},
+			},
+		},
+	}
+
+	err := cfg.validateAPIStorage()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only one backend")
+}
+
 func TestParseByteSize(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1435,7 +1435,7 @@ func TestValidateAPILocalStorage(t *testing.T) {
 			name: "valid local config",
 			localCfg: &APILocalStorageConfig{
 				Enabled:        true,
-				DiscoveryPaths: []string{"/data/results"},
+				DiscoveryPaths: map[string]string{"results": "/data/results"},
 			},
 			wantErr: false,
 		},
@@ -1443,25 +1443,25 @@ func TestValidateAPILocalStorage(t *testing.T) {
 			name: "empty discovery paths",
 			localCfg: &APILocalStorageConfig{
 				Enabled:        true,
-				DiscoveryPaths: []string{},
+				DiscoveryPaths: map[string]string{},
 			},
 			wantErr:   true,
 			errSubstr: "at least one discovery_path",
 		},
 		{
-			name: "empty string in discovery paths",
+			name: "empty value in discovery paths",
 			localCfg: &APILocalStorageConfig{
 				Enabled:        true,
-				DiscoveryPaths: []string{"/data/results", ""},
+				DiscoveryPaths: map[string]string{"results": ""},
 			},
 			wantErr:   true,
-			errSubstr: "must not be empty",
+			errSubstr: "path must not be empty",
 		},
 		{
 			name: "relative path in discovery paths",
 			localCfg: &APILocalStorageConfig{
 				Enabled:        true,
-				DiscoveryPaths: []string{"results/data"},
+				DiscoveryPaths: map[string]string{"results": "results/data"},
 			},
 			wantErr:   true,
 			errSubstr: "must be absolute",
@@ -1470,7 +1470,7 @@ func TestValidateAPILocalStorage(t *testing.T) {
 			name: "path traversal in discovery paths",
 			localCfg: &APILocalStorageConfig{
 				Enabled:        true,
-				DiscoveryPaths: []string{"/data/../etc/passwd"},
+				DiscoveryPaths: map[string]string{"results": "/data/../etc/passwd"},
 			},
 			wantErr:   true,
 			errSubstr: "must not contain \"..\"",
@@ -1478,10 +1478,31 @@ func TestValidateAPILocalStorage(t *testing.T) {
 		{
 			name: "multiple valid discovery paths",
 			localCfg: &APILocalStorageConfig{
-				Enabled:        true,
-				DiscoveryPaths: []string{"/data/results", "/archive/2024"},
+				Enabled: true,
+				DiscoveryPaths: map[string]string{
+					"results": "/data/results",
+					"archive": "/archive/2024",
+				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "key with slash",
+			localCfg: &APILocalStorageConfig{
+				Enabled:        true,
+				DiscoveryPaths: map[string]string{"a/b": "/data/results"},
+			},
+			wantErr:   true,
+			errSubstr: "must not contain \"/\"",
+		},
+		{
+			name: "key with dot-dot",
+			localCfg: &APILocalStorageConfig{
+				Enabled:        true,
+				DiscoveryPaths: map[string]string{"..": "/data/results"},
+			},
+			wantErr:   true,
+			errSubstr: "key must not contain \"..\"",
 		},
 	}
 
@@ -1521,7 +1542,7 @@ func TestValidateAPIStorageMutualExclusivity(t *testing.T) {
 				},
 				Local: &APILocalStorageConfig{
 					Enabled:        true,
-					DiscoveryPaths: []string{"/data/results"},
+					DiscoveryPaths: map[string]string{"results": "/data/results"},
 				},
 			},
 		},

--- a/ui/src/api/auth-client.ts
+++ b/ui/src/api/auth-client.ts
@@ -9,6 +9,10 @@ export interface AuthConfig {
       enabled: boolean
       discovery_paths: string[]
     }
+    local?: {
+      enabled: boolean
+      discovery_paths: string[]
+    }
   }
 }
 

--- a/ui/src/api/hooks/useIndex.ts
+++ b/ui/src/api/hooks/useIndex.ts
@@ -1,7 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchData, fetchViaS3 } from '../client'
 import type { Index } from '../types'
-import { loadRuntimeConfig, isS3Mode, isLocalMode, registerDiscoveryMapping } from '@/config/runtime'
+import {
+  loadRuntimeConfig,
+  isS3Mode,
+  isLocalMode,
+  registerDiscoveryMapping,
+} from '@/config/runtime'
 
 const emptyIndex: Index = { generated: 0, entries: [] }
 
@@ -34,37 +39,56 @@ async function fetchS3Index(): Promise<Index> {
     }),
   )
 
-  // Merge all index entries
+  return mergeIndexResults(results)
+}
+
+// Local mode uses the same discovery path iteration as S3, but fetches
+// files directly (with credentials) instead of via presigned URLs.
+async function fetchLocalIndex(): Promise<Index> {
+  const config = await loadRuntimeConfig()
+  if (!config.api?.baseUrl) return emptyIndex
+
+  const paths = config.storage?.local?.discovery_paths ?? []
+  if (paths.length === 0) return emptyIndex
+
+  const results = await Promise.all(
+    paths.map(async (dp) => {
+      try {
+        const url = `${config.api!.baseUrl}/api/v1/files/${dp}/runs/index.json`
+        const response = await fetch(url, { credentials: 'include' })
+        if (!response.ok) return null
+        const contentType = response.headers.get('content-type')
+        if (!contentType?.includes('application/json')) return null
+        const index: Index = await response.json()
+        // Register discovery mappings for each entry
+        for (const entry of index.entries) {
+          registerDiscoveryMapping(entry.run_id, dp)
+          if (entry.suite_hash) {
+            registerDiscoveryMapping(entry.suite_hash, dp)
+          }
+        }
+        return index
+      } catch {
+        return null
+      }
+    }),
+  )
+
+  return mergeIndexResults(results)
+}
+
+function mergeIndexResults(results: (Index | null)[]): Index {
   const allEntries = results
     .filter((r): r is Index => r !== null)
     .flatMap((r) => r.entries)
 
   if (allEntries.length === 0) return emptyIndex
 
-  // Use the most recent generated timestamp
   const generated = Math.max(
     ...results.filter((r): r is Index => r !== null).map((r) => r.generated),
   )
 
   return { generated, entries: allEntries }
-}
-
-// Local mode: the server searches its discovery roots internally,
-// so the UI just requests the relative path. No discovery path mapping needed.
-async function fetchLocalIndex(): Promise<Index> {
-  const config = await loadRuntimeConfig()
-  if (!config.api?.baseUrl) return emptyIndex
-
-  try {
-    const url = `${config.api.baseUrl}/api/v1/files/runs/index.json`
-    const response = await fetch(url, { credentials: 'include' })
-    if (!response.ok) return emptyIndex
-    const contentType = response.headers.get('content-type')
-    if (!contentType?.includes('application/json')) return emptyIndex
-    return await response.json()
-  } catch {
-    return emptyIndex
-  }
 }
 
 export function useIndex() {

--- a/ui/src/config/runtime.ts
+++ b/ui/src/config/runtime.ts
@@ -3,6 +3,10 @@ export interface StorageConfig {
     enabled: boolean
     discovery_paths: string[]
   }
+  local?: {
+    enabled: boolean
+    discovery_paths: string[]
+  }
 }
 
 export interface RuntimeConfig {
@@ -53,6 +57,10 @@ export function isS3Mode(config: RuntimeConfig): boolean {
   return config.storage?.s3?.enabled === true
 }
 
+export function isLocalMode(config: RuntimeConfig): boolean {
+  return config.storage?.local?.enabled === true
+}
+
 // Maps runId/suiteHash → discovery path for S3 routing
 const discoveryPathMap = new Map<string, string>()
 
@@ -63,17 +71,23 @@ export function registerDiscoveryMapping(key: string, discoveryPath: string): vo
 export function getDiscoveryPath(key: string, config: RuntimeConfig): string {
   const mapped = discoveryPathMap.get(key)
   if (mapped) return mapped
-  // Fall back to first discovery path
+  // Fall back to first S3 discovery path
   return config.storage?.s3?.discovery_paths?.[0] ?? 'results'
 }
 
 export function getDataUrl(path: string, config: RuntimeConfig): string {
+  // Local mode: the server searches its discovery roots internally,
+  // so the UI only sends the relative file path.
+  if (isLocalMode(config) && config.api?.baseUrl) {
+    return `${config.api.baseUrl}/api/v1/files/${path}`
+  }
+
   if (isS3Mode(config) && config.api?.baseUrl) {
-    // Extract run ID or suite hash from the path to look up the discovery path
+    // Extract run ID or suite hash from the path to look up the S3 discovery path
     const runMatch = path.match(/^runs\/([^/]+)/)
     const suiteMatch = path.match(/^suites\/([^/]+)/)
     const key = runMatch?.[1] ?? suiteMatch?.[1]
-    const dp = key ? getDiscoveryPath(key, config) : (config.storage?.s3?.discovery_paths?.[0] ?? 'results')
+    const dp = key ? getDiscoveryPath(key, config) : getDiscoveryPath('', config)
     return `${config.api.baseUrl}/api/v1/files/${dp}/${path}`
   }
 

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -459,11 +459,13 @@ function GitHubMappingsTab() {
 
 function ConfigOverview({ config }: { config: AuthConfig }) {
   const s3 = config.storage?.s3
+  const local = config.storage?.local
 
   const items: { label: string; enabled: boolean }[] = [
     { label: 'Basic Auth', enabled: config.auth.basic_enabled },
     { label: 'GitHub Auth', enabled: config.auth.github_enabled },
     { label: 'S3 Storage', enabled: s3?.enabled ?? false },
+    { label: 'Local Storage', enabled: local?.enabled ?? false },
   ]
 
   return (
@@ -485,6 +487,11 @@ function ConfigOverview({ config }: { config: AuthConfig }) {
       {s3?.enabled && s3.discovery_paths.length > 0 && (
         <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
           S3 discovery paths: {s3.discovery_paths.join(', ')}
+        </div>
+      )}
+      {local?.enabled && local.discovery_paths.length > 0 && (
+        <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          Local discovery paths: {local.discovery_paths.join(', ')}
         </div>
       )}
     </div>


### PR DESCRIPTION
Add a "local" storage backend that serves benchmark result files directly from local filesystem directories via http.ServeFile, enabling the API to run without S3 infrastructure.

- Add APILocalStorageConfig with discovery_paths (absolute dirs)
- Validate mutual exclusivity: only one backend (S3 or local) at a time
- Add localFileServer with path traversal protection and defense-in-depth
- Rename handlePresignedURL to handleFileRequest with dispatch logic
- Update UI to handle local mode (direct fetch, no presigned URL indirection)
- Update docs and example config