### PR TITLE
fix(api): update limit clamping test for new 10000 max

### DIFF
--- a/pkg/api/indexstore/query_test.go
+++ b/pkg/api/indexstore/query_test.go
@@ -156,7 +156,7 @@ func TestParseQueryParams_LimitClamping(t *testing.T) {
 		},
 		{
 			name:      "clamped to max",
-			raw:       url.Values{"limit": {"9999"}},
+			raw:       url.Values{"limit": {"99999"}},
 			wantLimit: indexstore.MaxQueryLimit,
 		},
 		{


### PR DESCRIPTION
The test input 9999 no longer exceeds MaxQueryLimit after the bump to 10000. Use 99999 so the clamping case is still exercised.