### PR TITLE
fix(ui): pass app version via Docker build arg

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,4 +36,3 @@ coverage.html
 # Misc
 *.log
 .ai_plans/
-!.build-version

--- a/.github/workflows/deploy-docker.core.yaml
+++ b/.github/workflows/deploy-docker.core.yaml
@@ -26,13 +26,13 @@ jobs:
           VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
           COMMIT=$(git rev-parse --short HEAD)
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          echo "VERSION=${VERSION}" >> .build-version
-          echo "COMMIT=${COMMIT}" >> .build-version
-          echo "DATE=${DATE}" >> .build-version
-          echo "Writing build version: VERSION=${VERSION} COMMIT=${COMMIT} DATE=${DATE}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "COMMIT=${COMMIT}" >> "$GITHUB_ENV"
+          echo "DATE=${DATE}" >> "$GITHUB_ENV"
+          echo "Build version: VERSION=${VERSION} COMMIT=${COMMIT} DATE=${DATE}"
 
       - name: Deploy docker images
-        uses: ethpandaops/actions/docker-build-push@7d7b7bfe36fe4cfa538acd0e23706a23ce07c3ac # master
+        uses: ethpandaops/actions/docker-build-push@99b48ca2b233a2eff93e6a6df76e46b718aca108
         with:
           registry: ghcr.io
           registry_username: ${{ github.actor }}
@@ -41,3 +41,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           file: Dockerfile
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            COMMIT=${{ env.COMMIT }}
+            DATE=${{ env.DATE }}

--- a/.github/workflows/deploy-docker.ui.yaml
+++ b/.github/workflows/deploy-docker.ui.yaml
@@ -24,12 +24,11 @@ jobs:
       - name: Set app version from git
         run: |
           VERSION=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)
-          echo "Setting VITE_APP_VERSION=${VERSION}"
-          # Write a .env file that Vite picks up at build time
-          echo "VITE_APP_VERSION=${VERSION}" > ui/.env.production
+          echo "Setting APP_VERSION=${VERSION}"
+          echo "APP_VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Deploy docker images
-        uses: ethpandaops/actions/docker-build-push@7d7b7bfe36fe4cfa538acd0e23706a23ce07c3ac # master
+        uses: ethpandaops/actions/docker-build-push@99b48ca2b233a2eff93e6a6df76e46b718aca108
         with:
           registry: ghcr.io
           registry_username: ${{ github.actor }}
