### PR TITLE
fix(checkpoint): set HealthLogDestination in ReadFileFromImage

### DIFF
--- a/pkg/podman/checkpoint.go
+++ b/pkg/podman/checkpoint.go
@@ -218,6 +218,7 @@ func (m *manager) ReadFileFromImage(
 	s.Name = fmt.Sprintf("benchmarkoor-readfile-%d", time.Now().UnixNano())
 	s.Image = imageName
 	s.Command = []string{"true"}
+	s.HealthLogDestination = "local"
 
 	resp, err := containers.CreateWithSpec(m.conn, s, nil)
 	if err != nil {


### PR DESCRIPTION
The throwaway container created by ReadFileFromImage inherits the image's HEALTHCHECK but has an empty HealthLogDestination, causing Podman to fail with "stat : no such file or directory". Set it to "local" to match CreateContainer.