### PR TITLE
✨ feat: Dynamic genesis files

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -138,44 +138,39 @@ runner:
     #
     #     # Option 3: EEST (Ethereum Execution Spec Tests) fixtures from GitHub releases.
     #     # Downloads fixtures directly from ethereum/execution-spec-tests releases.
-    #     # Genesis files are auto-resolved per client type from the release.
+    #     # Genesis files are generated dynamically from hive/{hash}.json files in the
+    #     # fixtures using mapper.jq scripts (no separate genesis download needed).
     #     # eest_fixtures:
     #     #   github_repo: ethereum/execution-spec-tests
     #     #   github_release: benchmark@v0.0.7
     #     #   # Optional: Override the subdirectory within fixtures tarball.
     #     #   # fixtures_subdir: fixtures/blockchain_tests_engine_x  # default
-    #     #   # Optional: Override URLs for fixtures/genesis tarballs.
+    #     #   # Optional: Override URL for fixtures tarball.
     #     #   # fixtures_url: https://example.com/fixtures_benchmark.tar.gz
-    #     #   # genesis_url: https://example.com/benchmark_genesis.tar.gz
     #
     #     # Option 3b: EEST fixtures from GitHub Actions artifacts.
     #     # Alternative to releases - downloads from workflow run artifacts.
-    #     # Uses the gh CLI if available, otherwise falls back to the GitHub REST API
-    #     # (requires runner.github_token or BENCHMARKOOR_RUNNER_GITHUB_TOKEN).
+    #     # Requires runner.github_token or BENCHMARKOOR_RUNNER_GITHUB_TOKEN.
     #     # eest_fixtures:
     #     #   github_repo: ethereum/execution-spec-tests
     #     #   fixtures_artifact_name: fixtures_benchmark_fast  # Required (instead of github_release)
-    #     #   genesis_artifact_name: benchmark_genesis         # Optional, defaults to 'benchmark_genesis'
     #     #   # Optional: Specify a specific workflow run ID (uses latest if not specified)
     #     #   # fixtures_artifact_run_id: "12345678901"
-    #     #   # genesis_artifact_run_id: "12345678901"
     #     #   # fixtures_subdir also works with artifacts
     #
     #     # Option 3c: EEST fixtures from local directories.
-    #     # Points directly at already-extracted fixtures and genesis directories.
+    #     # Points directly at already-extracted fixtures directory.
     #     # No downloading or caching — useful for local development with locally-built EEST fixtures.
     #     # eest_fixtures:
     #     #   local_fixtures_dir: /home/user/eest-output/fixtures
-    #     #   local_genesis_dir: /home/user/eest-output/genesis
     #     #   # fixtures_subdir also works with local directories
     #     #   # fixtures_subdir: fixtures/blockchain_tests_engine_x  # default
     #
-    #     # Option 3d: EEST fixtures from local .tar.gz tarballs.
-    #     # Extracts tarballs to a cache directory (keyed by content hash, re-extraction skipped
+    #     # Option 3d: EEST fixtures from local .tar.gz tarball.
+    #     # Extracts tarball to a cache directory (keyed by content hash, re-extraction skipped
     #     # if already cached). Useful when you have locally-built tarballs but haven't extracted them.
     #     # eest_fixtures:
     #     #   local_fixtures_tarball: /home/user/eest-output/fixtures_benchmark.tar.gz
-    #     #   local_genesis_tarball: /home/user/eest-output/benchmark_genesis.tar.gz
     #     #   # fixtures_subdir also works with local tarballs
 
 # Optional: API server for authentication and user management.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,39 +155,35 @@ type SourceConfig struct {
 }
 
 // EESTFixturesSource defines an EEST fixtures source from GitHub releases, artifacts,
-// or local directories/tarballs.
+// or local directories/tarballs. Genesis files are generated dynamically from
+// hive/{hash}.json files included in the fixtures using mapper.jq scripts.
 type EESTFixturesSource struct {
 	GitHubRepo     string `yaml:"github_repo,omitempty" mapstructure:"github_repo"`
 	GitHubRelease  string `yaml:"github_release,omitempty" mapstructure:"github_release"`
 	FixturesURL    string `yaml:"fixtures_url,omitempty" mapstructure:"fixtures_url"`
-	GenesisURL     string `yaml:"genesis_url,omitempty" mapstructure:"genesis_url"`
 	FixturesSubdir string `yaml:"fixtures_subdir,omitempty" mapstructure:"fixtures_subdir"`
 	// GitHub Actions artifact support (alternative to releases).
 	FixturesArtifactName  string `yaml:"fixtures_artifact_name,omitempty" mapstructure:"fixtures_artifact_name"`
-	GenesisArtifactName   string `yaml:"genesis_artifact_name,omitempty" mapstructure:"genesis_artifact_name"`
 	FixturesArtifactRunID string `yaml:"fixtures_artifact_run_id,omitempty" mapstructure:"fixtures_artifact_run_id"`
-	GenesisArtifactRunID  string `yaml:"genesis_artifact_run_id,omitempty" mapstructure:"genesis_artifact_run_id"`
 	// Local directory support (already-extracted fixtures).
 	LocalFixturesDir string `yaml:"local_fixtures_dir,omitempty" mapstructure:"local_fixtures_dir"`
-	LocalGenesisDir  string `yaml:"local_genesis_dir,omitempty" mapstructure:"local_genesis_dir"`
 	// Local tarball support (.tar.gz files).
 	LocalFixturesTarball string `yaml:"local_fixtures_tarball,omitempty" mapstructure:"local_fixtures_tarball"`
-	LocalGenesisTarball  string `yaml:"local_genesis_tarball,omitempty" mapstructure:"local_genesis_tarball"`
 }
 
 // UseArtifacts returns true if the source is configured to use GitHub Actions artifacts.
 func (e *EESTFixturesSource) UseArtifacts() bool {
-	return e.FixturesArtifactName != "" || e.GenesisArtifactName != ""
+	return e.FixturesArtifactName != ""
 }
 
