### PR TITLE
fix: rename docker_network to container_network

### DIFF
--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -288,7 +288,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 			ResultsDir:         cfg.Runner.Benchmark.ResultsDir,
 			ResultsOwner:       resultsOwner,
 			ClientLogsToStdout: cfg.Runner.ClientLogsToStdout,
-			DockerNetwork:      cfg.Runner.DockerNetwork,
+			ContainerNetwork:   cfg.Runner.ContainerNetwork,
 			JWT:                cfg.Runner.Client.Config.JWT,
 			GenesisURLs:        cfg.Runner.Client.Config.Genesis,
 			DataDirs:           cfg.Runner.Client.DataDirs,

--- a/config.example.docker.yaml
+++ b/config.example.docker.yaml
@@ -3,7 +3,7 @@ global:
 
 runner:
   client_logs_to_stdout: true
-  docker_network: benchmarkoor
+  container_network: benchmarkoor
   cleanup_on_start: false
 
   benchmark:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,7 +13,7 @@ runner:
   # When using Podman, ensure the socket is active: sudo systemctl start podman.socket
   # container_runtime: docker
   client_logs_to_stdout: true
-  docker_network: benchmarkoor
+  container_network: benchmarkoor
   cleanup_on_start: false
   # Optional: Global timeout for the entire run (all instances, setup, teardown).
   # If the run exceeds this duration, it will be cancelled.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,7 @@ The `runner` section contains all run-specific settings including benchmark conf
 runner:
   container_runtime: docker
   client_logs_to_stdout: true
-  docker_network: benchmarkoor
+  container_network: benchmarkoor
   cleanup_on_start: false
   run_timeout: 4h
   directories:
