### PR TITLE
feat(ui): add block logs comparison to compare page

### DIFF
--- a/ui/src/components/compare/BlockLogsComparison.tsx
+++ b/ui/src/components/compare/BlockLogsComparison.tsx
@@ -1,0 +1,344 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import ReactECharts from 'echarts-for-react'
+import { Blocks } from 'lucide-react'
+import type { BlockLogs, SuiteTest } from '@/api/types'
+import { type CompareRun, RUN_SLOTS } from './constants'
+
+function useDarkMode() {
+  const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'))
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains('dark'))
+    })
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  return isDark
+}
+
+interface BlockLogDataPoint {
+  testIndex: number
+  testName: string
+  throughput: number
+  executionMs: number
+  overheadMs: number
+  accountCacheHitRate: number
+  storageCacheHitRate: number
+  codeCacheHitRate: number
+}
+
+/** Build a unified, sorted list of test names across all runs. */
+function buildUnifiedTestList(
+  blockLogsPerRun: (BlockLogs | null)[],
+  suiteTests?: SuiteTest[],
+): string[] {
+  const allNames = new Set<string>()
+  for (const bl of blockLogsPerRun) {
+    if (bl) for (const name of Object.keys(bl)) allNames.add(name)
+  }
+
+  const suiteOrder = new Map<string, number>()
+  if (suiteTests) {
+    suiteTests.forEach((t, i) => suiteOrder.set(t.name, i))
+  }
+
+  return [...allNames].sort((a, b) => {
+    const orderA = suiteOrder.get(a)
+    const orderB = suiteOrder.get(b)
+    if (orderA !== undefined && orderB !== undefined) return orderA - orderB
+    if (orderA !== undefined) return -1
+    if (orderB !== undefined) return 1
+    return a.localeCompare(b)
+  })
+}
+
+/** Map a single run's block logs onto the unified test list indices. Missing tests produce no entry. */
+function buildBlockLogDataPoints(
+  blockLogs: BlockLogs,
+  unifiedTests: string[],
+): BlockLogDataPoint[] {
+  const points: BlockLogDataPoint[] = []
+  unifiedTests.forEach((testName, index) => {
+    const entry = blockLogs[testName]
+    if (!entry) return
+    points.push({
+      testIndex: index + 1,
+      testName,
+      throughput: entry.throughput.mgas_per_sec,
+      executionMs: entry.timing.execution_ms,
+      overheadMs: entry.timing.state_read_ms + entry.timing.state_hash_ms + entry.timing.commit_ms,
+      accountCacheHitRate: entry.cache.account.hit_rate,
+      storageCacheHitRate: entry.cache.storage.hit_rate,
+      codeCacheHitRate: entry.cache.code.hit_rate,
+    })
+  })
+  return points
+}
+
+interface ChartSectionProps {
+  title: string
+  option: object
+  onZoom: (start: number, end: number) => void
+}
+
+function ChartSection({ title, option, onZoom }: ChartSectionProps) {
+  const onEvents = useMemo(
+    () => ({
+      datazoom: (params: { start?: number; end?: number; batch?: Array<{ start: number; end: number }> }) => {
+        if (params.batch && params.batch.length > 0) {
+          onZoom(params.batch[0].start, params.batch[0].end)
+        } else if (params.start !== undefined && params.end !== undefined) {
+          onZoom(params.start, params.end)
+        }
+      },
+    }),
+    [onZoom],
+  )
+
+  return (
+    <div className="rounded-xs bg-gray-50 p-3 dark:bg-gray-700/50">
+      <h4 className="mb-2 text-xs font-medium text-gray-700 dark:text-gray-300">{title}</h4>
+      <ReactECharts
+        option={option}
+        style={{ height: '200px', width: '100%' }}
+        opts={{ renderer: 'svg' }}
+        onEvents={onEvents}
+      />
+    </div>
+  )
+}
+
+interface BlockLogsComparisonProps {
+  runs: CompareRun[]
+  blockLogsPerRun: (BlockLogs | null)[]
+  blockLogsLoading: boolean
+  suiteTests?: SuiteTest[]
+}
+
+export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, suiteTests }: BlockLogsComparisonProps) {
+  const isDark = useDarkMode()
+  const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
+  const prevZoomRef = useRef(zoomRange)
+
+  const handleZoom = useCallback((start: number, end: number) => {
+    if (prevZoomRef.current.start !== start || prevZoomRef.current.end !== end) {
+      prevZoomRef.current = { start, end }
+      setZoomRange({ start, end })
+    }
+  }, [])
+
+  const unifiedTests = useMemo(
+    () => buildUnifiedTestList(blockLogsPerRun, suiteTests),
+    [blockLogsPerRun, suiteTests],
+  )
+
+  const pointsPerRun = useMemo(
+    () => blockLogsPerRun.map((bl) => (bl ? buildBlockLogDataPoints(bl, unifiedTests) : [])),
+    [blockLogsPerRun, unifiedTests],
+  )
+
+  const hasAnyData = blockLogsPerRun.some((bl) => bl !== null)
+  const runsWithData = runs.filter((_, i) => blockLogsPerRun[i] !== null)
+  const runsWithoutData = runs.filter((_, i) => blockLogsPerRun[i] === null)
+
+  const chartOptions = useMemo(() => {
+    const textColor = isDark ? '#ffffff' : '#374151'
+    const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
+    const splitLineColor = isDark ? '#374151' : '#e5e7eb'
+    const maxLen = unifiedTests.length
+
+    const baseConfig = {
+      backgroundColor: 'transparent',
+      animation: maxLen <= 100,
+      textStyle: { color: textColor },
+      grid: {
+        left: '3%',
+        right: '4%',
+        bottom: '50',
+        top: '15%',
+        containLabel: true,
+      },
+      xAxis: {
+        type: 'value' as const,
+        min: 1,
+        max: maxLen || 1,
+        minInterval: 1,
+        axisLabel: {
+          color: textColor,
+          fontSize: 11,
+          formatter: (value: number) => `#${value}`,
+        },
+        axisLine: { show: true, lineStyle: { color: axisLineColor } },
+        axisTick: { show: true, lineStyle: { color: axisLineColor } },
+        splitLine: { show: false },
+      },
+      legend: {
+        bottom: 25,
+        textStyle: { color: textColor, fontSize: 11 },
+        itemWidth: 12,
+        itemHeight: 8,
+      },
+      dataZoom: [
+        {
+          type: 'slider' as const,
+          xAxisIndex: 0,
+          start: zoomRange.start,
+          end: zoomRange.end,
+          height: 20,
+          bottom: 5,
+          borderColor: axisLineColor,
+          fillerColor: isDark ? 'rgba(139, 92, 246, 0.3)' : 'rgba(139, 92, 246, 0.1)',
+          backgroundColor: isDark ? '#374151' : '#f3f4f6',
+          textStyle: { color: textColor },
+          labelFormatter: (value: number) => `#${Math.round(value)}`,
+        },
+        {
+          type: 'inside' as const,
+          xAxisIndex: 0,
+          start: zoomRange.start,
+          end: zoomRange.end,
+          zoomOnMouseWheel: true,
+          moveOnMouseMove: true,
+          moveOnMouseWheel: false,
+        },
+      ],
+    }
+
+    const createLineSeries = () => ({
+      type: 'line' as const,
+      smooth: maxLen <= 100,
+      showSymbol: maxLen <= 100,
+      symbolSize: 4,
+      lineStyle: { width: 2 },
+    })
+
+    const clientBySeriesName = new Map<string, string>()
+    for (let i = 0; i < runs.length; i++) {
+      const client = runs[i].config.instance.client
+      const label = RUN_SLOTS[i].label
+      clientBySeriesName.set(`Run ${label}`, client)
+    }
+
+    const createTooltip = (formatter: (value: number) => string) => ({
+      trigger: 'axis' as const,
+      appendToBody: true,
+      backgroundColor: isDark ? '#1f2937' : '#ffffff',
+      borderColor: isDark ? '#374151' : '#e5e7eb',
+      textStyle: { color: textColor },
+      extraCssText: 'max-width: 300px; white-space: normal;',
+      formatter: (
+        params: Array<{ seriesName: string; color: string; value: [number, number | null, string] }>,
+      ) => {
+        const visible = params.filter((p) => p.value[1] != null)
+        if (!visible.length) return ''
+        const testIndex = visible[0].value[0]
+        const testName = visible[0].value[2]
+        let content = `<strong>Test #${testIndex}</strong>`
+        if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
+        content += '<br/>'
+        visible.forEach((p) => {
+          const value = p.value[1] as number
+          const client = clientBySeriesName.get(p.seriesName)
+          const clientImg = client ? `<img src="/img/clients/${client}.jpg" style="display:inline-block;width:14px;height:14px;border-radius:50%;object-fit:cover;vertical-align:middle;margin-right:4px;" />` : ''
+          content += `${clientImg}<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${p.color};margin-right:6px;vertical-align:middle;"></span>${p.seriesName}: ${formatter(value)}<br/>`
+        })
+        return content
+      },
+    })
+
+    const createYAxis = (formatter: (value: number) => string) => ({
+      type: 'value' as const,
+      axisLabel: { color: textColor, fontSize: 11, formatter },
+      axisLine: { show: true, lineStyle: { color: axisLineColor } },
+      axisTick: { show: true, lineStyle: { color: axisLineColor } },
+      splitLine: { lineStyle: { color: splitLineColor } },
+    })
+
+    const buildSimpleSeries = (field: keyof BlockLogDataPoint) =>
+      runsWithData.map((run) => {
+        const slot = RUN_SLOTS[run.index]
+        const pointsByIndex = new Map(pointsPerRun[run.index].map((d) => [d.testIndex, d]))
+        return {
+          name: `Run ${slot.label}`,
+          ...createLineSeries(),
+          connectNulls: false,
+          data: unifiedTests.map((testName, i) => {
+            const d = pointsByIndex.get(i + 1)
+            return [i + 1, d ? d[field] : null, testName]
+          }),
+          itemStyle: { color: slot.color },
+          areaStyle: { opacity: 0.08, color: slot.color },
+        }
+      })
+
+    const buildChart = (field: keyof BlockLogDataPoint, yFmt: (v: number) => string, tipFmt: (v: number) => string) => ({
+      ...baseConfig,
+      tooltip: createTooltip(tipFmt),
+      yAxis: createYAxis(yFmt),
+      series: buildSimpleSeries(field),
+    })
+
+    return {
+      throughput: buildChart('throughput', (v) => `${v.toFixed(0)}`, (v) => `${v.toFixed(2)} MGas/s`),
+      executionMs: buildChart('executionMs', (v) => `${v.toFixed(0)} ms`, (v) => `${v.toFixed(2)} ms`),
+      overheadMs: buildChart('overheadMs', (v) => `${v.toFixed(0)} ms`, (v) => `${v.toFixed(2)} ms`),
+      accountCacheHitRate: buildChart('accountCacheHitRate', (v) => `${v.toFixed(0)}%`, (v) => `${v.toFixed(1)}%`),
+      storageCacheHitRate: buildChart('storageCacheHitRate', (v) => `${v.toFixed(0)}%`, (v) => `${v.toFixed(1)}%`),
+      codeCacheHitRate: buildChart('codeCacheHitRate', (v) => `${v.toFixed(0)}%`, (v) => `${v.toFixed(1)}%`),
+    }
+  }, [pointsPerRun, runs, runsWithData, isDark, zoomRange, unifiedTests])
+
+  if (blockLogsLoading) {
+    return (
+      <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
+        <div className="flex items-center justify-center py-8 text-sm/6 text-gray-500 dark:text-gray-400">
+          Loading block logs...
+        </div>
+      </div>
+    )
+  }
+
+  if (!hasAnyData) return null
+
+  return (
+    <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
+      <div className="mb-4 flex items-center gap-2">
+        <Blocks className="size-4 text-gray-400 dark:text-gray-500" />
+        <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">Block Logs Comparison</h3>
+        <div className="ml-auto flex items-center gap-2 text-xs/5">
+          {runsWithData.map((run) => {
+            const slot = RUN_SLOTS[run.index]
+            return (
+              <span key={slot.label} className={`inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 font-medium ${slot.badgeBgClass} ${slot.badgeTextClass}`}>
+                <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
+                {slot.label}
+              </span>
+            )
+          })}
+        </div>
+      </div>
+
+      {runsWithoutData.length > 0 && (
+        <p className="mb-3 text-xs/5 text-gray-500 dark:text-gray-400">
+          Block logs unavailable for run{runsWithoutData.length > 1 ? 's' : ''}{' '}
+          {runsWithoutData.map((r) => RUN_SLOTS[r.index].label).join(', ')}
+        </p>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <ChartSection title="Throughput (MGas/s)" option={chartOptions.throughput} onZoom={handleZoom} />
+        <ChartSection title="Execution Time (ms)" option={chartOptions.executionMs} onZoom={handleZoom} />
+        <ChartSection title="Overhead — State Read/Hash/Commit (ms)" option={chartOptions.overheadMs} onZoom={handleZoom} />
+        <ChartSection title="Account Cache Hit Rate (%)" option={chartOptions.accountCacheHitRate} onZoom={handleZoom} />
+        <ChartSection title="Storage Cache Hit Rate (%)" option={chartOptions.storageCacheHitRate} onZoom={handleZoom} />
+        <ChartSection title="Code Cache Hit Rate (%)" option={chartOptions.codeCacheHitRate} onZoom={handleZoom} />
+      </div>
+
+      <p className="mt-4 text-center text-xs/5 text-gray-500 dark:text-gray-400">
+        Block log metrics per test (ordered by execution) - drag slider to zoom
+      </p>
+    </div>
+  )
+}

--- a/ui/src/components/compare/CompareHeader.tsx
+++ b/ui/src/components/compare/CompareHeader.tsx
@@ -59,6 +59,14 @@ function RunCard({
             {runId}
           </Link>
         </div>
+        {config.instance.id && (
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="shrink-0 text-xs/5 text-gray-500 dark:text-gray-400">ID:</span>
+            <span className="truncate font-mono text-sm/6 text-gray-900 dark:text-gray-100" title={config.instance.id}>
+              {config.instance.id}
+            </span>
+          </div>
+        )}
         {config.instance.client_version && (
           <div className="flex min-w-0 items-center gap-2">
             <span className="shrink-0 text-xs/5 text-gray-500 dark:text-gray-400">Version:</span>

--- a/ui/src/components/compare/StickyRunBar.tsx
+++ b/ui/src/components/compare/StickyRunBar.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react'
+import clsx from 'clsx'
+import { type CompareRun, RUN_SLOTS } from './constants'
+
+interface StickyRunBarProps {
+  runs: CompareRun[]
+  /** Ref to the element that, when scrolled out of view, triggers the sticky bar */
+  sentinelRef: React.RefObject<HTMLDivElement | null>
+}
+
+export function StickyRunBar({ runs, sentinelRef }: StickyRunBarProps) {
+  const [visible, setVisible] = useState(false)
+  const observerRef = useRef<IntersectionObserver | null>(null)
+
+  useEffect(() => {
+    const el = sentinelRef.current
+    if (!el) return
+
+    observerRef.current = new IntersectionObserver(
+      ([entry]) => setVisible(!entry.isIntersecting),
+      { threshold: 0 },
+    )
+    observerRef.current.observe(el)
+
+    return () => observerRef.current?.disconnect()
+  }, [sentinelRef])
+
+  if (!visible) return null
+
+  return (
+    <div className="fixed top-0 right-0 left-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/95">
+      <div className="mx-auto flex max-w-7xl items-center justify-center gap-4 px-4 py-2">
+        {runs.map((run) => {
+          const slot = RUN_SLOTS[run.index]
+          return (
+            <div key={slot.label} className="flex items-center gap-2">
+              <span className={clsx('inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs/5 font-medium', slot.badgeBgClass, slot.badgeTextClass)}>
+                <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
+                {slot.label}
+              </span>
+              {run.config.instance.id && (
+                <span className="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400" title={run.config.instance.id}>
+                  {run.config.instance.id}
+                </span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import clsx from 'clsx'
-import type { SuiteTest, AggregatedStats } from '@/api/types'
+import type { SuiteTest, AggregatedStats, BlockLogs, BlockLogEntry } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { Pagination } from '@/components/shared/Pagination'
 import { type CompareRun, RUN_SLOTS } from './constants'
@@ -9,16 +9,46 @@ interface TestComparisonTableProps {
   runs: CompareRun[]
   suiteTests?: SuiteTest[]
   stepFilter: StepTypeOption[]
+  blockLogsPerRun?: (BlockLogs | null)[]
 }
 
-type SortColumn = 'order' | 'name' | 'avgMgas'
+type SortColumn = 'order' | 'name' | 'avgValue'
 type SortDirection = 'asc' | 'desc'
 
 interface ComparedTest {
   name: string
   order: number
-  mgas: (number | undefined)[]
-  avgMgas: number | undefined
+  values: (number | undefined)[]
+  avgValue: number | undefined
+}
+
+interface MetricTab {
+  id: string
+  label: string
+  unit: string
+  higherIsBetter: boolean
+  format: (v: number) => string
+}
+
+const BLOCK_LOG_METRICS: MetricTab[] = [
+  { id: 'bl-throughput', label: 'Throughput', unit: 'MGas/s', higherIsBetter: true, format: (v) => v.toFixed(2) },
+  { id: 'bl-execution', label: 'Execution Time', unit: 'ms', higherIsBetter: false, format: (v) => v.toFixed(2) },
+  { id: 'bl-overhead', label: 'Overhead', unit: 'ms', higherIsBetter: false, format: (v) => v.toFixed(2) },
+  { id: 'bl-account-cache', label: 'Account Cache HR', unit: '%', higherIsBetter: true, format: (v) => v.toFixed(1) },
+  { id: 'bl-storage-cache', label: 'Storage Cache HR', unit: '%', higherIsBetter: true, format: (v) => v.toFixed(1) },
+  { id: 'bl-code-cache', label: 'Code Cache HR', unit: '%', higherIsBetter: true, format: (v) => v.toFixed(1) },
+]
+
+function extractBlockLogMetric(entry: BlockLogEntry, metricId: string): number {
+  switch (metricId) {
+    case 'bl-throughput': return entry.throughput.mgas_per_sec
+    case 'bl-execution': return entry.timing.execution_ms
+    case 'bl-overhead': return entry.timing.state_read_ms + entry.timing.state_hash_ms + entry.timing.commit_ms
+    case 'bl-account-cache': return entry.cache.account.hit_rate
+    case 'bl-storage-cache': return entry.cache.storage.hit_rate
+    case 'bl-code-cache': return entry.cache.code.hit_rate
+    default: return 0
+  }
 }
 
 // Returns an RGB color interpolated from yellow (small diff) to red (large diff)
@@ -83,50 +113,82 @@ function SortableHeader({
 
 const PAGE_SIZE = 50
 
-export function TestComparisonTable({ runs, suiteTests, stepFilter }: TestComparisonTableProps) {
+export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun }: TestComparisonTableProps) {
+  const [activeTab, setActiveTab] = useState('mgas')
   const [sortBy, setSortBy] = useState<SortColumn>('order')
   const [sortDir, setSortDir] = useState<SortDirection>('asc')
   const [searchQuery, setSearchQuery] = useState('')
   const [useRegex, setUseRegex] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
 
+  const hasBlockLogs = blockLogsPerRun?.some((bl) => bl !== null) ?? false
+
+  const tabs: MetricTab[] = useMemo(() => {
+    const base: MetricTab[] = [
+      { id: 'mgas', label: 'MGas/s', unit: 'MGas/s', higherIsBetter: true, format: (v) => v.toFixed(2) },
+    ]
+    if (hasBlockLogs) {
+      return [...base, ...BLOCK_LOG_METRICS]
+    }
+    return base
+  }, [hasBlockLogs])
+
+  const activeMetric = tabs.find((t) => t.id === activeTab) ?? tabs[0]
+
+  const suiteOrder = useMemo(() => {
+    const map = new Map<string, number>()
+    if (suiteTests) {
+      suiteTests.forEach((t, i) => map.set(t.name, i + 1))
+    }
+    return map
+  }, [suiteTests])
+
   const comparedTests = useMemo(() => {
     const allTestNames = new Set<string>()
-    for (const run of runs) {
-      if (run.result) {
-        for (const name of Object.keys(run.result.tests)) {
-          allTestNames.add(name)
+
+    if (activeTab === 'mgas') {
+      for (const run of runs) {
+        if (run.result) {
+          for (const name of Object.keys(run.result.tests)) allTestNames.add(name)
         }
       }
-    }
-
-    const suiteOrder = new Map<string, number>()
-    if (suiteTests) {
-      suiteTests.forEach((t, i) => suiteOrder.set(t.name, i + 1))
+    } else {
+      if (blockLogsPerRun) {
+        for (const bl of blockLogsPerRun) {
+          if (bl) for (const name of Object.keys(bl)) allTestNames.add(name)
+        }
+      }
     }
 
     const tests: ComparedTest[] = []
     for (const name of allTestNames) {
-      const mgas: (number | undefined)[] = []
+      const values: (number | undefined)[] = []
       let order = suiteOrder.get(name) ?? 0
 
-      for (const run of runs) {
-        const entry = run.result?.tests[name]
-        const stats = entry ? getAggregatedStats(entry, stepFilter) : undefined
-        mgas.push(calculateMGasPerSec(stats))
-
-        if (order === 0 && entry) {
-          order = parseInt(entry.dir, 10) || 0
+      if (activeTab === 'mgas') {
+        for (const run of runs) {
+          const entry = run.result?.tests[name]
+          const stats = entry ? getAggregatedStats(entry, stepFilter) : undefined
+          values.push(calculateMGasPerSec(stats))
+          if (order === 0 && entry) {
+            order = parseInt(entry.dir, 10) || 0
+          }
+        }
+      } else {
+        for (let i = 0; i < runs.length; i++) {
+          const bl = blockLogsPerRun?.[i]
+          const entry = bl?.[name]
+          values.push(entry ? extractBlockLogMetric(entry, activeTab) : undefined)
         }
       }
 
-      const defined = mgas.filter((v): v is number => v !== undefined)
-      const avgMgas = defined.length > 0 ? defined.reduce((a, b) => a + b, 0) / defined.length : undefined
+      const defined = values.filter((v): v is number => v !== undefined)
+      const avgValue = defined.length > 0 ? defined.reduce((a, b) => a + b, 0) / defined.length : undefined
 
-      tests.push({ name, order, mgas, avgMgas })
+      tests.push({ name, order, values, avgValue })
     }
     return tests
-  }, [runs, suiteTests, stepFilter])
+  }, [runs, suiteOrder, stepFilter, activeTab, blockLogsPerRun])
 
   const filteredTests = useMemo(() => {
     if (!searchQuery) return comparedTests
@@ -153,8 +215,8 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter }: TestCompar
         case 'name':
           cmp = a.name.localeCompare(b.name)
           break
-        case 'avgMgas':
-          cmp = (a.avgMgas ?? 0) - (b.avgMgas ?? 0)
+        case 'avgValue':
+          cmp = (a.avgValue ?? 0) - (b.avgValue ?? 0)
           break
       }
       return sortDir === 'asc' ? cmp : -cmp
@@ -208,20 +270,41 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter }: TestCompar
           </button>
         </div>
       </div>
+
+      {tabs.length > 1 && (
+        <div className="flex gap-0 overflow-x-auto border-b border-gray-200 px-4 dark:border-gray-700">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => { setActiveTab(tab.id); setCurrentPage(1) }}
+              title={tab.id.startsWith('bl-') ? 'Extracted from block logs' : undefined}
+              className={clsx(
+                'shrink-0 border-b-2 px-3 py-2 text-xs/5 font-medium transition-colors',
+                activeTab === tab.id
+                  ? 'border-blue-500 text-blue-600 dark:border-blue-400 dark:text-blue-400'
+                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-300',
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      )}
+
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
           <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
               <SortableHeader label="#" column="order" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="w-12 px-3 py-3" />
               <SortableHeader label="Test Name" column="name" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
-              <SortableHeader label="Avg" column="avgMgas" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-4 py-3 text-right" />
+              <SortableHeader label="Avg" column="avgValue" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-4 py-3 text-right" />
               {runs.map((run) => {
                 const slot = RUN_SLOTS[run.index]
                 return (
                   <th key={slot.label} className={clsx('px-4 py-3 text-right text-xs/5 font-medium uppercase tracking-wider', slot.textClass, `dark:${slot.textDarkClass.replace('text-', 'text-')}`)}>
                     <div className="flex flex-col items-end gap-1">
                       <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-5 rounded-full object-cover" />
-                      {slot.label} MGas/s
+                      {slot.label} {activeMetric.unit}
                     </div>
                   </th>
                 )
@@ -230,8 +313,10 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter }: TestCompar
           </thead>
           <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
             {paginatedTests.map((test) => {
-              const definedMgas = test.mgas.filter((v): v is number => v !== undefined)
-              const maxMgas = definedMgas.length > 0 ? Math.max(...definedMgas) : undefined
+              const defined = test.values.filter((v): v is number => v !== undefined)
+              const bestValue = defined.length > 0
+                ? (activeMetric.higherIsBetter ? Math.max(...defined) : Math.min(...defined))
+                : undefined
 
               return (
                 <tr key={test.name} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
@@ -242,19 +327,21 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter }: TestCompar
                     {test.name}
                   </td>
                   <td className="whitespace-nowrap px-4 py-2 text-right text-sm/6 text-gray-400 dark:text-gray-500">
-                    {test.avgMgas !== undefined ? test.avgMgas.toFixed(2) : '-'}
+                    {test.avgValue !== undefined ? activeMetric.format(test.avgValue) : '-'}
                   </td>
-                  {test.mgas.map((val, i) => {
-                    const diff = val !== undefined && maxMgas !== undefined ? val - maxMgas : undefined
-                    const isFastest = val !== undefined && val === maxMgas
+                  {test.values.map((val, i) => {
+                    const isBest = val !== undefined && val === bestValue
+                    const diff = val !== undefined && bestValue !== undefined
+                      ? (activeMetric.higherIsBetter ? val - bestValue : bestValue - val)
+                      : undefined
                     return (
                       <td key={RUN_SLOTS[i].label} className="whitespace-nowrap px-4 py-2 text-right text-sm/6">
-                        <div className={isFastest ? 'font-semibold text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'}>
-                          {val !== undefined ? val.toFixed(2) : '-'}
+                        <div className={isBest ? 'font-semibold text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'}>
+                          {val !== undefined ? activeMetric.format(val) : '-'}
                         </div>
-                        {diff !== undefined && !isFastest && (
-                          <div className="text-xs/4" style={{ color: getDiffColor(diff, maxMgas!) }}>
-                            {diff.toFixed(2)}
+                        {diff !== undefined && !isBest && (
+                          <div className="text-xs/4" style={{ color: getDiffColor(diff, bestValue!) }}>
+                            {activeMetric.higherIsBetter ? diff.toFixed(2) : `+${Math.abs(diff).toFixed(2)}`}
                           </div>
                         )}
                       </td>

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { Link, useSearch, useNavigate } from '@tanstack/react-router'
 import { useQueries } from '@tanstack/react-query'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES } from '@/api/types'
-import type { RunConfig, RunResult } from '@/api/types'
+import type { BlockLogs, RunConfig, RunResult } from '@/api/types'
 import { fetchData } from '@/api/client'
 import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
@@ -13,6 +13,7 @@ import { MetricsComparison } from '@/components/compare/MetricsComparison'
 import { MGasComparisonChart } from '@/components/compare/MGasComparisonChart'
 import { TestComparisonTable } from '@/components/compare/TestComparisonTable'
 import { ResourceComparisonCharts } from '@/components/compare/ResourceComparisonCharts'
+import { BlockLogsComparison } from '@/components/compare/BlockLogsComparison'
 import { ConfigDiff } from '@/components/compare/ConfigDiff'
 import { type StepTypeOption, ALL_STEP_TYPES, DEFAULT_STEP_FILTER } from '@/pages/RunDetailPage'
 import { MIN_COMPARE_RUNS, MAX_COMPARE_RUNS, type CompareRun } from '@/components/compare/constants'
@@ -77,6 +78,23 @@ export function ComparePage() {
       enabled: !!runId,
     })),
   })
+
+  const blockLogQueries = useQueries({
+    queries: runIds.map((runId) => ({
+      queryKey: ['run', runId, 'block-logs'],
+      queryFn: async () => {
+        const { data, status } = await fetchData<BlockLogs>(`runs/${runId}/result.block-logs.json`)
+        if (!data) {
+          if (status === 404) return null
+          throw new Error(`Failed to fetch block logs: ${status}`)
+        }
+        return data
+      },
+      enabled: !!runId,
+    })),
+  })
+  const blockLogsPerRun = blockLogQueries.map((q) => q.data ?? null)
+  const blockLogsLoading = blockLogQueries.some((q) => q.isLoading)
 
   const suiteHash = configQueries.find((q) => q.data?.suite_hash)?.data?.suite_hash
   const { data: suite } = useSuite(suiteHash)
@@ -184,6 +202,8 @@ export function ComparePage() {
       )}
 
       {allResults && <ResourceComparisonCharts runs={runs} />}
+
+      <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} />
 
       <ConfigDiff runs={runs} />
     </div>

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Link, useSearch, useNavigate } from '@tanstack/react-router'
 import { useQueries } from '@tanstack/react-query'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES } from '@/api/types'
@@ -9,6 +9,7 @@ import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { CompareHeader } from '@/components/compare/CompareHeader'
+import { StickyRunBar } from '@/components/compare/StickyRunBar'
 import { MetricsComparison } from '@/components/compare/MetricsComparison'
 import { MGasComparisonChart } from '@/components/compare/MGasComparisonChart'
 import { TestComparisonTable } from '@/components/compare/TestComparisonTable'
@@ -98,6 +99,7 @@ export function ComparePage() {
 
   const suiteHash = configQueries.find((q) => q.data?.suite_hash)?.data?.suite_hash
   const { data: suite } = useSuite(suiteHash)
+  const headerRef = useRef<HTMLDivElement>(null)
 
   // Handle backward-compat redirect in progress
   if (search.a && search.b && !search.runs) {
@@ -140,6 +142,8 @@ export function ComparePage() {
 
   return (
     <div className="flex flex-col gap-6">
+      <StickyRunBar runs={runs} sentinelRef={headerRef} />
+
       {/* Breadcrumb */}
       <div className="flex min-w-0 items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
         <Link to="/runs" className="shrink-0 hover:text-gray-700 dark:hover:text-gray-300">
@@ -168,10 +172,12 @@ export function ComparePage() {
         </div>
       )}
 
-      <CompareHeader runs={runs} onRemoveRun={(id) => {
-        const remaining = runIds.filter((r) => r !== id)
-        navigate({ to: '/compare', search: { runs: remaining.join(','), steps: search.steps } })
-      }} />
+      <div ref={headerRef}>
+        <CompareHeader runs={runs} onRemoveRun={(id) => {
+          const remaining = runIds.filter((r) => r !== id)
+          navigate({ to: '/compare', search: { runs: remaining.join(','), steps: search.steps } })
+        }} />
+      </div>
 
 <MetricsComparison runs={runs} stepFilter={stepFilter} />
 

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -197,13 +197,13 @@ export function ComparePage() {
         <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} />
       )}
 
+      <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} />
+
       {allResults && (
-        <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} />
+        <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} />
       )}
 
       {allResults && <ResourceComparisonCharts runs={runs} />}
-
-      <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} />
 
       <ConfigDiff runs={runs} />
     </div>

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -173,25 +173,7 @@ export function ComparePage() {
         navigate({ to: '/compare', search: { runs: remaining.join(','), steps: search.steps } })
       }} />
 
-      <div className="flex items-center gap-2">
-        <span className="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Metric steps:</span>
-        <div className="flex items-center gap-1">
-          {ALL_INDEX_STEP_TYPES.map((step) => (
-            <span
-              key={step}
-              className={`rounded-sm px-2.5 py-1 text-xs font-medium capitalize ${
-                stepFilter.includes(step)
-                  ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300'
-                  : 'bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
-              }`}
-            >
-              {step}
-            </span>
-          ))}
-        </div>
-      </div>
-
-      <MetricsComparison runs={runs} stepFilter={stepFilter} />
+<MetricsComparison runs={runs} stepFilter={stepFilter} />
 
       {allResults && (
         <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} />


### PR DESCRIPTION
## Summary
- Add block logs comparison charts (throughput, execution time, overhead, cache hit rates) with unified test indices and synchronized zoom
- Add block log metric tabs to per-test comparison table with direction-aware diff coloring
- Add sticky run bar that shows slot badges and instance IDs when scrolling past the run cards
- Show instance ID on compare header cards and remove unused metric steps section

## Test plan
- [x] Compare page with runs that have block logs → 6 charts visible, tabbed table works
- [x] Compare page with runs that lack block logs → block logs section hidden, no extra tabs
- [x] Mix of runs with/without block logs → partial rendering with info text
- [x] Zoom slider synchronized across all 6 block log charts
- [x] Sticky bar appears when scrolling past run cards, disappears when scrolling back up
- [x] Dark mode renders correctly