-// UseLocalDir returns true if the source is configured to use local directories.
+// UseLocalDir returns true if the source is configured to use a local directory.
 func (e *EESTFixturesSource) UseLocalDir() bool {
-	return e.LocalFixturesDir != "" || e.LocalGenesisDir != ""
+	return e.LocalFixturesDir != ""
 }
 
-// UseLocalTarball returns true if the source is configured to use local tarballs.
+// UseLocalTarball returns true if the source is configured to use a local tarball.
 func (e *EESTFixturesSource) UseLocalTarball() bool {
-	return e.LocalFixturesTarball != "" || e.LocalGenesisTarball != ""
+	return e.LocalFixturesTarball != ""
 }
 
 // validate checks the EEST fixtures source configuration for errors.
@@ -219,8 +215,8 @@ func (e *EESTFixturesSource) validate() error {
 	if modeCount == 0 {
 		return fmt.Errorf(
 			"eest_fixtures: must specify one of: github_release, " +
-				"fixtures_artifact_name, local_fixtures_dir/local_genesis_dir, " +
-				"or local_fixtures_tarball/local_genesis_tarball",
+				"fixtures_artifact_name, local_fixtures_dir, " +
+				"or local_fixtures_tarball",
 		)
 	}
 
@@ -238,38 +234,14 @@ func (e *EESTFixturesSource) validate() error {
 
 	// Validate local dir mode.
 	if hasLocalDir {
-		if e.LocalFixturesDir == "" {
-			return fmt.Errorf("eest_fixtures: local_fixtures_dir is required when local_genesis_dir is set")
-		}
-
-		if e.LocalGenesisDir == "" {
-			return fmt.Errorf("eest_fixtures: local_genesis_dir is required when local_fixtures_dir is set")
-		}
-
 		if err := validateDirExists(e.LocalFixturesDir, "eest_fixtures.local_fixtures_dir"); err != nil {
-			return err
-		}
-
-		if err := validateDirExists(e.LocalGenesisDir, "eest_fixtures.local_genesis_dir"); err != nil {
 			return err
 		}
 	}
 
 	// Validate local tarball mode.
 	if hasLocalTarball {
-		if e.LocalFixturesTarball == "" {
-			return fmt.Errorf("eest_fixtures: local_fixtures_tarball is required when local_genesis_tarball is set")
-		}
-
-		if e.LocalGenesisTarball == "" {
-			return fmt.Errorf("eest_fixtures: local_genesis_tarball is required when local_fixtures_tarball is set")
-		}
-
 		if err := validateFileExists(e.LocalFixturesTarball, "eest_fixtures.local_fixtures_tarball"); err != nil {
-			return err
-		}
-
-		if err := validateFileExists(e.LocalGenesisTarball, "eest_fixtures.local_genesis_tarball"); err != nil {
 			return err
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -325,9 +325,7 @@ func TestSourceConfig_Validate(t *testing.T) {
 
 	// Create test tarballs for local tarball validation tests.
 	fixturesTarball := filepath.Join(tmpDir, "fixtures.tar.gz")
-	genesisTarball := filepath.Join(tmpDir, "genesis.tar.gz")
 	createTestTarball(t, fixturesTarball)
-	createTestTarball(t, genesisTarball)
 
 	tests := []struct {
 		name      string
@@ -445,37 +443,23 @@ func TestSourceConfig_Validate(t *testing.T) {
 			source: SourceConfig{
 				EESTFixtures: &EESTFixturesSource{
 					LocalFixturesDir: tmpDir,
-					LocalGenesisDir:  tmpDir,
 				},
 			},
 			wantErr: false,
 		},
 		{
-			name: "eest_fixtures local dir missing local_genesis_dir",
+			name: "eest_fixtures must specify a mode",
 			source: SourceConfig{
-				EESTFixtures: &EESTFixturesSource{
-					LocalFixturesDir: tmpDir,
-				},
+				EESTFixtures: &EESTFixturesSource{},
 			},
 			wantErr:   true,
-			errSubstr: "local_genesis_dir is required",
-		},
-		{
-			name: "eest_fixtures local dir missing local_fixtures_dir",
-			source: SourceConfig{
-				EESTFixtures: &EESTFixturesSource{
-					LocalGenesisDir: tmpDir,
-				},
-			},
-			wantErr:   true,
-			errSubstr: "local_fixtures_dir is required",
+			errSubstr: "must specify one of",
 		},
 		{
 			name: "eest_fixtures local dir path does not exist",
 			source: SourceConfig{
 				EESTFixtures: &EESTFixturesSource{
 					LocalFixturesDir: "/nonexistent/fixtures",
-					LocalGenesisDir:  tmpDir,
 				},
 			},
 			wantErr:   true,
@@ -486,7 +470,6 @@ func TestSourceConfig_Validate(t *testing.T) {
 			source: SourceConfig{
 				EESTFixtures: &EESTFixturesSource{
 					LocalFixturesDir: tmpDir,
-					LocalGenesisDir:  tmpDir,
 				},
 			},
 			wantErr: false,
@@ -498,7 +481,6 @@ func TestSourceConfig_Validate(t *testing.T) {
 					GitHubRepo:       "ethereum/execution-spec-tests",
 					GitHubRelease:    "benchmark@v0.0.6",
 					LocalFixturesDir: tmpDir,
-					LocalGenesisDir:  tmpDir,
 				},
 			},
 			wantErr:   true,
@@ -509,9 +491,7 @@ func TestSourceConfig_Validate(t *testing.T) {
 			source: SourceConfig{
 				EESTFixtures: &EESTFixturesSource{
 					LocalFixturesDir:     tmpDir,
-					LocalGenesisDir:      tmpDir,
 					LocalFixturesTarball: fixturesTarball,
-					LocalGenesisTarball:  genesisTarball,
 				},
 			},
 			wantErr:   true,
@@ -522,37 +502,15 @@ func TestSourceConfig_Validate(t *testing.T) {
 			source: SourceConfig{
 				EESTFixtures: &EESTFixturesSource{
 					LocalFixturesTarball: fixturesTarball,
-					LocalGenesisTarball:  genesisTarball,
 				},
 			},
 			wantErr: false,
-		},
-		{
-			name: "eest_fixtures local tarball missing local_genesis_tarball",
-			source: SourceConfig{
-				EESTFixtures: &EESTFixturesSource{
-					LocalFixturesTarball: fixturesTarball,
-				},
-			},
-			wantErr:   true,
-			errSubstr: "local_genesis_tarball is required",
-		},
-		{
-			name: "eest_fixtures local tarball missing local_fixtures_tarball",
-			source: SourceConfig{
-				EESTFixtures: &EESTFixturesSource{
-					LocalGenesisTarball: genesisTarball,
-				},
-			},
-			wantErr:   true,
-			errSubstr: "local_fixtures_tarball is required",
 		},
 		{
 			name: "eest_fixtures local tarball path does not exist",
 			source: SourceConfig{
 				EESTFixtures: &EESTFixturesSource{
 					LocalFixturesTarball: "/nonexistent/fixtures.tar.gz",
-					LocalGenesisTarball:  genesisTarball,
 				},
 			},
 			wantErr:   true,
@@ -565,7 +523,6 @@ func TestSourceConfig_Validate(t *testing.T) {
 					GitHubRepo:           "ethereum/execution-spec-tests",
 					FixturesArtifactName: "fixtures_benchmark",
 					LocalFixturesTarball: fixturesTarball,
-					LocalGenesisTarball:  genesisTarball,
 				},
 			},
 			wantErr:   true,

--- a/pkg/executor/eest_source.go
+++ b/pkg/executor/eest_source.go
@@ -27,14 +27,14 @@ type EESTSource struct {
 	filter        string
 	githubToken   string
 	fixturesDir   string
-	genesisDir    string
+	hiveDir       string
 	tests         []*TestWithSteps
 	genesisGroups []*GenesisGroup
-	// resolvedFixturesRunID and resolvedGenesisRunID store the actual run IDs
-	// used when downloading artifacts. When the config doesn't specify a run ID,
-	// these capture the latest run ID that was resolved during download.
+	genesisGen    *genesisGenerator
+	// resolvedFixturesRunID stores the actual run ID used when downloading
+	// artifacts. When the config doesn't specify a run ID, this captures the
+	// latest run ID that was resolved during download.
 	resolvedFixturesRunID string
-	resolvedGenesisRunID  string
 }
 
 // preAllocFile represents the JSON structure of a pre_alloc file.
@@ -59,19 +59,17 @@ func (s *EESTSource) Prepare(ctx context.Context) (*PreparedSource, error) {
 	// Handle local directory mode — no downloading or caching needed.
 	if s.cfg.UseLocalDir() {
 		s.fixturesDir = s.cfg.LocalFixturesDir
-		s.genesisDir = s.cfg.LocalGenesisDir
 
 		s.log.WithFields(logrus.Fields{
 			"fixtures_dir": s.fixturesDir,
-			"genesis_dir":  s.genesisDir,
-		}).Info("Using local EEST fixtures directories")
+		}).Info("Using local EEST fixtures directory")
 
-		return s.discoverTests()
+		return s.discoverTests(ctx)
 	}
 
 	// Handle local tarball mode — extract to cache.
 	if s.cfg.UseLocalTarball() {
-		return s.prepareLocalTarballs()
+		return s.prepareLocalTarballs(ctx)
 	}
 
 	// Build cache path based on source type.
@@ -107,24 +105,6 @@ func (s *EESTSource) Prepare(ctx context.Context) (*PreparedSource, error) {
 			s.log.WithField("run_id", runID).Info("Resolved latest fixtures artifact run ID")
 		}
 
-		genesisArtifact := s.cfg.GenesisArtifactName
-		if genesisArtifact == "" {
-			genesisArtifact = "benchmark_genesis"
-		}
-
-		if s.cfg.GenesisArtifactRunID != "" {
-			s.resolvedGenesisRunID = s.cfg.GenesisArtifactRunID
-		} else {
-			runID, err := s.resolveArtifactRunID(ctx, genesisArtifact)
-			if err != nil {
-				return nil, fmt.Errorf("resolving genesis artifact run ID: %w", err)
-			}
-
-			s.resolvedGenesisRunID = runID
-
-			s.log.WithField("run_id", runID).Info("Resolved latest genesis artifact run ID")
-		}
-
 		artifactKey := fmt.Sprintf("%s-%s", fixturesArtifact, s.resolvedFixturesRunID)
 
 		cacheBase = filepath.Join(s.cacheDir, "eest-artifacts", repoHash, artifactKey)
@@ -134,7 +114,6 @@ func (s *EESTSource) Prepare(ctx context.Context) (*PreparedSource, error) {
 	}
 
 	s.fixturesDir = filepath.Join(cacheBase, "fixtures")
-	s.genesisDir = filepath.Join(cacheBase, "genesis")
 
 	// Check if already extracted.
 	if _, err := os.Stat(s.fixturesDir); os.IsNotExist(err) {
@@ -156,28 +135,20 @@ func (s *EESTSource) Prepare(ctx context.Context) (*PreparedSource, error) {
 	}
 
 	// Parse fixtures and build tests.
-	return s.discoverTests()
+	return s.discoverTests(ctx)
 }
 
-// downloadAndExtract downloads and extracts the fixtures and genesis tarballs.
+// downloadAndExtract downloads and extracts the fixtures tarball.
 func (s *EESTSource) downloadAndExtract(ctx context.Context, cacheBase string) error {
 	if err := os.MkdirAll(cacheBase, 0755); err != nil {
 		return fmt.Errorf("creating cache directory: %w", err)
 	}
 
-	// Build download URLs.
+	// Build download URL.
 	fixturesURL := s.cfg.FixturesURL
 	if fixturesURL == "" {
 		fixturesURL = fmt.Sprintf(
 			"https://github.com/%s/releases/download/%s/fixtures_benchmark.tar.gz",
-			s.cfg.GitHubRepo, s.cfg.GitHubRelease,
-		)
-	}
-
-	genesisURL := s.cfg.GenesisURL
-	if genesisURL == "" {
-		genesisURL = fmt.Sprintf(
-			"https://github.com/%s/releases/download/%s/benchmark_genesis.tar.gz",
 			s.cfg.GitHubRepo, s.cfg.GitHubRelease,
 		)
 	}
@@ -187,13 +158,6 @@ func (s *EESTSource) downloadAndExtract(ctx context.Context, cacheBase string) e
 
 	if err := s.downloadAndExtractTarball(ctx, fixturesURL, s.fixturesDir); err != nil {
 		return fmt.Errorf("extracting fixtures: %w", err)
-	}
-
-	// Download and extract genesis.
-	s.log.WithField("url", genesisURL).Info("Downloading genesis tarball")
-
-	if err := s.downloadAndExtractTarball(ctx, genesisURL, s.genesisDir); err != nil {
-		return fmt.Errorf("extracting genesis: %w", err)
 	}
 
 	return nil
@@ -226,63 +190,35 @@ func (s *EESTSource) downloadArtifacts(ctx context.Context, cacheBase string) er
 		return fmt.Errorf("extracting fixtures tarballs: %w", err)
 	}
 
-	// Download genesis artifact.
-	genesisArtifact := s.cfg.GenesisArtifactName
-	if genesisArtifact == "" {
-		genesisArtifact = "benchmark_genesis"
-	}
-
-	s.log.WithFields(logrus.Fields{
-		"artifact": genesisArtifact,
-		"repo":     s.cfg.GitHubRepo,
-		"run_id":   s.resolvedGenesisRunID,
-	}).Info("Downloading genesis artifact")
-
-	if _, err := s.downloadGitHubArtifact(ctx, genesisArtifact, s.resolvedGenesisRunID, s.genesisDir); err != nil {
-		return fmt.Errorf("downloading genesis artifact: %w", err)
-	}
-
-	// Extract any .tar.gz files found inside the artifact.
-	if err := s.extractInnerTarballs(ctx, s.genesisDir); err != nil {
-		return fmt.Errorf("extracting genesis tarballs: %w", err)
-	}
-
 	return nil
 }
 
-// prepareLocalTarballs extracts local .tar.gz fixtures and genesis to a cache directory.
-func (s *EESTSource) prepareLocalTarballs() (*PreparedSource, error) {
-	// Build a cache key from the tarball paths so re-extractions can be skipped.
-	cacheKey := hashRepoURL(s.cfg.LocalFixturesTarball + "|" + s.cfg.LocalGenesisTarball)
+// prepareLocalTarballs extracts a local .tar.gz fixtures file to a cache directory.
+func (s *EESTSource) prepareLocalTarballs(ctx context.Context) (*PreparedSource, error) {
+	cacheKey := hashRepoURL(s.cfg.LocalFixturesTarball)
 	cacheBase := filepath.Join(s.cacheDir, "eest-local", cacheKey)
 
 	s.fixturesDir = filepath.Join(cacheBase, "fixtures")
-	s.genesisDir = filepath.Join(cacheBase, "genesis")
 
 	// Check if already extracted.
 	if _, err := os.Stat(s.fixturesDir); os.IsNotExist(err) {
 		s.log.WithFields(logrus.Fields{
 			"fixtures_tarball": s.cfg.LocalFixturesTarball,
-			"genesis_tarball":  s.cfg.LocalGenesisTarball,
 			"cache":            cacheBase,
-		}).Info("Extracting local EEST tarballs")
+		}).Info("Extracting local EEST tarball")
 
 		if err := os.MkdirAll(cacheBase, 0755); err != nil {
 			return nil, fmt.Errorf("creating cache directory: %w", err)
 		}
 
-		if err := s.extractLocalTarball(s.cfg.LocalFixturesTarball, s.fixturesDir); err != nil {
+		if err := extractLocalTarball(s.cfg.LocalFixturesTarball, s.fixturesDir); err != nil {
 			return nil, fmt.Errorf("extracting fixtures tarball: %w", err)
 		}
-
-		if err := s.extractLocalTarball(s.cfg.LocalGenesisTarball, s.genesisDir); err != nil {
-			return nil, fmt.Errorf("extracting genesis tarball: %w", err)
-		}
 	} else {
-		s.log.WithField("path", cacheBase).Info("Using cached local EEST tarballs")
+		s.log.WithField("path", cacheBase).Info("Using cached local EEST tarball")
 	}
 
-	return s.discoverTests()
+	return s.discoverTests(ctx)
 }
 
 // ghArtifactList represents a GitHub API response listing artifacts.
@@ -540,7 +476,7 @@ func (s *EESTSource) extractInnerTarballs(_ context.Context, dir string) error {
 
 		s.log.WithField("file", tarballPath).Debug("Extracting inner tarball")
 
-		if err := s.extractLocalTarball(tarballPath, dir); err != nil {
+		if err := extractLocalTarball(tarballPath, dir); err != nil {
 			return fmt.Errorf("extracting %s: %w", entry.Name(), err)
 		}
 
@@ -554,7 +490,7 @@ func (s *EESTSource) extractInnerTarballs(_ context.Context, dir string) error {
 }
 
 // extractLocalTarball extracts a local .tar.gz file to the target directory.
-func (s *EESTSource) extractLocalTarball(tarballPath, targetDir string) error {
+func extractLocalTarball(tarballPath, targetDir string) error {
 	f, err := os.Open(tarballPath)
 	if err != nil {
 		return fmt.Errorf("opening tarball: %w", err)
@@ -695,7 +631,7 @@ func (s *EESTSource) downloadAndExtractTarball(ctx context.Context, url, targetD
 }
 
 // discoverTests parses fixture files and creates test entries.
-func (s *EESTSource) discoverTests() (*PreparedSource, error) {
+func (s *EESTSource) discoverTests(ctx context.Context) (*PreparedSource, error) {
 	// Determine the fixtures search directory.
 	fixturesSubdir := s.cfg.FixturesSubdir
 	if fixturesSubdir == "" {
@@ -844,6 +780,31 @@ func (s *EESTSource) discoverTests() (*PreparedSource, error) {
 		s.log.WithError(err).Warn("Failed to parse pre_alloc directory")
 	}
 
+	// Discover hive directory and initialize genesis generator.
+	s.hiveDir = filepath.Join(searchDir, "hive")
+	if _, err := os.Stat(s.hiveDir); err == nil {
+		mapperDir := filepath.Join(s.cacheDir, "hive_mappers")
+		genesisCache := filepath.Join(s.cacheDir, "genesis_cache")
+
+		// Clean mapper and genesis cache from previous runs.
+		for _, dir := range []string{mapperDir, genesisCache} {
+			if err := os.RemoveAll(dir); err != nil {
+				return nil, fmt.Errorf("cleaning cache directory %s: %w", dir, err)
+			}
+		}
+
+		s.genesisGen = newGenesisGenerator(s.log, mapperDir, genesisCache)
+
+		// Fetch mapper.jq files from hive GitHub (once per run).
+		if err := s.genesisGen.FetchMappers(ctx); err != nil {
+			return nil, fmt.Errorf("fetching hive mappers: %w", err)
+		}
+
+		s.log.WithField("hive_dir", s.hiveDir).Info("Discovered hive directory for genesis generation")
+	} else {
+		s.log.Debug("No hive directory found, genesis generation unavailable")
+	}
+
 	// If genesis groups were found, reorder result.Tests to match execution
 	// order: groups iterated by genesis hash, tests sorted by name within
 	// each group. This ensures the suite summary reflects actual execution.
@@ -873,15 +834,10 @@ func (s *EESTSource) GetSourceInfo() (*SuiteSource, error) {
 		fixturesSubdir = config.DefaultEESTFixturesSubdir
 	}
 
-	// Use resolved run IDs when available, falling back to config values.
+	// Use resolved run ID when available, falling back to config value.
 	fixturesRunID := s.resolvedFixturesRunID
 	if fixturesRunID == "" {
 		fixturesRunID = s.cfg.FixturesArtifactRunID
-	}
-
-	genesisRunID := s.resolvedGenesisRunID
-	if genesisRunID == "" {
-		genesisRunID = s.cfg.GenesisArtifactRunID
 	}
 
 	return &SuiteSource{
@@ -889,16 +845,11 @@ func (s *EESTSource) GetSourceInfo() (*SuiteSource, error) {
 			GitHubRepo:            s.cfg.GitHubRepo,
 			GitHubRelease:         s.cfg.GitHubRelease,
 			FixturesURL:           s.cfg.FixturesURL,
-			GenesisURL:            s.cfg.GenesisURL,
 			FixturesSubdir:        fixturesSubdir,
 			FixturesArtifactName:  s.cfg.FixturesArtifactName,
-			GenesisArtifactName:   s.cfg.GenesisArtifactName,
 			FixturesArtifactRunID: fixturesRunID,
-			GenesisArtifactRunID:  genesisRunID,
 			LocalFixturesDir:      s.cfg.LocalFixturesDir,
-			LocalGenesisDir:       s.cfg.LocalGenesisDir,
 			LocalFixturesTarball:  s.cfg.LocalFixturesTarball,
-			LocalGenesisTarball:   s.cfg.LocalGenesisTarball,
 		},
 	}, nil
 }
@@ -989,76 +940,50 @@ func (s *EESTSource) GetGenesisGroups() []*GenesisGroup {
 	return s.genesisGroups
 }
 
-// GetGenesisPathForGroup returns the genesis file path for a specific
-// genesis hash and client type.
+// GetGenesisPathForGroup generates and returns the genesis file path for a
+// specific genesis hash and client type using hive files + mapper.jq.
 func (s *EESTSource) GetGenesisPathForGroup(genesisHash, clientType string) string {
-	clientDir, filename := s.resolveClientGenesis(clientType)
-
-	genesisPath := filepath.Join(
-		s.genesisDir, "genesis", genesisHash, clientDir, filename,
-	)
-
-	if _, err := os.Stat(genesisPath); err == nil {
-		return genesisPath
-	}
-
-	s.log.WithFields(logrus.Fields{
-		"genesis_hash": genesisHash,
-		"client":       clientType,
-		"path":         genesisPath,
-	}).Warn("Genesis file not found for group")
-
-	return ""
-}
-
-// resolveClientGenesis maps a client type to its genesis directory and filename.
-func (s *EESTSource) resolveClientGenesis(clientType string) (string, string) {
-	switch clientType {
-	case "geth", "erigon", "reth", "nimbus":
-		return "go-ethereum", "genesis.json"
-	case "nethermind":
-		return "nethermind", "chainspec.json"
-	case "besu":
-		return "besu", "genesis.json"
-	default:
-		return "go-ethereum", "genesis.json"
-	}
-}
-
-// GetGenesisPath returns the genesis file path for a client type.
-// Maps client types to their genesis directories in the EEST release.
-func (s *EESTSource) GetGenesisPath(clientType string) string {
-	clientDir, filename := s.resolveClientGenesis(clientType)
-
-	// Genesis files are in genesis/genesis/<hash>/<client>/<filename>
-	// Find the hash subdirectory (there should typically be one).
-	genesisBaseDir := filepath.Join(s.genesisDir, "genesis")
-
-	entries, err := os.ReadDir(genesisBaseDir)
-	if err != nil {
-		s.log.WithError(err).Warn("Failed to read genesis directory")
+	if s.genesisGen == nil {
+		s.log.Warn("Genesis generator not initialized (no hive directory?)")
 
 		return ""
 	}
 
-	// Find the first directory (the hash directory).
-	for _, entry := range entries {
-		if entry.IsDir() {
-			genesisPath := filepath.Join(
-				genesisBaseDir, entry.Name(), clientDir, filename,
-			)
-			if _, err := os.Stat(genesisPath); err == nil {
-				return genesisPath
-			}
-		}
+	hiveFilePath := filepath.Join(s.hiveDir, genesisHash+".json")
+
+	path, err := s.genesisGen.GenerateClientGenesis(
+		context.Background(), hiveFilePath, genesisHash, clientType,
+	)
+	if err != nil {
+		s.log.WithFields(logrus.Fields{
+			"genesis_hash": genesisHash,
+			"client":       clientType,
+			"error":        err,
+		}).Error("Failed to generate client genesis")
+
+		return ""
 	}
 
-	s.log.WithFields(logrus.Fields{
-		"client":  clientType,
-		"baseDir": genesisBaseDir,
-	}).Warn("Genesis file not found")
+	return path
+}
 
-	return ""
+// GetGenesisPath generates and returns the genesis file path for a client type.
+// Uses the first available hive file when no specific hash is requested.
+func (s *EESTSource) GetGenesisPath(clientType string) string {
+	if s.genesisGen == nil {
+		s.log.Warn("Genesis generator not initialized (no hive directory?)")
+
+		return ""
+	}
+
+	hashes, err := readHiveDir(s.hiveDir)
+	if err != nil || len(hashes) == 0 {
+		s.log.WithError(err).Warn("No hive files found")
+
+		return ""
+	}
+
+	return s.GetGenesisPathForGroup(hashes[0], clientType)
 }
 
 // linesProvider implements StepProvider for in-memory lines.
@@ -1081,16 +1006,11 @@ type EESTSourceInfo struct {
 	GitHubRepo     string `json:"github_repo,omitempty"`
 	GitHubRelease  string `json:"github_release,omitempty"`
 	FixturesURL    string `json:"fixtures_url,omitempty"`
-	GenesisURL     string `json:"genesis_url,omitempty"`
 	FixturesSubdir string `json:"fixtures_subdir,omitempty"`
 	// Artifact fields (alternative to releases).
 	FixturesArtifactName  string `json:"fixtures_artifact_name,omitempty"`
-	GenesisArtifactName   string `json:"genesis_artifact_name,omitempty"`
 	FixturesArtifactRunID string `json:"fixtures_artifact_run_id,omitempty"`
-	GenesisArtifactRunID  string `json:"genesis_artifact_run_id,omitempty"`
 	// Local source fields.
 	LocalFixturesDir     string `json:"local_fixtures_dir,omitempty"`
-	LocalGenesisDir      string `json:"local_genesis_dir,omitempty"`
 	LocalFixturesTarball string `json:"local_fixtures_tarball,omitempty"`
-	LocalGenesisTarball  string `json:"local_genesis_tarball,omitempty"`
 }

--- a/pkg/executor/genesis_generate.go
+++ b/pkg/executor/genesis_generate.go
@@ -1,0 +1,353 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// defaultHiveRepo is the GitHub repository for hive mapper files.
+	defaultHiveRepo = "ethereum/hive"
+
+	// defaultHiveBranch is the branch to fetch mapper files from.
+	defaultHiveBranch = "master"
+)
+
+// HiveFile represents the JSON structure of a hive/{hash}.json file
+// containing the generic genesis and HIVE_* environment variables.
+type HiveFile struct {
+	Genesis     json.RawMessage   `json:"genesis"`
+	Environment map[string]string `json:"environment"`
+}
+
+// mapperOutput defines a single jq mapper invocation and its output file.
+type mapperOutput struct {
+	MapperFile string // e.g., "mapper.jq"
+	OutputFile string // e.g., "genesis.json" or "chainspec.json"
+}
+
+// clientGenesisMapping defines the mapper directory and outputs for a client.
+type clientGenesisMapping struct {
+	MapperDir string         // Directory name under mapperDir (e.g., "go-ethereum")
+	Outputs   []mapperOutput // Mapper files to run and their outputs
+	// PrimaryOutput is the file benchmarkoor mounts into the container.
+	PrimaryOutput string
+	// CopyGenesis indicates whether the raw generic genesis should also be
+	// written to genesis.json alongside the mapper output.
+	CopyGenesis bool
+}
+
+// clientGenesisMappings maps client types to their mapper configuration.
+var clientGenesisMappings = map[string]clientGenesisMapping{
+	"geth": {
+		MapperDir:     "go-ethereum",
+		Outputs:       []mapperOutput{{MapperFile: "mapper.jq", OutputFile: "genesis.json"}},
+		PrimaryOutput: "genesis.json",
+	},
+	"erigon": {
+		MapperDir:     "erigon",
+		Outputs:       []mapperOutput{{MapperFile: "mapper.jq", OutputFile: "genesis.json"}},
+		PrimaryOutput: "genesis.json",
+	},
+	"reth": {
+		MapperDir:     "reth",
+		Outputs:       []mapperOutput{{MapperFile: "mapper.jq", OutputFile: "genesis.json"}},
+		PrimaryOutput: "genesis.json",
+	},
+	"nimbus": {
+		MapperDir:     "nimbus-el",
+		Outputs:       []mapperOutput{{MapperFile: "mapper.jq", OutputFile: "genesis.json"}},
+		PrimaryOutput: "genesis.json",
+	},
+	"besu": {
+		MapperDir:     "besu",
+		Outputs:       []mapperOutput{{MapperFile: "mapper.jq", OutputFile: "genesis.json"}},
+		PrimaryOutput: "genesis.json",
+	},
+	"nethermind": {
+		MapperDir: "nethermind",
+		Outputs: []mapperOutput{
+			{MapperFile: "mapper.jq", OutputFile: "chainspec.json"},
+		},
+		PrimaryOutput: "chainspec.json",
+		CopyGenesis:   true, // Also write raw generic genesis as genesis.json
+	},
+}
+
+// genesisGenerator handles generating client-native genesis files
+// from hive files using jq mapper scripts.
+type genesisGenerator struct {
+	log       logrus.FieldLogger
+	mapperDir string // Path to directory containing client mapper.jq files
+	cacheDir  string // Path to cache generated genesis files
+	mu        sync.RWMutex
+	generated map[string]string // cache key -> generated file path
+}
+
+// newGenesisGenerator creates a new genesis generator.
+func newGenesisGenerator(
+	log logrus.FieldLogger,
+	mapperDir, cacheDir string,
+) *genesisGenerator {
+	return &genesisGenerator{
+		log:       log,
+		mapperDir: mapperDir,
+		cacheDir:  cacheDir,
+		generated: make(map[string]string, 64),
+	}
+}
+
+// FetchMappers downloads mapper.jq files from the hive GitHub repository
+// for all configured client types. Called once per run to ensure fresh mappers.
+func (g *genesisGenerator) FetchMappers(ctx context.Context) error {
+	type mapperFile struct {
+		dir  string
+		file string
+	}
+
+	seen := make(map[string]bool, len(clientGenesisMappings)*2)
+	files := make([]mapperFile, 0, len(clientGenesisMappings)*2)
+
+	for _, mapping := range clientGenesisMappings {
+		for _, out := range mapping.Outputs {
+			key := mapping.MapperDir + "/" + out.MapperFile
+			if seen[key] {
+				continue
+			}
+
+			seen[key] = true
+
+			files = append(files, mapperFile{dir: mapping.MapperDir, file: out.MapperFile})
+		}
+	}
+
+	for _, mf := range files {
+		localPath := filepath.Join(g.mapperDir, mf.dir, mf.file)
+
+		rawURL := fmt.Sprintf(
+			"https://raw.githubusercontent.com/%s/%s/clients/%s/%s",
+			defaultHiveRepo, defaultHiveBranch, mf.dir, mf.file,
+		)
+
+		g.log.WithFields(logrus.Fields{
+			"client": mf.dir,
+			"file":   mf.file,
+		}).Info("Fetching mapper from hive")
+
+		if err := downloadFile(ctx, rawURL, localPath); err != nil {
+			return fmt.Errorf("fetching mapper %s/%s: %w", mf.dir, mf.file, err)
+		}
+	}
+
+	return nil
+}
+
+// downloadFile fetches a URL and writes the response body to localPath.
+func downloadFile(ctx context.Context, rawURL, localPath string) error {
+	if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
+		return fmt.Errorf("creating directory: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("downloading: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, rawURL)
+	}
+
+	f, err := os.Create(localPath)
+	if err != nil {
+		return fmt.Errorf("creating file: %w", err)
+	}
+
+	defer func() { _ = f.Close() }()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("writing file: %w", err)
+	}
+
+	return nil
+}
+
+// GenerateClientGenesis generates all client-native genesis files from a hive
+// file. It reads the hive file, runs the appropriate mapper.jq(s) with HIVE_*
+// env vars, and writes the outputs to the cache directory.
+// Return the path to the primary genesis file (the one benchmarkoor mounts).
+func (g *genesisGenerator) GenerateClientGenesis(
+	ctx context.Context,
+	hiveFilePath, genesisHash, clientType string,
+) (string, error) {
+	mapping, ok := clientGenesisMappings[clientType]
+	if !ok {
+		return "", fmt.Errorf("unsupported client type: %s", clientType)
+	}
+
+	cacheKey := genesisHash + "/" + mapping.MapperDir
+
+	// Check cache first.
+	g.mu.RLock()
+	if path, cached := g.generated[cacheKey]; cached {
+		g.mu.RUnlock()
+
+		return path, nil
+	}
+	g.mu.RUnlock()
+
+	// Read and parse the hive file.
+	data, err := os.ReadFile(hiveFilePath)
+	if err != nil {
+		return "", fmt.Errorf("reading hive file %s: %w", hiveFilePath, err)
+	}
+
+	var hf HiveFile
+	if err := json.Unmarshal(data, &hf); err != nil {
+		return "", fmt.Errorf("parsing hive file %s: %w", hiveFilePath, err)
+	}
+
+	// Create output directory.
+	outputDir := filepath.Join(
+		g.cacheDir, "generated_genesis", genesisHash, mapping.MapperDir,
+	)
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return "", fmt.Errorf("creating output directory: %w", err)
+	}
+
+	// Write generic genesis to a temp file for jq input.
+	tmpGenesis, err := os.CreateTemp("", "genesis-input-*.json")
+	if err != nil {
+		return "", fmt.Errorf("creating temp genesis file: %w", err)
+	}
+
+	defer func() {
+		_ = tmpGenesis.Close()
+		_ = os.Remove(tmpGenesis.Name())
+	}()
+
+	if _, err := tmpGenesis.Write(hf.Genesis); err != nil {
+		return "", fmt.Errorf("writing temp genesis: %w", err)
+	}
+
+	if err := tmpGenesis.Close(); err != nil {
+		return "", fmt.Errorf("closing temp genesis: %w", err)
+	}
+
+	// Build environment for jq: inherit minimal env + HIVE_* vars.
+	env := make([]string, 0, len(hf.Environment)+2)
+	env = append(env, "PATH="+os.Getenv("PATH"))
+	env = append(env, "HOME="+os.Getenv("HOME"))
+
+	for k, v := range hf.Environment {
+		env = append(env, k+"="+v)
+	}
+
+	// Run each mapper.
+	for _, out := range mapping.Outputs {
+		mapperPath := filepath.Join(
+			g.mapperDir, mapping.MapperDir, out.MapperFile,
+		)
+
+		cmd := exec.CommandContext(ctx, "jq", "-f", mapperPath, tmpGenesis.Name())
+		cmd.Env = env
+
+		output, err := cmd.Output()
+		if err != nil {
+			var stderr string
+
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				stderr = string(exitErr.Stderr)
+			}
+
+			return "", fmt.Errorf(
+				"running jq for %s/%s/%s: %w (stderr: %s)",
+				genesisHash, mapping.MapperDir, out.MapperFile,
+				err, stderr,
+			)
+		}
+
+		if !json.Valid(output) {
+			return "", fmt.Errorf(
+				"jq produced invalid JSON for %s/%s/%s",
+				genesisHash, mapping.MapperDir, out.MapperFile,
+			)
+		}
+
+		outputPath := filepath.Join(outputDir, out.OutputFile)
+		if err := os.WriteFile(outputPath, output, 0644); err != nil {
+			return "", fmt.Errorf("writing %s: %w", out.OutputFile, err)
+		}
+	}
+
+	// Copy raw generic genesis if needed (e.g., nethermind needs genesis.json).
+	if mapping.CopyGenesis {
+		genesisPath := filepath.Join(outputDir, "genesis.json")
+		if err := os.WriteFile(genesisPath, hf.Genesis, 0644); err != nil {
+			return "", fmt.Errorf("writing genesis.json copy: %w", err)
+		}
+	}
+
+	// Return path to primary output.
+	primaryPath := filepath.Join(outputDir, mapping.PrimaryOutput)
+
+	g.mu.Lock()
+	g.generated[cacheKey] = primaryPath
+	g.mu.Unlock()
+
+	g.log.WithFields(logrus.Fields{
+		"genesis_hash": genesisHash,
+		"client":       clientType,
+		"mapper_dir":   mapping.MapperDir,
+		"output":       primaryPath,
+	}).Debug("Generated client genesis")
+
+	return primaryPath, nil
+}
+
+// SupportedClientTypes returns the list of client types with mapper configs.
+func SupportedClientTypes() []string {
+	types := make([]string, 0, len(clientGenesisMappings))
+	for k := range clientGenesisMappings {
+		types = append(types, k)
+	}
+
+	return types
+}
+
+// readHiveDir returns a list of genesis hashes from the hive directory.
+func readHiveDir(hiveDir string) ([]string, error) {
+	entries, err := os.ReadDir(hiveDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading hive directory %s: %w", hiveDir, err)
+	}
+
+	hashes := make([]string, 0, len(entries))
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		hash := strings.TrimSuffix(entry.Name(), ".json")
+		hashes = append(hashes, hash)
+	}
+
+	return hashes, nil
+}


### PR DESCRIPTION
Benchmarkoor depends on EEST to generate client specific genesis file via a build artifact. This PR allows dynamic generation of client specific genesis files from a "generic" format that eest generates along with fixtures.

This cuts a dependency and makes iteration quicker. 

How it works

```
fill → pre_alloc + hive/{hash}.json → benchmarkoor → jq -f mapper.jq → client genesis → tests
```

1. EEST fixtures now have a file called  `hive/{hash}.json`
2. Once per run, we download the required mappers from hive's repo for all clients
3. We then generate client specific genesis from  from the generic file
4. Finally, tests are run as if we had pre-built genesis tarball

