### PR TITLE
perf(indexstore): add missing indexes and tune SQLite cache for slow queries

### DIFF
--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -844,6 +844,8 @@ func applySQLitePragmas(db *gorm.DB) error {
 		"PRAGMA busy_timeout=5000",
 		"PRAGMA foreign_keys=ON",
 		"PRAGMA temp_store=MEMORY",
+		"PRAGMA cache_size=-64000",
+		"PRAGMA mmap_size=268435456",
 	}
 
 	for _, p := range pragmas {

--- a/pkg/api/indexstore/run.go
+++ b/pkg/api/indexstore/run.go
@@ -7,7 +7,7 @@ type Run struct {
 	ID                uint   `gorm:"primaryKey"`
 	DiscoveryPath     string `gorm:"not null;uniqueIndex:idx_runs_dp_run"`
 	RunID             string `gorm:"not null;uniqueIndex:idx_runs_dp_run"`
-	Timestamp         int64
+	Timestamp         int64  `gorm:"index"`
 	TimestampEnd      int64
 	SuiteHash         string `gorm:"index"`
 	Status            string

--- a/pkg/api/indexstore/suite.go
+++ b/pkg/api/indexstore/suite.go
@@ -6,7 +6,7 @@ import "time"
 type Suite struct {
 	ID            uint   `gorm:"primaryKey"`
 	SuiteHash     string `gorm:"uniqueIndex;not null"`
-	DiscoveryPath string `gorm:"not null"`
+	DiscoveryPath string `gorm:"not null;index"`
 	Name          string
 	TestsTotal    int
 	IndexedAt     time.Time

--- a/pkg/api/indexstore/test_stat.go
+++ b/pkg/api/indexstore/test_stat.go
@@ -3,11 +3,11 @@ package indexstore
 // TestStat represents a single per-test timing entry for suite stats.
 type TestStat struct {
 	ID        uint   `gorm:"primaryKey"`
-	SuiteHash string `gorm:"not null;uniqueIndex:idx_td_suite_test_run"`
-	RunID     string `gorm:"not null;uniqueIndex:idx_td_suite_test_run"`
+	SuiteHash string `gorm:"not null;uniqueIndex:idx_td_suite_test_run;index:idx_ts_suite_run_start;index:idx_ts_suite_start_ttime"`
+	RunID     string `gorm:"not null;uniqueIndex:idx_td_suite_test_run;index:idx_ts_run_id"`
 	TestName  string `gorm:"not null;uniqueIndex:idx_td_suite_test_run"`
 	Client    string
-	RunStart  int64
+	RunStart  int64 `gorm:"index:idx_ts_suite_run_start;index:idx_ts_suite_start_ttime"`
 	RunEnd    int64
 
 	// Total (sum of all steps).
@@ -30,7 +30,7 @@ type TestStat struct {
 
 	// Test step.
 	TestGasUsed              uint64
-	TestTimeNs               int64
+	TestTimeNs               int64   `gorm:"index:idx_ts_suite_start_ttime"`
 	TestMGasS                float64 `gorm:"column:test_mgas_s"`
 	TestRPCCallsCount        int     `gorm:"column:test_rpc_calls_count"`
 	TestResourceCPUUsec      uint64  `gorm:"column:test_resource_cpu_usec"`


### PR DESCRIPTION
Add indexes on frequently-filtered/sorted columns to eliminate full table scans identified in slow query logs (500ms–62s):
- runs.timestamp: ORDER BY timestamp DESC
- test_stats.run_id: DELETE/WHERE by run_id
- test_stats (suite_hash, run_start, test_time_ns): composite for filtered counts
- suites.discovery_path: WHERE discovery_path lookups

Increase SQLite page cache to 64MB and enable 256MB mmap for read-heavy workloads against large working sets.