@@ -38,3 +37,5 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           file: Dockerfile.ui
+          build-args: |
+            APP_VERSION=${{ env.APP_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,8 @@ ARG VERSION=dev
 ARG COMMIT=none
 ARG DATE=unknown
 
-# Build the binary. If .build-version exists (CI), source it to override ARG defaults.
-RUN if [ -f .build-version ]; then \
-      . ./.build-version; \
-    fi && \
-    CGO_ENABLED=0 GOOS=linux go build \
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux go build \
     -tags "exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper,containers_image_openpgp" \
     -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
     -o /benchmarkoor ./cmd/benchmarkoor

--- a/Makefile
+++ b/Makefile
@@ -129,4 +129,4 @@ docker-run:
 ## docker-run-benchmark: Start the benchmarkoor service with docker-compose (CLIENT=name to limit, CONFIG=file to override config)
 CONFIG?=config.example.docker.yaml
 docker-run-benchmark:
-	USER_UID=$(shell id -u) USER_GID=$(shell id -g) BENCHMARKOOR_CONFIG=$(CONFIG) docker compose run --rm --build benchmarkoor run --config /app/config.yaml $(if $(CLIENT),--limit-instance-client=$(CLIENT))
+	VERSION=$(VERSION) COMMIT=$(COMMIT) DATE=$(DATE) USER_UID=$(shell id -u) USER_GID=$(shell id -g) BENCHMARKOOR_CONFIG=$(CONFIG) docker compose run --rm --build benchmarkoor run --config /app/config.yaml $(if $(CLIENT),--limit-instance-client=$(CLIENT))

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-core build-ui clean test-core test-coverage-core lint-core lint-core-all lint-ui fmt-core tidy-core install-core deps-ui run-core version-core run-ui help docker-build docker-build-core docker-build-ui docker-down docker-run docker-run-benchmark
+.PHONY: build build-core build-ui clean test-core test-coverage-core lint-core lint-core-all lint-ui fmt-core tidy-core install-core deps-ui run-core version-core run-ui help docker-build docker-build-core docker-build-ui docker-down docker-run docker-run-ui docker-run-api docker-run-benchmark
 
 # Build variables
 BINARY_NAME=benchmarkoor
@@ -120,11 +120,18 @@ docker-build-ui:
 docker-down:
 	docker compose down
 
-## docker-run: Start the UI and API services with docker-compose (UI_PORT=number to override UI port, API_PORT=number to override API port)
+## docker-run: Start the UI and API services with docker-compose
+docker-run: docker-run-ui docker-run-api
+
+## docker-run-ui: Start the UI service with docker-compose (UI_PORT=number to override UI port)
 UI_PORT?=8080
+docker-run-ui:
+	APP_VERSION=$(VERSION) UI_PORT=$(UI_PORT) docker compose up -d --build ui
+
+## docker-run-api: Start the API service with docker-compose (API_PORT=number to override API port)
 API_PORT?=9090
-docker-run:
-	APP_VERSION=$(VERSION) UI_PORT=$(UI_PORT) API_PORT=$(API_PORT) docker compose up -d --build ui
+docker-run-api:
+	VERSION=$(VERSION) COMMIT=$(COMMIT) DATE=$(DATE) API_PORT=$(API_PORT) docker compose up -d --build api
 
 ## docker-run-benchmark: Start the benchmarkoor service with docker-compose (CLIENT=name to limit, CONFIG=file to override config)
 CONFIG?=config.example.docker.yaml

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ docker-down:
 UI_PORT?=8080
 API_PORT?=9090
 docker-run:
-	UI_PORT=$(UI_PORT) API_PORT=$(API_PORT) docker compose up -d --build ui api
+	APP_VERSION=$(VERSION) UI_PORT=$(UI_PORT) API_PORT=$(API_PORT) docker compose up -d --build ui
 
 ## docker-run-benchmark: Start the benchmarkoor service with docker-compose (CLIENT=name to limit, CONFIG=file to override config)
 CONFIG?=config.example.docker.yaml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        VERSION: ${VERSION:-dev}
+        COMMIT: ${COMMIT:-none}
+        DATE: ${DATE:-unknown}
     # Required for dropping memory caches, ZFS/overlayfs datadir methods, etc.
     privileged: true
     # Share host PID namespace so nsenter can access /proc/<pid>/ns/net

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -69,6 +69,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.ui
+      args:
+        APP_VERSION: ${APP_VERSION:-dev}
     ports:
       - "${UI_PORT:-8080}:80"
     volumes:

--- a/ui/src/components/layout/Footer.tsx
+++ b/ui/src/components/layout/Footer.tsx
@@ -16,7 +16,7 @@ export function Footer() {
           ethpandaops/benchmarkoor
         </a>
         <span className="mx-2">•</span>
-        <span>v{appVersion}</span>
+        <span>{appVersion}</span>
       </div>
     </footer>
   )


### PR DESCRIPTION
## Summary
- The UI footer was showing `v0.0.1` because the Dockerfile set `ENV VITE_APP_VERSION=""` (empty build arg default), which took precedence over the `.env.production` file that the workflow was writing. The footer fell back to `package.json`'s version.
- Now passes the git version as a Docker `build-arg` (`APP_VERSION`) in the CI workflow, docker-compose, and Makefile.
- Removes the hardcoded `v` prefix from the footer since `git describe` already includes it.

## Test plan
- [x] Run `make docker-run` locally and verify the footer shows the correct version (e.g. `v0.1.0-58-g2d74b19-dirty`)
- [ ] Verify the CI workflow builds and pushes the image with the correct version baked in