### PR TITLE
fix(executor): wait for chain head advance between setup and test steps

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -433,6 +433,17 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 			}
 		}
 
+		// After setup step, wait for chain head to advance before running the test step.
+		// This is critical for multi-block EEST fixtures where the setup block deploys
+		// contracts and the test block calls them. Without this wait, the test block's
+		// engine_newPayload returns SYNCING because the node hasn't committed the setup
+		// block as the canonical head yet.
+		if test.Setup != nil && test.Test != nil && testPassed && opts.RPCEndpoint != "" {
+			if err := e.waitForChainHeadAdvance(ctx, opts.RPCEndpoint, rollbackInfo, log); err != nil {
+				log.WithError(err).Warn("Failed to wait for chain head advance after setup")
+			}
+		}
+
 		// Drop caches between setup and test.
 		if dropBetweenSteps && test.Setup != nil && test.Test != nil {
 			if err := e.dropMemoryCaches(dropCachesPath); err != nil {
@@ -1023,6 +1034,80 @@ func (e *executor) getBlockInfo(ctx context.Context, rpcEndpoint string) (*block
 		HexNumber: rpcResp.Result.Number,
 		Hash:      rpcResp.Result.Hash,
 	}, nil
+}
+
+// waitForChainHeadAdvance polls eth_blockNumber until the chain head has advanced
+// beyond the block number captured before the setup step. This ensures the node has
+// committed setup blocks (e.g., contract deployments) before the test step begins.
+// Without this, multi-block EEST fixtures fail because the test block's
+// engine_newPayload returns SYNCING — the node hasn't adopted the setup block yet.
+func (e *executor) waitForChainHeadAdvance(
+	ctx context.Context,
+	rpcEndpoint string,
+	preSetupBlock *blockInfo,
+	log *logrus.Entry,
+) error {
+	if preSetupBlock == nil {
+		// No baseline block info — just do a short sleep as fallback.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+
+		return nil
+	}
+
+	maxWait := 30 * time.Second
+	pollInterval := 200 * time.Millisecond
+	deadline := time.Now().Add(maxWait)
+
+	log.WithFields(logrus.Fields{
+		"pre_setup_block": preSetupBlock.HexNumber,
+	}).Debug("Waiting for chain head to advance after setup step")
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		current, err := e.getBlockInfo(ctx, rpcEndpoint)
+		if err != nil {
+			log.WithError(err).Debug("Failed to get block info while waiting")
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(pollInterval):
+			}
+
+			continue
+		}
+
+		if current.HexNumber != preSetupBlock.HexNumber {
+			log.WithFields(logrus.Fields{
+				"pre_setup_block": preSetupBlock.HexNumber,
+				"current_block":   current.HexNumber,
+			}).Debug("Chain head advanced after setup step")
+
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+
+	log.WithFields(logrus.Fields{
+		"pre_setup_block": preSetupBlock.HexNumber,
+		"timeout":         maxWait,
+	}).Warn("Timed out waiting for chain head to advance after setup step")
+
+	return nil // Don't fail the test, just warn — the test step's SYNCING retry may still succeed.
 }
 
 // rollback calls the client-specific rollback RPC method to revert chain state.


### PR DESCRIPTION
## Summary

When running multi-block EEST fixtures (e.g., BAL scenario benchmarks), the executor runs setup and test steps sequentially. The setup step deploys contracts via `engine_newPayload` + `engine_forkchoiceUpdated`, and the test step immediately sends the benchmark block.

**Problem:** The test block's `engine_newPayload` returns `SYNCING` because the node hasn't committed the setup block as the canonical head yet. The `engine_forkchoiceUpdated` from the setup step returns `VALID`, but the internal state update is asynchronous — the chain head hasn't actually advanced when the next `engine_newPayload` arrives milliseconds later.

**Fix:** After the setup step completes successfully and before the test step begins, poll `eth_blockNumber` until the chain head advances beyond the pre-setup block number. This ensures the node has fully committed the setup block before receiving the test block.

- Polls every 200ms with a 30s timeout
- Falls back to a 500ms sleep if no baseline block info is available
- Non-blocking: logs a warning on timeout but doesn't fail the test (the existing `retry_new_payloads_syncing_state` mechanism can still recover)

## Context

This is needed for EEST fixtures with setup+execution blocks, such as the [BAL scenario benchmarks](https://github.com/jochem-brouwer/execution-specs/pull/1) which test:
- Parallel execution (serial keccak chains)
- State root computation (disjoint SSTOREs)
- Cold storage prefetching (SLOAD linked-list chains)
- Deploy-then-interact (cross-tx code dependencies)
- Mixed dependency graphs (partial-order parallel scheduling)

These tests deploy contracts in a setup block and benchmark calls to them in the execution block. Without this fix, all multi-block tests fail with `SYNCING`.

## Test plan
- [x] Compiles successfully
- [ ] Run multi-block EEST BAL fixtures and verify setup blocks are committed before test blocks execute
- [ ] Verify single-block fixtures (no setup step) are unaffected
- [ ] Verify the wait doesn't add latency when chain head advances immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)