### PR TITLE
fix: Makefile: create tmp dir if not exists for docker-run-benchmarks target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,4 +136,5 @@ docker-run-api:
 ## docker-run-benchmark: Start the benchmarkoor service with docker-compose (CLIENT=name to limit, CONFIG=file to override config)
 CONFIG?=config.example.docker.yaml
 docker-run-benchmark:
+	@mkdir -p tmp
 	VERSION=$(VERSION) COMMIT=$(COMMIT) DATE=$(DATE) USER_UID=$(shell id -u) USER_GID=$(shell id -g) BENCHMARKOOR_CONFIG=$(CONFIG) docker compose run --rm --build benchmarkoor run --config /app/config.yaml $(if $(CLIENT),--limit-instance-client=$(CLIENT))


### PR DESCRIPTION
`tmp` is in gitignore so we can´t add it to the repo with a .gitkeep in it. 
Without this, a fresh clone of the repo will throw on `make docker-run-benchmark`.