### PR TITLE
fix(ui): mobile-friendly improvements across all pages

### DIFF
--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -135,7 +135,78 @@ function UserMenu({ onNavigate }: { onNavigate?: () => void }) {
   )
 }
 
-function AuthControls({ onNavigate }: { onNavigate?: () => void }) {
+function MobileUserMenu({ onNavigate }: { onNavigate?: () => void }) {
+  const { user, isAdmin, logout } = useAuth()
+  const navigate = useNavigate()
+
+  if (!user) return null
+
+  const handleLogout = async () => {
+    await logout()
+    onNavigate?.()
+    navigate({ to: '/runs' })
+  }
+
+  const handleNavigate = (to: string) => {
+    onNavigate?.()
+    navigate({ to })
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2 px-3 py-1.5 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+        {user.source === 'github' ? (
+          <img src={`https://github.com/${user.username}.png`} alt="" className="size-6 rounded-full" />
+        ) : (
+          <User className="size-4" />
+        )}
+        <span>{user.username}</span>
+        {isAdmin && <Shield className="size-3 text-purple-500" />}
+      </div>
+      <div className="ml-5 flex flex-col gap-1 border-l border-gray-200 pl-3 dark:border-gray-700">
+        <button
+          onClick={() => handleNavigate('/api-keys')}
+          className="flex items-center gap-2 rounded-sm px-3 py-1.5 text-left text-sm/6 text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700/50 dark:hover:text-gray-100"
+        >
+          <Shield className="size-3.5" />
+          API Keys
+        </button>
+        <button
+          onClick={() => handleNavigate('/api-docs')}
+          className="flex items-center gap-2 rounded-sm px-3 py-1.5 text-left text-sm/6 text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700/50 dark:hover:text-gray-100"
+        >
+          <FileText className="size-3.5" />
+          API Docs
+        </button>
+        <button
+          onClick={() => handleNavigate('/query')}
+          className="flex items-center gap-2 rounded-sm px-3 py-1.5 text-left text-sm/6 text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700/50 dark:hover:text-gray-100"
+        >
+          <Search className="size-3.5" />
+          Query Builder
+        </button>
+        {isAdmin && (
+          <button
+            onClick={() => handleNavigate('/admin')}
+            className="flex items-center gap-2 rounded-sm px-3 py-1.5 text-left text-sm/6 text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700/50 dark:hover:text-gray-100"
+          >
+            <User className="size-3.5" />
+            Admin
+          </button>
+        )}
+        <button
+          onClick={handleLogout}
+          className="flex items-center gap-2 rounded-sm px-3 py-1.5 text-left text-sm/6 text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700/50 dark:hover:text-gray-100"
+        >
+          <LogOut className="size-3.5" />
+          Sign out
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function AuthControls({ onNavigate, variant = 'desktop' }: { onNavigate?: () => void; variant?: 'desktop' | 'mobile' }) {
   const { user, isApiEnabled } = useAuth()
 
   if (!isApiEnabled) return null
@@ -151,6 +222,10 @@ function AuthControls({ onNavigate }: { onNavigate?: () => void }) {
         Sign in
       </Link>
     )
+  }
+
+  if (variant === 'mobile') {
+    return <MobileUserMenu onNavigate={onNavigate} />
   }
 
   return <UserMenu onNavigate={onNavigate} />
@@ -197,9 +272,11 @@ export function Header() {
             <NavLink to="/runs" onClick={closeMobile}>Runs</NavLink>
             <NavLink to="/suites" onClick={closeMobile}>Suites</NavLink>
           </nav>
-          <div className="mt-3 flex items-center gap-2 border-t border-gray-200 pt-3 dark:border-gray-700">
-            <AuthControls onNavigate={closeMobile} />
-            <ThemeSwitcher />
+          <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700">
+            <AuthControls onNavigate={closeMobile} variant="mobile" />
+            <div className="mt-2 flex items-center justify-end">
+              <ThemeSwitcher />
+            </div>
           </div>
         </div>
       )}

--- a/ui/src/components/run-detail/ClientRunsStrip.tsx
+++ b/ui/src/components/run-detail/ClientRunsStrip.tsx
@@ -81,69 +81,73 @@ export function ClientRunsStrip({ runs, currentRunId, stepFilter, selectable = f
   if (displayRuns.length <= 1) return null
 
   return (
-    <div className="relative flex items-center gap-3 rounded-sm bg-white px-4 py-3 shadow-xs dark:bg-gray-800">
-      <span className="shrink-0 text-xs/5 text-gray-400 dark:text-gray-500">Recent</span>
-      <div className="flex gap-1">
-        {displayRuns.map((run) => {
-          const stats = getIndexAggregatedStats(run, stepFilter)
-          const completed = isRunCompleted(run)
-          const mgas = calculateMGasPerSec(stats.gasUsed, stats.gasUsedDuration)
-          const color = completed && mgas !== undefined
-            ? getColorByNormalizedValue(mgas, minMgas, maxMgas, true)
-            : completed ? COLORS[2] : '#6b7280'
-          const isCurrent = run.run_id === currentRunId
+    <div className="relative flex flex-wrap items-center gap-x-3 gap-y-2 rounded-xs bg-white px-4 py-3 shadow-xs dark:bg-gray-800">
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="hidden shrink-0 text-xs/5 text-gray-400 sm:inline dark:text-gray-500">Recent</span>
+        <div className="flex flex-wrap gap-1">
+          {displayRuns.map((run) => {
+            const stats = getIndexAggregatedStats(run, stepFilter)
+            const completed = isRunCompleted(run)
+            const mgas = calculateMGasPerSec(stats.gasUsed, stats.gasUsedDuration)
+            const color = completed && mgas !== undefined
+              ? getColorByNormalizedValue(mgas, minMgas, maxMgas, true)
+              : completed ? COLORS[2] : '#6b7280'
+            const isCurrent = run.run_id === currentRunId
 
-          return (
-            <button
-              key={run.run_id}
-              onClick={() => {
-                if (selectable) {
-                  onSelectionChange?.(run.run_id, !selectedRunIds?.has(run.run_id))
-                } else {
-                  navigate({ to: '/runs/$runId', params: { runId: run.run_id } })
-                }
-              }}
-              onMouseEnter={(e) => {
-                const rect = e.currentTarget.getBoundingClientRect()
-                setTooltip({ run, x: rect.left + rect.width / 2, y: rect.top })
-              }}
-              onMouseLeave={() => setTooltip(null)}
-              className={clsx(
-                'relative size-5 shrink-0 cursor-pointer rounded-xs transition-all hover:scale-110',
-                selectable && selectedRunIds?.has(run.run_id) && 'scale-110 ring-2 ring-blue-500 dark:ring-blue-400',
-                !selectable && isCurrent && 'ring-2 ring-blue-500',
-                !selectable && !isCurrent && 'hover:ring-2 hover:ring-gray-400 dark:hover:ring-gray-500',
-                run.tests.tests_total - run.tests.tests_passed > 0 && completed && !isCurrent && !selectedRunIds?.has(run.run_id) && 'ring-2 ring-inset ring-orange-500',
-                !completed && !isCurrent && !selectedRunIds?.has(run.run_id) && 'ring-2 ring-inset ring-red-600 dark:ring-red-500',
-              )}
-              style={{ backgroundColor: color }}
-            >
-              {completed && run.tests.tests_total - run.tests.tests_passed > 0 && (
-                <svg className="absolute inset-0 size-5" viewBox="0 0 20 20" fill="none">
-                  <text x="10" y="15" textAnchor="middle" fill="white" fontSize="13" fontWeight="bold" fontFamily="system-ui">!</text>
-                </svg>
-              )}
-              {!completed && (
-                <svg className="absolute inset-0 size-5 text-red-600 dark:text-red-400" viewBox="0 0 20 20">
-                  <path d="M4 4l12 12M4 16L16 4" stroke="currentColor" strokeWidth="2" fill="none" />
-                </svg>
-              )}
-            </button>
-          )
-        })}
+            return (
+              <button
+                key={run.run_id}
+                onClick={() => {
+                  if (selectable) {
+                    onSelectionChange?.(run.run_id, !selectedRunIds?.has(run.run_id))
+                  } else {
+                    navigate({ to: '/runs/$runId', params: { runId: run.run_id } })
+                  }
+                }}
+                onMouseEnter={(e) => {
+                  const rect = e.currentTarget.getBoundingClientRect()
+                  setTooltip({ run, x: rect.left + rect.width / 2, y: rect.top })
+                }}
+                onMouseLeave={() => setTooltip(null)}
+                className={clsx(
+                  'relative size-5 shrink-0 cursor-pointer rounded-xs transition-all hover:scale-110',
+                  selectable && selectedRunIds?.has(run.run_id) && 'scale-110 ring-2 ring-blue-500 dark:ring-blue-400',
+                  !selectable && isCurrent && 'ring-2 ring-blue-500',
+                  !selectable && !isCurrent && 'hover:ring-2 hover:ring-gray-400 dark:hover:ring-gray-500',
+                  run.tests.tests_total - run.tests.tests_passed > 0 && completed && !isCurrent && !selectedRunIds?.has(run.run_id) && 'ring-2 ring-inset ring-orange-500',
+                  !completed && !isCurrent && !selectedRunIds?.has(run.run_id) && 'ring-2 ring-inset ring-red-600 dark:ring-red-500',
+                )}
+                style={{ backgroundColor: color }}
+              >
+                {completed && run.tests.tests_total - run.tests.tests_passed > 0 && (
+                  <svg className="absolute inset-0 size-5" viewBox="0 0 20 20" fill="none">
+                    <text x="10" y="15" textAnchor="middle" fill="white" fontSize="13" fontWeight="bold" fontFamily="system-ui">!</text>
+                  </svg>
+                )}
+                {!completed && (
+                  <svg className="absolute inset-0 size-5 text-red-600 dark:text-red-400" viewBox="0 0 20 20">
+                    <path d="M4 4l12 12M4 16L16 4" stroke="currentColor" strokeWidth="2" fill="none" />
+                  </svg>
+                )}
+              </button>
+            )
+          })}
+        </div>
+        <span className="hidden shrink-0 text-xs/5 text-gray-400 sm:inline dark:text-gray-500">Older</span>
       </div>
-      <span className="shrink-0 text-xs/5 text-gray-400 dark:text-gray-500">Older</span>
-      <div className="ml-2 flex items-center gap-1 border-l border-gray-200 pl-3 dark:border-gray-700">
-        <span className="flex gap-0.5">
-          {COLORS.map((color, i) => (
-            <span key={i} className="size-3 rounded-xs" style={{ backgroundColor: color }} />
-          ))}
-        </span>
-        <span className="ml-1 text-xs/5 text-gray-400 dark:text-gray-500">MGas/s</span>
-      </div>
-      <div className="ml-2 flex items-center gap-1 border-l border-gray-200 pl-3 dark:border-gray-700">
-        <span className="size-3 rounded-xs bg-blue-500 ring-2 ring-blue-500" />
-        <span className="text-xs/5 text-gray-400 dark:text-gray-500">Current</span>
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1 sm:border-l sm:border-gray-200 sm:pl-3 sm:dark:border-gray-700">
+          <span className="flex gap-0.5">
+            {COLORS.map((color, i) => (
+              <span key={i} className="size-3 rounded-xs" style={{ backgroundColor: color }} />
+            ))}
+          </span>
+          <span className="ml-1 text-xs/5 text-gray-400 dark:text-gray-500">MGas/s</span>
+        </div>
+        <div className="flex items-center gap-1 border-l border-gray-200 pl-3 dark:border-gray-700">
+          <span className="size-3 rounded-xs bg-blue-500 ring-2 ring-blue-500" />
+          <span className="text-xs/5 text-gray-400 dark:text-gray-500">Current</span>
+        </div>
       </div>
 
       {tooltip && (() => {

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -116,7 +116,7 @@ export function RunsTable({
   }
 
   return (
-    <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
+    <div className="overflow-x-auto rounded-xs bg-white shadow-xs dark:bg-gray-800">
       <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead className="bg-gray-50 dark:bg-gray-900">
           <tr>

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -48,6 +48,7 @@ function SortIcon({ direction, active }: { direction: SortDirection; active: boo
 
 function SortableHeader({
   label,
+  shortLabel,
   column,
   currentSort,
   currentDirection,
@@ -55,6 +56,7 @@ function SortableHeader({
   className,
 }: {
   label: string
+  shortLabel?: string
   column: SortColumn
   currentSort: SortColumn
   currentDirection: SortDirection
@@ -67,7 +69,12 @@ function SortableHeader({
       onClick={() => onSort(column)}
       className={clsx('cursor-pointer select-none text-left text-xs/5 font-medium uppercase tracking-wider text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300', className ?? 'px-3 py-2 sm:px-4 sm:py-2')}
     >
-      {label}
+      {shortLabel ? (
+        <>
+          <span className="sm:hidden">{shortLabel}</span>
+          <span className="hidden sm:inline">{label}</span>
+        </>
+      ) : label}
       <SortIcon direction={isActive ? currentDirection : 'asc'} active={isActive} />
     </th>
   )

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/shared/Badge'
 import { Duration } from '@/components/shared/Duration'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { StrategyIcon } from '@/components/shared/StrategyIcon'
-import { formatTimestamp, formatRelativeTime } from '@/utils/date'
+import { formatTimestampDate, formatTimestampTime, formatRelativeTime } from '@/utils/date'
 import { formatDuration, formatNumber } from '@/utils/format'
 import { type SortColumn, type SortDirection } from './sortEntries'
 
@@ -65,7 +65,7 @@ function SortableHeader({
   return (
     <th
       onClick={() => onSort(column)}
-      className={clsx('cursor-pointer select-none text-left text-xs/5 font-medium uppercase tracking-wider text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300', className ?? 'px-3 py-2 sm:px-6 sm:py-3')}
+      className={clsx('cursor-pointer select-none text-left text-xs/5 font-medium uppercase tracking-wider text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300', className ?? 'px-3 py-2 sm:px-4 sm:py-2')}
     >
       {label}
       <SortIcon direction={isActive ? currentDirection : 'asc'} active={isActive} />
@@ -120,16 +120,16 @@ export function RunsTable({
       <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead className="bg-gray-50 dark:bg-gray-900">
           <tr>
-            {selectable && <th className="w-10 px-2 py-2 sm:px-3 sm:py-3" />}
-            <SortableHeader label="Timestamp" column="timestamp" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
+            {selectable && <th className="w-10 px-2 py-2 sm:px-3 sm:py-2" />}
+            <SortableHeader label="Time" column="timestamp" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
             <SortableHeader label="Client" column="client" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
-            <SortableHeader label="Image" column="image" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="hidden px-3 py-2 sm:table-cell sm:px-6 sm:py-3" />
+            <SortableHeader label="Image" column="image" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="hidden px-3 py-2 sm:table-cell sm:px-4 sm:py-2" />
             {showSuite && <SortableHeader label="Suite" column="suite" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />}
             <SortableHeader label="MGas/s" column="mgas" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
             <SortableHeader label="Duration" column="duration" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
-            <SortableHeader label="F" column="failed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-3" />
-            <SortableHeader label="P" column="passed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-3" />
-            <SortableHeader label="T" column="total" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-3" />
+            <SortableHeader label="F" column="failed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-2" />
+            <SortableHeader label="P" column="passed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-2" />
+            <SortableHeader label="T" column="total" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-2" />
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
@@ -170,16 +170,19 @@ export function RunsTable({
                 </td>
               )}
               <td className={clsx(
-                'whitespace-nowrap px-3 py-2 text-sm/6 text-gray-500 sm:px-6 sm:py-4 dark:text-gray-400 border-l-3',
+                'whitespace-nowrap px-3 py-2 text-sm/6 text-gray-500 sm:px-4 sm:py-2.5 dark:text-gray-400 border-l-3',
                 entry.status === 'container_died' && 'border-red-400 dark:border-red-500',
                 entry.status === 'cancelled' && 'border-yellow-400 dark:border-yellow-500',
                 entry.status === 'timeout' && 'border-orange-400 dark:border-orange-500',
                 hasFailures && 'border-orange-400 dark:border-orange-500',
                 entry.status !== 'container_died' && entry.status !== 'cancelled' && entry.status !== 'timeout' && !hasFailures && 'border-transparent',
               )}>
-                <span title={formatRelativeTime(entry.timestamp)}>{formatTimestamp(entry.timestamp)}</span>
+                <span className="flex flex-col" title={formatRelativeTime(entry.timestamp)}>
+                  <span>{formatTimestampDate(entry.timestamp)}</span>
+                  <span className="text-xs/4 text-gray-400 dark:text-gray-500">{formatTimestampTime(entry.timestamp)}</span>
+                </span>
               </td>
-              <td className="whitespace-nowrap px-3 py-2 sm:px-6 sm:py-4">
+              <td className="whitespace-nowrap px-3 py-2 sm:px-4 sm:py-2.5">
                 <div className="flex items-center gap-2">
                   <span className="sm:hidden">
                     <ClientBadge client={entry.instance.client} hideLabel />
@@ -190,11 +193,11 @@ export function RunsTable({
                   <StrategyIcon strategy={entry.instance.rollback_strategy} />
                 </div>
               </td>
-              <td className="hidden max-w-xs truncate px-3 py-2 font-mono text-sm/6 text-gray-500 sm:table-cell sm:px-6 sm:py-4 dark:text-gray-400">
+              <td className="hidden max-w-xs truncate px-3 py-2 font-mono text-sm/6 text-gray-500 sm:table-cell sm:px-4 sm:py-2.5 dark:text-gray-400">
                 <span title={entry.instance.image}>{entry.instance.image}</span>
               </td>
               {showSuite && (
-                <td className="whitespace-nowrap px-3 py-2 font-mono text-sm/6 sm:px-6 sm:py-4">
+                <td className="whitespace-nowrap px-3 py-2 font-mono text-sm/6 sm:px-4 sm:py-2.5">
                   {entry.suite_hash ? (
                     <SuiteCell suiteHash={entry.suite_hash} />
                   ) : (
@@ -207,7 +210,7 @@ export function RunsTable({
                 return (
                   <>
                     <td
-                      className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 sm:px-6 sm:py-4 dark:text-gray-400"
+                      className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 sm:px-4 sm:py-2.5 dark:text-gray-400"
                       title={(() => {
                         const testStep = entry.tests.steps.test
                         if (!testStep) return undefined
@@ -222,20 +225,20 @@ export function RunsTable({
                         return mgas !== undefined ? mgas.toFixed(2) : '-'
                       })()}
                     </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 sm:px-6 sm:py-4 dark:text-gray-400">
+                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 sm:px-4 sm:py-2.5 dark:text-gray-400">
                       {entry.timestamp_end
                         ? <Duration nanoseconds={(entry.timestamp_end - entry.timestamp) * 1_000_000_000} />
                         : '-'}
                     </td>
-                    <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-4">
+                    <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-2.5">
                       {entry.tests.tests_total - entry.tests.tests_passed > 0 && (
                         <Badge variant="error">{entry.tests.tests_total - entry.tests.tests_passed}</Badge>
                       )}
                     </td>
-                    <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-4">
+                    <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-2.5">
                       <Badge variant="success">{entry.tests.tests_passed}</Badge>
                     </td>
-                    <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-4">
+                    <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-2.5">
                       <Badge>{entry.tests.tests_total}</Badge>
                     </td>
                   </>

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -65,7 +65,7 @@ function SortableHeader({
   return (
     <th
       onClick={() => onSort(column)}
-      className={clsx('cursor-pointer select-none text-left text-xs/5 font-medium uppercase tracking-wider text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300', className ?? 'px-6 py-3')}
+      className={clsx('cursor-pointer select-none text-left text-xs/5 font-medium uppercase tracking-wider text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300', className ?? 'px-3 py-2 sm:px-6 sm:py-3')}
     >
       {label}
       <SortIcon direction={isActive ? currentDirection : 'asc'} active={isActive} />
@@ -120,16 +120,16 @@ export function RunsTable({
       <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead className="bg-gray-50 dark:bg-gray-900">
           <tr>
-            {selectable && <th className="w-10 px-3 py-3" />}
+            {selectable && <th className="w-10 px-2 py-2 sm:px-3 sm:py-3" />}
             <SortableHeader label="Timestamp" column="timestamp" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
             <SortableHeader label="Client" column="client" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
-            <SortableHeader label="Image" column="image" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
+            <SortableHeader label="Image" column="image" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="hidden px-3 py-2 sm:table-cell sm:px-6 sm:py-3" />
             {showSuite && <SortableHeader label="Suite" column="suite" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />}
             <SortableHeader label="MGas/s" column="mgas" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
             <SortableHeader label="Duration" column="duration" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
-            <SortableHeader label="F" column="failed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-2 py-3" />
-            <SortableHeader label="P" column="passed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-2 py-3" />
-            <SortableHeader label="T" column="total" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-2 py-3" />
+            <SortableHeader label="F" column="failed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-3" />
+            <SortableHeader label="P" column="passed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-3" />
+            <SortableHeader label="T" column="total" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-3" />
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
@@ -156,7 +156,7 @@ export function RunsTable({
               )}
             >
               {selectable && (
-                <td className="whitespace-nowrap px-3 py-4 text-center">
+                <td className="whitespace-nowrap px-2 py-2 text-center sm:px-3 sm:py-4">
                   <input
                     type="checkbox"
                     checked={selectedRunIds?.has(entry.run_id) ?? false}
@@ -170,7 +170,7 @@ export function RunsTable({
                 </td>
               )}
               <td className={clsx(
-                'whitespace-nowrap px-6 py-4 text-sm/6 text-gray-500 dark:text-gray-400 border-l-3',
+                'whitespace-nowrap px-3 py-2 text-sm/6 text-gray-500 sm:px-6 sm:py-4 dark:text-gray-400 border-l-3',
                 entry.status === 'container_died' && 'border-red-400 dark:border-red-500',
                 entry.status === 'cancelled' && 'border-yellow-400 dark:border-yellow-500',
                 entry.status === 'timeout' && 'border-orange-400 dark:border-orange-500',
@@ -179,17 +179,22 @@ export function RunsTable({
               )}>
                 <span title={formatRelativeTime(entry.timestamp)}>{formatTimestamp(entry.timestamp)}</span>
               </td>
-              <td className="whitespace-nowrap px-6 py-4">
+              <td className="whitespace-nowrap px-3 py-2 sm:px-6 sm:py-4">
                 <div className="flex items-center gap-2">
-                  <ClientBadge client={entry.instance.client} />
+                  <span className="sm:hidden">
+                    <ClientBadge client={entry.instance.client} hideLabel />
+                  </span>
+                  <span className="hidden sm:inline-flex">
+                    <ClientBadge client={entry.instance.client} />
+                  </span>
                   <StrategyIcon strategy={entry.instance.rollback_strategy} />
                 </div>
               </td>
-              <td className="max-w-xs truncate px-6 py-4 font-mono text-sm/6 text-gray-500 dark:text-gray-400">
+              <td className="hidden max-w-xs truncate px-3 py-2 font-mono text-sm/6 text-gray-500 sm:table-cell sm:px-6 sm:py-4 dark:text-gray-400">
                 <span title={entry.instance.image}>{entry.instance.image}</span>
               </td>
               {showSuite && (
-                <td className="whitespace-nowrap px-6 py-4 font-mono text-sm/6">
+                <td className="whitespace-nowrap px-3 py-2 font-mono text-sm/6 sm:px-6 sm:py-4">
                   {entry.suite_hash ? (
                     <SuiteCell suiteHash={entry.suite_hash} />
                   ) : (
@@ -202,7 +207,7 @@ export function RunsTable({
                 return (
                   <>
                     <td
-                      className="whitespace-nowrap px-6 py-4 text-right text-sm/6 text-gray-500 dark:text-gray-400"
+                      className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 sm:px-6 sm:py-4 dark:text-gray-400"
                       title={(() => {
                         const testStep = entry.tests.steps.test
                         if (!testStep) return undefined
@@ -217,20 +222,20 @@ export function RunsTable({
                         return mgas !== undefined ? mgas.toFixed(2) : '-'
                       })()}
                     </td>
-                    <td className="whitespace-nowrap px-6 py-4 text-right text-sm/6 text-gray-500 dark:text-gray-400">
+                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 sm:px-6 sm:py-4 dark:text-gray-400">
                       {entry.timestamp_end
                         ? <Duration nanoseconds={(entry.timestamp_end - entry.timestamp) * 1_000_000_000} />
                         : '-'}
                     </td>
-                    <td className="whitespace-nowrap px-2 py-4 text-center">
+                    <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-4">
                       {entry.tests.tests_total - entry.tests.tests_passed > 0 && (
                         <Badge variant="error">{entry.tests.tests_total - entry.tests.tests_passed}</Badge>
                       )}
                     </td>
-                    <td className="whitespace-nowrap px-2 py-4 text-center">
+                    <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-4">
                       <Badge variant="success">{entry.tests.tests_passed}</Badge>
                     </td>
-                    <td className="whitespace-nowrap px-2 py-4 text-center">
+                    <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-4">
                       <Badge>{entry.tests.tests_total}</Badge>
                     </td>
                   </>

--- a/ui/src/components/shared/ClientBadge.tsx
+++ b/ui/src/components/shared/ClientBadge.tsx
@@ -4,6 +4,7 @@ import { getClientColors } from '@/utils/client-colors'
 interface ClientBadgeProps {
   client: string
   className?: string
+  hideLabel?: boolean
 }
 
 function capitalizeFirst(str: string): string {
@@ -11,14 +12,15 @@ function capitalizeFirst(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
-export function ClientBadge({ client, className }: ClientBadgeProps) {
+export function ClientBadge({ client, className, hideLabel = false }: ClientBadgeProps) {
   const colors = getClientColors(client)
   const logoPath = `/img/clients/${client}.jpg`
 
   return (
     <span
       className={clsx(
-        'inline-flex w-28 items-center gap-1.5 rounded-sm px-2.5 py-0.5 text-xs/5 font-medium',
+        'inline-flex items-center rounded-xs text-xs/5 font-medium',
+        hideLabel ? 'p-0.5' : 'w-28 gap-1.5 px-2.5 py-0.5',
         colors.bg,
         colors.text,
         colors.darkBg,
@@ -27,7 +29,7 @@ export function ClientBadge({ client, className }: ClientBadgeProps) {
       )}
     >
       <img src={logoPath} alt={`${client} logo`} className="size-4 rounded-full object-cover" />
-      {capitalizeFirst(client)}
+      {!hideLabel && capitalizeFirst(client)}
     </span>
   )
 }

--- a/ui/src/components/shared/Pagination.tsx
+++ b/ui/src/components/shared/Pagination.tsx
@@ -22,24 +22,24 @@ export function Pagination({ currentPage, totalPages, onPageChange }: Pagination
   }
 
   return (
-    <nav className="flex items-center justify-center gap-1" aria-label="Pagination">
+    <nav className="flex items-center justify-center gap-0.5 sm:gap-1" aria-label="Pagination">
       <button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
         className={clsx(
-          'flex size-8 items-center justify-center rounded-sm text-sm/6',
+          'flex size-7 items-center justify-center rounded-xs text-sm/6 sm:size-8',
           currentPage === 1
             ? 'cursor-not-allowed text-gray-300 dark:text-gray-600'
             : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700',
         )}
         aria-label="Previous page"
       >
-        <ChevronLeft className="size-5" />
+        <ChevronLeft className="size-4 sm:size-5" />
       </button>
 
       {pages.map((page, index) =>
         page === 'ellipsis' ? (
-          <span key={`ellipsis-${index}`} className="flex size-8 items-center justify-center text-gray-400">
+          <span key={`ellipsis-${index}`} className="flex size-7 items-center justify-center text-gray-400 sm:size-8">
             ...
           </span>
         ) : (
@@ -47,7 +47,7 @@ export function Pagination({ currentPage, totalPages, onPageChange }: Pagination
             key={page}
             onClick={() => onPageChange(page)}
             className={clsx(
-              'flex size-8 items-center justify-center rounded-sm text-sm/6 font-medium',
+              'flex size-7 items-center justify-center rounded-xs text-xs/5 font-medium sm:size-8 sm:text-sm/6',
               page === currentPage
                 ? 'bg-blue-600 text-white dark:bg-blue-500'
                 : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700',
@@ -63,14 +63,14 @@ export function Pagination({ currentPage, totalPages, onPageChange }: Pagination
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage === totalPages}
         className={clsx(
-          'flex size-8 items-center justify-center rounded-sm text-sm/6',
+          'flex size-7 items-center justify-center rounded-xs text-sm/6 sm:size-8',
           currentPage === totalPages
             ? 'cursor-not-allowed text-gray-300 dark:text-gray-600'
             : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700',
         )}
         aria-label="Next page"
       >
-        <ChevronRight className="size-5" />
+        <ChevronRight className="size-4 sm:size-5" />
       </button>
     </nav>
   )

--- a/ui/src/components/suite-detail/RunsHeatmap.tsx
+++ b/ui/src/components/suite-detail/RunsHeatmap.tsx
@@ -285,11 +285,11 @@ export function RunsHeatmap({
 
   return (
     <div className="relative">
-      <div className="mb-3 flex items-center justify-end gap-4">
+      <div className="mb-3 flex flex-wrap items-center justify-end gap-3 sm:gap-4">
         {/* Metric mode toggle */}
         <div className="flex items-center gap-2">
           <span className="text-xs/5 text-gray-500 dark:text-gray-400">Metric:</span>
-          <div className="flex items-center gap-1 rounded-sm bg-gray-100 p-0.5 dark:bg-gray-700">
+          <div className="flex items-center gap-1 rounded-xs bg-gray-100 p-0.5 dark:bg-gray-700">
             <button
               onClick={() => setMetricMode('mgas')}
               className={clsx(
@@ -319,7 +319,7 @@ export function RunsHeatmap({
         {onColorNormalizationChange && (
           <div className="flex items-center gap-2">
             <span className="text-xs/5 text-gray-500 dark:text-gray-400">Colors:</span>
-            <div className="flex items-center gap-1 rounded-sm bg-gray-100 p-0.5 dark:bg-gray-700">
+            <div className="flex items-center gap-1 rounded-xs bg-gray-100 p-0.5 dark:bg-gray-700">
               <button
                 onClick={() => onColorNormalizationChange('suite')}
                 className={clsx(
@@ -349,10 +349,10 @@ export function RunsHeatmap({
 
       <div className="flex flex-col gap-2">
         {/* Stats header */}
-        <div className="flex items-center gap-3">
-          <div className="w-28 shrink-0" />
+        <div className="flex items-center gap-2 sm:gap-3">
+          <div className="hidden w-28 shrink-0 sm:block" />
           <div className="flex-1" />
-          <div className="flex shrink-0 gap-3 border-l border-transparent pl-3 font-mono text-xs/5 font-medium text-gray-400 dark:text-gray-500">
+          <div className="hidden shrink-0 gap-3 border-l border-transparent pl-3 font-mono text-xs/5 font-medium text-gray-400 md:flex dark:text-gray-500">
             <span className="w-10 text-center">Min</span>
             <span className="w-10 text-center">Max</span>
             <span className="w-10 text-center">P95</span>
@@ -363,17 +363,22 @@ export function RunsHeatmap({
         </div>
         {clients.map((client) => {
           const stats = metricMode === 'mgas' ? clientMgasStats[client] : clientDurationStats[client]
-          const formatValue = (v?: number) => {
+          const formatStatValue = (v?: number) => {
             if (v === undefined) return '-'
             if (metricMode === 'mgas') return v.toFixed(1)
             return formatDurationCompact(v)
           }
           return (
-            <div key={client} className="flex items-center gap-3">
-              <div className="w-28 shrink-0">
-                <ClientBadge client={client} />
+            <div key={client} className="flex items-center gap-2 sm:gap-3">
+              <div className="shrink-0 sm:w-28">
+                <span className="sm:hidden">
+                  <ClientBadge client={client} hideLabel />
+                </span>
+                <span className="hidden sm:inline-flex">
+                  <ClientBadge client={client} />
+                </span>
               </div>
-              <div className="flex flex-1 gap-1">
+              <div className="flex min-w-0 flex-1 flex-wrap gap-1">
                 {clientRuns[client].map((run) => {
                   const runStats = getIndexAggregatedStats(run, stepFilter)
                   const completed = isRunCompleted(run)
@@ -406,17 +411,57 @@ export function RunsHeatmap({
                   )
                 })}
               </div>
-              <div className="flex shrink-0 gap-3 border-l border-gray-200 pl-3 font-mono text-xs/5 text-gray-500 dark:border-gray-700 dark:text-gray-400">
-                <span className="w-10 text-center">{formatValue(stats.min)}</span>
-                <span className="w-10 text-center">{formatValue(stats.max)}</span>
-                <span className="w-10 text-center">{formatValue(stats.p95)}</span>
-                <span className="w-10 text-center">{formatValue(stats.p99)}</span>
-                <span className="w-10 text-center">{formatValue(stats.mean)}</span>
-                <span className="w-10 text-center">{formatValue(stats.last)}</span>
+              <div className="hidden shrink-0 gap-3 border-l border-gray-200 pl-3 font-mono text-xs/5 text-gray-500 md:flex dark:border-gray-700 dark:text-gray-400">
+                <span className="w-10 text-center">{formatStatValue(stats.min)}</span>
+                <span className="w-10 text-center">{formatStatValue(stats.max)}</span>
+                <span className="w-10 text-center">{formatStatValue(stats.p95)}</span>
+                <span className="w-10 text-center">{formatStatValue(stats.p99)}</span>
+                <span className="w-10 text-center">{formatStatValue(stats.mean)}</span>
+                <span className="w-10 text-center">{formatStatValue(stats.last)}</span>
               </div>
             </div>
           )
         })}
+      </div>
+
+      {/* Mobile stats summary */}
+      <div className="mt-3 overflow-x-auto md:hidden">
+        <table className="w-full text-xs/5">
+          <thead>
+            <tr className="text-gray-400 dark:text-gray-500">
+              <th className="py-1 pr-3 text-left font-medium">Client</th>
+              <th className="px-2 py-1 text-center font-medium">Min</th>
+              <th className="px-2 py-1 text-center font-medium">Max</th>
+              <th className="px-2 py-1 text-center font-medium">P95</th>
+              <th className="px-2 py-1 text-center font-medium">P99</th>
+              <th className="px-2 py-1 text-center font-medium">Mean</th>
+              <th className="px-2 py-1 text-center font-medium">Last</th>
+            </tr>
+          </thead>
+          <tbody className="font-mono text-gray-500 dark:text-gray-400">
+            {clients.map((client) => {
+              const s = metricMode === 'mgas' ? clientMgasStats[client] : clientDurationStats[client]
+              const fmt = (v?: number) => {
+                if (v === undefined) return '-'
+                if (metricMode === 'mgas') return v.toFixed(1)
+                return formatDurationCompact(v)
+              }
+              return (
+                <tr key={client} className="border-t border-gray-100 dark:border-gray-700">
+                  <td className="py-1 pr-3">
+                    <ClientBadge client={client} hideLabel />
+                  </td>
+                  <td className="px-2 py-1 text-center">{fmt(s.min)}</td>
+                  <td className="px-2 py-1 text-center">{fmt(s.max)}</td>
+                  <td className="px-2 py-1 text-center">{fmt(s.p95)}</td>
+                  <td className="px-2 py-1 text-center">{fmt(s.p99)}</td>
+                  <td className="px-2 py-1 text-center">{fmt(s.mean)}</td>
+                  <td className="px-2 py-1 text-center">{fmt(s.last)}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
       </div>
 
       {/* Legend */}

--- a/ui/src/components/suite-detail/TestHeatmap.tsx
+++ b/ui/src/components/suite-detail/TestHeatmap.tsx
@@ -498,8 +498,8 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
   }
 
   const header = (
-    <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
-      <div className="flex items-center gap-3">
+    <div className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 px-3 py-2 sm:px-4 sm:py-3 dark:border-gray-700">
+      <div className="flex items-center gap-2 sm:gap-3">
         {fullscreen && suiteHash && (
           <div className="flex items-center gap-2">
             <JDenticon value={suiteHash} size={24} className="shrink-0 rounded-xs" />
@@ -511,7 +511,8 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
         )}
         <h3 className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-gray-100">
           <Flame className="size-4 text-gray-400 dark:text-gray-500" />
-          Test Heatmap
+          <span className="hidden sm:inline">Test Heatmap</span>
+          <span className="sm:hidden">Heatmap</span>
         </h3>
         {isLoading && <Spinner size="sm" />}
         <span className="rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900/50 dark:text-purple-300">
@@ -523,9 +524,9 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
           type="text"
           value={search}
           onChange={(e) => handleSearchChange(e.target.value)}
-          placeholder={useRegex ? 'Regex pattern...' : 'Filter tests...'}
+          placeholder={useRegex ? 'Regex...' : 'Filter...'}
           className={clsx(
-            'rounded-xs border bg-white px-3 py-1 text-sm placeholder-gray-400 focus:outline-hidden focus:ring-1 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
+            'w-28 rounded-xs border bg-white px-2 py-1 text-sm placeholder-gray-400 focus:outline-hidden focus:ring-1 sm:w-auto sm:px-3 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
             useRegex && search && (() => { try { new RegExp(search); return false } catch { return true } })()
               ? 'border-red-400 focus:border-red-500 focus:ring-red-500 dark:border-red-500'
               : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600',
@@ -570,18 +571,18 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
   }
 
   const controls = (
-    <div className={clsx('flex items-start justify-between gap-x-6 gap-y-2', fullscreen ? 'shrink-0 px-4 pt-4 pb-2' : 'px-4 pt-4')}>
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+    <div className={clsx('flex flex-wrap items-start justify-between gap-x-4 gap-y-2', fullscreen ? 'shrink-0 px-3 pt-3 pb-2 sm:px-4 sm:pt-4' : 'px-3 pt-3 sm:px-4 sm:pt-4')}>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 sm:gap-x-6">
           {/* Threshold control */}
           <div className="flex items-center gap-2">
-            <span className="text-xs/5 text-gray-500 dark:text-gray-400">Slow threshold:</span>
+            <span className="text-xs/5 text-gray-500 dark:text-gray-400"><span className="hidden sm:inline">Slow </span>Threshold:</span>
             <input
               type="range"
               min={MIN_THRESHOLD}
               max={MAX_THRESHOLD}
               value={threshold}
               onChange={(e) => handleThresholdChange(Number(e.target.value))}
-              className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-gray-200 accent-blue-500 dark:bg-gray-700"
+              className="h-1.5 w-20 cursor-pointer appearance-none rounded-full bg-gray-200 accent-blue-500 sm:w-24 dark:bg-gray-700"
             />
             <input
               type="number"
@@ -589,9 +590,8 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
               max={MAX_THRESHOLD}
               value={threshold}
               onChange={(e) => handleThresholdChange(Number(e.target.value))}
-              className="w-16 rounded-sm border border-gray-300 bg-white px-1.5 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              className="w-14 rounded-sm border border-gray-300 bg-white px-1 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 sm:w-16 sm:px-1.5 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
             />
-            <span className="text-xs/5 text-gray-500 dark:text-gray-400">MGas/s</span>
             {threshold !== DEFAULT_THRESHOLD && (
               <button
                 onClick={() => setThreshold(DEFAULT_THRESHOLD)}
@@ -602,34 +602,32 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
             )}
           </div>
 
-          {/* Client stat toggle */}
-          <label className="flex cursor-pointer items-center gap-1.5">
-            <input
-              type="checkbox"
-              checked={showClientStat}
-              onChange={(e) => setShowClientStat(e.target.checked)}
-              className="size-3.5 cursor-pointer rounded-xs border-gray-300 text-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
-            />
-            <span className="text-xs/5 text-gray-500 dark:text-gray-400">Client stats</span>
-          </label>
+          {/* Toggles */}
+          <div className="flex items-center gap-3 sm:gap-4">
+            <label className="flex cursor-pointer items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={showClientStat}
+                onChange={(e) => setShowClientStat(e.target.checked)}
+                className="size-3.5 cursor-pointer rounded-xs border-gray-300 text-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+              />
+              <span className="text-xs/5 text-gray-500 dark:text-gray-400"><span className="hidden sm:inline">Client </span>Stats</span>
+            </label>
 
-          {/* Show test name toggle */}
-          <label className="flex cursor-pointer items-center gap-1.5">
-            <input
-              type="checkbox"
-              checked={showTestName}
-              onChange={(e) => onShowTestNameChange?.(e.target.checked)}
-              className="size-3.5 cursor-pointer rounded-xs border-gray-300 text-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
-            />
-            <span className="text-xs/5 text-gray-500 dark:text-gray-400">Test name</span>
-          </label>
-
-          {/* Separator */}
-          <div className="hidden h-4 w-px bg-gray-200 sm:block dark:bg-gray-700" />
+            <label className="flex cursor-pointer items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={showTestName}
+                onChange={(e) => onShowTestNameChange?.(e.target.checked)}
+                className="size-3.5 cursor-pointer rounded-xs border-gray-300 text-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+              />
+              <span className="text-xs/5 text-gray-500 dark:text-gray-400"><span className="hidden sm:inline">Test </span>Name</span>
+            </label>
+          </div>
 
           {/* Runs per client */}
           <div className="flex items-center gap-1.5">
-            <span className="text-xs/5 text-gray-500 dark:text-gray-400">Runs per client:</span>
+            <span className="text-xs/5 text-gray-500 dark:text-gray-400"><span className="hidden sm:inline">Runs per client</span><span className="sm:hidden">Runs</span>:</span>
             <select
               value={runsPerClient}
               onChange={(e) => setRunsPerClient(Number(e.target.value))}
@@ -659,7 +657,7 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
                 </option>
               ))}
             </select>
-            <span className="text-xs/5 text-gray-500 dark:text-gray-400">per page</span>
+            <span className="hidden text-xs/5 text-gray-500 sm:inline dark:text-gray-400">per page</span>
           </div>
           {totalPages > 1 && <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />}
         </div>
@@ -667,7 +665,7 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
   )
 
   const tableContent = (
-    <div className={fullscreen ? 'min-h-0 flex-1 overflow-auto px-4' : 'max-h-[75vh] overflow-auto px-4'}>
+    <div className={fullscreen ? 'min-h-0 flex-1 overflow-auto px-3 sm:px-4' : 'max-h-[75vh] overflow-auto px-3 sm:px-4'}>
       <table className="w-full border-collapse text-sm/6">
           <thead className="sticky top-0 z-20">
             <tr>
@@ -691,7 +689,12 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
               </th>
               {clients.map((client) => (
                 <th key={client} className={clsx('px-1 pt-0 pb-2 text-center', fullscreen ? 'bg-white dark:bg-gray-900' : 'bg-white dark:bg-gray-800')}>
-                  <ClientBadge client={client} />
+                  <span className="sm:hidden">
+                    <ClientBadge client={client} hideLabel />
+                  </span>
+                  <span className="hidden sm:inline-flex">
+                    <ClientBadge client={client} />
+                  </span>
                 </th>
               ))}
               {STAT_COLUMNS.map((col) => (
@@ -744,7 +747,7 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
                               {Array.from({ length: BOXES_PER_ROW }).map((_, i) => (
                                 <div
                                   key={i}
-                                  className="size-5 rounded-xs bg-gray-100 dark:bg-gray-700"
+                                  className="size-4 rounded-xs bg-gray-100 sm:size-5 dark:bg-gray-700"
                                   title="No data"
                                 />
                               ))}
@@ -769,7 +772,7 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
                                 return (
                                   <div
                                     key={colIdx}
-                                    className="size-5 rounded-xs bg-gray-100 dark:bg-gray-700"
+                                    className="size-4 rounded-xs bg-gray-100 sm:size-5 dark:bg-gray-700"
                                     title="No data"
                                   />
                                 )
@@ -782,7 +785,7 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
                                   search={{ testModal: test.name }}
                                   onMouseEnter={(e) => handleMouseEnter(test, client, run, e)}
                                   onMouseLeave={handleMouseLeave}
-                                  className="block size-5 rounded-xs border-2 transition-all hover:scale-110 hover:ring-2 hover:ring-gray-400 dark:hover:ring-gray-500"
+                                  className="block size-4 rounded-xs border-2 transition-all hover:scale-110 hover:ring-2 hover:ring-gray-400 sm:size-5 dark:hover:ring-gray-500"
                                   style={{
                                     backgroundColor: getColorByThreshold(run.mgas, threshold),
                                     borderColor: getColorByNormalizedValue(run.mgas, test.minMgas, test.maxMgas),
@@ -829,7 +832,7 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
   )
 
   const bottomSection = (
-    <div className={clsx('flex flex-col gap-4', fullscreen ? 'shrink-0 px-4 pb-4' : 'px-4 pb-4')}>
+    <div className={clsx('flex flex-col gap-4', fullscreen ? 'shrink-0 px-3 pb-3 sm:px-4 sm:pb-4' : 'px-3 pb-3 sm:px-4 sm:pb-4')}>
       {/* Pagination */}
       {totalPages > 1 && (
         <div className="flex justify-end">
@@ -843,7 +846,7 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
           <p className="text-xs/5 text-gray-400 dark:text-gray-500">
             Stats are computed from the {runsPerClient} most recent runs per client visible in the heatmap. Changing &quot;Runs per client&quot; alters these values.
           </p>
-          <div className="mb-1 flex items-center justify-between">
+          <div className="mb-1 flex flex-wrap items-center justify-between gap-2">
             <span className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Distribution by threshold</span>
             <div className="flex items-center gap-2">
               <span className="text-xs/5 text-gray-500 dark:text-gray-400">Stat:</span>
@@ -865,7 +868,7 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
               </div>
             </div>
           </div>
-          <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {/* All clients (global) */}
             <div className="flex flex-col gap-1 rounded-sm border border-gray-200 p-2 dark:border-gray-700">
               <div className="flex items-center justify-between">

--- a/ui/src/components/suites/SuitesTable.tsx
+++ b/ui/src/components/suites/SuitesTable.tsx
@@ -5,7 +5,7 @@ import { useSuite } from '@/api/hooks/useSuite'
 import { Badge } from '@/components/shared/Badge'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { SourceBadge } from '@/components/shared/SourceBadge'
-import { formatTimestamp, formatRelativeTime } from '@/utils/date'
+import { formatTimestampDate, formatTimestampTime, formatRelativeTime } from '@/utils/date'
 
 export type SuiteSortColumn = 'lastRun' | 'hash' | 'runs'
 export type SuiteSortDirection = 'asc' | 'desc'
@@ -56,7 +56,7 @@ function SortableHeader({
   return (
     <th
       onClick={() => onSort(column)}
-      className="cursor-pointer select-none px-6 py-3 text-left text-xs/5 font-medium uppercase tracking-wider text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+      className="cursor-pointer select-none px-3 py-2 text-left text-xs/5 font-medium uppercase tracking-wider text-gray-500 hover:text-gray-700 sm:px-4 dark:text-gray-400 dark:hover:text-gray-300"
     >
       {label}
       <SortIcon direction={isActive ? currentDirection : 'asc'} active={isActive} />
@@ -66,7 +66,7 @@ function SortableHeader({
 
 function StaticHeader({ label }: { label: string }) {
   return (
-    <th className="px-6 py-3 text-left text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+    <th className="hidden px-3 py-2 text-left text-xs/5 font-medium uppercase tracking-wider text-gray-500 sm:px-4 md:table-cell dark:text-gray-400">
       {label}
     </th>
   )
@@ -81,10 +81,13 @@ function SuiteRow({ suite }: { suite: SuiteEntry }) {
       onClick={() => navigate({ to: '/suites/$suiteHash', params: { suiteHash: suite.hash } })}
       className="cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
     >
-      <td className="whitespace-nowrap px-6 py-4 text-sm/6 text-gray-500 dark:text-gray-400">
-        <span title={formatRelativeTime(suite.lastRun)}>{formatTimestamp(suite.lastRun)}</span>
+      <td className="whitespace-nowrap px-3 py-2 text-sm/6 text-gray-500 sm:px-4 sm:py-2.5 dark:text-gray-400">
+        <span className="flex flex-col" title={formatRelativeTime(suite.lastRun)}>
+          <span>{formatTimestampDate(suite.lastRun)}</span>
+          <span className="text-xs/4 text-gray-400 dark:text-gray-500">{formatTimestampTime(suite.lastRun)}</span>
+        </span>
       </td>
-      <td className="whitespace-nowrap px-6 py-4">
+      <td className="whitespace-nowrap px-3 py-2 sm:px-4 sm:py-2.5">
         <div className="flex items-center gap-2">
           <JDenticon value={suite.hash} size={24} className="shrink-0 rounded-xs" />
           <div className="flex flex-col">
@@ -102,7 +105,7 @@ function SuiteRow({ suite }: { suite: SuiteEntry }) {
           </div>
         </div>
       </td>
-      <td className="whitespace-nowrap px-6 py-4">
+      <td className="hidden whitespace-nowrap px-3 py-2 sm:px-4 sm:py-2.5 md:table-cell">
         {suiteInfo?.source ? (
           <div className="flex items-center gap-2">
             <SourceBadge source={suiteInfo.source} />
@@ -112,21 +115,21 @@ function SuiteRow({ suite }: { suite: SuiteEntry }) {
           <span className="text-gray-400 dark:text-gray-500">-</span>
         )}
       </td>
-      <td className="whitespace-nowrap px-6 py-4">
+      <td className="hidden whitespace-nowrap px-3 py-2 sm:px-4 sm:py-2.5 md:table-cell">
         {suiteInfo?.pre_run_steps && suiteInfo.pre_run_steps.length > 0 ? (
           <Badge variant="default">{suiteInfo.pre_run_steps.length}</Badge>
         ) : (
           <span className="text-gray-400 dark:text-gray-500">-</span>
         )}
       </td>
-      <td className="whitespace-nowrap px-6 py-4">
+      <td className="hidden whitespace-nowrap px-3 py-2 sm:px-4 sm:py-2.5 md:table-cell">
         {suiteInfo?.filter ? (
           <span className="font-mono text-sm/6 text-gray-700 dark:text-gray-300">{suiteInfo.filter}</span>
         ) : (
           <span className="text-gray-400 dark:text-gray-500">-</span>
         )}
       </td>
-      <td className="whitespace-nowrap px-6 py-4">
+      <td className="whitespace-nowrap px-3 py-2 sm:px-4 sm:py-2.5">
         <Badge variant="info">{suite.runCount} runs</Badge>
       </td>
     </tr>
@@ -165,7 +168,7 @@ export function SuitesTable({
   }, [suites, sortBy, sortDir])
 
   return (
-    <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
+    <div className="overflow-x-auto rounded-xs bg-white shadow-xs dark:bg-gray-800">
       <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead className="bg-gray-50 dark:bg-gray-900">
           <tr>

--- a/ui/src/pages/AdminPage.tsx
+++ b/ui/src/pages/AdminPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useAuth } from '@/hooks/useAuth'
 import type { AuthConfig } from '@/api/auth-client'
+import type { AuthUser } from '@/api/auth-client'
 import { Modal } from '@/components/shared/Modal'
 import {
   useUsers,
@@ -17,10 +18,80 @@ import {
   useUpsertUserMapping,
   useDeleteUserMapping,
   useRunIndexer,
+  type AdminSession,
 } from '@/api/hooks/useAdmin'
-import { useAdminApiKeys, useDeleteAdminApiKey } from '@/api/hooks/useApiKeys'
-import { Plus, Pencil, Trash2, Play, Loader2 } from 'lucide-react'
+import { useAdminApiKeys, useDeleteAdminApiKey, type AdminApiKey } from '@/api/hooks/useApiKeys'
+import { Plus, Pencil, Trash2, Play, Loader2, ChevronUp, ChevronDown } from 'lucide-react'
 import clsx from 'clsx'
+
+type SortDirection = 'asc' | 'desc'
+
+function useSortState<T extends string>(defaultColumn: T, defaultDir: SortDirection = 'asc') {
+  const [sortBy, setSortBy] = useState<T>(defaultColumn)
+  const [sortDir, setSortDir] = useState<SortDirection>(defaultDir)
+
+  const toggle = (column: T) => {
+    if (sortBy === column) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortBy(column)
+      setSortDir('asc')
+    }
+  }
+
+  return { sortBy, sortDir, toggle }
+}
+
+function SortIcon({ direction, active }: { direction: SortDirection; active: boolean }) {
+  const Icon = direction === 'asc' ? ChevronUp : ChevronDown
+  return <Icon className={clsx('ml-0.5 inline-block size-3', active ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400')} />
+}
+
+function SortableTh<T extends string>({
+  label,
+  column,
+  sortBy,
+  sortDir,
+  onSort,
+  className,
+}: {
+  label: string
+  column: T
+  sortBy: T
+  sortDir: SortDirection
+  onSort: (column: T) => void
+  className?: string
+}) {
+  const active = sortBy === column
+  return (
+    <th
+      onClick={() => onSort(column)}
+      className={clsx(
+        'cursor-pointer select-none px-4 py-2 hover:text-gray-700 dark:hover:text-gray-300',
+        className,
+      )}
+    >
+      {label}
+      <SortIcon direction={active ? sortDir : 'asc'} active={active} />
+    </th>
+  )
+}
+
+function sortItems<T>(items: T[], sortBy: string, sortDir: SortDirection, comparators: Record<string, (a: T, b: T) => number>): T[] {
+  const cmp = comparators[sortBy]
+  if (!cmp) return items
+  const sorted = [...items].sort(cmp)
+  return sortDir === 'desc' ? sorted.reverse() : sorted
+}
+
+const cmpStr = (a: string, b: string) => a.localeCompare(b)
+const cmpDate = (a: string, b: string) => new Date(a).getTime() - new Date(b).getTime()
+const cmpDateNullable = (a: string | null, b: string | null) => {
+  if (!a && !b) return 0
+  if (!a) return -1
+  if (!b) return 1
+  return cmpDate(a, b)
+}
 
 type Tab = 'users' | 'github-mappings' | 'sessions' | 'api-keys'
 
@@ -90,6 +161,14 @@ export function AdminPage() {
 
 // --- Users Tab ---
 
+type UserSortColumn = 'username' | 'role' | 'source'
+
+const userComparators: Record<UserSortColumn, (a: AuthUser, b: AuthUser) => number> = {
+  username: (a, b) => cmpStr(a.username, b.username),
+  role: (a, b) => cmpStr(a.role, b.role),
+  source: (a, b) => cmpStr(a.source, b.source),
+}
+
 function UsersTab() {
   const { data: users = [], isLoading } = useUsers()
   const createUser = useCreateUser()
@@ -102,6 +181,12 @@ function UsersTab() {
   const [form, setForm] = useState({ username: '', password: '', role: 'readonly' })
   const [editForm, setEditForm] = useState({ password: '', role: '' })
   const [error, setError] = useState<string | null>(null)
+  const sort = useSortState<UserSortColumn>('username')
+
+  const sortedUsers = useMemo(
+    () => sortItems(users, sort.sortBy, sort.sortDir, userComparators),
+    [users, sort.sortBy, sort.sortDir],
+  )
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -151,14 +236,14 @@ function UsersTab() {
         <table className="w-full text-left text-sm">
           <thead className="bg-gray-50 text-xs text-gray-500 uppercase dark:bg-gray-800 dark:text-gray-400">
             <tr>
-              <th className="px-4 py-2">Username</th>
-              <th className="px-4 py-2">Role</th>
-              <th className="px-4 py-2">Source</th>
+              <SortableTh label="Username" column="username" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
+              <SortableTh label="Role" column="role" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
+              <SortableTh label="Source" column="source" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
               <th className="px-4 py-2 text-right">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-            {users.map((u) => (
+            {sortedUsers.map((u) => (
               <tr key={u.id} className="bg-white dark:bg-gray-900">
                 <td className="px-4 py-2 font-medium text-gray-900 dark:text-gray-100">{u.username}</td>
                 <td className="px-4 py-2">
@@ -256,9 +341,25 @@ function formatTimestamp(iso: string): string {
   return `${relative} (${date.toLocaleString()})`
 }
 
+type SessionSortColumn = 'username' | 'source' | 'created' | 'lastActive' | 'expires'
+
+const sessionComparators: Record<SessionSortColumn, (a: AdminSession, b: AdminSession) => number> = {
+  username: (a, b) => cmpStr(a.username || '', b.username || ''),
+  source: (a, b) => cmpStr(a.source, b.source),
+  created: (a, b) => cmpDate(a.created_at, b.created_at),
+  lastActive: (a, b) => cmpDateNullable(a.last_active_at, b.last_active_at),
+  expires: (a, b) => cmpDate(a.expires_at, b.expires_at),
+}
+
 function SessionsTab() {
   const { data: sessions = [], isLoading } = useSessions()
   const deleteSession = useDeleteSession()
+  const sort = useSortState<SessionSortColumn>('created', 'desc')
+
+  const sortedSessions = useMemo(
+    () => sortItems(sessions, sort.sortBy, sort.sortDir, sessionComparators),
+    [sessions, sort.sortBy, sort.sortDir],
+  )
 
   if (isLoading) return <div className="text-sm text-gray-500">Loading...</div>
 
@@ -274,16 +375,16 @@ function SessionsTab() {
         <table className="w-full text-left text-sm">
           <thead className="bg-gray-50 text-xs text-gray-500 uppercase dark:bg-gray-800 dark:text-gray-400">
             <tr>
-              <th className="px-4 py-2">Username</th>
-              <th className="px-4 py-2">Source</th>
-              <th className="px-4 py-2">Created</th>
-              <th className="px-4 py-2">Last Active</th>
-              <th className="px-4 py-2">Expires</th>
+              <SortableTh label="Username" column="username" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
+              <SortableTh label="Source" column="source" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
+              <SortableTh label="Created" column="created" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
+              <SortableTh label="Last Active" column="lastActive" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
+              <SortableTh label="Expires" column="expires" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
               <th className="px-4 py-2 text-right">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-            {sessions.map((s) => (
+            {sortedSessions.map((s) => (
               <tr key={s.id} className="bg-white dark:bg-gray-900">
                 <td className="px-4 py-2 font-medium text-gray-900 dark:text-gray-100">
                   {s.username || `User #${s.user_id}`}
@@ -461,9 +562,25 @@ function GitHubMappingsTab() {
 
 // --- Admin API Keys Tab ---
 
+type ApiKeySortColumn = 'name' | 'user' | 'expires' | 'lastUsed' | 'created'
+
+const apiKeyComparators: Record<ApiKeySortColumn, (a: AdminApiKey, b: AdminApiKey) => number> = {
+  name: (a, b) => cmpStr(a.name, b.name),
+  user: (a, b) => cmpStr(a.username, b.username),
+  expires: (a, b) => cmpDateNullable(a.expires_at, b.expires_at),
+  lastUsed: (a, b) => cmpDateNullable(a.last_used_at, b.last_used_at),
+  created: (a, b) => cmpDate(a.created_at, b.created_at),
+}
+
 function AdminAPIKeysTab() {
   const { data: keys = [], isLoading } = useAdminApiKeys()
   const deleteKey = useDeleteAdminApiKey()
+  const sort = useSortState<ApiKeySortColumn>('created', 'desc')
+
+  const sortedKeys = useMemo(
+    () => sortItems(keys, sort.sortBy, sort.sortDir, apiKeyComparators),
+    [keys, sort.sortBy, sort.sortDir],
+  )
 
   if (isLoading) return <div className="text-sm text-gray-500">Loading...</div>
 
@@ -479,17 +596,17 @@ function AdminAPIKeysTab() {
         <table className="w-full text-left text-sm">
           <thead className="bg-gray-50 text-xs text-gray-500 uppercase dark:bg-gray-800 dark:text-gray-400">
             <tr>
-              <th className="px-4 py-2">Name</th>
-              <th className="px-4 py-2">User</th>
+              <SortableTh label="Name" column="name" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
+              <SortableTh label="User" column="user" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
               <th className="px-4 py-2">Key</th>
-              <th className="px-4 py-2">Expires</th>
-              <th className="px-4 py-2">Last Used</th>
-              <th className="px-4 py-2">Created</th>
+              <SortableTh label="Expires" column="expires" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
+              <SortableTh label="Last Used" column="lastUsed" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
+              <SortableTh label="Created" column="created" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
               <th className="px-4 py-2 text-right">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-            {keys.map((k) => (
+            {sortedKeys.map((k) => (
               <tr key={k.id} className="bg-white dark:bg-gray-900">
                 <td className="px-4 py-2 font-medium text-gray-900 dark:text-gray-100">{k.name}</td>
                 <td className="px-4 py-2 text-gray-500 dark:text-gray-400">{k.username}</td>
@@ -668,6 +785,8 @@ function RoleSelect({ value, onChange }: { value: string; onChange: (v: string) 
   )
 }
 
+type MappingSortColumn = 'name' | 'role'
+
 function MappingTable<T extends { id: number; role: string }>({
   items,
   nameKey,
@@ -679,18 +798,28 @@ function MappingTable<T extends { id: number; role: string }>({
   nameLabel: string
   onDelete: (id: number) => void
 }) {
+  const sort = useSortState<MappingSortColumn>('name')
+
+  const sortedItems = useMemo(
+    () => sortItems(items, sort.sortBy, sort.sortDir, {
+      name: (a, b) => String(a[nameKey]).localeCompare(String(b[nameKey])),
+      role: (a, b) => a.role.localeCompare(b.role),
+    } as Record<string, (a: T, b: T) => number>),
+    [items, sort.sortBy, sort.sortDir, nameKey],
+  )
+
   return (
     <div className="overflow-hidden rounded-sm border border-gray-200 dark:border-gray-700">
       <table className="w-full text-left text-sm">
         <thead className="bg-gray-50 text-xs text-gray-500 uppercase dark:bg-gray-800 dark:text-gray-400">
           <tr>
-            <th className="px-4 py-2">{nameLabel}</th>
-            <th className="px-4 py-2">Role</th>
+            <SortableTh label={nameLabel} column="name" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
+            <SortableTh label="Role" column="role" sortBy={sort.sortBy} sortDir={sort.sortDir} onSort={sort.toggle} />
             <th className="px-4 py-2 text-right">Actions</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-          {items.map((item) => (
+          {sortedItems.map((item) => (
             <tr key={item.id} className="bg-white dark:bg-gray-900">
               <td className="px-4 py-2 font-medium text-gray-900 dark:text-gray-100">
                 {String(item[nameKey])}

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -123,8 +123,8 @@ export function ComparePage() {
   return (
     <div className="flex flex-col gap-6">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
-        <Link to="/runs" className="hover:text-gray-700 dark:hover:text-gray-300">
+      <div className="flex min-w-0 items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
+        <Link to="/runs" className="shrink-0 hover:text-gray-700 dark:hover:text-gray-300">
           Runs
         </Link>
         <span>/</span>
@@ -133,15 +133,15 @@ export function ComparePage() {
             <Link
               to="/suites/$suiteHash"
               params={{ suiteHash }}
-              className={`flex items-center gap-1.5 hover:text-gray-700 dark:hover:text-gray-300${suite?.metadata?.labels?.name ? '' : ' font-mono'}`}
+              className={`flex min-w-0 items-center gap-1.5 hover:text-gray-700 dark:hover:text-gray-300${suite?.metadata?.labels?.name ? '' : ' font-mono'}`}
             >
               <JDenticon value={suiteHash} size={16} className="shrink-0 rounded-xs" />
-              {suite?.metadata?.labels?.name ?? suiteHash}
+              <span className="truncate">{suite?.metadata?.labels?.name ?? suiteHash}</span>
             </Link>
             <span>/</span>
           </>
         )}
-        <span className="text-gray-900 dark:text-gray-100">Compare</span>
+        <span className="shrink-0 text-gray-900 dark:text-gray-100">Compare</span>
       </div>
 
       {suiteMismatch && (

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -496,8 +496,8 @@ export function FileViewerPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
-        <Link to="/suites" className="hover:text-gray-700 dark:hover:text-gray-300">
+      <div className="flex min-w-0 items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
+        <Link to="/suites" className="shrink-0 hover:text-gray-700 dark:hover:text-gray-300">
           Suites
         </Link>
         <span>/</span>
@@ -506,10 +506,10 @@ export function FileViewerPage() {
             <Link
               to="/suites/$suiteHash"
               params={{ suiteHash: config.suite_hash }}
-              className={`flex items-center gap-1.5 hover:text-gray-700 dark:hover:text-gray-300${suite?.metadata?.labels?.name ? '' : ' font-mono'}`}
+              className={`flex min-w-0 items-center gap-1.5 hover:text-gray-700 dark:hover:text-gray-300${suite?.metadata?.labels?.name ? '' : ' font-mono'}`}
             >
               <JDenticon value={config.suite_hash} size={16} className="shrink-0 rounded-xs" />
-              {suite?.metadata?.labels?.name ?? config.suite_hash}
+              <span className="truncate">{suite?.metadata?.labels?.name ?? config.suite_hash}</span>
             </Link>
             <span>/</span>
           </>
@@ -517,12 +517,12 @@ export function FileViewerPage() {
         <Link
           to="/runs/$runId"
           params={{ runId }}
-          className="hover:text-gray-700 dark:hover:text-gray-300"
+          className="truncate hover:text-gray-700 dark:hover:text-gray-300"
         >
           {runId}
         </Link>
         <span>/</span>
-        <span className="font-mono text-gray-900 dark:text-gray-100">{filename}</span>
+        <span className="shrink-0 font-mono text-gray-900 dark:text-gray-100">{filename}</span>
       </div>
 
       <div className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen overflow-hidden bg-gray-900 shadow-xs">

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -320,42 +320,44 @@ export function RunDetailPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
-        <Link to="/suites" className="hover:text-gray-700 dark:hover:text-gray-300">
-          Suites
-        </Link>
-        <span>/</span>
-        {config.suite_hash && (
-          <>
-            <Link
-              to="/suites/$suiteHash"
-              params={{ suiteHash: config.suite_hash }}
-              className={`flex items-center gap-1.5 hover:text-gray-700 dark:hover:text-gray-300${suite?.metadata?.labels?.name ? '' : ' font-mono'}`}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm/6 text-gray-500 dark:text-gray-400">
+        <div className="flex min-w-0 items-center gap-2">
+          <Link to="/suites" className="shrink-0 hover:text-gray-700 dark:hover:text-gray-300">
+            Suites
+          </Link>
+          <span>/</span>
+          {config.suite_hash && (
+            <>
+              <Link
+                to="/suites/$suiteHash"
+                params={{ suiteHash: config.suite_hash }}
+                className={`flex min-w-0 items-center gap-1.5 hover:text-gray-700 dark:hover:text-gray-300${suite?.metadata?.labels?.name ? '' : ' font-mono'}`}
+              >
+                <JDenticon value={config.suite_hash} size={16} className="shrink-0 rounded-xs" />
+                <span className="truncate">{suite?.metadata?.labels?.name ?? config.suite_hash}</span>
+              </Link>
+              <span>/</span>
+            </>
+          )}
+          <span className="truncate text-gray-900 dark:text-gray-100">{runId}</span>
+          {isAdmin && (
+            <button
+              disabled={deleteRuns.isPending}
+              onClick={() => {
+                if (!window.confirm('Delete this run? This cannot be undone.')) return
+                deleteRuns.mutate([runId], {
+                  onSuccess: () => navigate({ to: '/runs' }),
+                })
+              }}
+              className="ml-1 flex shrink-0 items-center justify-center rounded-xs p-1 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600 disabled:opacity-50 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+              title="Delete this run"
             >
-              <JDenticon value={config.suite_hash} size={16} className="shrink-0 rounded-xs" />
-              {suite?.metadata?.labels?.name ?? config.suite_hash}
-            </Link>
-            <span>/</span>
-          </>
-        )}
-        <span className="text-gray-900 dark:text-gray-100">{runId}</span>
-        {isAdmin && (
-          <button
-            disabled={deleteRuns.isPending}
-            onClick={() => {
-              if (!window.confirm('Delete this run? This cannot be undone.')) return
-              deleteRuns.mutate([runId], {
-                onSuccess: () => navigate({ to: '/runs' }),
-              })
-            }}
-            className="ml-1 flex items-center justify-center rounded-sm p-1 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600 disabled:opacity-50 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-            title="Delete this run"
-          >
-            <Trash2 className="size-3.5" />
-          </button>
-        )}
+              <Trash2 className="size-3.5" />
+            </button>
+          )}
+        </div>
         {(benchmarkoorLogLoading || benchmarkoorLogHead?.exists || containerLogLoading || containerLogHead?.exists) && (
-          <div className="ml-auto flex items-center gap-2">
+          <div className="flex items-center gap-2 sm:ml-auto">
             <span className="font-medium text-gray-900 dark:text-gray-100">Logs:</span>
             {(benchmarkoorLogLoading || benchmarkoorLogHead?.exists) && (
               <>

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -423,14 +423,14 @@ export function RunDetailPage() {
       </div>
 
       {clientRuns.length > 1 && (
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <div className="min-w-0 flex-1">
             <ClientRunsStrip runs={clientRuns} currentRunId={runId} stepFilter={indexStepFilter} selectable={compareMode} selectedRunIds={selectedRunIds} onSelectionChange={handleSelectionChange} />
           </div>
           <div className="flex shrink-0 items-center gap-1.5">
             <button
               onClick={() => compareMode ? handleExitCompareMode() : setCompareMode(true)}
-              className={`flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
+              className={`flex cursor-pointer items-center justify-center rounded-xs p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
                 compareMode
                   ? 'bg-blue-600 text-white ring-blue-600 hover:bg-blue-700 hover:ring-blue-700'
                   : 'bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200'
@@ -445,7 +445,7 @@ export function RunDetailPage() {
                 const ids = recentRuns.map((r) => r.run_id)
                 navigate({ to: '/compare', search: { runs: ids.join(',') } })
               }}
-              className="flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+              className="flex cursor-pointer items-center justify-center rounded-xs p-1.5 shadow-xs ring-1 ring-inset transition-colors bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
               title={`Compare last ${recentRuns.length} runs`}
             >
               <GitCompareArrows className="size-4" />

--- a/ui/src/pages/RunsPage.tsx
+++ b/ui/src/pages/RunsPage.tsx
@@ -314,11 +314,11 @@ export function RunsPage() {
         />
       ) : (
         <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-3">
               <button
                 onClick={() => compareMode ? handleExitCompareMode() : handleEnterCompareMode()}
-                className={`flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
+                className={`flex cursor-pointer items-center justify-center rounded-xs p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
                   compareMode
                     ? 'bg-blue-600 text-white ring-blue-600 hover:bg-blue-700 hover:ring-blue-700'
                     : 'bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200'
@@ -330,7 +330,7 @@ export function RunsPage() {
               {isAdmin && (
                 <button
                   onClick={() => deleteMode ? handleExitDeleteMode() : handleEnterDeleteMode()}
-                  className={`flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
+                  className={`flex cursor-pointer items-center justify-center rounded-xs p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
                     deleteMode
                       ? 'bg-red-600 text-white ring-red-600 hover:bg-red-700 hover:ring-red-700'
                       : 'bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200'
@@ -344,7 +344,7 @@ export function RunsPage() {
               <select
                 value={localPageSize}
                 onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-                className="rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
               >
                 {PAGE_SIZE_OPTIONS.map((size) => (
                   <option key={size} value={size}>
@@ -352,7 +352,7 @@ export function RunsPage() {
                   </option>
                 ))}
               </select>
-              <span className="text-sm/6 text-gray-500 dark:text-gray-400">per page</span>
+              <span className="hidden text-sm/6 text-gray-500 sm:inline dark:text-gray-400">per page</span>
             </div>
             {totalPages > 1 && (
               <Pagination currentPage={localPage} totalPages={totalPages} onPageChange={handlePageChange} />
@@ -370,13 +370,13 @@ export function RunsPage() {
             onSelectionChange={deleteMode ? handleDeleteSelectionChange : handleSelectionChange}
             selectionVariant={deleteMode ? 'delete' : 'compare'}
           />
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <span className="text-sm/6 text-gray-500 dark:text-gray-400">Show</span>
               <select
                 value={localPageSize}
                 onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-                className="rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
               >
                 {PAGE_SIZE_OPTIONS.map((size) => (
                   <option key={size} value={size}>
@@ -384,7 +384,7 @@ export function RunsPage() {
                   </option>
                 ))}
               </select>
-              <span className="text-sm/6 text-gray-500 dark:text-gray-400">per page</span>
+              <span className="hidden text-sm/6 text-gray-500 sm:inline dark:text-gray-400">per page</span>
             </div>
             {totalPages > 1 && (
               <Pagination currentPage={localPage} totalPages={totalPages} onPageChange={handlePageChange} />

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -526,11 +526,11 @@ export function SuiteDetailPage() {
       </div>
 
       <TabGroup selectedIndex={getTabIndex()} onChange={handleTabChange}>
-        <TabList className="flex gap-1 rounded-sm bg-gray-100 p-1 dark:bg-gray-800">
+        <TabList className="flex gap-1 overflow-x-auto rounded-xs bg-gray-100 p-1 dark:bg-gray-800">
           <Tab
             className={({ selected }) =>
               clsx(
-                'flex cursor-pointer items-center gap-2 rounded-sm px-4 py-2 text-sm/6 font-medium transition-colors focus:outline-hidden',
+                'flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-xs px-2.5 py-1.5 text-xs/5 font-medium transition-colors focus:outline-hidden sm:gap-2 sm:px-4 sm:py-2 sm:text-sm/6',
                 selected
                   ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-700 dark:text-gray-100'
                   : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
@@ -543,7 +543,7 @@ export function SuiteDetailPage() {
           <Tab
             className={({ selected }) =>
               clsx(
-                'flex cursor-pointer items-center gap-2 rounded-sm px-4 py-2 text-sm/6 font-medium transition-colors focus:outline-hidden',
+                'flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-xs px-2.5 py-1.5 text-xs/5 font-medium transition-colors focus:outline-hidden sm:gap-2 sm:px-4 sm:py-2 sm:text-sm/6',
                 selected
                   ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-700 dark:text-gray-100'
                   : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
@@ -557,21 +557,22 @@ export function SuiteDetailPage() {
             <Tab
               className={({ selected }) =>
                 clsx(
-                  'flex cursor-pointer items-center gap-2 rounded-sm px-4 py-2 text-sm/6 font-medium transition-colors focus:outline-hidden',
+                  'flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-xs px-2.5 py-1.5 text-xs/5 font-medium transition-colors focus:outline-hidden sm:gap-2 sm:px-4 sm:py-2 sm:text-sm/6',
                   selected
                     ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-700 dark:text-gray-100'
                     : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
                 )
               }
             >
-              Pre-Run Steps
+              <span className="sm:hidden">Pre-Run</span>
+              <span className="hidden sm:inline">Pre-Run Steps</span>
               <Badge variant="default">{suite.pre_run_steps!.length}</Badge>
             </Tab>
           )}
           <Tab
             className={({ selected }) =>
               clsx(
-                'flex cursor-pointer items-center gap-2 rounded-sm px-4 py-2 text-sm/6 font-medium transition-colors focus:outline-hidden',
+                'flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-xs px-2.5 py-1.5 text-xs/5 font-medium transition-colors focus:outline-hidden sm:gap-2 sm:px-4 sm:py-2 sm:text-sm/6',
                 selected
                   ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-700 dark:text-gray-100'
                   : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
@@ -590,8 +591,8 @@ export function SuiteDetailPage() {
             ) : (
               <div className="flex flex-col gap-4">
                 {/* Step Filter Control */}
-                <div className="flex items-center gap-3 rounded-sm bg-white p-3 shadow-xs dark:bg-gray-800">
-                  <span className="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Metric steps:</span>
+                <div className="flex flex-wrap items-center gap-2 rounded-xs bg-white p-2 shadow-xs sm:gap-3 sm:p-3 dark:bg-gray-800">
+                  <span className="text-xs/5 font-medium text-gray-700 sm:text-sm/6 dark:text-gray-300">Metric steps:</span>
                   <div className="flex items-center gap-1">
                     {ALL_INDEX_STEP_TYPES.map((step) => (
                       <button
@@ -604,7 +605,7 @@ export function SuiteDetailPage() {
                             handleStepFilterChange(newFilter)
                           }
                         }}
-                        className={`rounded-sm px-2.5 py-1 text-xs font-medium capitalize transition-colors ${
+                        className={`rounded-xs px-2 py-0.5 text-xs font-medium capitalize transition-colors sm:px-2.5 sm:py-1 ${
                           stepFilter.includes(step)
                             ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300'
                             : 'bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
@@ -615,7 +616,7 @@ export function SuiteDetailPage() {
                       </button>
                     ))}
                   </div>
-                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                  <span className="hidden text-xs text-gray-500 sm:inline dark:text-gray-400">
                     (affects Duration, MGas/s calculations)
                   </span>
                 </div>

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -791,11 +791,11 @@ export function SuiteDetailPage() {
                   </p>
                 ) : (
                   <>
-                    <div className="flex items-center justify-between">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
                       <div className="flex items-center gap-3">
                         <button
                           onClick={() => compareMode ? handleExitCompareMode() : handleEnterCompareMode()}
-                          className={`flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
+                          className={`flex cursor-pointer items-center justify-center rounded-xs p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
                             compareMode
                               ? 'bg-blue-600 text-white ring-blue-600 hover:bg-blue-700 hover:ring-blue-700'
                               : 'bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200'
@@ -810,7 +810,7 @@ export function SuiteDetailPage() {
                             const ids = recentSuccessfulPerClient.map((r) => r.run_id)
                             navigate({ to: '/compare', search: { runs: ids.join(',') } })
                           }}
-                          className="flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                          className="flex cursor-pointer items-center justify-center rounded-xs p-1.5 shadow-xs ring-1 ring-inset transition-colors bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
                           title="Compare latest successful run per client"
                         >
                           <GitCompareArrows className="size-4" />
@@ -818,7 +818,7 @@ export function SuiteDetailPage() {
                         {isAdmin && (
                           <button
                             onClick={() => deleteMode ? handleExitDeleteMode() : handleEnterDeleteMode()}
-                            className={`flex cursor-pointer items-center justify-center rounded-sm p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
+                            className={`flex cursor-pointer items-center justify-center rounded-xs p-1.5 shadow-xs ring-1 ring-inset transition-colors ${
                               deleteMode
                                 ? 'bg-red-600 text-white ring-red-600 hover:bg-red-700 hover:ring-red-700'
                                 : 'bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200'
@@ -832,7 +832,7 @@ export function SuiteDetailPage() {
                         <select
                           value={runsPageSize}
                           onChange={(e) => handleRunsPageSizeChange(Number(e.target.value))}
-                          className="rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                          className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
                         >
                           {PAGE_SIZE_OPTIONS.map((size) => (
                             <option key={size} value={size}>
@@ -840,7 +840,7 @@ export function SuiteDetailPage() {
                             </option>
                           ))}
                         </select>
-                        <span className="text-sm/6 text-gray-500 dark:text-gray-400">per page</span>
+                        <span className="hidden text-sm/6 text-gray-500 sm:inline dark:text-gray-400">per page</span>
                       </div>
                       {totalRunsPages > 1 && (
                         <Pagination currentPage={runsPage} totalPages={totalRunsPages} onPageChange={setRunsPage} />
@@ -857,13 +857,13 @@ export function SuiteDetailPage() {
                       onSelectionChange={deleteMode ? handleDeleteSelectionChange : handleSelectionChange}
                       selectionVariant={deleteMode ? 'delete' : 'compare'}
                     />
-                    <div className="flex items-center justify-between">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
                       <div className="flex items-center gap-2">
                         <span className="text-sm/6 text-gray-500 dark:text-gray-400">Show</span>
                         <select
                           value={runsPageSize}
                           onChange={(e) => handleRunsPageSizeChange(Number(e.target.value))}
-                          className="rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                          className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
                         >
                           {PAGE_SIZE_OPTIONS.map((size) => (
                             <option key={size} value={size}>
@@ -871,7 +871,7 @@ export function SuiteDetailPage() {
                             </option>
                           ))}
                         </select>
-                        <span className="text-sm/6 text-gray-500 dark:text-gray-400">per page</span>
+                        <span className="hidden text-sm/6 text-gray-500 sm:inline dark:text-gray-400">per page</span>
                       </div>
                       {totalRunsPages > 1 && (
                         <Pagination currentPage={runsPage} totalPages={totalRunsPages} onPageChange={setRunsPage} />

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -619,8 +619,8 @@ export function SuiteDetailPage() {
                     (affects Duration, MGas/s calculations)
                   </span>
                 </div>
-                <div className="overflow-hidden rounded-sm border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-                  <div className="flex items-center justify-between px-4 py-3">
+                <div className="overflow-hidden rounded-xs border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+                  <div className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 sm:px-4 sm:py-3">
                     <button
                       onClick={() => setHeatmapExpanded(!heatmapExpanded)}
                       className="flex items-center gap-2 text-left text-sm/6 font-medium text-gray-900 hover:text-gray-700 dark:text-gray-100 dark:hover:text-gray-300"
@@ -633,7 +633,7 @@ export function SuiteDetailPage() {
                       <button
                         onClick={() => compareMode ? handleExitCompareMode() : handleEnterCompareMode()}
                         className={clsx(
-                          'flex cursor-pointer items-center justify-center rounded-sm p-1 shadow-xs ring-1 ring-inset transition-colors',
+                          'flex cursor-pointer items-center justify-center rounded-xs p-1 shadow-xs ring-1 ring-inset transition-colors',
                           compareMode
                             ? 'bg-blue-600 text-white ring-blue-600 hover:bg-blue-700 hover:ring-blue-700'
                             : 'bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200',
@@ -648,7 +648,7 @@ export function SuiteDetailPage() {
                           const ids = recentSuccessfulPerClient.map((r) => r.run_id)
                           navigate({ to: '/compare', search: { runs: ids.join(',') } })
                         }}
-                        className="flex cursor-pointer items-center justify-center rounded-sm p-1 shadow-xs ring-1 ring-inset transition-colors bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                        className="flex cursor-pointer items-center justify-center rounded-xs p-1 shadow-xs ring-1 ring-inset transition-colors bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
                         title="Compare latest successful run per client"
                       >
                         <GitCompareArrows className="size-3.5" />
@@ -656,7 +656,7 @@ export function SuiteDetailPage() {
                     </div>
                   </div>
                   {heatmapExpanded && (
-                    <div className="border-t border-gray-200 p-4 dark:border-gray-700">
+                    <div className="border-t border-gray-200 p-3 sm:p-4 dark:border-gray-700">
                       <RunsHeatmap runs={suiteRunsAll} isDark={isDark} colorNormalization={heatmapColor} onColorNormalizationChange={handleHeatmapColorChange} stepFilter={stepFilter} selectable={compareMode} selectedRunIds={selectedRunIds} onSelectionChange={handleSelectionChange} />
                     </div>
                   )}

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -482,12 +482,12 @@ export function SuiteDetailPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
-        <Link to="/suites" className="hover:text-gray-700 dark:hover:text-gray-300">
+      <div className="flex min-w-0 items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
+        <Link to="/suites" className="shrink-0 hover:text-gray-700 dark:hover:text-gray-300">
           Suites
         </Link>
         <span>/</span>
-        <span className="font-mono text-gray-900 dark:text-gray-100">
+        <span className="truncate font-mono text-gray-900 dark:text-gray-100">
           {suite.metadata?.labels?.name ?? suiteHash}
         </span>
       </div>

--- a/ui/src/utils/date.ts
+++ b/ui/src/utils/date.ts
@@ -3,6 +3,16 @@ export function formatTimestamp(timestamp: number): string {
   return date.toLocaleString()
 }
 
+export function formatTimestampDate(timestamp: number): string {
+  const date = new Date(timestamp * 1000)
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+export function formatTimestampTime(timestamp: number): string {
+  const date = new Date(timestamp * 1000)
+  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}
+
 export function formatDurationSeconds(totalSeconds: number): string {
   if (totalSeconds < 0) return '0s'
   const hours = Math.floor(totalSeconds / 3600)


### PR DESCRIPTION
## Summary

- **Breadcrumbs**: flex-wrap, truncation, and proper overflow handling on all pages (RunDetail, FileViewer, Compare)
- **Runs table**: compact padding, two-line timestamp, logo-only client badges, hidden image column, horizontal scroll on mobile
- **Suites table**: compact layout, hidden secondary columns, two-line time format on mobile
- **Pagination**: smaller buttons, wrapped controls, hidden "per page" label on mobile
- **Run detail page**: stacking recent runs strip and compare buttons, wrapping heatmap squares
- **Suite detail page**: compact tabs with shorter labels, compact metric step filters, mobile-friendly runs heatmap with stats table
- **Test heatmap**: wrapping controls, shortened labels, smaller boxes, logo-only client badges, single-column histogram grid on mobile
- **Header**: inline user menu items in mobile hamburger menu instead of popup dropdown
- **Admin page**: sortable column headers on all admin tables (Users, Sessions, GitHub Mappings, API Keys)

## Test plan
- [x] Verify all pages render correctly on mobile viewport (375px width)
- [x] Verify tables scroll horizontally where needed
- [x] Verify breadcrumbs truncate and wrap properly
- [x] Verify user menu works in mobile hamburger menu
- [x] Verify admin table sorting works on all tabs
- [x] Verify desktop layout is unchanged