@@ -114,7 +114,7 @@ runner:
 |--------|------|---------|-------------|
 | `container_runtime` | string | `docker` | Container runtime to use: `docker` or `podman`. See [Container Runtime](#container-runtime) |
 | `client_logs_to_stdout` | bool | `false` | Stream client container logs to stdout |
-| `docker_network` | string | `benchmarkoor` | Docker network name for containers |
+| `container_network` | string | `benchmarkoor` | Container network name |
 | `cleanup_on_start` | bool | `false` | Remove leftover containers/networks on startup |
 | `run_timeout` | string | - | Global timeout for the entire run covering all instances, setup, and teardown. Uses Go duration format (e.g., `4h`, `30m`). See [Runner Run Timeout](#runner-run-timeout) |
 | `directories.tmp_datadir` | string | system temp | Directory for temporary datadir copies |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -191,7 +191,7 @@ Benchmarkoor creates a dedicated Docker bridge network for container communicati
 
 ```yaml
 global:
-  docker_network: benchmarkoor  # default
+  container_network: benchmarkoor  # default
 ```
 
 ### Network Behavior

--- a/examples/configuration/config.stateful.zfs.yaml
+++ b/examples/configuration/config.stateful.zfs.yaml
@@ -3,7 +3,7 @@ global:
 
 runner:
   client_logs_to_stdout: true
-  docker_network: benchmarkoor
+  container_network: benchmarkoor
   cleanup_on_start: false
 
   benchmark:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,8 +23,8 @@ const (
 	// DefaultJWT is the default JWT secret used for Engine API authentication.
 	DefaultJWT = "5a64f13bfb41a147711492237995b437433bcbec80a7eb2daae11132098d7bae"
 
-	// DefaultDockerNetwork is the default Docker network name.
-	DefaultDockerNetwork = "benchmarkoor"
+	// DefaultContainerNetwork is the default container network name.
+	DefaultContainerNetwork = "benchmarkoor"
 
 	// DefaultLogLevel is the default logging level.
 	DefaultLogLevel = "info"
@@ -72,7 +72,7 @@ type Config struct {
 type RunnerConfig struct {
 	ContainerRuntime   string            `yaml:"container_runtime,omitempty" mapstructure:"container_runtime"`
 	ClientLogsToStdout bool              `yaml:"client_logs_to_stdout" mapstructure:"client_logs_to_stdout"`
-	DockerNetwork      string            `yaml:"docker_network" mapstructure:"docker_network"`
+	ContainerNetwork   string            `yaml:"container_network" mapstructure:"container_network"`
 	CleanupOnStart     bool              `yaml:"cleanup_on_start" mapstructure:"cleanup_on_start"`
 	RunTimeout         string            `yaml:"run_timeout,omitempty" mapstructure:"run_timeout"`
 	Directories        DirectoriesConfig `yaml:"directories,omitempty" mapstructure:"directories"`
@@ -717,7 +717,7 @@ func bindEnvKeys(v *viper.Viper) {
 		// Runner settings
 		"runner.container_runtime",
 		"runner.client_logs_to_stdout",
-		"runner.docker_network",
+		"runner.container_network",
 		"runner.cleanup_on_start",
 		"runner.run_timeout",
 		"runner.directories.tmp_datadir",
@@ -793,8 +793,8 @@ func (c *Config) applyDefaults() {
 		c.Global.LogLevel = DefaultLogLevel
 	}
 
-	if c.Runner.DockerNetwork == "" {
-		c.Runner.DockerNetwork = DefaultDockerNetwork
+	if c.Runner.ContainerNetwork == "" {
+		c.Runner.ContainerNetwork = DefaultContainerNetwork
 	}
 
 	if c.Runner.Benchmark.ResultsDir == "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,7 @@ func TestLoad_EnvVarOverrides(t *testing.T) {
 global:
   log_level: info
 runner:
-  docker_network: test-network
+  container_network: test-network
   client_logs_to_stdout: false
   cleanup_on_start: false
   directories:
@@ -54,7 +54,7 @@ runner:
 			envVars: map[string]string{},
 			validate: func(t *testing.T, cfg *Config) {
 				assert.Equal(t, "info", cfg.Global.LogLevel)
-				assert.Equal(t, "test-network", cfg.Runner.DockerNetwork)
+				assert.Equal(t, "test-network", cfg.Runner.ContainerNetwork)
 				assert.Equal(t, "./original-results", cfg.Runner.Benchmark.ResultsDir)
 				assert.Equal(t, "original-jwt", cfg.Runner.Client.Config.JWT)
 			},
@@ -69,12 +69,12 @@ runner:
 			},
 		},
 		{
-			name: "string override - docker_network",
+			name: "string override - container_network",
 			envVars: map[string]string{
-				"BENCHMARKOOR_RUNNER_DOCKER_NETWORK": "custom-network",
+				"BENCHMARKOOR_RUNNER_CONTAINER_NETWORK": "custom-network",
 			},
 			validate: func(t *testing.T, cfg *Config) {
-				assert.Equal(t, "custom-network", cfg.Runner.DockerNetwork)
+				assert.Equal(t, "custom-network", cfg.Runner.ContainerNetwork)
 			},
 		},
 		{
@@ -162,13 +162,13 @@ runner:
 			name: "multiple overrides",
 			envVars: map[string]string{
 				"BENCHMARKOOR_GLOBAL_LOG_LEVEL":             "trace",
-				"BENCHMARKOOR_RUNNER_DOCKER_NETWORK":        "multi-network",
+				"BENCHMARKOOR_RUNNER_CONTAINER_NETWORK":     "multi-network",
 				"BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_DIR": "/results/multi",
 				"BENCHMARKOOR_RUNNER_CLEANUP_ON_START":      "true",
 			},
 			validate: func(t *testing.T, cfg *Config) {
 				assert.Equal(t, "trace", cfg.Global.LogLevel)
-				assert.Equal(t, "multi-network", cfg.Runner.DockerNetwork)
+				assert.Equal(t, "multi-network", cfg.Runner.ContainerNetwork)
 				assert.Equal(t, "/results/multi", cfg.Runner.Benchmark.ResultsDir)
 				assert.True(t, cfg.Runner.CleanupOnStart)
 			},
@@ -272,7 +272,7 @@ runner:
 
 	// Verify defaults are applied.
 	assert.Equal(t, DefaultLogLevel, cfg.Global.LogLevel)
-	assert.Equal(t, DefaultDockerNetwork, cfg.Runner.DockerNetwork)
+	assert.Equal(t, DefaultContainerNetwork, cfg.Runner.ContainerNetwork)
 	assert.Equal(t, DefaultResultsDir, cfg.Runner.Benchmark.ResultsDir)
 	assert.Equal(t, DefaultJWT, cfg.Runner.Client.Config.JWT)
 	assert.Equal(t, DefaultPullPolicy, cfg.Runner.Instances[0].PullPolicy)
@@ -992,7 +992,7 @@ func TestGetBootstrapFCU(t *testing.T) {
 func TestLoad_PreservesEnvironmentKeyCasing(t *testing.T) {
 	configContent := `
 runner:
-  docker_network: test-network
+  container_network: test-network
   client:
     config:
       jwt: test-jwt

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -264,7 +264,7 @@ func (r *runner) runContainerLifecycle(
 			Image:       imageName,
 			Command:     spec.InitCommand(),
 			Mounts:      mounts,
-			NetworkName: r.cfg.DockerNetwork,
+			NetworkName: r.cfg.ContainerNetwork,
 			Labels: map[string]string{
 				"benchmarkoor.instance":   instance.ID,
 				"benchmarkoor.client":     instance.Client,
@@ -639,7 +639,7 @@ func (r *runner) runContainerLifecycle(
 		Command:        cmd,
 		Env:            env,
 		Mounts:         mounts,
-		NetworkName:    r.cfg.DockerNetwork,
+		NetworkName:    r.cfg.ContainerNetwork,
 		ResourceLimits: containerResourceLimits,
 		Labels: map[string]string{
 			"benchmarkoor.instance":   instance.ID,
@@ -816,7 +816,7 @@ func (r *runner) runContainerLifecycle(
 
 	// Get container IP for health checks.
 	containerIP, err := r.containerMgr.GetContainerIP(
-		ctx, containerID, r.cfg.DockerNetwork,
+		ctx, containerID, r.cfg.ContainerNetwork,
 	)
 	if err != nil {
 		return fmt.Errorf("getting container IP: %w", err)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -51,7 +51,7 @@ type Config struct {
 	ResultsDir         string
 	ResultsOwner       *fsutil.OwnerConfig // Optional file ownership for results directory
 	ClientLogsToStdout bool
-	DockerNetwork      string
+	ContainerNetwork   string
 	JWT                string
 	GenesisURLs        map[string]string
 	DataDirs           map[string]*config.DataDirConfig
@@ -235,7 +235,7 @@ func (r *runner) Start(ctx context.Context) error {
 	}
 
 	// Ensure container network exists.
-	if err := r.containerMgr.EnsureNetwork(ctx, r.cfg.DockerNetwork); err != nil {
+	if err := r.containerMgr.EnsureNetwork(ctx, r.cfg.ContainerNetwork); err != nil {
 		return fmt.Errorf("ensuring container network: %w", err)
 	}
 

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -115,7 +115,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 		// IP may change after restart; refresh it.
 		newIP, err := r.containerMgr.GetContainerIP(
-			ctx, containerID, r.cfg.DockerNetwork,
+			ctx, containerID, r.cfg.ContainerNetwork,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("getting container IP after checkpoint restart: %w", err)
@@ -417,7 +417,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 		restoredID, err := cpMgr.RestoreContainer(ctx, exportPath, &podman.RestoreOptions{
 			Name:        restoreName,
-			NetworkName: r.cfg.DockerNetwork,
+			NetworkName: r.cfg.ContainerNetwork,
 		})
 		if err != nil {
 			combined.TotalDuration = time.Since(startTime)
@@ -438,7 +438,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 		// Get container IP.
 		restoredIP, err := r.containerMgr.GetContainerIP(
-			ctx, restoredID, r.cfg.DockerNetwork,
+			ctx, restoredID, r.cfg.ContainerNetwork,
 		)
 		if err != nil {
 			combined.TotalDuration = time.Since(startTime)

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -330,7 +330,7 @@ func (r *runner) runTestsWithContainerStrategy(
 
 			// Get new container IP.
 			newIP, err := r.containerMgr.GetContainerIP(
-				ctx, newID, r.cfg.DockerNetwork,
+				ctx, newID, r.cfg.ContainerNetwork,
 			)
 			if err != nil {
 				waitForLogDrain(logDone, logCancel, logDrainTimeout)
@@ -549,7 +549,7 @@ func (r *runner) runTestsWithContainerStrategy(
 
 			// Get new container IP.
 			newIP, err := r.containerMgr.GetContainerIP(
-				ctx, newID, r.cfg.DockerNetwork,
+				ctx, newID, r.cfg.ContainerNetwork,
 			)
 			if err != nil {
 				waitForLogDrain(logDone, logCancel, logDrainTimeout)
@@ -858,7 +858,7 @@ func (r *runner) runInitForRecreate(
 		Image:       params.ImageName,
 		Command:     spec.InitCommand(),
 		Mounts:      mounts,
-		NetworkName: r.cfg.DockerNetwork,
+		NetworkName: r.cfg.ContainerNetwork,
 		Labels: map[string]string{
 			"benchmarkoor.instance":   instance.ID,
 			"benchmarkoor.client":     instance.Client,


### PR DESCRIPTION
## Summary
- Rename `docker_network` config field to `container_network` since it's used for both Docker and Podman networking
- Updates constant, struct field, YAML/mapstructure tags, env var binding (`BENCHMARKOOR_RUNNER_CONTAINER_NETWORK`), tests, docs, and example configs

## Test plan
- [x] `go build` passes
- [x] `go test ./pkg/config/...` passes
- [x] `golangci-lint` clean
- [x] Verify existing configs with `docker_network` still work (viper should ignore unknown keys) or update local configs