### PR TITLE
feat(ui): enhance compare page with % diff chart, filters, and UX improvements

### DIFF
--- a/ui/src/components/compare/BlockLogsComparison.tsx
+++ b/ui/src/components/compare/BlockLogsComparison.tsx
@@ -153,6 +153,14 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
     const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
     const splitLineColor = isDark ? '#374151' : '#e5e7eb'
     const maxLen = unifiedTests.length
+    const suiteOrder = new Map<string, number>()
+    if (suiteTests) {
+      suiteTests.forEach((t, i) => suiteOrder.set(t.name, i + 1))
+    }
+    const indexToOrder = new Map<number, number>()
+    unifiedTests.forEach((name, i) => {
+      indexToOrder.set(i + 1, suiteOrder.get(name) ?? (i + 1))
+    })
 
     const baseConfig = {
       backgroundColor: 'transparent',
@@ -173,7 +181,7 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
         axisLabel: {
           color: textColor,
           fontSize: 11,
-          formatter: (value: number) => `#${value}`,
+          formatter: (value: number) => `#${indexToOrder.get(value) ?? value}`,
         },
         axisLine: { show: true, lineStyle: { color: axisLineColor } },
         axisTick: { show: true, lineStyle: { color: axisLineColor } },
@@ -197,7 +205,7 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
           fillerColor: isDark ? 'rgba(139, 92, 246, 0.3)' : 'rgba(139, 92, 246, 0.1)',
           backgroundColor: isDark ? '#374151' : '#f3f4f6',
           textStyle: { color: textColor },
-          labelFormatter: (value: number) => `#${Math.round(value)}`,
+          labelFormatter: (value: number) => `#${indexToOrder.get(Math.round(value)) ?? Math.round(value)}`,
         },
         {
           type: 'inside' as const,
@@ -234,13 +242,13 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
       textStyle: { color: textColor },
       extraCssText: 'max-width: 300px; white-space: normal;',
       formatter: (
-        params: Array<{ seriesName: string; color: string; value: [number, number | null, string] }>,
+        params: Array<{ seriesName: string; color: string; value: [number, number | null, string, number] }>,
       ) => {
         const visible = params.filter((p) => p.value[1] != null)
         if (!visible.length) return ''
-        const testIndex = visible[0].value[0]
         const testName = visible[0].value[2]
-        let content = `<strong>Test #${testIndex}</strong>`
+        const testOrder = visible[0].value[3]
+        let content = `<strong>Test #${testOrder}</strong>`
         if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
         content += '<br/>'
         visible.forEach((p) => {
@@ -271,7 +279,7 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
           connectNulls: false,
           data: unifiedTests.map((testName, i) => {
             const d = pointsByIndex.get(i + 1)
-            return [i + 1, d ? d[field] : null, testName]
+            return [i + 1, d ? d[field] : null, testName, indexToOrder.get(i + 1) ?? (i + 1)]
           }),
           itemStyle: { color: slot.color },
           areaStyle: { opacity: 0.08, color: slot.color },
@@ -293,7 +301,7 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
       storageCacheHitRate: buildChart('storageCacheHitRate', (v) => `${v.toFixed(0)}%`, (v) => `${v.toFixed(1)}%`),
       codeCacheHitRate: buildChart('codeCacheHitRate', (v) => `${v.toFixed(0)}%`, (v) => `${v.toFixed(1)}%`),
     }
-  }, [pointsPerRun, runs, runsWithData, isDark, zoomRange, unifiedTests, labelMode])
+  }, [pointsPerRun, runs, runsWithData, isDark, zoomRange, unifiedTests, labelMode, suiteTests])
 
   if (blockLogsLoading) {
     return (

--- a/ui/src/components/compare/BlockLogsComparison.tsx
+++ b/ui/src/components/compare/BlockLogsComparison.tsx
@@ -33,10 +33,13 @@ interface BlockLogDataPoint {
 function buildUnifiedTestList(
   blockLogsPerRun: (BlockLogs | null)[],
   suiteTests?: SuiteTest[],
+  nameFilter?: (name: string) => boolean,
 ): string[] {
   const allNames = new Set<string>()
   for (const bl of blockLogsPerRun) {
-    if (bl) for (const name of Object.keys(bl)) allNames.add(name)
+    if (bl) for (const name of Object.keys(bl)) {
+      if (!nameFilter || nameFilter(name)) allNames.add(name)
+    }
   }
 
   const suiteOrder = new Map<string, number>()
@@ -116,9 +119,10 @@ interface BlockLogsComparisonProps {
   blockLogsLoading: boolean
   suiteTests?: SuiteTest[]
   labelMode: LabelMode
+  testNameFilter?: (name: string) => boolean
 }
 
-export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, suiteTests, labelMode }: BlockLogsComparisonProps) {
+export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, suiteTests, labelMode, testNameFilter }: BlockLogsComparisonProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
@@ -131,8 +135,8 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
   }, [])
 
   const unifiedTests = useMemo(
-    () => buildUnifiedTestList(blockLogsPerRun, suiteTests),
-    [blockLogsPerRun, suiteTests],
+    () => buildUnifiedTestList(blockLogsPerRun, suiteTests, testNameFilter),
+    [blockLogsPerRun, suiteTests, testNameFilter],
   )
 
   const pointsPerRun = useMemo(

--- a/ui/src/components/compare/BlockLogsComparison.tsx
+++ b/ui/src/components/compare/BlockLogsComparison.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import { Blocks } from 'lucide-react'
 import type { BlockLogs, SuiteTest } from '@/api/types'
-import { type CompareRun, RUN_SLOTS } from './constants'
+import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 function useDarkMode() {
   const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'))
@@ -115,9 +115,10 @@ interface BlockLogsComparisonProps {
   blockLogsPerRun: (BlockLogs | null)[]
   blockLogsLoading: boolean
   suiteTests?: SuiteTest[]
+  labelMode: LabelMode
 }
 
-export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, suiteTests }: BlockLogsComparisonProps) {
+export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, suiteTests, labelMode }: BlockLogsComparisonProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
@@ -261,7 +262,7 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
         const slot = RUN_SLOTS[run.index]
         const pointsByIndex = new Map(pointsPerRun[run.index].map((d) => [d.testIndex, d]))
         return {
-          name: `Run ${slot.label}`,
+          name: `Run ${formatRunLabel(slot, run, labelMode)}`,
           ...createLineSeries(),
           connectNulls: false,
           data: unifiedTests.map((testName, i) => {
@@ -288,7 +289,7 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
       storageCacheHitRate: buildChart('storageCacheHitRate', (v) => `${v.toFixed(0)}%`, (v) => `${v.toFixed(1)}%`),
       codeCacheHitRate: buildChart('codeCacheHitRate', (v) => `${v.toFixed(0)}%`, (v) => `${v.toFixed(1)}%`),
     }
-  }, [pointsPerRun, runs, runsWithData, isDark, zoomRange, unifiedTests])
+  }, [pointsPerRun, runs, runsWithData, isDark, zoomRange, unifiedTests, labelMode])
 
   if (blockLogsLoading) {
     return (
@@ -313,7 +314,7 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
             return (
               <span key={slot.label} className={`inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 font-medium ${slot.badgeBgClass} ${slot.badgeTextClass}`}>
                 <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
-                {slot.label}
+                {formatRunLabel(slot, run, labelMode)}
               </span>
             )
           })}

--- a/ui/src/components/compare/CompareHeader.tsx
+++ b/ui/src/components/compare/CompareHeader.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import clsx from 'clsx'
-import { X } from 'lucide-react'
+import { X, ChevronLeft, ChevronRight } from 'lucide-react'
 import type { RunConfig } from '@/api/types'
 import { ClientBadge } from '@/components/shared/ClientBadge'
 import { StrategyIcon } from '@/components/shared/StrategyIcon'
