### PR TITLE
feat: add Amsterdam support up to bal-devnet-2

### DIFF
--- a/pkg/eest/converter.go
+++ b/pkg/eest/converter.go
@@ -120,6 +120,14 @@ func buildNewPayloadCall(payload *EngineNewPayload, id int) (string, error) {
 			payload.ParentBeaconBlockRoot,
 			payload.ExecutionRequests,
 		}
+	case 5:
+		// V5 (Amsterdam): executionPayload, expectedBlobVersionedHashes, parentBeaconBlockRoot, executionRequests
+		params = []any{
+			execPayload,
+			payload.BlobVersionedHashes,
+			payload.ParentBeaconBlockRoot,
+			payload.ExecutionRequests,
+		}
 	default:
 		return "", fmt.Errorf("unsupported payload version: %d", payload.NewPayloadVersion)
 	}
@@ -218,6 +226,17 @@ func buildExecutionPayloadJSON(ep *ExecutionPayload, version int) map[string]any
 
 	// Note: V4 deposit/withdrawal/consolidation requests are passed as executionRequests
 	// parameter, not in the payload itself.
+
+	// Add Amsterdam fields for V5+.
+	if version >= 5 {
+		if ep.BlockAccessList != "" {
+			result["blockAccessList"] = ep.BlockAccessList
+		}
+
+		if ep.SlotNumber != "" {
+			result["slotNumber"] = ep.SlotNumber
+		}
+	}
 
 	return result
 }

--- a/pkg/eest/converter_test.go
+++ b/pkg/eest/converter_test.go
@@ -165,6 +165,7 @@ func TestConvertFixture_PayloadVersions(t *testing.T) {
 		{2, 1, "engine_newPayloadV2", "engine_forkchoiceUpdatedV1"},
 		{3, 3, "engine_newPayloadV3", "engine_forkchoiceUpdatedV3"},
 		{4, 3, "engine_newPayloadV4", "engine_forkchoiceUpdatedV3"},
+		{5, 4, "engine_newPayloadV5", "engine_forkchoiceUpdatedV4"},
 	}
 
 	for _, tc := range tests {

--- a/pkg/eest/fixture.go
+++ b/pkg/eest/fixture.go
@@ -171,6 +171,8 @@ type ExecutionPayload struct {
 	DepositRequests       []*Deposit     `json:"depositRequests,omitempty"`
 	WithdrawalRequests    []*WithdrawReq `json:"withdrawalRequests,omitempty"`
 	ConsolidationRequests []*Consolidate `json:"consolidationRequests,omitempty"`
+	BlockAccessList       string         `json:"blockAccessList,omitempty"`
+	SlotNumber            string         `json:"slotNumber,omitempty"`
 }
 
 // Withdrawal represents a withdrawal in the execution payload.


### PR DESCRIPTION
Updates `engine_newPayloadV5` for `engine_forkchoiceUpdatedV4` with fields present up to `bal-devnet-2`. Tested locally against geth `bal-devnet-2` branch, with up-to-date execution-specs branch at my fork fselmo/execution-specs, branch `devnets/bal/2`.

Working well locally though I couldn't run all the tests locally as I ran into an unrelated (I believe) issue. Can use a sanity check on tests but the benchmark run ran through locally for `-m repricing tests/benchmark/compute` EELS tests 👍🏼.