### PR TITLE
feat(api,ui): add bulk delete runs endpoint and delete mode UI

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -340,6 +340,7 @@ All endpoints are under the `/api/v1` prefix.
 | `POST` | `/admin/github/user-mappings` | Create/update user mapping |
 | `DELETE` | `/admin/github/user-mappings/{id}` | Delete user mapping |
 | `POST` | `/admin/indexer/run` | Trigger an immediate indexing pass. Returns 409 if already running. Requires [indexing](#indexing) to be enabled |
+| `POST` | `/admin/runs/delete` | Bulk-delete runs from storage and index. Requires [indexing](#indexing) to be enabled |
 
 ### Index (requires authentication unless `anonymous_read` is enabled)
 

--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -637,6 +637,14 @@ func (s *server) handleDeleteRuns(
 			continue
 		}
 
+		// Clean up suite if no other runs reference it.
+		if err := s.indexStore.DeleteOrphanedSuite(
+			ctx, run.SuiteHash,
+		); err != nil {
+			s.log.WithError(err).WithField("run_id", runID).
+				Warn("Failed to delete orphaned suite")
+		}
+
 		deleted++
 	}
 

--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -599,7 +599,7 @@ func (s *server) handleDeleteRuns(
 			continue
 		}
 
-		// Delete from storage.
+		// Delete from storage first.
 		if err := s.storageDeleter.DeleteRun(
 			ctx, run.DiscoveryPath, runID,
 		); err != nil {
@@ -612,37 +612,18 @@ func (s *server) handleDeleteRuns(
 			continue
 		}
 
-		// Delete from index (test stats, block logs, run record).
-		if err := s.indexStore.DeleteTestStatsForRun(
+		// Delete from index (transactional: test_stats,
+		// block_logs, run, orphaned suite — all or nothing).
+		if err := s.indexStore.DeleteRunCascade(
 			ctx, runID,
 		); err != nil {
 			s.log.WithError(err).WithField("run_id", runID).
-				Warn("Failed to delete test stats")
-		}
-
-		if err := s.indexStore.DeleteTestStatsBlockLogsForRun(
-			ctx, runID,
-		); err != nil {
-			s.log.WithError(err).WithField("run_id", runID).
-				Warn("Failed to delete test stats block logs")
-		}
-
-		if err := s.indexStore.DeleteRun(ctx, runID); err != nil {
-			s.log.WithError(err).WithField("run_id", runID).
-				Warn("Failed to delete run from index")
+				Error("Failed to delete run from index")
 			errs = append(errs, fmt.Sprintf(
 				"%s: index delete failed: %v", runID, err,
 			))
 
 			continue
-		}
-
-		// Clean up suite if no other runs reference it.
-		if err := s.indexStore.DeleteOrphanedSuite(
-			ctx, run.SuiteHash,
-		); err != nil {
-			s.log.WithError(err).WithField("run_id", runID).
-				Warn("Failed to delete orphaned suite")
 		}
 
 		deleted++

--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -544,6 +544,111 @@ func (s *server) handleDeleteUserMapping(
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+// --- Run deletion ---
+
+type deleteRunsRequest struct {
+	RunIDs []string `json:"run_ids"`
+}
+
+type deleteRunsResponse struct {
+	Status  string   `json:"status"`
+	Deleted int      `json:"deleted"`
+	Errors  []string `json:"errors,omitempty"`
+}
+
+// handleDeleteRuns bulk-deletes runs from storage and the index database.
+func (s *server) handleDeleteRuns(
+	w http.ResponseWriter, r *http.Request,
+) {
+	if s.storageDeleter == nil {
+		writeJSON(w, http.StatusServiceUnavailable,
+			errorResponse{"storage backend does not support deletion"})
+
+		return
+	}
+
+	var req deleteRunsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest,
+			errorResponse{"invalid request body"})
+
+		return
+	}
+
+	if len(req.RunIDs) == 0 {
+		writeJSON(w, http.StatusBadRequest,
+			errorResponse{"run_ids is required"})
+
+		return
+	}
+
+	ctx := r.Context()
+
+	var (
+		deleted int
+		errs    []string
+	)
+
+	for _, runID := range req.RunIDs {
+		run, err := s.indexStore.GetRunByRunID(ctx, runID)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf(
+				"%s: not found in index", runID,
+			))
+
+			continue
+		}
+
+		// Delete from storage.
+		if err := s.storageDeleter.DeleteRun(
+			ctx, run.DiscoveryPath, runID,
+		); err != nil {
+			s.log.WithError(err).WithField("run_id", runID).
+				Error("Failed to delete run from storage")
+			errs = append(errs, fmt.Sprintf(
+				"%s: storage delete failed: %v", runID, err,
+			))
+
+			continue
+		}
+
+		// Delete from index (test stats, block logs, run record).
+		if err := s.indexStore.DeleteTestStatsForRun(
+			ctx, runID,
+		); err != nil {
+			s.log.WithError(err).WithField("run_id", runID).
+				Warn("Failed to delete test stats")
+		}
+
+		if err := s.indexStore.DeleteTestStatsBlockLogsForRun(
+			ctx, runID,
+		); err != nil {
+			s.log.WithError(err).WithField("run_id", runID).
+				Warn("Failed to delete test stats block logs")
+		}
+
+		if err := s.indexStore.DeleteRun(ctx, runID); err != nil {
+			s.log.WithError(err).WithField("run_id", runID).
+				Warn("Failed to delete run from index")
+			errs = append(errs, fmt.Sprintf(
+				"%s: index delete failed: %v", runID, err,
+			))
+
+			continue
+		}
+
+		deleted++
+	}
+
+	resp := deleteRunsResponse{
+		Status:  "ok",
+		Deleted: deleted,
+		Errors:  errs,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // parseIDParam extracts and validates the {id} URL parameter.
 func parseIDParam(r *http.Request) (uint, error) {
 	idStr := chi.URLParam(r, "id")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -31,17 +31,18 @@ type Server interface {
 var _ Server = (*server)(nil)
 
 type server struct {
-	log           logrus.FieldLogger
-	cfg           *config.APIConfig
-	store         store.Store
-	presigner     *s3Presigner
-	localServer   *localFileServer
-	indexStore    indexstore.Store
-	indexer       indexer.Indexer
-	storageReader storage.Reader
-	httpServer    *http.Server
-	wg            sync.WaitGroup
-	done          chan struct{}
+	log            logrus.FieldLogger
+	cfg            *config.APIConfig
+	store          store.Store
+	presigner      *s3Presigner
+	localServer    *localFileServer
+	indexStore     indexstore.Store
+	indexer        indexer.Indexer
+	storageReader  storage.Reader
+	storageDeleter storage.Deleter
+	httpServer     *http.Server
+	wg             sync.WaitGroup
+	done           chan struct{}
 }
 
 // NewServer creates a new API server.
@@ -234,6 +235,11 @@ func (s *server) prepareIndexing(ctx context.Context) error {
 		s.storageReader = storage.NewLocalReader(s.cfg.Storage.Local)
 	default:
 		return fmt.Errorf("no storage backend configured for indexing")
+	}
+
+	// Try to use the storage reader as a deleter too.
+	if d, ok := s.storageReader.(storage.Deleter); ok {
+		s.storageDeleter = d
 	}
 
 	// Create and start the index store (DB connection + migrations).

--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -35,6 +35,9 @@ type Store interface {
 
 	ListAllRuns(ctx context.Context) ([]Run, error)
 
+	GetRunByRunID(ctx context.Context, runID string) (*Run, error)
+	DeleteRun(ctx context.Context, runID string) error
+
 	UpsertSuite(ctx context.Context, suite *Suite) error
 
 	BulkInsertTestStatsBlockLogs(
@@ -198,6 +201,33 @@ func (s *store) ListAllRuns(ctx context.Context) ([]Run, error) {
 	}
 
 	return runs, nil
+}
+
+// GetRunByRunID returns a single run by its run ID.
+func (s *store) GetRunByRunID(
+	ctx context.Context, runID string,
+) (*Run, error) {
+	var run Run
+	if err := s.db.WithContext(ctx).
+		Where("run_id = ?", runID).
+		First(&run).Error; err != nil {
+		return nil, fmt.Errorf("getting run by run_id: %w", err)
+	}
+
+	return &run, nil
+}
+
+// DeleteRun removes a run record by run ID.
+func (s *store) DeleteRun(
+	ctx context.Context, runID string,
+) error {
+	if err := s.db.WithContext(ctx).
+		Where("run_id = ?", runID).
+		Delete(&Run{}).Error; err != nil {
+		return fmt.Errorf("deleting run: %w", err)
+	}
+
+	return nil
 }
 
 // ListRunIDs returns just the run IDs for a given discovery path.

--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -37,6 +37,7 @@ type Store interface {
 
 	GetRunByRunID(ctx context.Context, runID string) (*Run, error)
 	DeleteRun(ctx context.Context, runID string) error
+	DeleteOrphanedSuite(ctx context.Context, suiteHash string) error
 
 	UpsertSuite(ctx context.Context, suite *Suite) error
 
@@ -225,6 +226,35 @@ func (s *store) DeleteRun(
 		Where("run_id = ?", runID).
 		Delete(&Run{}).Error; err != nil {
 		return fmt.Errorf("deleting run: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteOrphanedSuite deletes a suite if no runs reference it anymore.
+func (s *store) DeleteOrphanedSuite(
+	ctx context.Context, suiteHash string,
+) error {
+	if suiteHash == "" {
+		return nil
+	}
+
+	var count int64
+	if err := s.db.WithContext(ctx).
+		Model(&Run{}).
+		Where("suite_hash = ?", suiteHash).
+		Count(&count).Error; err != nil {
+		return fmt.Errorf("counting runs for suite: %w", err)
+	}
+
+	if count > 0 {
+		return nil
+	}
+
+	if err := s.db.WithContext(ctx).
+		Where("suite_hash = ?", suiteHash).
+		Delete(&Suite{}).Error; err != nil {
+		return fmt.Errorf("deleting orphaned suite: %w", err)
 	}
 
 	return nil

--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -37,6 +37,7 @@ type Store interface {
 
 	GetRunByRunID(ctx context.Context, runID string) (*Run, error)
 	DeleteRun(ctx context.Context, runID string) error
+	DeleteRunCascade(ctx context.Context, runID string) error
 	DeleteOrphanedSuite(ctx context.Context, suiteHash string) error
 
 	UpsertSuite(ctx context.Context, suite *Suite) error
@@ -229,6 +230,56 @@ func (s *store) DeleteRun(
 	}
 
 	return nil
+}
+
+// DeleteRunCascade deletes a run and all related rows (test_stats,
+// test_stats_block_logs, and the orphaned suite) in a single transaction.
+func (s *store) DeleteRunCascade(
+	ctx context.Context, runID string,
+) error {
+	// Look up the run first so we know the suite_hash for orphan cleanup.
+	var run Run
+	if err := s.db.WithContext(ctx).
+		Where("run_id = ?", runID).
+		First(&run).Error; err != nil {
+		return fmt.Errorf("looking up run: %w", err)
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("run_id = ?", runID).
+			Delete(&TestStat{}).Error; err != nil {
+			return fmt.Errorf("deleting test stats: %w", err)
+		}
+
+		if err := tx.Where("run_id = ?", runID).
+			Delete(&TestStatsBlockLog{}).Error; err != nil {
+			return fmt.Errorf("deleting block logs: %w", err)
+		}
+
+		if err := tx.Where("run_id = ?", runID).
+			Delete(&Run{}).Error; err != nil {
+			return fmt.Errorf("deleting run: %w", err)
+		}
+
+		// Clean up suite if no other runs reference it.
+		if run.SuiteHash != "" {
+			var count int64
+			if err := tx.Model(&Run{}).
+				Where("suite_hash = ?", run.SuiteHash).
+				Count(&count).Error; err != nil {
+				return fmt.Errorf("counting runs for suite: %w", err)
+			}
+
+			if count == 0 {
+				if err := tx.Where("suite_hash = ?", run.SuiteHash).
+					Delete(&Suite{}).Error; err != nil {
+					return fmt.Errorf("deleting orphaned suite: %w", err)
+				}
+			}
+		}
+
+		return nil
+	})
 }
 
 // DeleteOrphanedSuite deletes a suite if no runs reference it anymore.

--- a/pkg/api/openapi.yaml
+++ b/pkg/api/openapi.yaml
@@ -1133,6 +1133,80 @@ paths:
                     type: string
                     example: Indexing pass already in progress
 
+  /admin/runs/delete:
+    post:
+      operationId: deleteRuns
+      tags: [admin]
+      summary: Bulk-delete runs
+      description: |
+        Deletes one or more runs from both storage (S3/local) and the index database.
+        Each run is looked up in the index to determine its discovery path, then removed
+        from storage and all related index tables (test_stats, block_logs, runs).
+        Partial success is possible — the response includes a count of deleted runs
+        and any per-run errors.
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [run_ids]
+              properties:
+                run_ids:
+                  type: array
+                  items:
+                    type: string
+                  description: List of run IDs to delete
+                  example: ["abc123", "def456"]
+      responses:
+        "200":
+          description: Delete operation completed (may include partial errors)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  deleted:
+                    type: integer
+                    description: Number of runs successfully deleted
+                    example: 2
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                    description: Per-run error messages (omitted when empty)
+                    example: []
+        "400":
+          description: Invalid request body or empty run_ids
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: Storage backend does not support deletion
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
 # ── Components ──────────────────────────────────────────────────────
 components:
   securitySchemes:

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -134,6 +134,11 @@ func (s *server) buildRouter() http.Handler {
 			r.Delete("/github/user-mappings/{id}",
 				s.handleDeleteUserMapping)
 
+			// Run deletion (requires indexing).
+			if s.indexStore != nil {
+				r.Post("/runs/delete", s.handleDeleteRuns)
+			}
+
 			// Indexer management.
 			if s.indexer != nil {
 				r.Post("/indexer/run", s.handleRunIndexer)

--- a/pkg/api/storage/local.go
+++ b/pkg/api/storage/local.go
@@ -11,8 +11,11 @@ import (
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
 )
 
-// Compile-time interface check.
-var _ Reader = (*localReader)(nil)
+// Compile-time interface checks.
+var (
+	_ Reader  = (*localReader)(nil)
+	_ Deleter = (*localReader)(nil)
+)
 
 type localReader struct {
 	// paths maps discovery path names to absolute directory paths.
@@ -95,6 +98,26 @@ func (r *localReader) GetRunFile(
 	}
 
 	return data, nil
+}
+
+// DeleteRun removes the run directory {dirPath}/runs/{runID}.
+func (r *localReader) DeleteRun(
+	_ context.Context, discoveryPath, runID string,
+) error {
+	dirPath, ok := r.paths[discoveryPath]
+	if !ok {
+		return fmt.Errorf(
+			"unknown discovery path: %q", discoveryPath,
+		)
+	}
+
+	p := filepath.Join(dirPath, "runs", runID)
+
+	if err := os.RemoveAll(p); err != nil {
+		return fmt.Errorf("removing run directory %s: %w", p, err)
+	}
+
+	return nil
 }
 
 // GetSuiteFile reads a file from {dirPath}/suites/{suiteHash}/{filename}.

--- a/pkg/api/storage/s3.go
+++ b/pkg/api/storage/s3.go
@@ -149,7 +149,7 @@ func (r *s3Reader) DeleteRun(
 			end := min(i+maxDeleteBatch, len(objects))
 			batch := objects[i:end]
 
-			_, err := r.client.DeleteObjects(
+			out, err := r.client.DeleteObjects(
 				ctx, &s3.DeleteObjectsInput{
 					Bucket: aws.String(r.bucket),
 					Delete: &s3types.Delete{
@@ -162,6 +162,26 @@ func (r *s3Reader) DeleteRun(
 				return fmt.Errorf(
 					"deleting objects under %q: %w",
 					prefix, err,
+				)
+			}
+
+			if len(out.Errors) > 0 {
+				var errs []error
+				for _, e := range out.Errors {
+					errs = append(errs, fmt.Errorf(
+						"key %s: %s (%s)",
+						aws.ToString(e.Key),
+						aws.ToString(e.Message),
+						aws.ToString(e.Code),
+					))
+				}
+
+				return fmt.Errorf(
+					"deleting objects under %q: %d of %d failed: %w",
+					prefix,
+					len(out.Errors),
+					len(batch),
+					errors.Join(errs...),
 				)
 			}
 		}

--- a/pkg/api/storage/s3.go
+++ b/pkg/api/storage/s3.go
@@ -16,8 +16,11 @@ import (
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
 )
 
-// Compile-time interface check.
-var _ Reader = (*s3Reader)(nil)
+// Compile-time interface checks.
+var (
+	_ Reader  = (*s3Reader)(nil)
+	_ Deleter = (*s3Reader)(nil)
+)
 
 type s3Reader struct {
 	client         *s3.Client
@@ -102,6 +105,69 @@ func (r *s3Reader) GetSuiteFile(
 	key := discoveryPath + "/suites/" + suiteHash + "/" + filename
 
 	return r.getObject(ctx, key)
+}
+
+// DeleteRun removes all objects under {dp}/runs/{runID}/ from S3.
+func (r *s3Reader) DeleteRun(
+	ctx context.Context, discoveryPath, runID string,
+) error {
+	prefix := discoveryPath + "/runs/" + runID + "/"
+
+	paginator := s3.NewListObjectsV2Paginator(
+		r.client, &s3.ListObjectsV2Input{
+			Bucket: aws.String(r.bucket),
+			Prefix: aws.String(prefix),
+		},
+	)
+
+	const maxDeleteBatch = 1000
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf(
+				"listing objects under %q: %w", prefix, err,
+			)
+		}
+
+		if len(page.Contents) == 0 {
+			continue
+		}
+
+		objects := make(
+			[]s3types.ObjectIdentifier,
+			0, len(page.Contents),
+		)
+		for _, obj := range page.Contents {
+			objects = append(objects, s3types.ObjectIdentifier{
+				Key: obj.Key,
+			})
+		}
+
+		// Batch delete in chunks of 1000 (S3 limit).
+		for i := 0; i < len(objects); i += maxDeleteBatch {
+			end := min(i+maxDeleteBatch, len(objects))
+			batch := objects[i:end]
+
+			_, err := r.client.DeleteObjects(
+				ctx, &s3.DeleteObjectsInput{
+					Bucket: aws.String(r.bucket),
+					Delete: &s3types.Delete{
+						Objects: batch,
+						Quiet:   aws.Bool(true),
+					},
+				},
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"deleting objects under %q: %w",
+					prefix, err,
+				)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (r *s3Reader) getObject(

--- a/pkg/api/storage/storage.go
+++ b/pkg/api/storage/storage.go
@@ -2,6 +2,13 @@ package storage
 
 import "context"
 
+// Deleter provides delete access to benchmark run data stored in a backend.
+type Deleter interface {
+	// DeleteRun removes all objects/files for a run under the given
+	// discovery path.
+	DeleteRun(ctx context.Context, discoveryPath, runID string) error
+}
+
 // Reader provides read access to benchmark run data stored in a backend
 // (local filesystem or S3). It is used by the indexer to discover and
 // read run/suite files without knowing the underlying storage details.

--- a/ui/src/api/hooks/useAdmin.ts
+++ b/ui/src/api/hooks/useAdmin.ts
@@ -143,6 +143,25 @@ export function useRunIndexer() {
   })
 }
 
+// Run deletion
+interface DeleteRunsResponse {
+  status: string
+  deleted: number
+  errors?: string[]
+}
+
+export function useDeleteRuns() {
+  const queryClient = useQueryClient()
+  return useMutation<DeleteRunsResponse, Error, string[]>({
+    mutationFn: (runIds: string[]) =>
+      adminFetch('/api/v1/admin/runs/delete', {
+        method: 'POST',
+        body: JSON.stringify({ run_ids: runIds }),
+      }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['index'] }),
+  })
+}
+
 // GitHub User Mappings
 export function useUserMappings() {
   return useQuery<GitHubUserMapping[]>({

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -27,6 +27,7 @@ interface RunsTableProps {
   selectable?: boolean
   selectedRunIds?: Set<string>
   onSelectionChange?: (runId: string, selected: boolean) => void
+  selectionVariant?: 'compare' | 'delete'
 }
 
 function SortIcon({ direction, active }: { direction: SortDirection; active: boolean }) {
@@ -103,6 +104,7 @@ export function RunsTable({
   selectable = false,
   selectedRunIds,
   onSelectionChange,
+  selectionVariant = 'compare',
 }: RunsTableProps) {
   const navigate = useNavigate()
 
@@ -148,7 +150,8 @@ export function RunsTable({
                 entry.status === 'container_died' && 'bg-red-50/50 dark:bg-red-900/10',
                 entry.status === 'cancelled' && 'bg-yellow-50/50 dark:bg-yellow-900/10',
                 hasFailures && 'bg-orange-50/50 dark:bg-orange-900/10',
-                selectable && selectedRunIds?.has(entry.run_id) && 'ring-2 ring-inset ring-blue-400 dark:ring-blue-500',
+                selectable && selectedRunIds?.has(entry.run_id) && selectionVariant === 'compare' && 'ring-2 ring-inset ring-blue-400 dark:ring-blue-500',
+                selectable && selectedRunIds?.has(entry.run_id) && selectionVariant === 'delete' && 'ring-2 ring-inset ring-red-400 dark:ring-red-500',
               )}
             >
               {selectable && (
@@ -161,7 +164,7 @@ export function RunsTable({
                       onSelectionChange?.(entry.run_id, e.target.checked)
                     }}
                     onClick={(e) => e.stopPropagation()}
-                    className="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600"
+                    className={clsx('size-4 rounded-xs border-gray-300 dark:border-gray-600', selectionVariant === 'delete' ? 'text-red-600 focus:ring-red-500' : 'text-blue-600 focus:ring-blue-500')}
                   />
                 </td>
               )}

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -26,8 +26,10 @@ import { type IndexStepType, ALL_INDEX_STEP_TYPES } from '@/api/types'
 import { ClientRunsStrip } from '@/components/run-detail/ClientRunsStrip'
 import { BlockLogsDashboard } from '@/components/run-detail/block-logs-dashboard'
 import { useBlockLogs } from '@/api/hooks/useBlockLogs'
-import { Flame, Download, Github, ExternalLink, SquareStack, GitCompareArrows } from 'lucide-react'
+import { Flame, Download, Github, ExternalLink, SquareStack, GitCompareArrows, Trash2 } from 'lucide-react'
 import { MAX_COMPARE_RUNS, MIN_COMPARE_RUNS } from '@/components/compare/constants'
+import { useAuth } from '@/hooks/useAuth'
+import { useDeleteRuns } from '@/api/hooks/useAdmin'
 
 // Step types that can be included in MGas/s calculation
 export type StepTypeOption = 'setup' | 'test' | 'cleanup'
@@ -112,6 +114,8 @@ function serializeStepFilter(steps: StepTypeOption[]): string | undefined {
 export function RunDetailPage() {
   const { runId } = useParams({ from: '/runs/$runId' })
   const navigate = useNavigate()
+  const { isAdmin } = useAuth()
+  const deleteRuns = useDeleteRuns()
   const search = useSearch({ from: '/runs/$runId' }) as {
     page?: number
     pageSize?: number
@@ -335,6 +339,21 @@ export function RunDetailPage() {
           </>
         )}
         <span className="text-gray-900 dark:text-gray-100">{runId}</span>
+        {isAdmin && (
+          <button
+            disabled={deleteRuns.isPending}
+            onClick={() => {
+              if (!window.confirm('Delete this run? This cannot be undone.')) return
+              deleteRuns.mutate([runId], {
+                onSuccess: () => navigate({ to: '/runs' }),
+              })
+            }}
+            className="ml-1 flex items-center justify-center rounded-sm p-1 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600 disabled:opacity-50 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+            title="Delete this run"
+          >
+            <Trash2 className="size-3.5" />
+          </button>
+        )}
         {(benchmarkoorLogLoading || benchmarkoorLogHead?.exists || containerLogLoading || containerLogHead?.exists) && (
           <div className="ml-auto flex items-center gap-2">
             <span className="font-medium text-gray-900 dark:text-gray-100">Logs:</span>

--- a/ui/src/pages/RunsPage.tsx
+++ b/ui/src/pages/RunsPage.tsx
@@ -1,8 +1,9 @@
 import { useNavigate, useSearch } from '@tanstack/react-router'
-import { SquareStack } from 'lucide-react'
+import { SquareStack, Trash2 } from 'lucide-react'
 import { useMemo, useState, useEffect, useCallback } from 'react'
 import { useQueries } from '@tanstack/react-query'
 import { useIndex } from '@/api/hooks/useIndex'
+import { useDeleteRuns } from '@/api/hooks/useAdmin'
 import { fetchData } from '@/api/client'
 import type { SuiteInfo } from '@/api/types'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES, DEFAULT_INDEX_STEP_FILTER } from '@/api/types'
@@ -14,12 +15,15 @@ import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { MAX_COMPARE_RUNS, MIN_COMPARE_RUNS } from '@/components/compare/constants'
+import { useAuth } from '@/hooks/useAuth'
 
 const PAGE_SIZE_OPTIONS = [50, 100, 200] as const
 const DEFAULT_PAGE_SIZE = 100
 
 export function RunsPage() {
   const navigate = useNavigate()
+  const { isAdmin } = useAuth()
+  const deleteRuns = useDeleteRuns()
   const search = useSearch({ from: '/runs' }) as {
     page?: number
     pageSize?: number
@@ -164,6 +168,10 @@ export function RunsPage() {
   const [compareMode, setCompareMode] = useState(false)
   const [selectedRunIds, setSelectedRunIds] = useState<Set<string>>(new Set())
 
+  // Delete mode state (mutually exclusive with compare mode)
+  const [deleteMode, setDeleteMode] = useState(false)
+  const [deleteSelectedIds, setDeleteSelectedIds] = useState<Set<string>>(new Set())
+
   const handleSelectionChange = useCallback((runId: string, selected: boolean) => {
     setSelectedRunIds((prev) => {
       const next = new Set(prev)
@@ -177,10 +185,49 @@ export function RunsPage() {
     })
   }, [])
 
+  const handleDeleteSelectionChange = useCallback((runId: string, selected: boolean) => {
+    setDeleteSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (selected) {
+        next.add(runId)
+      } else {
+        next.delete(runId)
+      }
+      return next
+    })
+  }, [])
+
   const handleExitCompareMode = useCallback(() => {
     setCompareMode(false)
     setSelectedRunIds(new Set())
   }, [])
+
+  const handleEnterDeleteMode = useCallback(() => {
+    setCompareMode(false)
+    setSelectedRunIds(new Set())
+    setDeleteMode(true)
+  }, [])
+
+  const handleExitDeleteMode = useCallback(() => {
+    setDeleteMode(false)
+    setDeleteSelectedIds(new Set())
+  }, [])
+
+  const handleEnterCompareMode = useCallback(() => {
+    setDeleteMode(false)
+    setDeleteSelectedIds(new Set())
+    setCompareMode(true)
+  }, [])
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (deleteSelectedIds.size === 0) return
+    if (!window.confirm(`Delete ${deleteSelectedIds.size} run(s)? This cannot be undone.`)) return
+    deleteRuns.mutate(Array.from(deleteSelectedIds), {
+      onSuccess: () => {
+        handleExitDeleteMode()
+      },
+    })
+  }, [deleteSelectedIds, deleteRuns, handleExitDeleteMode])
 
   // Suite match validation for selected runs
   const selectedSuiteInfo = useMemo(() => {
@@ -204,6 +251,8 @@ export function RunsPage() {
   if (!index || index.entries.length === 0) {
     return <EmptyState title="No runs found" message="No benchmark runs have been recorded yet." />
   }
+
+  const isSelectable = compareMode || deleteMode
 
   return (
     <div className="flex flex-col gap-6">
@@ -266,7 +315,7 @@ export function RunsPage() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <button
-                onClick={() => compareMode ? handleExitCompareMode() : setCompareMode(true)}
+                onClick={() => compareMode ? handleExitCompareMode() : handleEnterCompareMode()}
                 className={`flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
                   compareMode
                     ? 'bg-blue-600 text-white ring-blue-600 hover:bg-blue-700 hover:ring-blue-700'
@@ -276,6 +325,19 @@ export function RunsPage() {
               >
                 <SquareStack className="size-4" />
               </button>
+              {isAdmin && (
+                <button
+                  onClick={() => deleteMode ? handleExitDeleteMode() : handleEnterDeleteMode()}
+                  className={`flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
+                    deleteMode
+                      ? 'bg-red-600 text-white ring-red-600 hover:bg-red-700 hover:ring-red-700'
+                      : 'bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200'
+                  }`}
+                  title="Delete runs"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              )}
               <span className="text-sm/6 text-gray-500 dark:text-gray-400">Show</span>
               <select
                 value={localPageSize}
@@ -294,7 +356,18 @@ export function RunsPage() {
               <Pagination currentPage={localPage} totalPages={totalPages} onPageChange={handlePageChange} />
             )}
           </div>
-          <RunsTable entries={paginatedEntries} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} showSuite stepFilter={stepFilter} selectable={compareMode} selectedRunIds={selectedRunIds} onSelectionChange={handleSelectionChange} />
+          <RunsTable
+            entries={paginatedEntries}
+            sortBy={sortBy}
+            sortDir={sortDir}
+            onSortChange={handleSortChange}
+            showSuite
+            stepFilter={stepFilter}
+            selectable={isSelectable}
+            selectedRunIds={deleteMode ? deleteSelectedIds : selectedRunIds}
+            onSelectionChange={deleteMode ? handleDeleteSelectionChange : handleSelectionChange}
+            selectionVariant={deleteMode ? 'delete' : 'compare'}
+          />
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <span className="text-sm/6 text-gray-500 dark:text-gray-400">Show</span>
@@ -347,6 +420,31 @@ export function RunsPage() {
                 className="rounded-sm bg-blue-600 px-4 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Compare
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {deleteMode && (
+        <div className="fixed inset-x-0 bottom-0 z-50 border-t border-red-200 bg-white px-6 py-3 shadow-sm dark:border-red-800 dark:bg-gray-800">
+          <div className="mx-auto flex max-w-7xl items-center justify-between">
+            <span className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+              {deleteSelectedIds.size} selected for deletion
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleExitDeleteMode}
+                className="rounded-sm px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                Cancel
+              </button>
+              <button
+                disabled={deleteSelectedIds.size === 0 || deleteRuns.isPending}
+                onClick={handleDeleteConfirm}
+                className="rounded-sm bg-red-600 px-4 py-1.5 text-sm/6 font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {deleteRuns.isPending ? 'Deleting...' : 'Delete'}
               </button>
             </div>
           </div>

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -2,11 +2,12 @@ import { useCallback, useMemo, useState, useEffect } from 'react'
 import { Link, useParams, useNavigate, useSearch } from '@tanstack/react-router'
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
 import clsx from 'clsx'
-import { ChevronRight, SquareStack, GitCompareArrows, LayoutGrid, Clock, Grid3X3 } from 'lucide-react'
+import { ChevronRight, SquareStack, GitCompareArrows, LayoutGrid, Clock, Grid3X3, Trash2 } from 'lucide-react'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES, DEFAULT_INDEX_STEP_FILTER, type SuiteTest } from '@/api/types'
 import { useSuite } from '@/api/hooks/useSuite'
 import { useSuiteStats } from '@/api/hooks/useSuiteStats'
 import { useIndex } from '@/api/hooks/useIndex'
+import { useDeleteRuns } from '@/api/hooks/useAdmin'
 import { DurationChart, type XAxisMode } from '@/components/suite-detail/DurationChart'
 import { MGasChart } from '@/components/suite-detail/MGasChart'
 import { ResourceCharts } from '@/components/suite-detail/ResourceCharts'
@@ -24,6 +25,7 @@ import { Badge } from '@/components/shared/Badge'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { Pagination } from '@/components/shared/Pagination'
 import { MAX_COMPARE_RUNS, MIN_COMPARE_RUNS } from '@/components/compare/constants'
+import { useAuth } from '@/hooks/useAuth'
 
 const PAGE_SIZE_OPTIONS = [50, 100, 200] as const
 const DEFAULT_PAGE_SIZE = 100
@@ -69,6 +71,8 @@ function OpcodeHeatmapSection({ tests, onTestClick }: { tests: SuiteTest[]; onTe
 export function SuiteDetailPage() {
   const { suiteHash } = useParams({ from: '/suites/$suiteHash' })
   const navigate = useNavigate()
+  const { isAdmin } = useAuth()
+  const deleteRuns = useDeleteRuns()
   const search = useSearch({ from: '/suites/$suiteHash' }) as {
     tab?: string
     client?: string
@@ -105,6 +109,10 @@ export function SuiteDetailPage() {
   const [compareMode, setCompareMode] = useState(false)
   const [selectedRunIds, setSelectedRunIds] = useState<Set<string>>(new Set())
 
+  // Delete mode state (mutually exclusive with compare mode)
+  const [deleteMode, setDeleteMode] = useState(false)
+  const [deleteSelectedIds, setDeleteSelectedIds] = useState<Set<string>>(new Set())
+
   const handleSelectionChange = useCallback((runId: string, selected: boolean) => {
     setSelectedRunIds((prev) => {
       const next = new Set(prev)
@@ -118,10 +126,49 @@ export function SuiteDetailPage() {
     })
   }, [])
 
+  const handleDeleteSelectionChange = useCallback((runId: string, selected: boolean) => {
+    setDeleteSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (selected) {
+        next.add(runId)
+      } else {
+        next.delete(runId)
+      }
+      return next
+    })
+  }, [])
+
   const handleExitCompareMode = useCallback(() => {
     setCompareMode(false)
     setSelectedRunIds(new Set())
   }, [])
+
+  const handleEnterDeleteMode = useCallback(() => {
+    setCompareMode(false)
+    setSelectedRunIds(new Set())
+    setDeleteMode(true)
+  }, [])
+
+  const handleExitDeleteMode = useCallback(() => {
+    setDeleteMode(false)
+    setDeleteSelectedIds(new Set())
+  }, [])
+
+  const handleEnterCompareMode = useCallback(() => {
+    setDeleteMode(false)
+    setDeleteSelectedIds(new Set())
+    setCompareMode(true)
+  }, [])
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (deleteSelectedIds.size === 0) return
+    if (!window.confirm(`Delete ${deleteSelectedIds.size} run(s)? This cannot be undone.`)) return
+    deleteRuns.mutate(Array.from(deleteSelectedIds), {
+      onSuccess: () => {
+        handleExitDeleteMode()
+      },
+    })
+  }, [deleteSelectedIds, deleteRuns, handleExitDeleteMode])
 
   const [heatmapExpanded, setHeatmapExpanded] = useState(true)
   const [chartExpanded, setChartExpanded] = useState(true)
@@ -429,6 +476,8 @@ export function SuiteDetailPage() {
     })
   }
 
+  const isSelectable = compareMode || deleteMode
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
@@ -580,7 +629,7 @@ export function SuiteDetailPage() {
                     </button>
                     <div className="flex items-center gap-1.5">
                       <button
-                        onClick={() => compareMode ? handleExitCompareMode() : setCompareMode(true)}
+                        onClick={() => compareMode ? handleExitCompareMode() : handleEnterCompareMode()}
                         className={clsx(
                           'flex cursor-pointer items-center justify-center rounded-sm p-1 shadow-xs ring-1 ring-inset transition-colors',
                           compareMode
@@ -743,7 +792,7 @@ export function SuiteDetailPage() {
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
                         <button
-                          onClick={() => compareMode ? handleExitCompareMode() : setCompareMode(true)}
+                          onClick={() => compareMode ? handleExitCompareMode() : handleEnterCompareMode()}
                           className={`flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
                             compareMode
                               ? 'bg-blue-600 text-white ring-blue-600 hover:bg-blue-700 hover:ring-blue-700'
@@ -764,6 +813,19 @@ export function SuiteDetailPage() {
                         >
                           <GitCompareArrows className="size-4" />
                         </button>
+                        {isAdmin && (
+                          <button
+                            onClick={() => deleteMode ? handleExitDeleteMode() : handleEnterDeleteMode()}
+                            className={`flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
+                              deleteMode
+                                ? 'bg-red-600 text-white ring-red-600 hover:bg-red-700 hover:ring-red-700'
+                                : 'bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200'
+                            }`}
+                            title="Delete runs"
+                          >
+                            <Trash2 className="size-4" />
+                          </button>
+                        )}
                         <span className="text-sm/6 text-gray-500 dark:text-gray-400">Show</span>
                         <select
                           value={runsPageSize}
@@ -782,7 +844,17 @@ export function SuiteDetailPage() {
                         <Pagination currentPage={runsPage} totalPages={totalRunsPages} onPageChange={setRunsPage} />
                       )}
                     </div>
-                    <RunsTable entries={paginatedRuns} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} stepFilter={stepFilter} selectable={compareMode} selectedRunIds={selectedRunIds} onSelectionChange={handleSelectionChange} />
+                    <RunsTable
+                      entries={paginatedRuns}
+                      sortBy={sortBy}
+                      sortDir={sortDir}
+                      onSortChange={handleSortChange}
+                      stepFilter={stepFilter}
+                      selectable={isSelectable}
+                      selectedRunIds={deleteMode ? deleteSelectedIds : selectedRunIds}
+                      onSelectionChange={deleteMode ? handleDeleteSelectionChange : handleSelectionChange}
+                      selectionVariant={deleteMode ? 'delete' : 'compare'}
+                    />
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
                         <span className="text-sm/6 text-gray-500 dark:text-gray-400">Show</span>
@@ -883,6 +955,31 @@ export function SuiteDetailPage() {
                 className="rounded-sm bg-blue-600 px-4 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Compare
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {deleteMode && (
+        <div className="fixed inset-x-0 bottom-0 z-50 border-t border-red-200 bg-white px-6 py-3 shadow-sm dark:border-red-800 dark:bg-gray-800">
+          <div className="mx-auto flex max-w-7xl items-center justify-between">
+            <span className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+              {deleteSelectedIds.size} selected for deletion
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleExitDeleteMode}
+                className="rounded-sm px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                Cancel
+              </button>
+              <button
+                disabled={deleteSelectedIds.size === 0 || deleteRuns.isPending}
+                onClick={handleDeleteConfirm}
+                className="rounded-sm bg-red-600 px-4 py-1.5 text-sm/6 font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {deleteRuns.isPending ? 'Deleting...' : 'Delete'}
               </button>
             </div>
           </div>


### PR DESCRIPTION
Add DELETE capability for benchmark runs across storage (S3/local) and the index database, with admin-only UI integration on all run pages.

Backend:
- Add Deleter interface to storage package with S3 batch delete and local os.RemoveAll implementations
- Add GetRunByRunID and DeleteRun methods to index store
- Add POST /admin/runs/delete bulk handler that removes from storage then cleans up test_stats, block_logs, and run records from index

Frontend:
- Add useDeleteRuns mutation hook invalidating index queries
- Add selectionVariant prop to RunsTable (red ring for delete mode)
- Add delete mode to RunsPage and SuiteDetailPage with red bottom action bar, confirmation dialog, and mutually exclusive compare mode
- Add inline delete button on RunDetailPage breadcrumb (admin-only)