@@ -12,6 +12,7 @@ interface CompareHeaderProps {
   runs: CompareRun[]
   labelMode: LabelMode
   onRemoveRun?: (runId: string) => void
+  onMoveRun?: (fromIndex: number, toIndex: number) => void
 }
 
 function RunCard({
@@ -20,24 +21,48 @@ function RunCard({
   label,
   accentClass,
   onRemove,
+  onMoveLeft,
+  onMoveRight,
 }: {
   config: RunConfig
   runId: string
   label: string
   accentClass: string
   onRemove?: () => void
+  onMoveLeft?: () => void
+  onMoveRight?: () => void
 }) {
   return (
     <div className={clsx('relative flex-1 rounded-sm border-t-3 bg-white p-4 shadow-xs dark:bg-gray-800', accentClass)}>
-      {onRemove && (
-        <button
-          onClick={onRemove}
-          className="absolute top-2 right-2 rounded-sm p-0.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-          title="Remove from comparison"
-        >
-          <X className="size-3.5" />
-        </button>
-      )}
+      <div className="absolute top-2 right-2 flex items-center gap-0.5">
+        {onMoveLeft && (
+          <button
+            onClick={onMoveLeft}
+            className="rounded-sm p-0.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+            title="Move left"
+          >
+            <ChevronLeft className="size-3.5" />
+          </button>
+        )}
+        {onMoveRight && (
+          <button
+            onClick={onMoveRight}
+            className="rounded-sm p-0.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+            title="Move right"
+          >
+            <ChevronRight className="size-3.5" />
+          </button>
+        )}
+        {onRemove && (
+          <button
+            onClick={onRemove}
+            className="rounded-sm p-0.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+            title="Remove from comparison"
+          >
+            <X className="size-3.5" />
+          </button>
+        )}
+      </div>
       <div className="mb-2 flex items-center gap-2">
         <span className="text-xs/5 font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
           {label}
@@ -100,10 +125,10 @@ const GRID_COLS: Record<number, string> = {
   5: 'grid-cols-1 lg:grid-cols-2 xl:grid-cols-5',
 }
 
-export function CompareHeader({ runs, labelMode, onRemoveRun }: CompareHeaderProps) {
+export function CompareHeader({ runs, labelMode, onRemoveRun, onMoveRun }: CompareHeaderProps) {
   return (
     <div className={clsx('grid gap-4', GRID_COLS[runs.length] ?? GRID_COLS[2])}>
-      {runs.map((run) => {
+      {runs.map((run, i) => {
         const slot = RUN_SLOTS[run.index]
         return (
           <RunCard
@@ -113,6 +138,8 @@ export function CompareHeader({ runs, labelMode, onRemoveRun }: CompareHeaderPro
             label={`Run ${formatRunLabel(slot, run, labelMode)}`}
             accentClass={slot.borderClass}
             onRemove={onRemoveRun && runs.length > 2 ? () => onRemoveRun(run.runId) : undefined}
+            onMoveLeft={onMoveRun && i > 0 ? () => onMoveRun(i, i - 1) : undefined}
+            onMoveRight={onMoveRun && i < runs.length - 1 ? () => onMoveRun(i, i + 1) : undefined}
           />
         )
       })}

--- a/ui/src/components/compare/CompareHeader.tsx
+++ b/ui/src/components/compare/CompareHeader.tsx
@@ -6,10 +6,11 @@ import { ClientBadge } from '@/components/shared/ClientBadge'
 import { StrategyIcon } from '@/components/shared/StrategyIcon'
 import { StatusBadge } from '@/components/shared/StatusBadge'
 import { formatTimestamp, formatRelativeTime } from '@/utils/date'
-import { type CompareRun, RUN_SLOTS } from './constants'
+import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 interface CompareHeaderProps {
   runs: CompareRun[]
+  labelMode: LabelMode
   onRemoveRun?: (runId: string) => void
 }
 
@@ -99,7 +100,7 @@ const GRID_COLS: Record<number, string> = {
   5: 'grid-cols-1 lg:grid-cols-2 xl:grid-cols-5',
 }
 
-export function CompareHeader({ runs, onRemoveRun }: CompareHeaderProps) {
+export function CompareHeader({ runs, labelMode, onRemoveRun }: CompareHeaderProps) {
   return (
     <div className={clsx('grid gap-4', GRID_COLS[runs.length] ?? GRID_COLS[2])}>
       {runs.map((run) => {
@@ -109,7 +110,7 @@ export function CompareHeader({ runs, onRemoveRun }: CompareHeaderProps) {
             key={run.runId}
             config={run.config}
             runId={run.runId}
-            label={`Run ${slot.label}`}
+            label={`Run ${formatRunLabel(slot, run, labelMode)}`}
             accentClass={slot.borderClass}
             onRemove={onRemoveRun && runs.length > 2 ? () => onRemoveRun(run.runId) : undefined}
           />

--- a/ui/src/components/compare/ConfigDiff.tsx
+++ b/ui/src/components/compare/ConfigDiff.tsx
@@ -77,7 +77,7 @@ export function ConfigDiff({ runs, labelMode }: ConfigDiffProps) {
                   const slot = RUN_SLOTS[run.index]
                   return (
                     <th key={slot.label} className={clsx('px-3 py-2 text-left text-xs/5 font-medium uppercase tracking-wider', slot.textClass, `dark:${slot.textDarkClass.replace('text-', 'text-')}`)}>
-                      Run {formatRunLabel(slot, run, labelMode)}
+                      <span title={formatRunLabel(slot, run, labelMode)}>Run {slot.label}</span>
                     </th>
                   )
                 })}

--- a/ui/src/components/compare/ConfigDiff.tsx
+++ b/ui/src/components/compare/ConfigDiff.tsx
@@ -2,10 +2,11 @@ import { useState } from 'react'
 import clsx from 'clsx'
 import { Settings, ChevronDown } from 'lucide-react'
 import { formatBytes, formatFrequency } from '@/utils/format'
-import { type CompareRun, RUN_SLOTS } from './constants'
+import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 interface ConfigDiffProps {
   runs: CompareRun[]
+  labelMode: LabelMode
 }
 
 function DiffRow({ label, values }: { label: string; values: string[] }) {
@@ -25,7 +26,7 @@ function DiffRow({ label, values }: { label: string; values: string[] }) {
   )
 }
 
-export function ConfigDiff({ runs }: ConfigDiffProps) {
+export function ConfigDiff({ runs, labelMode }: ConfigDiffProps) {
   const [expanded, setExpanded] = useState(true)
 
   const instances = runs.map((r) => r.config.instance)
@@ -76,7 +77,7 @@ export function ConfigDiff({ runs }: ConfigDiffProps) {
                   const slot = RUN_SLOTS[run.index]
                   return (
                     <th key={slot.label} className={clsx('px-3 py-2 text-left text-xs/5 font-medium uppercase tracking-wider', slot.textClass, `dark:${slot.textDarkClass.replace('text-', 'text-')}`)}>
-                      Run {slot.label}
+                      Run {formatRunLabel(slot, run, labelMode)}
                     </th>
                   )
                 })}

--- a/ui/src/components/compare/MGasComparisonChart.tsx
+++ b/ui/src/components/compare/MGasComparisonChart.tsx
@@ -10,6 +10,7 @@ interface MGasComparisonChartProps {
   suiteTests?: SuiteTest[]
   stepFilter: StepTypeOption[]
   labelMode: LabelMode
+  testNameFilter?: (name: string) => boolean
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -41,6 +42,7 @@ function buildMGasData(
   result: RunResult,
   suiteTests: SuiteTest[] | undefined,
   stepFilter: StepTypeOption[],
+  nameFilter?: (name: string) => boolean,
 ): MGasDataPoint[] {
   const suiteOrder = new Map<string, number>()
   if (suiteTests) {
@@ -49,6 +51,7 @@ function buildMGasData(
 
   const entries: { name: string; order: number; mgas: number }[] = []
   for (const [name, entry] of Object.entries(result.tests)) {
+    if (nameFilter && !nameFilter(name)) continue
     const stats = getAggregatedStats(entry, stepFilter)
     const mgas = calculateMGasPerSec(stats)
     if (mgas === undefined) continue
@@ -57,10 +60,10 @@ function buildMGasData(
   }
 
   entries.sort((a, b) => a.order - b.order)
-  return entries.map((e, i) => ({ testIndex: i + 1, testName: e.name, mgas: e.mgas }))
+  return entries.map((e) => ({ testIndex: e.order, testName: e.name, mgas: e.mgas }))
 }
 
-export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode }: MGasComparisonChartProps) {
+export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, testNameFilter }: MGasComparisonChartProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
@@ -84,15 +87,18 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode }:
   const onEvents = useMemo(() => ({ datazoom: handleZoom }), [handleZoom])
 
   const pointsPerRun = useMemo(
-    () => runs.map((r) => r.result ? buildMGasData(r.result, suiteTests, stepFilter) : []),
-    [runs, suiteTests, stepFilter],
+    () => runs.map((r) => r.result ? buildMGasData(r.result, suiteTests, stepFilter, testNameFilter) : []),
+    [runs, suiteTests, stepFilter, testNameFilter],
   )
 
   const option = useMemo(() => {
     const textColor = isDark ? '#ffffff' : '#374151'
     const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
     const splitLineColor = isDark ? '#374151' : '#e5e7eb'
-    const maxLen = Math.max(...pointsPerRun.map((p) => p.length))
+    const allIndices = pointsPerRun.flatMap((p) => p.map((d) => d.testIndex))
+    const maxLen = allIndices.length
+    const xMin = allIndices.length > 0 ? Math.min(...allIndices) : 1
+    const xMax = allIndices.length > 0 ? Math.max(...allIndices) : 1
     const clientBySeriesName = new Map(runs.map((r, i) => [`Run ${formatRunLabel(RUN_SLOTS[i], r, labelMode)}`, r.config.instance.client]))
 
     return {
@@ -133,8 +139,8 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode }:
       },
       xAxis: {
         type: 'value' as const,
-        min: 1,
-        max: maxLen,
+        min: xMin,
+        max: xMax,
         minInterval: 1,
         axisLabel: {
           color: textColor,
@@ -193,18 +199,14 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode }:
         const points = pointsPerRun[i]
         return {
           name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
-          type: 'line' as const,
-          smooth: maxLen <= 100,
-          showSymbol: maxLen <= 100,
-          symbolSize: 4,
-          lineStyle: { width: 2 },
+          type: 'bar' as const,
+          barMaxWidth: 6,
           data: points.map((d) => [d.testIndex, d.mgas, d.testName]),
           itemStyle: { color: slot.color },
-          areaStyle: { opacity: 0.08, color: slot.color },
         }
       }),
     }
-  }, [pointsPerRun, runs, isDark, zoomRange, labelMode])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, testNameFilter])
 
   if (pointsPerRun.every((p) => p.length === 0)) return null
 

--- a/ui/src/components/compare/MGasComparisonChart.tsx
+++ b/ui/src/components/compare/MGasComparisonChart.tsx
@@ -2,12 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { RunResult, SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
-import { type CompareRun, RUN_SLOTS } from './constants'
+import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 interface MGasComparisonChartProps {
   runs: CompareRun[]
   suiteTests?: SuiteTest[]
   stepFilter: StepTypeOption[]
+  labelMode: LabelMode
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -58,7 +59,7 @@ function buildMGasData(
   return entries.map((e, i) => ({ testIndex: i + 1, testName: e.name, mgas: e.mgas }))
 }
 
-export function MGasComparisonChart({ runs, suiteTests, stepFilter }: MGasComparisonChartProps) {
+export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode }: MGasComparisonChartProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
@@ -91,7 +92,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter }: MGasCompar
     const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
     const splitLineColor = isDark ? '#374151' : '#e5e7eb'
     const maxLen = Math.max(...pointsPerRun.map((p) => p.length))
-    const clientBySeriesName = new Map(runs.map((_r, i) => [`Run ${RUN_SLOTS[i].label}`, runs[i].config.instance.client]))
+    const clientBySeriesName = new Map(runs.map((r, i) => [`Run ${formatRunLabel(RUN_SLOTS[i], r, labelMode)}`, r.config.instance.client]))
 
     return {
       backgroundColor: 'transparent',
@@ -190,7 +191,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter }: MGasCompar
         const slot = RUN_SLOTS[i]
         const points = pointsPerRun[i]
         return {
-          name: `Run ${slot.label}`,
+          name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
           type: 'line' as const,
           smooth: maxLen <= 100,
           showSymbol: maxLen <= 100,
@@ -202,7 +203,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter }: MGasCompar
         }
       }),
     }
-  }, [pointsPerRun, runs, isDark, zoomRange])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode])
 
   if (pointsPerRun.every((p) => p.length === 0)) return null
 
@@ -216,7 +217,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter }: MGasCompar
             return (
               <span key={slot.label} className={`inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 font-medium ${slot.badgeBgClass} ${slot.badgeTextClass}`}>
                 <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
-                {slot.label}
+                {formatRunLabel(slot, run, labelMode)}
               </span>
             )
           })}

--- a/ui/src/components/compare/MGasComparisonChart.tsx
+++ b/ui/src/components/compare/MGasComparisonChart.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
+import { Flame } from 'lucide-react'
 import type { RunResult, SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
@@ -210,7 +211,10 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode }:
   return (
     <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">MGas/s per Test</h3>
+        <div className="flex items-center gap-2">
+          <Flame className="size-4 text-gray-400 dark:text-gray-500" />
+          <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">MGas/s per Test</h3>
+        </div>
         <div className="flex items-center gap-2 text-xs/5">
           {runs.map((run) => {
             const slot = RUN_SLOTS[run.index]

--- a/ui/src/components/compare/MGasComparisonChart.tsx
+++ b/ui/src/components/compare/MGasComparisonChart.tsx
@@ -34,6 +34,7 @@ function useDarkMode() {
 
 interface MGasDataPoint {
   testIndex: number
+  testOrder: number
   testName: string
   mgas: number
 }
@@ -60,7 +61,7 @@ function buildMGasData(
   }
 
   entries.sort((a, b) => a.order - b.order)
-  return entries.map((e) => ({ testIndex: e.order, testName: e.name, mgas: e.mgas }))
+  return entries.map((e, i) => ({ testIndex: i + 1, testOrder: e.order, testName: e.name, mgas: e.mgas }))
 }
 
 export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, testNameFilter }: MGasComparisonChartProps) {
@@ -95,10 +96,14 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
     const textColor = isDark ? '#ffffff' : '#374151'
     const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
     const splitLineColor = isDark ? '#374151' : '#e5e7eb'
-    const allIndices = pointsPerRun.flatMap((p) => p.map((d) => d.testIndex))
-    const maxLen = allIndices.length
-    const xMin = allIndices.length > 0 ? Math.min(...allIndices) : 1
-    const xMax = allIndices.length > 0 ? Math.max(...allIndices) : 1
+    const maxLen = Math.max(...pointsPerRun.map((p) => p.length))
+    // Build a map from sequential index to original test order for axis labels
+    const indexToOrder = new Map<number, number>()
+    for (const points of pointsPerRun) {
+      for (const d of points) {
+        indexToOrder.set(d.testIndex, d.testOrder)
+      }
+    }
     const clientBySeriesName = new Map(runs.map((r, i) => [`Run ${formatRunLabel(RUN_SLOTS[i], r, labelMode)}`, r.config.instance.client]))
 
     return {
@@ -120,12 +125,12 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
         textStyle: { color: textColor },
         extraCssText: 'max-width: 300px; white-space: normal;',
         formatter: (
-          params: Array<{ seriesName: string; color: string; value: [number, number, string] }>,
+          params: Array<{ seriesName: string; color: string; value: [number, number, string, number] }>,
         ) => {
           if (!params.length) return ''
-          const testIndex = params[0].value[0]
+          const testOrder = params[0].value[3]
           const testName = params[0].value[2]
-          let content = `<strong>Test #${testIndex}</strong>`
+          let content = `<strong>Test #${testOrder}</strong>`
           if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
           content += '<br/>'
           params.forEach((p) => {
@@ -139,13 +144,13 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
       },
       xAxis: {
         type: 'value' as const,
-        min: xMin,
-        max: xMax,
+        min: 1,
+        max: maxLen,
         minInterval: 1,
         axisLabel: {
           color: textColor,
           fontSize: 11,
-          formatter: (value: number) => `#${value}`,
+          formatter: (value: number) => `#${indexToOrder.get(value) ?? value}`,
         },
         axisLine: { show: true, lineStyle: { color: axisLineColor } },
         axisTick: { show: true, lineStyle: { color: axisLineColor } },
@@ -182,7 +187,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
           fillerColor: isDark ? 'rgba(139, 92, 246, 0.3)' : 'rgba(139, 92, 246, 0.1)',
           backgroundColor: isDark ? '#374151' : '#f3f4f6',
           textStyle: { color: textColor },
-          labelFormatter: (value: number) => `#${Math.round(value)}`,
+          labelFormatter: (value: number) => `#${indexToOrder.get(Math.round(value)) ?? Math.round(value)}`,
         },
         {
           type: 'inside' as const,
@@ -201,7 +206,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
           name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
           type: 'bar' as const,
           barMaxWidth: 6,
-          data: points.map((d) => [d.testIndex, d.mgas, d.testName]),
+          data: points.map((d) => [d.testIndex, d.mgas, d.testName, d.testOrder]),
           itemStyle: { color: slot.color },
         }
       }),

--- a/ui/src/components/compare/MGasComparisonChart.tsx
+++ b/ui/src/components/compare/MGasComparisonChart.tsx
@@ -204,10 +204,14 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
         const points = pointsPerRun[i]
         return {
           name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
-          type: 'bar' as const,
-          barMaxWidth: 6,
+          type: 'line' as const,
+          smooth: maxLen <= 100,
+          showSymbol: maxLen <= 100,
+          symbolSize: 4,
+          lineStyle: { width: 2 },
           data: points.map((d) => [d.testIndex, d.mgas, d.testName, d.testOrder]),
           itemStyle: { color: slot.color },
+          areaStyle: { opacity: 0.08, color: slot.color },
         }
       }),
     }

--- a/ui/src/components/compare/MetricsComparison.tsx
+++ b/ui/src/components/compare/MetricsComparison.tsx
@@ -9,6 +9,8 @@ import { type CompareRun, RUN_SLOTS } from './constants'
 interface MetricsComparisonProps {
   runs: CompareRun[]
   stepFilter: StepTypeOption[]
+  baselineIdx: number
+  onBaselineChange: (idx: number) => void
 }
 
 interface ComputedMetrics {
@@ -84,6 +86,7 @@ function MetricCard({
   higherIsBetter = true,
   formatDelta,
   extra,
+  baselineIdx = 0,
 }: {
   label: string
   values: React.ReactNode[]
@@ -93,8 +96,9 @@ function MetricCard({
   higherIsBetter?: boolean
   formatDelta?: (v: number) => string
   extra?: React.ReactNode[]
+  baselineIdx?: number
 }) {
-  const hasDeltas = deltas?.some((d, i) => i > 0 && d !== undefined)
+  const hasDeltas = deltas?.some((d, i) => i !== baselineIdx && d !== undefined)
 
   return (
     <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
@@ -104,7 +108,7 @@ function MetricCard({
           {values.map((val, i) => {
             const slot = RUN_SLOTS[i]
             const delta = deltas?.[i]
-            const isBaseline = i === 0
+            const isBaseline = i === baselineIdx
             return (
               <tr key={slot.label}>
                 <td className="w-5 py-0.5 align-middle">
@@ -127,7 +131,7 @@ function MetricCard({
                       <span className="flex items-center justify-end gap-1">
                         <DeltaIndicator value={delta} formatValue={formatDelta} higherIsBetter={higherIsBetter} />
                         {percentValues && (
-                          <PercentDelta a={percentValues[0]} b={percentValues[i]} higherIsBetter={higherIsBetter} />
+                          <PercentDelta a={percentValues[baselineIdx]} b={percentValues[i]} higherIsBetter={higherIsBetter} />
                         )}
                       </span>
                     )}
@@ -142,59 +146,95 @@ function MetricCard({
   )
 }
 
-export function MetricsComparison({ runs, stepFilter }: MetricsComparisonProps) {
+export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineChange }: MetricsComparisonProps) {
   const metrics = runs.map((r) => computeMetrics(r.config, r.result, stepFilter))
   const clients = runs.map((r) => r.config.instance.client)
+  const base = metrics[baselineIdx]
 
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      <MetricCard
-        label="Tests"
-        clients={clients}
-        values={metrics.map((m) => m.testCount)}
-        extra={metrics.map((m) => (
-          <span className="flex items-center justify-end gap-1.5">
-            {m.failedTests > 0 && <span className="text-xs font-medium text-red-600 dark:text-red-400">{m.failedTests} Failed</span>}
-            <span className="text-xs font-medium text-green-600 dark:text-green-400">{m.passedTests} Passed</span>
-          </span>
-        ))}
-      />
-      <MetricCard
-        label="MGas/s"
-        clients={clients}
-        values={metrics.map((m) => m.mgasPerSec !== undefined ? m.mgasPerSec.toFixed(2) : '-')}
-        deltas={metrics.map((m, i) => i === 0 ? undefined : (m.mgasPerSec !== undefined && metrics[0].mgasPerSec !== undefined ? m.mgasPerSec - metrics[0].mgasPerSec : undefined))}
-        percentValues={metrics.map((m) => m.mgasPerSec)}
-        higherIsBetter
-      />
-      <MetricCard
-        label="Total Gas"
-        clients={clients}
-        values={metrics.map((m) => formatGas(m.totalGasUsed))}
-      />
-      <MetricCard
-        label="Test Duration"
-        clients={clients}
-        values={metrics.map((m) => <Duration nanoseconds={m.totalDuration} />)}
-        deltas={metrics.map((m, i) => i === 0 ? undefined : (m.totalDuration > 0 && metrics[0].totalDuration > 0 ? m.totalDuration - metrics[0].totalDuration : undefined))}
-        percentValues={metrics.map((m) => m.totalDuration)}
-        higherIsBetter={false}
-        formatDelta={(v) => formatDuration(v)}
-      />
-      <MetricCard
-        label="Total Runtime"
-        clients={clients}
-        values={metrics.map((m) => m.totalRuntime !== undefined ? formatDurationSeconds(m.totalRuntime) : '-')}
-        deltas={metrics.map((m, i) => i === 0 ? undefined : (m.totalRuntime !== undefined && metrics[0].totalRuntime !== undefined ? m.totalRuntime - metrics[0].totalRuntime : undefined))}
-        percentValues={metrics.map((m) => m.totalRuntime)}
-        higherIsBetter={false}
-        formatDelta={(v) => formatDurationSeconds(v)}
-      />
-      <MetricCard
-        label="Calls"
-        clients={clients}
-        values={metrics.map((m) => formatNumber(m.totalMsgCount))}
-      />
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
+        <span>Baseline:</span>
+        <div className="flex gap-1">
+          {runs.map((run, i) => {
+            const slot = RUN_SLOTS[run.index]
+            return (
+              <button
+                key={slot.label}
+                onClick={() => onBaselineChange(i)}
+                className={clsx(
+                  'inline-flex items-center gap-1 rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                  baselineIdx === i
+                    ? `${slot.badgeBgClass} ${slot.badgeTextClass} ring-1 ring-current`
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                )}
+              >
+                <img
+                  src={`/img/clients/${run.config.instance.client}.jpg`}
+                  alt={run.config.instance.client}
+                  className="size-3.5 rounded-full object-cover"
+                />
+                {slot.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <MetricCard
+          label="Tests"
+          clients={clients}
+          baselineIdx={baselineIdx}
+          values={metrics.map((m) => m.testCount)}
+          extra={metrics.map((m) => (
+            <span className="flex items-center justify-end gap-1.5">
+              {m.failedTests > 0 && <span className="text-xs font-medium text-red-600 dark:text-red-400">{m.failedTests} Failed</span>}
+              <span className="text-xs font-medium text-green-600 dark:text-green-400">{m.passedTests} Passed</span>
+            </span>
+          ))}
+        />
+        <MetricCard
+          label="MGas/s"
+          clients={clients}
+          baselineIdx={baselineIdx}
+          values={metrics.map((m) => m.mgasPerSec !== undefined ? m.mgasPerSec.toFixed(2) : '-')}
+          deltas={metrics.map((m, i) => i === baselineIdx ? undefined : (m.mgasPerSec !== undefined && base.mgasPerSec !== undefined ? m.mgasPerSec - base.mgasPerSec : undefined))}
+          percentValues={metrics.map((m) => m.mgasPerSec)}
+          higherIsBetter
+        />
+        <MetricCard
+          label="Total Gas"
+          clients={clients}
+          baselineIdx={baselineIdx}
+          values={metrics.map((m) => formatGas(m.totalGasUsed))}
+        />
+        <MetricCard
+          label="Test Duration"
+          clients={clients}
+          baselineIdx={baselineIdx}
+          values={metrics.map((m) => <Duration nanoseconds={m.totalDuration} />)}
+          deltas={metrics.map((m, i) => i === baselineIdx ? undefined : (m.totalDuration > 0 && base.totalDuration > 0 ? m.totalDuration - base.totalDuration : undefined))}
+          percentValues={metrics.map((m) => m.totalDuration)}
+          higherIsBetter={false}
+          formatDelta={(v) => formatDuration(v)}
+        />
+        <MetricCard
+          label="Total Runtime"
+          clients={clients}
+          baselineIdx={baselineIdx}
+          values={metrics.map((m) => m.totalRuntime !== undefined ? formatDurationSeconds(m.totalRuntime) : '-')}
+          deltas={metrics.map((m, i) => i === baselineIdx ? undefined : (m.totalRuntime !== undefined && base.totalRuntime !== undefined ? m.totalRuntime - base.totalRuntime : undefined))}
+          percentValues={metrics.map((m) => m.totalRuntime)}
+          higherIsBetter={false}
+          formatDelta={(v) => formatDurationSeconds(v)}
+        />
+        <MetricCard
+          label="Calls"
+          clients={clients}
+          baselineIdx={baselineIdx}
+          values={metrics.map((m) => formatNumber(m.totalMsgCount))}
+        />
+      </div>
     </div>
   )
 }

--- a/ui/src/components/compare/MetricsComparison.tsx
+++ b/ui/src/components/compare/MetricsComparison.tsx
@@ -4,13 +4,14 @@ import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { Duration } from '@/components/shared/Duration'
 import { formatDuration, formatNumber } from '@/utils/format'
 import { formatDurationSeconds } from '@/utils/date'
-import { type CompareRun, RUN_SLOTS } from './constants'
+import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 interface MetricsComparisonProps {
   runs: CompareRun[]
   stepFilter: StepTypeOption[]
   baselineIdx: number
   onBaselineChange: (idx: number) => void
+  labelMode: LabelMode
 }
 
 interface ComputedMetrics {
@@ -87,6 +88,7 @@ function MetricCard({
   formatDelta,
   extra,
   baselineIdx = 0,
+  runLabels,
 }: {
   label: string
   values: React.ReactNode[]
@@ -97,6 +99,7 @@ function MetricCard({
   formatDelta?: (v: number) => string
   extra?: React.ReactNode[]
   baselineIdx?: number
+  runLabels: string[]
 }) {
   const hasDeltas = deltas?.some((d, i) => i !== baselineIdx && d !== undefined)
 
@@ -114,8 +117,8 @@ function MetricCard({
                 <td className="w-5 py-0.5 align-middle">
                   <img src={`/img/clients/${clients[i]}.jpg`} alt={clients[i]} className="size-4 rounded-full object-cover" />
                 </td>
-                <td className={clsx('w-4 py-0.5 align-middle text-xs/5 font-semibold', slot.textClass, `dark:${slot.textDarkClass.replace('text-', 'text-')}`)}>
-                  {slot.label}
+                <td className={clsx('py-0.5 align-middle text-xs/5 font-semibold', slot.textClass, `dark:${slot.textDarkClass.replace('text-', 'text-')}`)}>
+                  {runLabels[i]}
                 </td>
                 <td className="py-0.5 align-middle text-base/6 font-semibold text-gray-900 dark:text-gray-100">
                   {val}
@@ -146,9 +149,10 @@ function MetricCard({
   )
 }
 
-export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineChange }: MetricsComparisonProps) {
+export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineChange, labelMode }: MetricsComparisonProps) {
   const metrics = runs.map((r) => computeMetrics(r.config, r.result, stepFilter))
   const clients = runs.map((r) => r.config.instance.client)
+  const runLabels = runs.map((r) => formatRunLabel(RUN_SLOTS[r.index], r, labelMode))
   const base = metrics[baselineIdx]
 
   return (
@@ -174,7 +178,7 @@ export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineCha
                   alt={run.config.instance.client}
                   className="size-3.5 rounded-full object-cover"
                 />
-                {slot.label}
+                {formatRunLabel(slot, run, labelMode)}
               </button>
             )
           })}
@@ -185,6 +189,7 @@ export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineCha
           label="Tests"
           clients={clients}
           baselineIdx={baselineIdx}
+          runLabels={runLabels}
           values={metrics.map((m) => m.testCount)}
           extra={metrics.map((m) => (
             <span className="flex items-center justify-end gap-1.5">
@@ -197,6 +202,7 @@ export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineCha
           label="MGas/s"
           clients={clients}
           baselineIdx={baselineIdx}
+          runLabels={runLabels}
           values={metrics.map((m) => m.mgasPerSec !== undefined ? m.mgasPerSec.toFixed(2) : '-')}
           deltas={metrics.map((m, i) => i === baselineIdx ? undefined : (m.mgasPerSec !== undefined && base.mgasPerSec !== undefined ? m.mgasPerSec - base.mgasPerSec : undefined))}
           percentValues={metrics.map((m) => m.mgasPerSec)}
@@ -206,12 +212,14 @@ export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineCha
           label="Total Gas"
           clients={clients}
           baselineIdx={baselineIdx}
+          runLabels={runLabels}
           values={metrics.map((m) => formatGas(m.totalGasUsed))}
         />
         <MetricCard
           label="Test Duration"
           clients={clients}
           baselineIdx={baselineIdx}
+          runLabels={runLabels}
           values={metrics.map((m) => <Duration nanoseconds={m.totalDuration} />)}
           deltas={metrics.map((m, i) => i === baselineIdx ? undefined : (m.totalDuration > 0 && base.totalDuration > 0 ? m.totalDuration - base.totalDuration : undefined))}
           percentValues={metrics.map((m) => m.totalDuration)}
@@ -222,6 +230,7 @@ export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineCha
           label="Total Runtime"
           clients={clients}
           baselineIdx={baselineIdx}
+          runLabels={runLabels}
           values={metrics.map((m) => m.totalRuntime !== undefined ? formatDurationSeconds(m.totalRuntime) : '-')}
           deltas={metrics.map((m, i) => i === baselineIdx ? undefined : (m.totalRuntime !== undefined && base.totalRuntime !== undefined ? m.totalRuntime - base.totalRuntime : undefined))}
           percentValues={metrics.map((m) => m.totalRuntime)}
@@ -232,6 +241,7 @@ export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineCha
           label="Calls"
           clients={clients}
           baselineIdx={baselineIdx}
+          runLabels={runLabels}
           values={metrics.map((m) => formatNumber(m.totalMsgCount))}
         />
       </div>

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
+import { ArrowRightLeft } from 'lucide-react'
 import type { SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
@@ -296,9 +297,10 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
   return (
     <div className="rounded-xs bg-white p-4 shadow-xs dark:bg-gray-800">
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
-          % Difference vs Baseline
-        </h3>
+        <div className="flex items-center gap-2">
+          <ArrowRightLeft className="size-4 text-gray-400 dark:text-gray-500" />
+          <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">% Difference vs Baseline</h3>
+        </div>
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
             <span>Baseline:</span>
@@ -356,6 +358,69 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
         opts={{ renderer: 'svg' }}
         onEvents={onEvents}
       />
+      <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700">
+        <table className="w-full text-xs/5">
+          <thead>
+            <tr className="text-gray-500 dark:text-gray-400">
+              <th className="pb-1 text-left font-medium">Run</th>
+              <th className="pb-1 text-right font-medium">Faster</th>
+              <th className="pb-1 text-right font-medium">Avg %</th>
+              <th className="pb-1 text-right font-medium">P95 %</th>
+              <th className="pb-1 text-right font-medium">P99 %</th>
+              <th className="pb-1 text-right font-medium">Slower</th>
+              <th className="pb-1 text-right font-medium">Avg %</th>
+              <th className="pb-1 text-right font-medium">P95 %</th>
+              <th className="pb-1 text-right font-medium">P99 %</th>
+              <th className="pb-1 text-right font-medium">Equal</th>
+              <th className="pb-1 text-right font-medium">Total</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-700/50">
+            {otherRunIndices.map((ri, seriesIdx) => {
+              const slot = RUN_SLOTS[ri]
+              const run = runs[ri]
+              const fasterPcts: number[] = []
+              const slowerPcts: number[] = []
+              let equal = 0
+              for (const d of diffData) {
+                const diff = d.diffs[seriesIdx]
+                if (diff === null) continue
+                if (diff > 0) fasterPcts.push(diff)
+                else if (diff < 0) slowerPcts.push(Math.abs(diff))
+                else equal++
+              }
+              const total = fasterPcts.length + slowerPcts.length + equal
+              const avg = (arr: number[]) => arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : 0
+              const percentile = (arr: number[], p: number) => {
+                if (arr.length === 0) return 0
+                const sorted = [...arr].sort((a, b) => a - b)
+                const idx = Math.ceil((p / 100) * sorted.length) - 1
+                return sorted[Math.max(0, idx)]
+              }
+              return (
+                <tr key={slot.label}>
+                  <td className="py-1">
+                    <span className="inline-flex items-center gap-1.5 font-medium" style={{ color: slot.color }}>
+                      <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
+                      {formatRunLabel(slot, run, labelMode)}
+                    </span>
+                  </td>
+                  <td className="py-1 text-right font-medium text-green-600 dark:text-green-400">{fasterPcts.length}</td>
+                  <td className="py-1 text-right text-green-600 dark:text-green-400">{fasterPcts.length > 0 ? `+${avg(fasterPcts).toFixed(1)}%` : '-'}</td>
+                  <td className="py-1 text-right text-green-600 dark:text-green-400">{fasterPcts.length > 0 ? `+${percentile(fasterPcts, 95).toFixed(1)}%` : '-'}</td>
+                  <td className="py-1 text-right text-green-600 dark:text-green-400">{fasterPcts.length > 0 ? `+${percentile(fasterPcts, 99).toFixed(1)}%` : '-'}</td>
+                  <td className="py-1 text-right font-medium text-red-600 dark:text-red-400">{slowerPcts.length}</td>
+                  <td className="py-1 text-right text-red-600 dark:text-red-400">{slowerPcts.length > 0 ? `-${avg(slowerPcts).toFixed(1)}%` : '-'}</td>
+                  <td className="py-1 text-right text-red-600 dark:text-red-400">{slowerPcts.length > 0 ? `-${percentile(slowerPcts, 95).toFixed(1)}%` : '-'}</td>
+                  <td className="py-1 text-right text-red-600 dark:text-red-400">{slowerPcts.length > 0 ? `-${percentile(slowerPcts, 99).toFixed(1)}%` : '-'}</td>
+                  <td className="py-1 text-right text-gray-400 dark:text-gray-500">{equal}</td>
+                  <td className="py-1 text-right text-gray-500 dark:text-gray-400">{total}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -8,6 +8,8 @@ interface PercentageDiffChartProps {
   runs: CompareRun[]
   suiteTests?: SuiteTest[]
   stepFilter: StepTypeOption[]
+  baselineIdx: number
+  onBaselineChange: (idx: number) => void
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -98,9 +100,8 @@ function buildDiffData(
   }))
 }
 
-export function PercentageDiffChart({ runs, suiteTests, stepFilter }: PercentageDiffChartProps) {
+export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange }: PercentageDiffChartProps) {
   const isDark = useDarkMode()
-  const [baselineIdx, setBaselineIdx] = useState(0)
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
 
@@ -306,7 +307,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter }: Percentage
                 return (
                   <button
                     key={slot.label}
-                    onClick={() => setBaselineIdx(i)}
+                    onClick={() => onBaselineChange(i)}
                     className={`inline-flex items-center gap-1 rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
                       baselineIdx === i
                         ? `${slot.badgeBgClass} ${slot.badgeTextClass} ring-1 ring-current`

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -1,0 +1,359 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import ReactECharts from 'echarts-for-react'
+import type { SuiteTest, AggregatedStats } from '@/api/types'
+import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
+import { type CompareRun, RUN_SLOTS } from './constants'
+
+interface PercentageDiffChartProps {
+  runs: CompareRun[]
+  suiteTests?: SuiteTest[]
+  stepFilter: StepTypeOption[]
+}
+
+function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
+  if (!stats || stats.gas_used_time_total <= 0 || stats.gas_used_total <= 0) return undefined
+  return (stats.gas_used_total * 1000) / stats.gas_used_time_total
+}
+
+function useDarkMode() {
+  const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'))
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains('dark'))
+    })
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  return isDark
+}
+
+interface TestDiffPoint {
+  testIndex: number
+  testName: string
+  baselineValue: number
+  diffs: (number | null)[] // % diff per non-baseline run
+  values: (number | null)[] // absolute MGas/s per non-baseline run
+}
+
+function buildDiffData(
+  runs: CompareRun[],
+  baselineIdx: number,
+  suiteTests: SuiteTest[] | undefined,
+  stepFilter: StepTypeOption[],
+): TestDiffPoint[] {
+  const suiteOrder = new Map<string, number>()
+  if (suiteTests) {
+    suiteTests.forEach((t, i) => suiteOrder.set(t.name, i + 1))
+  }
+
+  const baselineResult = runs[baselineIdx].result
+  if (!baselineResult) return []
+
+  // Collect all test names from all runs
+  const allTestNames = new Set<string>()
+  for (const run of runs) {
+    if (run.result) {
+      for (const name of Object.keys(run.result.tests)) allTestNames.add(name)
+    }
+  }
+
+  const entries: { name: string; order: number; baselineValue: number; diffs: (number | null)[]; values: (number | null)[] }[] = []
+
+  for (const name of allTestNames) {
+    const baseEntry = baselineResult.tests[name]
+    const baseStats = baseEntry ? getAggregatedStats(baseEntry, stepFilter) : undefined
+    const baseMGas = calculateMGasPerSec(baseStats)
+    if (baseMGas === undefined || baseMGas <= 0) continue
+
+    const order = suiteOrder.get(name) ?? (baseEntry ? parseInt(baseEntry.dir, 10) || 0 : 0)
+    const diffs: (number | null)[] = []
+    const values: (number | null)[] = []
+
+    for (let i = 0; i < runs.length; i++) {
+      if (i === baselineIdx) continue
+      const entry = runs[i].result?.tests[name]
+      const stats = entry ? getAggregatedStats(entry, stepFilter) : undefined
+      const mgas = calculateMGasPerSec(stats)
+      if (mgas === undefined) {
+        diffs.push(null)
+        values.push(null)
+      } else {
+        diffs.push(((mgas - baseMGas) / baseMGas) * 100)
+        values.push(mgas)
+      }
+    }
+
+    entries.push({ name, order, baselineValue: baseMGas, diffs, values })
+  }
+
+  entries.sort((a, b) => a.order - b.order)
+  return entries.map((e, i) => ({
+    testIndex: i + 1,
+    testName: e.name,
+    baselineValue: e.baselineValue,
+    diffs: e.diffs,
+    values: e.values,
+  }))
+}
+
+export function PercentageDiffChart({ runs, suiteTests, stepFilter }: PercentageDiffChartProps) {
+  const isDark = useDarkMode()
+  const [baselineIdx, setBaselineIdx] = useState(0)
+  const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
+  const prevZoomRef = useRef(zoomRange)
+
+  const handleZoom = useCallback((params: { start?: number; end?: number; batch?: Array<{ start: number; end: number }> }) => {
+    let start: number | undefined
+    let end: number | undefined
+    if (params.batch && params.batch.length > 0) {
+      start = params.batch[0].start
+      end = params.batch[0].end
+    } else {
+      start = params.start
+      end = params.end
+    }
+    if (start !== undefined && end !== undefined && (prevZoomRef.current.start !== start || prevZoomRef.current.end !== end)) {
+      prevZoomRef.current = { start, end }
+      setZoomRange({ start, end })
+    }
+  }, [])
+
+  const onEvents = useMemo(() => ({ datazoom: handleZoom }), [handleZoom])
+
+  // Build the non-baseline run indices for series mapping
+  const otherRunIndices = useMemo(
+    () => runs.map((_, i) => i).filter((i) => i !== baselineIdx),
+    [runs, baselineIdx],
+  )
+
+  const diffData = useMemo(
+    () => buildDiffData(runs, baselineIdx, suiteTests, stepFilter),
+    [runs, baselineIdx, suiteTests, stepFilter],
+  )
+
+  const option = useMemo(() => {
+    const textColor = isDark ? '#ffffff' : '#374151'
+    const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
+    const splitLineColor = isDark ? '#374151' : '#e5e7eb'
+    const maxLen = Math.max(diffData.length, 1)
+
+    return {
+      backgroundColor: 'transparent',
+      animation: maxLen <= 100,
+      textStyle: { color: textColor },
+      grid: {
+        left: '3%',
+        right: '4%',
+        bottom: '50',
+        top: '15%',
+        containLabel: true,
+      },
+      tooltip: {
+        trigger: 'axis' as const,
+        appendToBody: true,
+        backgroundColor: isDark ? '#1f2937' : '#ffffff',
+        borderColor: isDark ? '#374151' : '#e5e7eb',
+        textStyle: { color: textColor },
+        extraCssText: 'max-width: 350px; white-space: normal;',
+        formatter: (
+          // value: [testIndex, %diff, testName, baselineMGas, absoluteMGas]
+          params: Array<{ seriesName: string; color: string; value: [number, number, string, number, number] }>,
+        ) => {
+          if (!params.length) return ''
+          const testIndex = params[0].value[0]
+          const testName = params[0].value[2]
+          const baseValue = params[0].value[3]
+          const baseSlot = RUN_SLOTS[baselineIdx]
+          const baseClient = runs[baselineIdx].config.instance.client
+          const baseImg = `<img src="/img/clients/${baseClient}.jpg" style="display:inline-block;width:14px;height:14px;border-radius:50%;object-fit:cover;vertical-align:middle;margin-right:4px;" />`
+
+          let content = `<strong>Test #${testIndex}</strong>`
+          if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
+          content += `<br/>${baseImg}<span style="font-size: 11px;">Baseline ${baseSlot.label}: ${baseValue.toFixed(2)} MGas/s</span><br/>`
+
+          params.forEach((p) => {
+            const diff = p.value[1]
+            const absMGas = p.value[4]
+            const sign = diff >= 0 ? '+' : ''
+            const color = diff >= 0 ? '#10b981' : '#ef4444'
+            const label = diff >= 0 ? 'faster' : 'slower'
+            const seriesRunIdx = otherRunIndices.find((ri) => `vs ${RUN_SLOTS[ri].label}` === p.seriesName)
+            const client = seriesRunIdx !== undefined ? runs[seriesRunIdx].config.instance.client : undefined
+            const clientImg = client ? `<img src="/img/clients/${client}.jpg" style="display:inline-block;width:14px;height:14px;border-radius:50%;object-fit:cover;vertical-align:middle;margin-right:4px;" />` : ''
+            content += `${clientImg}<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${p.color};margin-right:6px;vertical-align:middle;"></span>${p.seriesName}: ${absMGas.toFixed(2)} MGas/s <span style="color:${color};font-weight:600;">(${sign}${diff.toFixed(1)}% ${label})</span><br/>`
+          })
+          return content
+        },
+      },
+      xAxis: {
+        type: 'value' as const,
+        min: 1,
+        max: maxLen,
+        minInterval: 1,
+        axisLabel: {
+          color: textColor,
+          fontSize: 11,
+          formatter: (value: number) => `#${value}`,
+        },
+        axisLine: { show: true, lineStyle: { color: axisLineColor } },
+        axisTick: { show: true, lineStyle: { color: axisLineColor } },
+        splitLine: { show: false },
+      },
+      yAxis: {
+        type: 'value' as const,
+        axisLabel: {
+          color: textColor,
+          fontSize: 11,
+          formatter: (value: number) => `${value > 0 ? '+' : ''}${value.toFixed(0)}%`,
+        },
+        axisLine: { show: true, lineStyle: { color: axisLineColor } },
+        axisTick: { show: true, lineStyle: { color: axisLineColor } },
+        splitLine: { lineStyle: { color: splitLineColor } },
+        name: '% Difference',
+        nameTextStyle: { color: textColor, fontSize: 11 },
+      },
+      legend: {
+        bottom: 25,
+        textStyle: { color: textColor, fontSize: 11 },
+        itemWidth: 12,
+        itemHeight: 8,
+      },
+      dataZoom: [
+        {
+          type: 'slider' as const,
+          xAxisIndex: 0,
+          start: zoomRange.start,
+          end: zoomRange.end,
+          height: 20,
+          bottom: 5,
+          borderColor: axisLineColor,
+          fillerColor: isDark ? 'rgba(139, 92, 246, 0.3)' : 'rgba(139, 92, 246, 0.1)',
+          backgroundColor: isDark ? '#374151' : '#f3f4f6',
+          textStyle: { color: textColor },
+          labelFormatter: (value: number) => `#${Math.round(value)}`,
+        },
+        {
+          type: 'inside' as const,
+          xAxisIndex: 0,
+          start: zoomRange.start,
+          end: zoomRange.end,
+          zoomOnMouseWheel: true,
+          moveOnMouseMove: true,
+          moveOnMouseWheel: false,
+        },
+      ],
+      // Zero reference line
+      markLine: undefined,
+      series: [
+        // Invisible reference series just for the zero line
+        {
+          name: '_zero',
+          type: 'line' as const,
+          data: [],
+          markLine: {
+            silent: true,
+            symbol: 'none',
+            lineStyle: {
+              color: isDark ? '#6b7280' : '#9ca3af',
+              type: 'dashed' as const,
+              width: 1,
+            },
+            label: { show: false },
+            data: [{ yAxis: 0 }],
+          },
+        },
+        ...otherRunIndices.map((runIdx, seriesIdx) => {
+          const slot = RUN_SLOTS[runIdx]
+          return {
+            name: `vs ${slot.label}`,
+            type: 'bar' as const,
+            barMaxWidth: 6,
+            data: diffData.map((d) => {
+              const diff = d.diffs[seriesIdx]
+              const absMGas = d.values[seriesIdx]
+              if (diff === null || absMGas === null) return null
+              return {
+                value: [d.testIndex, diff, d.testName, d.baselineValue, absMGas],
+                itemStyle: {
+                  color: diff >= 0 ? slot.color : slot.colorLight,
+                  opacity: diff >= 0 ? 1 : 0.6,
+                },
+              }
+            }).filter(Boolean),
+            itemStyle: { color: slot.color },
+          }
+        }),
+      ],
+    }
+  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange])
+
+  if (runs.every((r) => r.result === null)) return null
+
+  return (
+    <div className="rounded-xs bg-white p-4 shadow-xs dark:bg-gray-800">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+          % Difference vs Baseline
+        </h3>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
+            <span>Baseline:</span>
+            <div className="flex gap-1">
+              {runs.map((run, i) => {
+                const slot = RUN_SLOTS[run.index]
+                return (
+                  <button
+                    key={slot.label}
+                    onClick={() => setBaselineIdx(i)}
+                    className={`inline-flex items-center gap-1 rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+                      baselineIdx === i
+                        ? `${slot.badgeBgClass} ${slot.badgeTextClass} ring-1 ring-current`
+                        : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                    }`}
+                  >
+                    <img
+                      src={`/img/clients/${run.config.instance.client}.jpg`}
+                      alt={run.config.instance.client}
+                      className="size-3.5 rounded-full object-cover"
+                    />
+                    {slot.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 text-xs/5">
+            {otherRunIndices.map((ri) => {
+              const slot = RUN_SLOTS[ri]
+              const run = runs[ri]
+              return (
+                <span
+                  key={slot.label}
+                  className={`inline-flex items-center gap-1.5 rounded-xs px-2 py-0.5 font-medium ${slot.badgeBgClass} ${slot.badgeTextClass}`}
+                >
+                  <img
+                    src={`/img/clients/${run.config.instance.client}.jpg`}
+                    alt={run.config.instance.client}
+                    className="size-3.5 rounded-full object-cover"
+                  />
+                  vs {slot.label}
+                </span>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+      <p className="mb-2 text-xs/5 text-gray-400 dark:text-gray-500">
+        Positive = faster than baseline, Negative = slower
+      </p>
+      <ReactECharts
+        option={option}
+        style={{ height: '300px', width: '100%' }}
+        opts={{ renderer: 'svg' }}
+        onEvents={onEvents}
+      />
+    </div>
+  )
+}

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -102,9 +102,12 @@ function buildDiffData(
   }))
 }
 
+type DiffFilter = 'all' | 'faster' | 'slower'
+
 export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode }: PercentageDiffChartProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
+  const [diffFilter, setDiffFilter] = useState<DiffFilter>('all')
   const prevZoomRef = useRef(zoomRange)
 
   const handleZoom = useCallback((params: { start?: number; end?: number; batch?: Array<{ start: number; end: number }> }) => {
@@ -277,6 +280,8 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
               const diff = d.diffs[seriesIdx]
               const absMGas = d.values[seriesIdx]
               if (diff === null || absMGas === null) return null
+              if (diffFilter === 'faster' && diff < 0) return null
+              if (diffFilter === 'slower' && diff > 0) return null
               return {
                 value: [d.testIndex, diff, d.testName, d.baselineValue, absMGas],
                 itemStyle: {
@@ -290,7 +295,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
         }),
       ],
     }
-  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange, labelMode])
+  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange, labelMode, diffFilter])
 
   if (runs.every((r) => r.result === null)) return null
 
@@ -349,9 +354,26 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
           </div>
         </div>
       </div>
-      <p className="mb-2 text-xs/5 text-gray-400 dark:text-gray-500">
-        Positive = faster than baseline, Negative = slower
-      </p>
+      <div className="mb-2 flex items-center justify-between">
+        <p className="text-xs/5 text-gray-400 dark:text-gray-500">
+          Positive = faster than baseline, Negative = slower
+        </p>
+        <div className="flex gap-1">
+          {([['all', 'Show All'], ['faster', 'Faster'], ['slower', 'Slower']] as const).map(([value, label]) => (
+            <button
+              key={value}
+              onClick={() => setDiffFilter(value)}
+              className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+                diffFilter === value
+                  ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
       <ReactECharts
         option={option}
         style={{ height: '300px', width: '100%' }}

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -14,6 +14,7 @@ interface PercentageDiffChartProps {
   labelMode: LabelMode
   diffFilter: 'all' | 'faster' | 'slower'
   onDiffFilterChange: (val: 'all' | 'faster' | 'slower') => void
+  testNameFilter?: (name: string) => boolean
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -48,6 +49,7 @@ function buildDiffData(
   baselineIdx: number,
   suiteTests: SuiteTest[] | undefined,
   stepFilter: StepTypeOption[],
+  nameFilter?: (name: string) => boolean,
 ): TestDiffPoint[] {
   const suiteOrder = new Map<string, number>()
   if (suiteTests) {
@@ -68,6 +70,7 @@ function buildDiffData(
   const entries: { name: string; order: number; baselineValue: number; diffs: (number | null)[]; values: (number | null)[] }[] = []
 
   for (const name of allTestNames) {
+    if (nameFilter && !nameFilter(name)) continue
     const baseEntry = baselineResult.tests[name]
     const baseStats = baseEntry ? getAggregatedStats(baseEntry, stepFilter) : undefined
     const baseMGas = calculateMGasPerSec(baseStats)
@@ -95,8 +98,8 @@ function buildDiffData(
   }
 
   entries.sort((a, b) => a.order - b.order)
-  return entries.map((e, i) => ({
-    testIndex: i + 1,
+  return entries.map((e) => ({
+    testIndex: e.order,
     testName: e.name,
     baselineValue: e.baselineValue,
     diffs: e.diffs,
@@ -104,7 +107,7 @@ function buildDiffData(
   }))
 }
 
-export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode, diffFilter, onDiffFilterChange }: PercentageDiffChartProps) {
+export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode, diffFilter, onDiffFilterChange, testNameFilter }: PercentageDiffChartProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
@@ -134,15 +137,18 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
   )
 
   const diffData = useMemo(
-    () => buildDiffData(runs, baselineIdx, suiteTests, stepFilter),
-    [runs, baselineIdx, suiteTests, stepFilter],
+    () => buildDiffData(runs, baselineIdx, suiteTests, stepFilter, testNameFilter),
+    [runs, baselineIdx, suiteTests, stepFilter, testNameFilter],
   )
 
   const option = useMemo(() => {
     const textColor = isDark ? '#ffffff' : '#374151'
     const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
     const splitLineColor = isDark ? '#374151' : '#e5e7eb'
-    const maxLen = Math.max(diffData.length, 1)
+    const allIndices = diffData.map((d) => d.testIndex)
+    const maxLen = allIndices.length
+    const xMin = allIndices.length > 0 ? Math.min(...allIndices) : 1
+    const xMax = allIndices.length > 0 ? Math.max(...allIndices) : 1
 
     return {
       backgroundColor: 'transparent',
@@ -194,8 +200,8 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
       },
       xAxis: {
         type: 'value' as const,
-        min: 1,
-        max: maxLen,
+        min: xMin,
+        max: xMax,
         minInterval: 1,
         axisLabel: {
           color: textColor,

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -38,6 +38,7 @@ function useDarkMode() {
 
 interface TestDiffPoint {
   testIndex: number
+  testOrder: number
   testName: string
   baselineValue: number
   diffs: (number | null)[] // % diff per non-baseline run
@@ -98,8 +99,9 @@ function buildDiffData(
   }
 
   entries.sort((a, b) => a.order - b.order)
-  return entries.map((e) => ({
-    testIndex: e.order,
+  return entries.map((e, i) => ({
+    testIndex: i + 1,
+    testOrder: e.order,
     testName: e.name,
     baselineValue: e.baselineValue,
     diffs: e.diffs,
@@ -145,10 +147,8 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
     const textColor = isDark ? '#ffffff' : '#374151'
     const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
     const splitLineColor = isDark ? '#374151' : '#e5e7eb'
-    const allIndices = diffData.map((d) => d.testIndex)
-    const maxLen = allIndices.length
-    const xMin = allIndices.length > 0 ? Math.min(...allIndices) : 1
-    const xMax = allIndices.length > 0 ? Math.max(...allIndices) : 1
+    const maxLen = Math.max(diffData.length, 1)
+    const indexToOrder = new Map(diffData.map((d) => [d.testIndex, d.testOrder]))
 
     return {
       backgroundColor: 'transparent',
@@ -170,17 +170,17 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
         extraCssText: 'max-width: 350px; white-space: normal;',
         formatter: (
           // value: [testIndex, %diff, testName, baselineMGas, absoluteMGas]
-          params: Array<{ seriesName: string; color: string; value: [number, number, string, number, number] }>,
+          params: Array<{ seriesName: string; color: string; value: [number, number, string, number, number, number] }>,
         ) => {
           if (!params.length) return ''
-          const testIndex = params[0].value[0]
           const testName = params[0].value[2]
           const baseValue = params[0].value[3]
+          const testOrder = params[0].value[5]
           const baseSlot = RUN_SLOTS[baselineIdx]
           const baseClient = runs[baselineIdx].config.instance.client
           const baseImg = `<img src="/img/clients/${baseClient}.jpg" style="display:inline-block;width:14px;height:14px;border-radius:50%;object-fit:cover;vertical-align:middle;margin-right:4px;" />`
 
-          let content = `<strong>Test #${testIndex}</strong>`
+          let content = `<strong>Test #${testOrder}</strong>`
           if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
           content += `<br/>${baseImg}<span style="font-size: 11px;">Baseline ${baseSlot.label}: ${baseValue.toFixed(2)} MGas/s</span><br/>`
 
@@ -200,13 +200,13 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
       },
       xAxis: {
         type: 'value' as const,
-        min: xMin,
-        max: xMax,
+        min: 1,
+        max: maxLen,
         minInterval: 1,
         axisLabel: {
           color: textColor,
           fontSize: 11,
-          formatter: (value: number) => `#${value}`,
+          formatter: (value: number) => `#${indexToOrder.get(value) ?? value}`,
         },
         axisLine: { show: true, lineStyle: { color: axisLineColor } },
         axisTick: { show: true, lineStyle: { color: axisLineColor } },
@@ -243,7 +243,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
           fillerColor: isDark ? 'rgba(139, 92, 246, 0.3)' : 'rgba(139, 92, 246, 0.1)',
           backgroundColor: isDark ? '#374151' : '#f3f4f6',
           textStyle: { color: textColor },
-          labelFormatter: (value: number) => `#${Math.round(value)}`,
+          labelFormatter: (value: number) => `#${indexToOrder.get(Math.round(value)) ?? Math.round(value)}`,
         },
         {
           type: 'inside' as const,
@@ -288,7 +288,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
               if (diffFilter === 'faster' && diff < 0) return null
               if (diffFilter === 'slower' && diff > 0) return null
               return {
-                value: [d.testIndex, diff, d.testName, d.baselineValue, absMGas],
+                value: [d.testIndex, diff, d.testName, d.baselineValue, absMGas, d.testOrder],
                 itemStyle: {
                   color: diff >= 0 ? slot.color : slot.colorLight,
                   opacity: diff >= 0 ? 1 : 0.6,

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -12,6 +12,8 @@ interface PercentageDiffChartProps {
   baselineIdx: number
   onBaselineChange: (idx: number) => void
   labelMode: LabelMode
+  diffFilter: 'all' | 'faster' | 'slower'
+  onDiffFilterChange: (val: 'all' | 'faster' | 'slower') => void
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -102,12 +104,9 @@ function buildDiffData(
   }))
 }
 
-type DiffFilter = 'all' | 'faster' | 'slower'
-
-export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode }: PercentageDiffChartProps) {
+export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode, diffFilter, onDiffFilterChange }: PercentageDiffChartProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
-  const [diffFilter, setDiffFilter] = useState<DiffFilter>('all')
   const prevZoomRef = useRef(zoomRange)
 
   const handleZoom = useCallback((params: { start?: number; end?: number; batch?: Array<{ start: number; end: number }> }) => {
@@ -362,7 +361,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
           {([['all', 'Show All'], ['faster', 'Faster'], ['slower', 'Slower']] as const).map(([value, label]) => (
             <button
               key={value}
-              onClick={() => setDiffFilter(value)}
+              onClick={() => onDiffFilterChange(value)}
               className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
                 diffFilter === value
                   ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
-import { type CompareRun, RUN_SLOTS } from './constants'
+import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 interface PercentageDiffChartProps {
   runs: CompareRun[]
@@ -10,6 +10,7 @@ interface PercentageDiffChartProps {
   stepFilter: StepTypeOption[]
   baselineIdx: number
   onBaselineChange: (idx: number) => void
+  labelMode: LabelMode
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -100,7 +101,7 @@ function buildDiffData(
   }))
 }
 
-export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange }: PercentageDiffChartProps) {
+export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode }: PercentageDiffChartProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
@@ -180,7 +181,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
             const sign = diff >= 0 ? '+' : ''
             const color = diff >= 0 ? '#10b981' : '#ef4444'
             const label = diff >= 0 ? 'faster' : 'slower'
-            const seriesRunIdx = otherRunIndices.find((ri) => `vs ${RUN_SLOTS[ri].label}` === p.seriesName)
+            const seriesRunIdx = otherRunIndices.find((ri) => `vs ${formatRunLabel(RUN_SLOTS[ri], runs[ri], labelMode)}` === p.seriesName)
             const client = seriesRunIdx !== undefined ? runs[seriesRunIdx].config.instance.client : undefined
             const clientImg = client ? `<img src="/img/clients/${client}.jpg" style="display:inline-block;width:14px;height:14px;border-radius:50%;object-fit:cover;vertical-align:middle;margin-right:4px;" />` : ''
             content += `${clientImg}<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${p.color};margin-right:6px;vertical-align:middle;"></span>${p.seriesName}: ${absMGas.toFixed(2)} MGas/s <span style="color:${color};font-weight:600;">(${sign}${diff.toFixed(1)}% ${label})</span><br/>`
@@ -268,7 +269,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
         ...otherRunIndices.map((runIdx, seriesIdx) => {
           const slot = RUN_SLOTS[runIdx]
           return {
-            name: `vs ${slot.label}`,
+            name: `vs ${formatRunLabel(slot, runs[runIdx], labelMode)}`,
             type: 'bar' as const,
             barMaxWidth: 6,
             data: diffData.map((d) => {
@@ -288,7 +289,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
         }),
       ],
     }
-  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange])
+  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange, labelMode])
 
   if (runs.every((r) => r.result === null)) return null
 
@@ -319,7 +320,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
                       alt={run.config.instance.client}
                       className="size-3.5 rounded-full object-cover"
                     />
-                    {slot.label}
+                    {formatRunLabel(slot, run, labelMode)}
                   </button>
                 )
               })}
@@ -339,7 +340,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
                     alt={run.config.instance.client}
                     className="size-3.5 rounded-full object-cover"
                   />
-                  vs {slot.label}
+                  vs {formatRunLabel(slot, run, labelMode)}
                 </span>
               )
             })}

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -279,8 +279,11 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
           const slot = RUN_SLOTS[runIdx]
           return {
             name: `vs ${formatRunLabel(slot, runs[runIdx], labelMode)}`,
-            type: 'bar' as const,
-            barMaxWidth: 6,
+            type: 'line' as const,
+            smooth: diffData.length <= 100,
+            showSymbol: diffData.length <= 100,
+            symbolSize: 4,
+            lineStyle: { width: 2 },
             data: diffData.map((d) => {
               const diff = d.diffs[seriesIdx]
               const absMGas = d.values[seriesIdx]
@@ -289,13 +292,10 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
               if (diffFilter === 'slower' && diff > 0) return null
               return {
                 value: [d.testIndex, diff, d.testName, d.baselineValue, absMGas, d.testOrder],
-                itemStyle: {
-                  color: diff >= 0 ? slot.color : slot.colorLight,
-                  opacity: diff >= 0 ? 1 : 0.6,
-                },
               }
             }).filter(Boolean),
             itemStyle: { color: slot.color },
+            areaStyle: { opacity: 0.08, color: slot.color },
           }
         }),
       ],

--- a/ui/src/components/compare/ResourceComparisonCharts.tsx
+++ b/ui/src/components/compare/ResourceComparisonCharts.tsx
@@ -76,6 +76,7 @@ function useDarkMode() {
 interface ResourceComparisonChartsProps {
   runs: CompareRun[]
   labelMode: LabelMode
+  testNameFilter?: (name: string) => boolean
 }
 
 interface ResourceDataPoint {
@@ -103,12 +104,14 @@ function formatOps(ops: number): string {
   return `${(ops / 1_000_000).toFixed(1)}M`
 }
 
-function buildDataPoints(tests: Record<string, TestEntry>): ResourceDataPoint[] {
-  const sortedTests = Object.entries(tests).sort(([, a], [, b]) => {
-    const aNum = parseInt(a.dir, 10) || 0
-    const bNum = parseInt(b.dir, 10) || 0
-    return aNum - bNum
-  })
+function buildDataPoints(tests: Record<string, TestEntry>, nameFilter?: (name: string) => boolean): ResourceDataPoint[] {
+  const sortedTests = Object.entries(tests)
+    .filter(([name]) => !nameFilter || nameFilter(name))
+    .sort(([, a], [, b]) => {
+      const aNum = parseInt(a.dir, 10) || 0
+      const bNum = parseInt(b.dir, 10) || 0
+      return aNum - bNum
+    })
 
   const points: ResourceDataPoint[] = []
   sortedTests.forEach(([testName, test], index) => {
@@ -169,7 +172,7 @@ function ChartSection({ title, option, onZoom }: ChartSectionProps) {
   )
 }
 
-export function ResourceComparisonCharts({ runs, labelMode }: ResourceComparisonChartsProps) {
+export function ResourceComparisonCharts({ runs, labelMode, testNameFilter }: ResourceComparisonChartsProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
@@ -182,8 +185,8 @@ export function ResourceComparisonCharts({ runs, labelMode }: ResourceComparison
   }, [])
 
   const pointsPerRun = useMemo(
-    () => runs.map((r) => r.result ? buildDataPoints(r.result.tests) : []),
-    [runs],
+    () => runs.map((r) => r.result ? buildDataPoints(r.result.tests, testNameFilter) : []),
+    [runs, testNameFilter],
   )
 
   const hasData = pointsPerRun.some((p) => p.length > 0)

--- a/ui/src/components/compare/ResourceComparisonCharts.tsx
+++ b/ui/src/components/compare/ResourceComparisonCharts.tsx
@@ -3,7 +3,7 @@ import ReactECharts from 'echarts-for-react'
 import { Cpu } from 'lucide-react'
 import type { TestEntry, ResourceTotals } from '@/api/types'
 import { formatBytes } from '@/utils/format'
-import { type CompareRun, RUN_SLOTS } from './constants'
+import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 interface AggregatedResourceData {
   totals: ResourceTotals
@@ -75,6 +75,7 @@ function useDarkMode() {
 
 interface ResourceComparisonChartsProps {
   runs: CompareRun[]
+  labelMode: LabelMode
 }
 
 interface ResourceDataPoint {
@@ -168,7 +169,7 @@ function ChartSection({ title, option, onZoom }: ChartSectionProps) {
   )
 }
 
-export function ResourceComparisonCharts({ runs }: ResourceComparisonChartsProps) {
+export function ResourceComparisonCharts({ runs, labelMode }: ResourceComparisonChartsProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
@@ -310,7 +311,7 @@ export function ResourceComparisonCharts({ runs }: ResourceComparisonChartsProps
         const slot = RUN_SLOTS[i]
         const points = pointsPerRun[i]
         return {
-          name: `Run ${slot.label}`,
+          name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
           ...createLineSeries(),
           data: points.map((d) => [d.testIndex, d[field], d.testName]),
           itemStyle: { color: slot.color },
@@ -375,7 +376,7 @@ export function ResourceComparisonCharts({ runs }: ResourceComparisonChartsProps
     }
 
     return { cpuPercentOption, memoryMBOption, cpuTimeOption, memoryDeltaOption, diskReadBytesOption, diskWriteBytesOption, diskReadOpsOption, diskWriteOpsOption }
-  }, [pointsPerRun, runs, isDark, zoomRange])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode])
 
   if (!hasData) return null
 
@@ -390,7 +391,7 @@ export function ResourceComparisonCharts({ runs }: ResourceComparisonChartsProps
             return (
               <span key={slot.label} className={`inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 font-medium ${slot.badgeBgClass} ${slot.badgeTextClass}`}>
                 <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
-                {slot.label}
+                {formatRunLabel(slot, run, labelMode)}
               </span>
             )
           })}

--- a/ui/src/components/compare/ResourceComparisonCharts.tsx
+++ b/ui/src/components/compare/ResourceComparisonCharts.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import { Cpu } from 'lucide-react'
-import type { TestEntry, ResourceTotals } from '@/api/types'
+import type { TestEntry, ResourceTotals, SuiteTest } from '@/api/types'
 import { formatBytes } from '@/utils/format'
 import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
@@ -77,10 +77,12 @@ interface ResourceComparisonChartsProps {
   runs: CompareRun[]
   labelMode: LabelMode
   testNameFilter?: (name: string) => boolean
+  suiteTests?: SuiteTest[]
 }
 
 interface ResourceDataPoint {
   testIndex: number
+  testOrder: number
   testName: string
   cpuPercent: number
   memoryMB: number
@@ -104,12 +106,17 @@ function formatOps(ops: number): string {
   return `${(ops / 1_000_000).toFixed(1)}M`
 }
 
-function buildDataPoints(tests: Record<string, TestEntry>, nameFilter?: (name: string) => boolean): ResourceDataPoint[] {
+function buildDataPoints(tests: Record<string, TestEntry>, nameFilter?: (name: string) => boolean, suiteTests?: SuiteTest[]): ResourceDataPoint[] {
+  const suiteOrder = new Map<string, number>()
+  if (suiteTests) {
+    suiteTests.forEach((t, i) => suiteOrder.set(t.name, i + 1))
+  }
+
   const sortedTests = Object.entries(tests)
     .filter(([name]) => !nameFilter || nameFilter(name))
-    .sort(([, a], [, b]) => {
-      const aNum = parseInt(a.dir, 10) || 0
-      const bNum = parseInt(b.dir, 10) || 0
+    .sort(([nameA, a], [nameB, b]) => {
+      const aNum = suiteOrder.get(nameA) ?? (parseInt(a.dir, 10) || 0)
+      const bNum = suiteOrder.get(nameB) ?? (parseInt(b.dir, 10) || 0)
       return aNum - bNum
     })
 
@@ -124,6 +131,7 @@ function buildDataPoints(tests: Record<string, TestEntry>, nameFilter?: (name: s
       }
       points.push({
         testIndex: index + 1,
+        testOrder: suiteOrder.get(testName) ?? (parseInt(test.dir, 10) || (index + 1)),
         testName,
         cpuPercent,
         memoryMB: agg.memoryBytes / (1024 * 1024),
@@ -172,7 +180,7 @@ function ChartSection({ title, option, onZoom }: ChartSectionProps) {
   )
 }
 
-export function ResourceComparisonCharts({ runs, labelMode, testNameFilter }: ResourceComparisonChartsProps) {
+export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suiteTests }: ResourceComparisonChartsProps) {
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
@@ -185,8 +193,8 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter }: Re
   }, [])
 
   const pointsPerRun = useMemo(
-    () => runs.map((r) => r.result ? buildDataPoints(r.result.tests, testNameFilter) : []),
-    [runs, testNameFilter],
+    () => runs.map((r) => r.result ? buildDataPoints(r.result.tests, testNameFilter, suiteTests) : []),
+    [runs, testNameFilter, suiteTests],
   )
 
   const hasData = pointsPerRun.some((p) => p.length > 0)
@@ -196,6 +204,12 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter }: Re
     const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
     const splitLineColor = isDark ? '#374151' : '#e5e7eb'
     const maxLen = Math.max(...pointsPerRun.map((p) => p.length))
+    const indexToOrder = new Map<number, number>()
+    for (const points of pointsPerRun) {
+      for (const d of points) {
+        indexToOrder.set(d.testIndex, d.testOrder)
+      }
+    }
 
     const baseConfig = {
       backgroundColor: 'transparent',
@@ -216,7 +230,7 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter }: Re
         axisLabel: {
           color: textColor,
           fontSize: 11,
-          formatter: (value: number) => `#${value}`,
+          formatter: (value: number) => `#${indexToOrder.get(value) ?? value}`,
         },
         axisLine: { show: true, lineStyle: { color: axisLineColor } },
         axisTick: { show: true, lineStyle: { color: axisLineColor } },
@@ -240,7 +254,7 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter }: Re
           fillerColor: isDark ? 'rgba(139, 92, 246, 0.3)' : 'rgba(139, 92, 246, 0.1)',
           backgroundColor: isDark ? '#374151' : '#f3f4f6',
           textStyle: { color: textColor },
-          labelFormatter: (value: number) => `#${Math.round(value)}`,
+          labelFormatter: (value: number) => `#${indexToOrder.get(Math.round(value)) ?? Math.round(value)}`,
         },
         {
           type: 'inside' as const,
@@ -282,12 +296,12 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter }: Re
       textStyle: { color: textColor },
       extraCssText: 'max-width: 300px; white-space: normal;',
       formatter: (
-        params: Array<{ seriesName: string; color: string; value: [number, number, string] }>,
+        params: Array<{ seriesName: string; color: string; value: [number, number, string, number] }>,
       ) => {
         if (!params.length) return ''
-        const testIndex = params[0].value[0]
         const testName = params[0].value[2]
-        let content = `<strong>Test #${testIndex}</strong>`
+        const testOrder = params[0].value[3]
+        let content = `<strong>Test #${testOrder}</strong>`
         if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
         content += '<br/>'
         params.forEach((p) => {
@@ -316,7 +330,7 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter }: Re
         return {
           name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
           ...createLineSeries(),
-          data: points.map((d) => [d.testIndex, d[field], d.testName]),
+          data: points.map((d) => [d.testIndex, d[field], d.testName, d.testOrder]),
           itemStyle: { color: slot.color },
           areaStyle: { opacity: 0.08, color: slot.color },
         }

--- a/ui/src/components/compare/StickyRunBar.tsx
+++ b/ui/src/components/compare/StickyRunBar.tsx
@@ -34,17 +34,10 @@ export function StickyRunBar({ runs, sentinelRef, labelMode }: StickyRunBarProps
         {runs.map((run) => {
           const slot = RUN_SLOTS[run.index]
           return (
-            <div key={slot.label} className="flex items-center gap-2">
-              <span className={clsx('inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs/5 font-medium', slot.badgeBgClass, slot.badgeTextClass)}>
-                <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
-                {formatRunLabel(slot, run, labelMode)}
-              </span>
-              {run.config.instance.id && (
-                <span className="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400" title={run.config.instance.id}>
-                  {run.config.instance.id}
-                </span>
-              )}
-            </div>
+            <span key={slot.label} className={clsx('inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs/5 font-medium', slot.badgeBgClass, slot.badgeTextClass)}>
+              <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
+              {formatRunLabel(slot, run, labelMode)}
+            </span>
           )
         })}
       </div>

--- a/ui/src/components/compare/StickyRunBar.tsx
+++ b/ui/src/components/compare/StickyRunBar.tsx
@@ -1,15 +1,20 @@
 import { useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
-import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
+import { type CompareRun, type LabelMode, LABEL_MODE_OPTIONS, RUN_SLOTS, formatRunLabel } from './constants'
 
 interface StickyRunBarProps {
   runs: CompareRun[]
   /** Ref to the element that, when scrolled out of view, triggers the sticky bar */
   sentinelRef: React.RefObject<HTMLDivElement | null>
   labelMode: LabelMode
+  onLabelModeChange: (mode: LabelMode) => void
+  testFilter: string
+  testFilterRegex: boolean
+  onTestFilterChange: (query: string) => void
+  onTestFilterRegexChange: (enabled: boolean) => void
 }
 
-export function StickyRunBar({ runs, sentinelRef, labelMode }: StickyRunBarProps) {
+export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, testFilter, testFilterRegex, onTestFilterChange, onTestFilterRegexChange }: StickyRunBarProps) {
   const [visible, setVisible] = useState(false)
   const observerRef = useRef<IntersectionObserver | null>(null)
 
@@ -40,6 +45,51 @@ export function StickyRunBar({ runs, sentinelRef, labelMode }: StickyRunBarProps
             </span>
           )
         })}
+        <div className="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
+          <span>Labels:</span>
+          <div className="flex gap-1">
+            {LABEL_MODE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => onLabelModeChange(opt.value)}
+                className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+                  labelMode === opt.value
+                    ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
+          <span>Filter:</span>
+          <input
+            type="text"
+            placeholder={testFilterRegex ? 'Regex...' : 'Filter...'}
+            value={testFilter}
+            onChange={(e) => onTestFilterChange(e.target.value)}
+            className={clsx(
+              'w-36 rounded-xs border bg-white px-2 py-0.5 text-xs/5 placeholder-gray-400 focus:outline-hidden focus:ring-1 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
+              testFilterRegex && testFilter && (() => { try { new RegExp(testFilter); return false } catch { return true } })()
+                ? 'border-red-400 focus:border-red-500 focus:ring-red-500 dark:border-red-500'
+                : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600',
+            )}
+          />
+          <button
+            onClick={() => onTestFilterRegexChange(!testFilterRegex)}
+            title={testFilterRegex ? 'Regex mode' : 'Text mode'}
+            className={clsx(
+              'rounded-xs px-1 py-0.5 font-mono text-xs/5 transition-colors',
+              testFilterRegex
+                ? 'bg-blue-500 text-white'
+                : 'border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+            )}
+          >
+            .*
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/ui/src/components/compare/StickyRunBar.tsx
+++ b/ui/src/components/compare/StickyRunBar.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
-import { type CompareRun, RUN_SLOTS } from './constants'
+import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 interface StickyRunBarProps {
   runs: CompareRun[]
   /** Ref to the element that, when scrolled out of view, triggers the sticky bar */
   sentinelRef: React.RefObject<HTMLDivElement | null>
+  labelMode: LabelMode
 }
 
-export function StickyRunBar({ runs, sentinelRef }: StickyRunBarProps) {
+export function StickyRunBar({ runs, sentinelRef, labelMode }: StickyRunBarProps) {
   const [visible, setVisible] = useState(false)
   const observerRef = useRef<IntersectionObserver | null>(null)
 
@@ -36,7 +37,7 @@ export function StickyRunBar({ runs, sentinelRef }: StickyRunBarProps) {
             <div key={slot.label} className="flex items-center gap-2">
               <span className={clsx('inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs/5 font-medium', slot.badgeBgClass, slot.badgeTextClass)}>
                 <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
-                {slot.label}
+                {formatRunLabel(slot, run, labelMode)}
               </span>
               {run.config.instance.id && (
                 <span className="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400" title={run.config.instance.id}>

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import clsx from 'clsx'
+import { Table } from 'lucide-react'
 import type { SuiteTest, AggregatedStats, BlockLogs, BlockLogEntry } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { Pagination } from '@/components/shared/Pagination'
@@ -267,9 +268,10 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
   return (
     <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
       <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
-        <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
-          Per-Test Comparison ({filteredTests.length})
-        </h3>
+        <div className="flex items-center gap-2">
+          <Table className="size-4 text-gray-400 dark:text-gray-500" />
+          <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">Per-Test Comparison ({filteredTests.length})</h3>
+        </div>
         <div className="flex items-center gap-1.5">
           <input
             type="text"

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -303,9 +303,10 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
                 const slot = RUN_SLOTS[run.index]
                 return (
                   <th key={slot.label} className={clsx('px-4 py-3 text-right text-xs/5 font-medium uppercase tracking-wider', slot.textClass, `dark:${slot.textDarkClass.replace('text-', 'text-')}`)}>
-                    <div className="flex flex-col items-end gap-1">
+                    <div className="flex flex-col items-end gap-1" title={formatRunLabel(slot, run, labelMode)}>
                       <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-5 rounded-full object-cover" />
-                      {formatRunLabel(slot, run, labelMode)} {activeMetric.unit}
+                      <span>{slot.label}</span>
+                      <span>{activeMetric.unit}</span>
                     </div>
                   </th>
                 )

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -17,6 +17,7 @@ interface TestComparisonTableProps {
   sortBy: SortColumn
   sortDir: SortDirection
   onSortChange: (column: SortColumn, direction: SortDirection) => void
+  testNameFilter?: (name: string) => boolean
 }
 
 type SortColumn = 'order' | 'name' | 'avgValue' | `run-${number}`
@@ -128,10 +129,8 @@ function SortableHeader({
 
 const PAGE_SIZE = 50
 
-export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun, labelMode, tableBaseline, onTableBaselineChange, sortBy, sortDir, onSortChange }: TestComparisonTableProps) {
+export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun, labelMode, tableBaseline, onTableBaselineChange, sortBy, sortDir, onSortChange, testNameFilter }: TestComparisonTableProps) {
   const [activeTab, setActiveTab] = useState('mgas')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [useRegex, setUseRegex] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
 
   const hasBlockLogs = blockLogsPerRun?.some((bl) => bl !== null) ?? false
@@ -204,18 +203,9 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
   }, [runs, suiteOrder, stepFilter, activeTab, blockLogsPerRun])
 
   const filteredTests = useMemo(() => {
-    if (!searchQuery) return comparedTests
-    if (useRegex) {
-      try {
-        const re = new RegExp(searchQuery, 'i')
-        return comparedTests.filter((t) => re.test(t.name))
-      } catch {
-        return comparedTests
-      }
-    }
-    const q = searchQuery.toLowerCase()
-    return comparedTests.filter((t) => t.name.toLowerCase().includes(q))
-  }, [comparedTests, searchQuery, useRegex])
+    if (!testNameFilter) return comparedTests
+    return comparedTests.filter((t) => testNameFilter(t.name))
+  }, [comparedTests, testNameFilter])
 
   const sortedTests = useMemo(() => {
     const sorted = [...filteredTests]
@@ -267,36 +257,10 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
 
   return (
     <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
-      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+      <div className="flex items-center border-b border-gray-200 px-4 py-3 dark:border-gray-700">
         <div className="flex items-center gap-2">
           <Table className="size-4 text-gray-400 dark:text-gray-500" />
           <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">Per-Test Comparison ({filteredTests.length})</h3>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <input
-            type="text"
-            placeholder={useRegex ? 'Regex pattern...' : 'Filter tests...'}
-            value={searchQuery}
-            onChange={(e) => { setSearchQuery(e.target.value); setCurrentPage(1) }}
-            className={clsx(
-              'rounded-xs border bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:outline-hidden focus:ring-1 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
-              useRegex && searchQuery && (() => { try { new RegExp(searchQuery); return false } catch { return true } })()
-                ? 'border-red-400 focus:border-red-500 focus:ring-red-500 dark:border-red-500'
-                : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600',
-            )}
-          />
-          <button
-            onClick={() => setUseRegex(!useRegex)}
-            title={useRegex ? 'Regex mode (click to switch to text)' : 'Text mode (click to switch to regex)'}
-            className={clsx(
-              'rounded-xs px-1.5 py-1 font-mono text-sm/6 transition-colors',
-              useRegex
-                ? 'bg-blue-500 text-white'
-                : 'border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
-            )}
-          >
-            .*
-          </button>
         </div>
       </div>
 

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -3,13 +3,14 @@ import clsx from 'clsx'
 import type { SuiteTest, AggregatedStats, BlockLogs, BlockLogEntry } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { Pagination } from '@/components/shared/Pagination'
-import { type CompareRun, RUN_SLOTS } from './constants'
+import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 interface TestComparisonTableProps {
   runs: CompareRun[]
   suiteTests?: SuiteTest[]
   stepFilter: StepTypeOption[]
   blockLogsPerRun?: (BlockLogs | null)[]
+  labelMode: LabelMode
 }
 
 type SortColumn = 'order' | 'name' | 'avgValue'
@@ -113,7 +114,7 @@ function SortableHeader({
 
 const PAGE_SIZE = 50
 
-export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun }: TestComparisonTableProps) {
+export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun, labelMode }: TestComparisonTableProps) {
   const [activeTab, setActiveTab] = useState('mgas')
   const [sortBy, setSortBy] = useState<SortColumn>('order')
   const [sortDir, setSortDir] = useState<SortDirection>('asc')
@@ -304,7 +305,7 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
                   <th key={slot.label} className={clsx('px-4 py-3 text-right text-xs/5 font-medium uppercase tracking-wider', slot.textClass, `dark:${slot.textDarkClass.replace('text-', 'text-')}`)}>
                     <div className="flex flex-col items-end gap-1">
                       <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-5 rounded-full object-cover" />
-                      {slot.label} {activeMetric.unit}
+                      {formatRunLabel(slot, run, labelMode)} {activeMetric.unit}
                     </div>
                   </th>
                 )

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -39,7 +39,7 @@ interface MetricTab {
 }
 
 const BLOCK_LOG_METRICS: MetricTab[] = [
-  { id: 'bl-throughput', label: 'Throughput', unit: 'MGas/s', higherIsBetter: true, format: (v) => v.toFixed(2) },
+  { id: 'bl-throughput', label: 'Throughput', unit: 'MGas/s', higherIsBetter: true, format: (v) => v >= 100 ? v.toFixed(0) : v.toFixed(2) },
   { id: 'bl-execution', label: 'Execution Time', unit: 'ms', higherIsBetter: false, format: (v) => v.toFixed(2) },
   { id: 'bl-overhead', label: 'Overhead', unit: 'ms', higherIsBetter: false, format: (v) => v.toFixed(2) },
   { id: 'bl-account-cache', label: 'Account Cache HR', unit: '%', higherIsBetter: true, format: (v) => v.toFixed(1) },
@@ -138,7 +138,7 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
 
   const tabs: MetricTab[] = useMemo(() => {
     const base: MetricTab[] = [
-      { id: 'mgas', label: 'MGas/s', unit: 'MGas/s', higherIsBetter: true, format: (v) => v.toFixed(2) },
+      { id: 'mgas', label: 'MGas/s', unit: 'MGas/s', higherIsBetter: true, format: (v) => v >= 100 ? v.toFixed(0) : v.toFixed(2) },
     ]
     if (hasBlockLogs) {
       return [...base, ...BLOCK_LOG_METRICS]
@@ -428,7 +428,7 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
                         </div>
                         {diff !== undefined && !isRef && refValue! > 0 && (
                           <div className="text-xs/4" style={{ color: getDiffColor(diff, refValue!) }}>
-                            {diff >= 0 ? `+${diff.toFixed(2)}` : diff.toFixed(2)}
+                            {diff >= 0 ? '+' : '-'}{activeMetric.format(Math.abs(diff))}
                             {' '}({diff >= 0 ? '+' : '-'}{((Math.abs(diff) / refValue!) * 100).toFixed(1)}%)
                           </div>
                         )}

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -15,6 +15,7 @@ interface TestComparisonTableProps {
 
 type SortColumn = 'order' | 'name' | 'avgValue'
 type SortDirection = 'asc' | 'desc'
+type TableBaseline = 'best' | 'worst' | number
 
 interface ComparedTest {
   name: string
@@ -52,12 +53,19 @@ function extractBlockLogMetric(entry: BlockLogEntry, metricId: string): number {
   }
 }
 
-// Returns an RGB color interpolated from yellow (small diff) to red (large diff)
-// based on the percentage deviation from the best value.
-function getDiffColor(diff: number, best: number): string {
-  if (best <= 0) return 'rgb(239, 68, 68)' // red
-  const pct = Math.abs(diff) / best // 0..1+
-  const t = Math.min(pct / 0.5, 1) // clamp: 0% → 0, ≥50% → 1
+// Returns an RGB color based on percentage deviation from reference value.
+// Positive diff (better): green tones. Negative diff (worse): yellow → red.
+function getDiffColor(diff: number, ref: number): string {
+  if (ref <= 0) return 'rgb(239, 68, 68)'
+  const pct = Math.abs(diff) / ref
+  const t = Math.min(pct / 0.5, 1)
+  if (diff >= 0) {
+    // light green (134,239,172) → green (22,163,74)
+    const r = Math.round(134 - t * (134 - 22))
+    const g = Math.round(239 - t * (239 - 163))
+    const b = Math.round(172 - t * (172 - 74))
+    return `rgb(${r}, ${g}, ${b})`
+  }
   // yellow (234,179,8) → red (239,68,68)
   const r = Math.round(234 + t * (239 - 234))
   const g = Math.round(179 - t * (179 - 68))
@@ -121,6 +129,7 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
   const [searchQuery, setSearchQuery] = useState('')
   const [useRegex, setUseRegex] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
+  const [tableBaseline, setTableBaseline] = useState<TableBaseline>('best')
 
   const hasBlockLogs = blockLogsPerRun?.some((bl) => bl !== null) ?? false
 
@@ -292,6 +301,44 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
         </div>
       )}
 
+      <div className="flex items-center gap-1.5 border-b border-gray-200 px-4 py-2 dark:border-gray-700">
+        <span className="text-xs/5 text-gray-500 dark:text-gray-400">Baseline:</span>
+        <div className="flex flex-wrap gap-1">
+          {(['best', 'worst'] as const).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => setTableBaseline(mode)}
+              className={clsx(
+                'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                tableBaseline === mode
+                  ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+              )}
+            >
+              {mode === 'best' ? (activeMetric.higherIsBetter ? 'Fastest' : 'Lowest') : (activeMetric.higherIsBetter ? 'Slowest' : 'Highest')}
+            </button>
+          ))}
+          {runs.map((run, i) => {
+            const slot = RUN_SLOTS[run.index]
+            return (
+              <button
+                key={slot.label}
+                onClick={() => setTableBaseline(i)}
+                className={clsx(
+                  'inline-flex items-center gap-1 rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                  tableBaseline === i
+                    ? `${slot.badgeBgClass} ${slot.badgeTextClass} ring-1 ring-current`
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                )}
+              >
+                <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
+                {formatRunLabel(slot, run, labelMode)}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
           <thead className="bg-gray-50 dark:bg-gray-900">
@@ -316,9 +363,14 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
           <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
             {paginatedTests.map((test) => {
               const defined = test.values.filter((v): v is number => v !== undefined)
-              const bestValue = defined.length > 0
-                ? (activeMetric.higherIsBetter ? Math.max(...defined) : Math.min(...defined))
-                : undefined
+              let refValue: number | undefined
+              if (typeof tableBaseline === 'number') {
+                refValue = test.values[tableBaseline]
+              } else if (defined.length > 0) {
+                refValue = tableBaseline === 'best'
+                  ? (activeMetric.higherIsBetter ? Math.max(...defined) : Math.min(...defined))
+                  : (activeMetric.higherIsBetter ? Math.min(...defined) : Math.max(...defined))
+              }
 
               return (
                 <tr key={test.name} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
@@ -332,18 +384,19 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
                     {test.avgValue !== undefined ? activeMetric.format(test.avgValue) : '-'}
                   </td>
                   {test.values.map((val, i) => {
-                    const isBest = val !== undefined && val === bestValue
-                    const diff = val !== undefined && bestValue !== undefined
-                      ? (activeMetric.higherIsBetter ? val - bestValue : bestValue - val)
+                    const isRef = val !== undefined && val === refValue
+                    const diff = val !== undefined && refValue !== undefined
+                      ? (activeMetric.higherIsBetter ? val - refValue : refValue - val)
                       : undefined
                     return (
                       <td key={RUN_SLOTS[i].label} className="whitespace-nowrap px-4 py-2 text-right text-sm/6">
-                        <div className={isBest ? 'font-semibold text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'}>
+                        <div className={isRef ? 'font-semibold text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'}>
                           {val !== undefined ? activeMetric.format(val) : '-'}
                         </div>
-                        {diff !== undefined && !isBest && (
-                          <div className="text-xs/4" style={{ color: getDiffColor(diff, bestValue!) }}>
-                            {activeMetric.higherIsBetter ? diff.toFixed(2) : `+${Math.abs(diff).toFixed(2)}`}
+                        {diff !== undefined && !isRef && refValue! > 0 && (
+                          <div className="text-xs/4" style={{ color: getDiffColor(diff, refValue!) }}>
+                            {diff >= 0 ? `+${diff.toFixed(2)}` : diff.toFixed(2)}
+                            {' '}({diff >= 0 ? '+' : '-'}{((Math.abs(diff) / refValue!) * 100).toFixed(1)}%)
                           </div>
                         )}
                       </td>

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -11,9 +11,14 @@ interface TestComparisonTableProps {
   stepFilter: StepTypeOption[]
   blockLogsPerRun?: (BlockLogs | null)[]
   labelMode: LabelMode
+  tableBaseline: TableBaseline
+  onTableBaselineChange: (val: TableBaseline) => void
+  sortBy: SortColumn
+  sortDir: SortDirection
+  onSortChange: (column: SortColumn, direction: SortDirection) => void
 }
 
-type SortColumn = 'order' | 'name' | 'avgValue'
+type SortColumn = 'order' | 'name' | 'avgValue' | `run-${number}`
 type SortDirection = 'asc' | 'desc'
 type TableBaseline = 'best' | 'worst' | number
 
@@ -122,14 +127,11 @@ function SortableHeader({
 
 const PAGE_SIZE = 50
 
-export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun, labelMode }: TestComparisonTableProps) {
+export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun, labelMode, tableBaseline, onTableBaselineChange, sortBy, sortDir, onSortChange }: TestComparisonTableProps) {
   const [activeTab, setActiveTab] = useState('mgas')
-  const [sortBy, setSortBy] = useState<SortColumn>('order')
-  const [sortDir, setSortDir] = useState<SortDirection>('asc')
   const [searchQuery, setSearchQuery] = useState('')
   const [useRegex, setUseRegex] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
-  const [tableBaseline, setTableBaseline] = useState<TableBaseline>('best')
 
   const hasBlockLogs = blockLogsPerRun?.some((bl) => bl !== null) ?? false
 
@@ -218,31 +220,46 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
     const sorted = [...filteredTests]
     sorted.sort((a, b) => {
       let cmp = 0
-      switch (sortBy) {
-        case 'order':
-          cmp = a.order - b.order
-          break
-        case 'name':
-          cmp = a.name.localeCompare(b.name)
-          break
-        case 'avgValue':
-          cmp = (a.avgValue ?? 0) - (b.avgValue ?? 0)
-          break
+      if (sortBy.startsWith('run-') && typeof tableBaseline === 'number') {
+        const runIdx = parseInt(sortBy.slice(4), 10)
+        const getPctDiff = (test: ComparedTest) => {
+          const val = test.values[runIdx]
+          const ref = test.values[tableBaseline]
+          if (val === undefined || ref === undefined || ref === 0) return undefined
+          return ((val - ref) / ref) * 100
+        }
+        const aDiff = getPctDiff(a)
+        const bDiff = getPctDiff(b)
+        if (aDiff === undefined && bDiff === undefined) cmp = 0
+        else if (aDiff === undefined) cmp = 1
+        else if (bDiff === undefined) cmp = -1
+        else cmp = aDiff - bDiff
+      } else {
+        switch (sortBy) {
+          case 'order':
+            cmp = a.order - b.order
+            break
+          case 'name':
+            cmp = a.name.localeCompare(b.name)
+            break
+          case 'avgValue':
+            cmp = (a.avgValue ?? 0) - (b.avgValue ?? 0)
+            break
+        }
       }
       return sortDir === 'asc' ? cmp : -cmp
     })
     return sorted
-  }, [filteredTests, sortBy, sortDir])
+  }, [filteredTests, sortBy, sortDir, tableBaseline])
 
   const totalPages = Math.ceil(sortedTests.length / PAGE_SIZE)
   const paginatedTests = sortedTests.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
 
   const handleSort = (column: SortColumn) => {
     if (sortBy === column) {
-      setSortDir(sortDir === 'desc' ? 'asc' : 'desc')
+      onSortChange(column, sortDir === 'desc' ? 'asc' : 'desc')
     } else {
-      setSortBy(column)
-      setSortDir('asc')
+      onSortChange(column, 'asc')
     }
     setCurrentPage(1)
   }
@@ -307,7 +324,7 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
           {(['best', 'worst'] as const).map((mode) => (
             <button
               key={mode}
-              onClick={() => setTableBaseline(mode)}
+              onClick={() => onTableBaselineChange(mode)}
               className={clsx(
                 'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
                 tableBaseline === mode
@@ -323,7 +340,7 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
             return (
               <button
                 key={slot.label}
-                onClick={() => setTableBaseline(i)}
+                onClick={() => onTableBaselineChange(i)}
                 className={clsx(
                   'inline-flex items-center gap-1 rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
                   tableBaseline === i
@@ -346,13 +363,27 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
               <SortableHeader label="#" column="order" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="w-12 px-3 py-3" />
               <SortableHeader label="Test Name" column="name" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
               <SortableHeader label="Avg" column="avgValue" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-4 py-3 text-right" />
-              {runs.map((run) => {
+              {runs.map((run, i) => {
                 const slot = RUN_SLOTS[run.index]
+                const colId: SortColumn = `run-${i}`
+                const isSortable = typeof tableBaseline === 'number' && i !== tableBaseline
+                const isActive = sortBy === colId
                 return (
-                  <th key={slot.label} className={clsx('px-4 py-3 text-right text-xs/5 font-medium uppercase tracking-wider', slot.textClass, `dark:${slot.textDarkClass.replace('text-', 'text-')}`)}>
+                  <th
+                    key={slot.label}
+                    onClick={isSortable ? () => handleSort(colId) : undefined}
+                    className={clsx(
+                      'px-4 py-3 text-right text-xs/5 font-medium uppercase tracking-wider',
+                      slot.textClass, `dark:${slot.textDarkClass.replace('text-', 'text-')}`,
+                      isSortable && 'cursor-pointer select-none',
+                    )}
+                  >
                     <div className="flex flex-col items-end gap-1" title={formatRunLabel(slot, run, labelMode)}>
                       <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-5 rounded-full object-cover" />
-                      <span>{slot.label}</span>
+                      <span className="inline-flex items-center">
+                        {slot.label}
+                        {isSortable && <SortIcon direction={isActive ? sortDir : 'asc'} active={isActive} />}
+                      </span>
                       <span>{activeMetric.unit}</span>
                     </div>
                   </th>

--- a/ui/src/components/compare/constants.ts
+++ b/ui/src/components/compare/constants.ts
@@ -85,3 +85,17 @@ export interface CompareRun {
   result: RunResult | null
   index: number
 }
+
+export type LabelMode = 'none' | 'instance-id'
+
+export const LABEL_MODE_OPTIONS: { value: LabelMode; label: string }[] = [
+  { value: 'none', label: 'None' },
+  { value: 'instance-id', label: 'Instance ID' },
+]
+
+export function formatRunLabel(slot: RunSlot, run: CompareRun, labelMode: LabelMode): string {
+  if (labelMode === 'instance-id' && run.config.instance.id) {
+    return `${slot.label} (${run.config.instance.id})`
+  }
+  return slot.label
+}

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -18,7 +18,7 @@ import { ResourceComparisonCharts } from '@/components/compare/ResourceCompariso
 import { BlockLogsComparison } from '@/components/compare/BlockLogsComparison'
 import { ConfigDiff } from '@/components/compare/ConfigDiff'
 import { type StepTypeOption, ALL_STEP_TYPES, DEFAULT_STEP_FILTER } from '@/pages/RunDetailPage'
-import { MIN_COMPARE_RUNS, MAX_COMPARE_RUNS, type CompareRun } from '@/components/compare/constants'
+import { MIN_COMPARE_RUNS, MAX_COMPARE_RUNS, LABEL_MODE_OPTIONS, type CompareRun, type LabelMode } from '@/components/compare/constants'
 
 function parseStepFilter(param: string | undefined): StepTypeOption[] {
   if (!param) return DEFAULT_STEP_FILTER
@@ -34,6 +34,7 @@ export function ComparePage() {
     b?: string
     steps?: string
     baseline?: string
+    labels?: string
   }
 
   // Backward-compat redirect: ?a=X&b=Y → ?runs=X,Y
@@ -103,13 +104,21 @@ export function ComparePage() {
   const { data: suite } = useSuite(suiteHash)
   const headerRef = useRef<HTMLDivElement>(null)
   const baselineIdx = Math.min(Math.max(parseInt(search.baseline ?? '0', 10) || 0, 0), runIds.length - 1)
+  const labelMode: LabelMode = search.labels === 'instance-id' ? 'instance-id' : 'none'
   const setBaselineIdx = useCallback((idx: number) => {
     navigate({
       to: '/compare',
-      search: { runs: search.runs, steps: search.steps, baseline: idx > 0 ? String(idx) : undefined },
+      search: { runs: search.runs, steps: search.steps, baseline: idx > 0 ? String(idx) : undefined, labels: search.labels },
       replace: true,
     })
-  }, [navigate, search.runs, search.steps])
+  }, [navigate, search.runs, search.steps, search.labels])
+  const setLabelMode = useCallback((mode: LabelMode) => {
+    navigate({
+      to: '/compare',
+      search: { runs: search.runs, steps: search.steps, baseline: search.baseline, labels: mode === 'none' ? undefined : mode },
+      replace: true,
+    })
+  }, [navigate, search.runs, search.steps, search.baseline])
 
   // Handle backward-compat redirect in progress
   if (search.a && search.b && !search.runs) {
@@ -152,7 +161,7 @@ export function ComparePage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <StickyRunBar runs={runs} sentinelRef={headerRef} />
+      <StickyRunBar runs={runs} sentinelRef={headerRef} labelMode={labelMode} />
 
       {/* Breadcrumb */}
       <div className="flex min-w-0 items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
@@ -176,6 +185,25 @@ export function ComparePage() {
         <span className="shrink-0 text-gray-900 dark:text-gray-100">Compare</span>
       </div>
 
+      <div className="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
+        <span>Labels:</span>
+        <div className="flex gap-1">
+          {LABEL_MODE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => setLabelMode(opt.value)}
+              className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+                labelMode === opt.value
+                  ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
       {suiteMismatch && (
         <div className="rounded-sm border border-yellow-300 bg-yellow-50 p-3 text-sm/6 text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-300">
           Warning: These runs belong to different suites. Test-level comparison may not be meaningful.
@@ -183,31 +211,31 @@ export function ComparePage() {
       )}
 
       <div ref={headerRef}>
-        <CompareHeader runs={runs} onRemoveRun={(id) => {
+        <CompareHeader runs={runs} labelMode={labelMode} onRemoveRun={(id) => {
           const remaining = runIds.filter((r) => r !== id)
           navigate({ to: '/compare', search: { runs: remaining.join(','), steps: search.steps } })
         }} />
       </div>
 
-      <MetricsComparison runs={runs} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} />
+      <MetricsComparison runs={runs} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} />
 
       {allResults && (
-        <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} />
+        <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} labelMode={labelMode} />
       )}
 
       {allResults && (
-        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} />
+        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} />
       )}
 
-      <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} />
+      <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} labelMode={labelMode} />
 
       {allResults && (
-        <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} />
+        <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} />
       )}
 
-      {allResults && <ResourceComparisonCharts runs={runs} />}
+      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} />}
 
-      <ConfigDiff runs={runs} />
+      <ConfigDiff runs={runs} labelMode={labelMode} />
     </div>
   )
 }

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { Link, useSearch, useNavigate } from '@tanstack/react-router'
 import { useQueries } from '@tanstack/react-query'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES } from '@/api/types'
@@ -33,6 +33,7 @@ export function ComparePage() {
     a?: string
     b?: string
     steps?: string
+    baseline?: string
   }
 
   // Backward-compat redirect: ?a=X&b=Y → ?runs=X,Y
@@ -101,6 +102,14 @@ export function ComparePage() {
   const suiteHash = configQueries.find((q) => q.data?.suite_hash)?.data?.suite_hash
   const { data: suite } = useSuite(suiteHash)
   const headerRef = useRef<HTMLDivElement>(null)
+  const baselineIdx = Math.min(Math.max(parseInt(search.baseline ?? '0', 10) || 0, 0), runIds.length - 1)
+  const setBaselineIdx = useCallback((idx: number) => {
+    navigate({
+      to: '/compare',
+      search: { runs: search.runs, steps: search.steps, baseline: idx > 0 ? String(idx) : undefined },
+      replace: true,
+    })
+  }, [navigate, search.runs, search.steps])
 
   // Handle backward-compat redirect in progress
   if (search.a && search.b && !search.runs) {
@@ -180,14 +189,14 @@ export function ComparePage() {
         }} />
       </div>
 
-<MetricsComparison runs={runs} stepFilter={stepFilter} />
+      <MetricsComparison runs={runs} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} />
 
       {allResults && (
         <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} />
       )}
 
       {allResults && (
-        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} />
+        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} />
       )}
 
       <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} />

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -232,6 +232,11 @@ export function ComparePage() {
         <CompareHeader runs={runs} labelMode={labelMode} onRemoveRun={(id) => {
           const remaining = runIds.filter((r) => r !== id)
           navigate({ to: '/compare', search: { runs: remaining.join(','), steps: search.steps } })
+        }} onMoveRun={(from, to) => {
+          const reordered = [...runIds]
+          const [moved] = reordered.splice(from, 1)
+          reordered.splice(to, 0, moved)
+          updateSearch({ runs: reordered.join(',') })
         }} />
       </div>
 

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import clsx from 'clsx'
 import { Link, useSearch, useNavigate } from '@tanstack/react-router'
 import { useQueries } from '@tanstack/react-query'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES } from '@/api/types'
@@ -39,6 +40,8 @@ export function ComparePage() {
     sort?: string
     sortDir?: string
     diffFilter?: string
+    filter?: string
+    filterRegex?: string
   }
 
   // Backward-compat redirect: ?a=X&b=Y → ?runs=X,Y
@@ -118,14 +121,30 @@ export function ComparePage() {
   const tableSortBy = (search.sort ?? 'order') as 'order' | 'name' | 'avgValue' | `run-${number}`
   const tableSortDir = (search.sortDir === 'desc' ? 'desc' : 'asc') as 'asc' | 'desc'
   const diffFilter = (search.diffFilter === 'faster' || search.diffFilter === 'slower' ? search.diffFilter : 'all') as 'all' | 'faster' | 'slower'
+  const testFilter = search.filter ?? ''
+  const testFilterRegex = search.filterRegex === '1'
+
+  const testNameFilter = useMemo(() => {
+    if (!testFilter) return undefined
+    if (testFilterRegex) {
+      try {
+        const re = new RegExp(testFilter, 'i')
+        return (name: string) => re.test(name)
+      } catch {
+        return undefined
+      }
+    }
+    const q = testFilter.toLowerCase()
+    return (name: string) => name.toLowerCase().includes(q)
+  }, [testFilter, testFilterRegex])
 
   const updateSearch = useCallback((patch: Record<string, string | undefined>) => {
     navigate({
       to: '/compare',
-      search: { runs: search.runs, steps: search.steps, baseline: search.baseline, labels: search.labels, tableBase: search.tableBase, sort: search.sort, sortDir: search.sortDir, diffFilter: search.diffFilter, ...patch },
+      search: { runs: search.runs, steps: search.steps, baseline: search.baseline, labels: search.labels, tableBase: search.tableBase, sort: search.sort, sortDir: search.sortDir, diffFilter: search.diffFilter, filter: search.filter, filterRegex: search.filterRegex, ...patch },
       replace: true,
     })
-  }, [navigate, search.runs, search.steps, search.baseline, search.labels, search.tableBase, search.sort, search.sortDir, search.diffFilter])
+  }, [navigate, search.runs, search.steps, search.baseline, search.labels, search.tableBase, search.sort, search.sortDir, search.diffFilter, search.filter, search.filterRegex])
 
   const setBaselineIdx = useCallback((idx: number) => {
     updateSearch({ baseline: idx > 0 ? String(idx) : undefined })
@@ -141,6 +160,12 @@ export function ComparePage() {
   }, [updateSearch])
   const setDiffFilter = useCallback((val: 'all' | 'faster' | 'slower') => {
     updateSearch({ diffFilter: val === 'all' ? undefined : val })
+  }, [updateSearch])
+  const setTestFilter = useCallback((query: string) => {
+    updateSearch({ filter: query || undefined })
+  }, [updateSearch])
+  const setTestFilterRegex = useCallback((enabled: boolean) => {
+    updateSearch({ filterRegex: enabled ? '1' : undefined })
   }, [updateSearch])
 
   // Handle backward-compat redirect in progress
@@ -184,7 +209,7 @@ export function ComparePage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <StickyRunBar runs={runs} sentinelRef={headerRef} labelMode={labelMode} />
+      <StickyRunBar runs={runs} sentinelRef={headerRef} labelMode={labelMode} onLabelModeChange={setLabelMode} testFilter={testFilter} testFilterRegex={testFilterRegex} onTestFilterChange={setTestFilter} onTestFilterRegexChange={setTestFilterRegex} />
 
       {/* Breadcrumb */}
       <div className="flex min-w-0 items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
@@ -208,22 +233,51 @@ export function ComparePage() {
         <span className="shrink-0 text-gray-900 dark:text-gray-100">Compare</span>
       </div>
 
-      <div className="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
-        <span>Labels:</span>
-        <div className="flex gap-1">
-          {LABEL_MODE_OPTIONS.map((opt) => (
-            <button
-              key={opt.value}
-              onClick={() => setLabelMode(opt.value)}
-              className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
-                labelMode === opt.value
-                  ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
-                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
-              }`}
-            >
-              {opt.label}
-            </button>
-          ))}
+      <div className="flex flex-wrap items-center gap-4 text-xs/5 text-gray-500 dark:text-gray-400">
+        <div className="flex items-center gap-1.5">
+          <span>Labels:</span>
+          <div className="flex gap-1">
+            {LABEL_MODE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => setLabelMode(opt.value)}
+                className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+                  labelMode === opt.value
+                    ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span>Filter:</span>
+          <input
+            type="text"
+            placeholder={testFilterRegex ? 'Regex pattern...' : 'Filter tests...'}
+            value={testFilter}
+            onChange={(e) => setTestFilter(e.target.value)}
+            className={clsx(
+              'rounded-xs border bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:outline-hidden focus:ring-1 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
+              testFilterRegex && testFilter && (() => { try { new RegExp(testFilter); return false } catch { return true } })()
+                ? 'border-red-400 focus:border-red-500 focus:ring-red-500 dark:border-red-500'
+                : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600',
+            )}
+          />
+          <button
+            onClick={() => setTestFilterRegex(!testFilterRegex)}
+            title={testFilterRegex ? 'Regex mode (click to switch to text)' : 'Text mode (click to switch to regex)'}
+            className={clsx(
+              'rounded-xs px-1.5 py-1 font-mono text-sm/6 transition-colors',
+              testFilterRegex
+                ? 'bg-blue-500 text-white'
+                : 'border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+            )}
+          >
+            .*
+          </button>
         </div>
       </div>
 
@@ -248,20 +302,20 @@ export function ComparePage() {
       <MetricsComparison runs={runs} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} />
 
       {allResults && (
-        <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} labelMode={labelMode} />
+        <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} labelMode={labelMode} testNameFilter={testNameFilter} />
       )}
 
       {allResults && (
-        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} diffFilter={diffFilter} onDiffFilterChange={setDiffFilter} />
+        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} diffFilter={diffFilter} onDiffFilterChange={setDiffFilter} testNameFilter={testNameFilter} />
       )}
 
-      <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} labelMode={labelMode} />
+      <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} labelMode={labelMode} testNameFilter={testNameFilter} />
 
       {allResults && (
-        <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} tableBaseline={tableBaseline} onTableBaselineChange={setTableBaseline} sortBy={tableSortBy} sortDir={tableSortDir} onSortChange={setTableSort} />
+        <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} tableBaseline={tableBaseline} onTableBaselineChange={setTableBaseline} sortBy={tableSortBy} sortDir={tableSortDir} onSortChange={setTableSort} testNameFilter={testNameFilter} />
       )}
 
-      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} />}
+      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} />}
 
       <ConfigDiff runs={runs} labelMode={labelMode} />
     </div>

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -35,6 +35,9 @@ export function ComparePage() {
     steps?: string
     baseline?: string
     labels?: string
+    tableBase?: string
+    sort?: string
+    sortDir?: string
   }
 
   // Backward-compat redirect: ?a=X&b=Y → ?runs=X,Y
@@ -105,20 +108,35 @@ export function ComparePage() {
   const headerRef = useRef<HTMLDivElement>(null)
   const baselineIdx = Math.min(Math.max(parseInt(search.baseline ?? '0', 10) || 0, 0), runIds.length - 1)
   const labelMode: LabelMode = search.labels === 'instance-id' ? 'instance-id' : 'none'
+  const tableBaseline: 'best' | 'worst' | number = search.tableBase === 'worst'
+    ? 'worst'
+    : search.tableBase !== undefined && search.tableBase !== 'best'
+      ? Math.min(parseInt(search.tableBase, 10) || 0, runIds.length - 1)
+      : 'best'
+
+  const tableSortBy = (search.sort ?? 'order') as 'order' | 'name' | 'avgValue' | `run-${number}`
+  const tableSortDir = (search.sortDir === 'desc' ? 'desc' : 'asc') as 'asc' | 'desc'
+
+  const updateSearch = useCallback((patch: Record<string, string | undefined>) => {
+    navigate({
+      to: '/compare',
+      search: { runs: search.runs, steps: search.steps, baseline: search.baseline, labels: search.labels, tableBase: search.tableBase, sort: search.sort, sortDir: search.sortDir, ...patch },
+      replace: true,
+    })
+  }, [navigate, search.runs, search.steps, search.baseline, search.labels, search.tableBase, search.sort, search.sortDir])
+
   const setBaselineIdx = useCallback((idx: number) => {
-    navigate({
-      to: '/compare',
-      search: { runs: search.runs, steps: search.steps, baseline: idx > 0 ? String(idx) : undefined, labels: search.labels },
-      replace: true,
-    })
-  }, [navigate, search.runs, search.steps, search.labels])
+    updateSearch({ baseline: idx > 0 ? String(idx) : undefined })
+  }, [updateSearch])
   const setLabelMode = useCallback((mode: LabelMode) => {
-    navigate({
-      to: '/compare',
-      search: { runs: search.runs, steps: search.steps, baseline: search.baseline, labels: mode === 'none' ? undefined : mode },
-      replace: true,
-    })
-  }, [navigate, search.runs, search.steps, search.baseline])
+    updateSearch({ labels: mode === 'none' ? undefined : mode })
+  }, [updateSearch])
+  const setTableBaseline = useCallback((val: 'best' | 'worst' | number) => {
+    updateSearch({ tableBase: val === 'best' ? undefined : String(val) })
+  }, [updateSearch])
+  const setTableSort = useCallback((column: string, direction: string) => {
+    updateSearch({ sort: column === 'order' ? undefined : column, sortDir: direction === 'asc' ? undefined : direction })
+  }, [updateSearch])
 
   // Handle backward-compat redirect in progress
   if (search.a && search.b && !search.runs) {
@@ -230,7 +248,7 @@ export function ComparePage() {
       <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} labelMode={labelMode} />
 
       {allResults && (
-        <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} />
+        <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} tableBaseline={tableBaseline} onTableBaselineChange={setTableBaseline} sortBy={tableSortBy} sortDir={tableSortDir} onSortChange={setTableSort} />
       )}
 
       {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} />}

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -38,6 +38,7 @@ export function ComparePage() {
     tableBase?: string
     sort?: string
     sortDir?: string
+    diffFilter?: string
   }
 
   // Backward-compat redirect: ?a=X&b=Y → ?runs=X,Y
@@ -116,14 +117,15 @@ export function ComparePage() {
 
   const tableSortBy = (search.sort ?? 'order') as 'order' | 'name' | 'avgValue' | `run-${number}`
   const tableSortDir = (search.sortDir === 'desc' ? 'desc' : 'asc') as 'asc' | 'desc'
+  const diffFilter = (search.diffFilter === 'faster' || search.diffFilter === 'slower' ? search.diffFilter : 'all') as 'all' | 'faster' | 'slower'
 
   const updateSearch = useCallback((patch: Record<string, string | undefined>) => {
     navigate({
       to: '/compare',
-      search: { runs: search.runs, steps: search.steps, baseline: search.baseline, labels: search.labels, tableBase: search.tableBase, sort: search.sort, sortDir: search.sortDir, ...patch },
+      search: { runs: search.runs, steps: search.steps, baseline: search.baseline, labels: search.labels, tableBase: search.tableBase, sort: search.sort, sortDir: search.sortDir, diffFilter: search.diffFilter, ...patch },
       replace: true,
     })
-  }, [navigate, search.runs, search.steps, search.baseline, search.labels, search.tableBase, search.sort, search.sortDir])
+  }, [navigate, search.runs, search.steps, search.baseline, search.labels, search.tableBase, search.sort, search.sortDir, search.diffFilter])
 
   const setBaselineIdx = useCallback((idx: number) => {
     updateSearch({ baseline: idx > 0 ? String(idx) : undefined })
@@ -136,6 +138,9 @@ export function ComparePage() {
   }, [updateSearch])
   const setTableSort = useCallback((column: string, direction: string) => {
     updateSearch({ sort: column === 'order' ? undefined : column, sortDir: direction === 'asc' ? undefined : direction })
+  }, [updateSearch])
+  const setDiffFilter = useCallback((val: 'all' | 'faster' | 'slower') => {
+    updateSearch({ diffFilter: val === 'all' ? undefined : val })
   }, [updateSearch])
 
   // Handle backward-compat redirect in progress
@@ -247,7 +252,7 @@ export function ComparePage() {
       )}
 
       {allResults && (
-        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} />
+        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} diffFilter={diffFilter} onDiffFilterChange={setDiffFilter} />
       )}
 
       <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} labelMode={labelMode} />

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -12,6 +12,7 @@ import { CompareHeader } from '@/components/compare/CompareHeader'
 import { StickyRunBar } from '@/components/compare/StickyRunBar'
 import { MetricsComparison } from '@/components/compare/MetricsComparison'
 import { MGasComparisonChart } from '@/components/compare/MGasComparisonChart'
+import { PercentageDiffChart } from '@/components/compare/PercentageDiffChart'
 import { TestComparisonTable } from '@/components/compare/TestComparisonTable'
 import { ResourceComparisonCharts } from '@/components/compare/ResourceComparisonCharts'
 import { BlockLogsComparison } from '@/components/compare/BlockLogsComparison'
@@ -183,6 +184,10 @@ export function ComparePage() {
 
       {allResults && (
         <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} />
+      )}
+
+      {allResults && (
+        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} />
       )}
 
       <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} />

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -311,11 +311,11 @@ export function ComparePage() {
 
       <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} labelMode={labelMode} testNameFilter={testNameFilter} />
 
+      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} suiteTests={suite?.tests} />}
+
       {allResults && (
         <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} tableBaseline={tableBaseline} onTableBaselineChange={setTableBaseline} sortBy={tableSortBy} sortDir={tableSortDir} onSortChange={setTableSort} testNameFilter={testNameFilter} />
       )}
-
-      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} suiteTests={suite?.tests} />}
 
       <ConfigDiff runs={runs} labelMode={labelMode} />
     </div>

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -315,7 +315,7 @@ export function ComparePage() {
         <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} tableBaseline={tableBaseline} onTableBaselineChange={setTableBaseline} sortBy={tableSortBy} sortDir={tableSortDir} onSortChange={setTableSort} testNameFilter={testNameFilter} />
       )}
 
-      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} />}
+      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} suiteTests={suite?.tests} />}
 
       <ConfigDiff runs={runs} labelMode={labelMode} />
     </div>


### PR DESCRIPTION
## Summary
- Add **% Difference vs Baseline** chart showing per-test performance delta with faster/slower/equal summary table (Avg, P95, P99 percentages)
- Add **shared test filter** (text/regex) across all compare components (MGas/s, % Diff, Block Logs, Resources, Per-Test table), persisted in URL
- Add **baseline selector** synced between metrics cards and % diff chart via URL, with per-test table having its own baseline (Fastest/Slowest/Run A,B,C...)
- Add **label mode toggle** (None / Instance ID) to show instance IDs on run labels across all components
- Add **run reordering** via left/right arrows on compare header cards
- Add **sortable run columns** in per-test table when a specific run baseline is selected
- Show **signed diffs with percentages** and green/red color coding in per-test table
- Add **section icons** (Flame, ArrowRightLeft, Table) matching existing patterns
- Add **labels and filter controls** to sticky header bar
- Use **sequential x-axis positions** with original test order numbers to avoid gaps when filtering
- All interactive state persisted in URL (baseline, labels, tableBase, sort, sortDir, diffFilter, filter, filterRegex)

## Test plan
- [x] Compare 2+ runs and verify all charts render correctly
- [x] Toggle label mode and verify instance ID appears across all components
- [x] Use test filter (text and regex) and verify all charts/tables filter consistently
- [x] Change baseline in metrics cards and verify % diff chart syncs
- [x] Change per-test table baseline and verify diff calculations and sorting
- [x] Reorder runs via arrows and verify URL updates
- [x] Refresh page and verify all URL-persisted state restores correctly
- [x] Filter tests with non-contiguous order numbers and verify no large gaps in charts