### PR TITLE
feat: move metadata labels to client level with per-instance merge

### DIFF
--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -64,11 +64,11 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("invalid metadata label %q: must be key=value", entry)
 		}
 
-		if cfg.Runner.Metadata.Labels == nil {
-			cfg.Runner.Metadata.Labels = make(map[string]string, len(metadataLabels))
+		if cfg.Runner.Client.Config.Metadata.Labels == nil {
+			cfg.Runner.Client.Config.Metadata.Labels = make(map[string]string, len(metadataLabels))
 		}
 
-		cfg.Runner.Metadata.Labels[k] = v
+		cfg.Runner.Client.Config.Metadata.Labels[k] = v
 	}
 
 	// Parse results owner configuration.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,13 +20,6 @@ runner:
   # Uses Go duration format (e.g., "1h", "30m", "2h30m").
   # Can also be set via BENCHMARKOOR_RUNNER_RUN_TIMEOUT environment variable.
   # run_timeout: 4h
-  # Optional: Arbitrary key-value labels attached to this benchmark run.
-  # Labels appear in the run's config.json and can be used for filtering/organization.
-  # Can also be set via CLI: --metadata.label=env=production --metadata.label=team=platform
-  # metadata:
-  #   labels:
-  #     env: production
-  #     team: platform
   # Optional directory configurations.
   # directories:
   #   # Directory for temporary datadir copies (defaults to system temp).
@@ -379,6 +372,14 @@ runner:
       #   # CPU frequency governor (common: performance, powersave, schedutil)
       #   # Defaults to "performance" when cpu_freq is set
       #   cpu_freq_governor: performance
+      # Optional: Default metadata labels for all instances.
+      # Labels appear in each run's config.json and can be used for filtering/organization.
+      # Can also be set via CLI: --metadata.label=env=production --metadata.label=team=platform
+      # Instance-level labels (see instances below) are merged and take precedence.
+      # metadata:
+      #   labels:
+      #     env: production
+      #     team: platform
       # Genesis file URLs per client type
       genesis:
         besu: https://github.com/nethermindeth/gas-benchmarks/raw/refs/heads/main/scripts/genesisfiles/besu/zkevmgenesis.json
@@ -466,6 +467,9 @@ runner:
       #       enabled: true
       #       filename: trace
       # bootstrap_fcu: true  # Instance-level override (optional)
+      # metadata:  # Instance-level labels (optional, merged with client defaults, instance wins)
+      #   labels:
+      #     variant: snap-sync
 
     # Example: running multiple clients
     # - id: nethermind-latest

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,17 +141,30 @@ sudo systemctl start podman.socket
 
 #### Metadata Labels
 
-The `runner.metadata.labels` field attaches arbitrary key-value pairs to a benchmark run. Labels are included in the output `config.json` and can be used for filtering and organization (e.g., in the UI or CI pipelines).
+The `runner.client.config.metadata.labels` field attaches arbitrary key-value pairs to benchmark runs. Labels are included in each run's output `config.json` and can be used for filtering and organization (e.g., in the UI or CI pipelines).
+
+Labels can be set at the client level (defaults for all instances) and overridden per instance. Instance-level labels are merged with client-level labels, with instance values taking precedence on conflict.
 
 ```yaml
 runner:
-  metadata:
-    labels:
-      env: production
-      team: platform
+  client:
+    config:
+      metadata:
+        labels:
+          env: production
+          team: platform
+  instances:
+    - id: geth-latest
+      client: geth
+      metadata:
+        labels:
+          env: staging      # overrides client-level "env"
+          variant: snap-sync  # additional instance-specific label
 ```
 
-Labels can also be set (or overridden) via the CLI flag `--metadata.label`:
+In this example, `geth-latest` runs will have labels `env=staging`, `team=platform`, and `variant=snap-sync`.
+
+Labels can also be set (or overridden) at the client level via the CLI flag `--metadata.label`:
 
 ```bash
 benchmarkoor run --config config.yaml \

--- a/pkg/api/handlers_index.go
+++ b/pkg/api/handlers_index.go
@@ -68,6 +68,13 @@ func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
 			entry.Tests.Steps = &executor.IndexStepsStats{}
 		}
 
+		if run.MetadataJSON != "" {
+			var m map[string]string
+			if json.Unmarshal([]byte(run.MetadataJSON), &m) == nil {
+				entry.Metadata = m
+			}
+		}
+
 		entries = append(entries, indexEntryWithDP{
 			DiscoveryPath: run.DiscoveryPath,
 			IndexEntry:    entry,

--- a/pkg/api/indexer/indexer.go
+++ b/pkg/api/indexer/indexer.go
@@ -430,6 +430,15 @@ func (idx *indexer) indexRun(
 		}
 	}
 
+	// Serialize metadata labels to JSON.
+	metadataJSON := ""
+	if len(entry.Metadata) > 0 {
+		b, mErr := json.Marshal(entry.Metadata)
+		if mErr == nil {
+			metadataJSON = string(b)
+		}
+	}
+
 	now := time.Now().UTC()
 
 	run := &indexstore.Run{
@@ -449,6 +458,7 @@ func (idx *indexer) indexRun(
 		TestsPassed:       entry.Tests.TestsPassed,
 		TestsFailed:       entry.Tests.TestsFailed,
 		StepsJSON:         stepsJSON,
+		MetadataJSON:      metadataJSON,
 		IndexedAt:         now,
 	}
 

--- a/pkg/api/indexstore/run.go
+++ b/pkg/api/indexstore/run.go
@@ -28,6 +28,9 @@ type Run struct {
 	// Per-step stats serialized as JSON.
 	StepsJSON string `gorm:"type:text"`
 
+	// Run metadata labels serialized as JSON.
+	MetadataJSON string `gorm:"type:text"`
+
 	IndexedAt   time.Time
 	ReindexedAt *time.Time
 }

--- a/pkg/api/openapi.yaml
+++ b/pkg/api/openapi.yaml
@@ -1474,6 +1474,11 @@ components:
           type: string
         termination_reason:
           type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: Run metadata labels (key-value pairs)
         instance:
           type: object
           properties:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,7 +79,6 @@ type RunnerConfig struct {
 	DropCachesPath     string            `yaml:"drop_caches_path,omitempty" mapstructure:"drop_caches_path"`
 	CPUSysfsPath       string            `yaml:"cpu_sysfs_path,omitempty" mapstructure:"cpu_sysfs_path"`
 	GitHubToken        string            `yaml:"github_token,omitempty" mapstructure:"github_token"`
-	Metadata           MetadataConfig    `yaml:"metadata,omitempty" mapstructure:"metadata"`
 	Benchmark          BenchmarkConfig   `yaml:"benchmark" mapstructure:"benchmark"`
 	Client             ClientConfig      `yaml:"client" mapstructure:"client"`
 	Instances          []ClientInstance  `yaml:"instances" mapstructure:"instances"`
@@ -598,6 +597,7 @@ type ClientDefaults struct {
 	PostTestRPCCalls                 []PostTestRPCCall                 `yaml:"post_test_rpc_calls,omitempty" mapstructure:"post_test_rpc_calls"`
 	BootstrapFCU                     *BootstrapFCUConfig               `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
 	CheckpointRestoreStrategyOptions *CheckpointRestoreStrategyOptions `yaml:"checkpoint_restore_strategy_options,omitempty" mapstructure:"checkpoint_restore_strategy_options"`
+	Metadata                         MetadataConfig                    `yaml:"metadata,omitempty" mapstructure:"metadata"`
 }
 
 // ClientInstance defines a single client instance to benchmark.
@@ -622,6 +622,7 @@ type ClientInstance struct {
 	PostTestRPCCalls                 []PostTestRPCCall                 `yaml:"post_test_rpc_calls,omitempty" mapstructure:"post_test_rpc_calls"`
 	BootstrapFCU                     *BootstrapFCUConfig               `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
 	CheckpointRestoreStrategyOptions *CheckpointRestoreStrategyOptions `yaml:"checkpoint_restore_strategy_options,omitempty" mapstructure:"checkpoint_restore_strategy_options"`
+	Metadata                         MetadataConfig                    `yaml:"metadata,omitempty" mapstructure:"metadata"`
 }
 
 // expandEnvWithDefaults is a mapping function for os.Expand that supports
@@ -1426,6 +1427,29 @@ func (c *Config) GetCheckpointRestartContainer(instance *ClientInstance) bool {
 	}
 
 	return opts.RestartContainer
+}
+
+// GetMetadataLabels returns the merged metadata labels for an instance.
+// Client-level metadata labels serve as defaults; instance-level labels
+// override specific keys.
+func (c *Config) GetMetadataLabels(instance *ClientInstance) map[string]string {
+	defaults := c.Runner.Client.Config.Metadata.Labels
+	overrides := instance.Metadata.Labels
+
+	if len(defaults) == 0 && len(overrides) == 0 {
+		return nil
+	}
+
+	merged := make(map[string]string, len(defaults)+len(overrides))
+	for k, v := range defaults {
+		merged[k] = v
+	}
+
+	for k, v := range overrides {
+		merged[k] = v
+	}
+
+	return merged
 }
 
 // ParseByteSize parses a human-readable byte size string into bytes.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1195,14 +1195,14 @@ func TestLoad_MetadataLabels(t *testing.T) {
 	t.Run("parses labels from yaml", func(t *testing.T) {
 		configContent := `
 runner:
-  metadata:
-    labels:
-      env: production
-      team: platform
   client:
     config:
       genesis:
         geth: http://example.com/genesis.json
+      metadata:
+        labels:
+          env: production
+          team: platform
   instances:
     - id: test-instance
       client: geth
@@ -1214,9 +1214,9 @@ runner:
 		cfg, err := Load(configPath)
 		require.NoError(t, err)
 
-		require.Len(t, cfg.Runner.Metadata.Labels, 2)
-		assert.Equal(t, "production", cfg.Runner.Metadata.Labels["env"])
-		assert.Equal(t, "platform", cfg.Runner.Metadata.Labels["team"])
+		require.Len(t, cfg.Runner.Client.Config.Metadata.Labels, 2)
+		assert.Equal(t, "production", cfg.Runner.Client.Config.Metadata.Labels["env"])
+		assert.Equal(t, "platform", cfg.Runner.Client.Config.Metadata.Labels["team"])
 	})
 
 	t.Run("empty metadata produces no errors", func(t *testing.T) {
@@ -1237,18 +1237,18 @@ runner:
 		cfg, err := Load(configPath)
 		require.NoError(t, err)
 
-		assert.Nil(t, cfg.Runner.Metadata.Labels)
+		assert.Nil(t, cfg.Runner.Client.Config.Metadata.Labels)
 	})
 
 	t.Run("empty labels map produces no errors", func(t *testing.T) {
 		configContent := `
 runner:
-  metadata:
-    labels: {}
   client:
     config:
       genesis:
         geth: http://example.com/genesis.json
+      metadata:
+        labels: {}
   instances:
     - id: test-instance
       client: geth
@@ -1260,8 +1260,64 @@ runner:
 		cfg, err := Load(configPath)
 		require.NoError(t, err)
 
-		assert.Empty(t, cfg.Runner.Metadata.Labels)
+		assert.Empty(t, cfg.Runner.Client.Config.Metadata.Labels)
 	})
+}
+
+func TestGetMetadataLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		clientLabels   map[string]string
+		instanceLabels map[string]string
+		expected       map[string]string
+	}{
+		{
+			name:     "no labels at either level",
+			expected: nil,
+		},
+		{
+			name:         "only client-level labels",
+			clientLabels: map[string]string{"env": "production", "team": "platform"},
+			expected:     map[string]string{"env": "production", "team": "platform"},
+		},
+		{
+			name:           "only instance-level labels",
+			instanceLabels: map[string]string{"variant": "snap-sync"},
+			expected:       map[string]string{"variant": "snap-sync"},
+		},
+		{
+			name:           "both levels no overlap",
+			clientLabels:   map[string]string{"env": "production"},
+			instanceLabels: map[string]string{"variant": "snap-sync"},
+			expected:       map[string]string{"env": "production", "variant": "snap-sync"},
+		},
+		{
+			name:           "instance overrides client on conflict",
+			clientLabels:   map[string]string{"env": "production", "team": "platform"},
+			instanceLabels: map[string]string{"env": "staging"},
+			expected:       map[string]string{"env": "staging", "team": "platform"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Runner: RunnerConfig{
+					Client: ClientConfig{
+						Config: ClientDefaults{
+							Metadata: MetadataConfig{Labels: tt.clientLabels},
+						},
+					},
+				},
+			}
+			instance := &ClientInstance{
+				Metadata: MetadataConfig{Labels: tt.instanceLabels},
+			}
+
+			result := cfg.GetMetadataLabels(instance)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 func TestValidateAPIStorage(t *testing.T) {

--- a/pkg/executor/index.go
+++ b/pkg/executor/index.go
@@ -23,14 +23,15 @@ type Index struct {
 
 // IndexEntry contains summary information for a single benchmark run.
 type IndexEntry struct {
-	RunID             string          `json:"run_id"`
-	Timestamp         int64           `json:"timestamp"`
-	TimestampEnd      int64           `json:"timestamp_end,omitempty"`
-	SuiteHash         string          `json:"suite_hash,omitempty"`
-	Instance          *IndexInstance  `json:"instance"`
-	Tests             *IndexTestStats `json:"tests"`
-	Status            string          `json:"status,omitempty"`
-	TerminationReason string          `json:"termination_reason,omitempty"`
+	RunID             string            `json:"run_id"`
+	Timestamp         int64             `json:"timestamp"`
+	TimestampEnd      int64             `json:"timestamp_end,omitempty"`
+	SuiteHash         string            `json:"suite_hash,omitempty"`
+	Instance          *IndexInstance    `json:"instance"`
+	Tests             *IndexTestStats   `json:"tests"`
+	Status            string            `json:"status,omitempty"`
+	TerminationReason string            `json:"termination_reason,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
 }
 
 // IndexInstance contains the client instance information for the index.
@@ -84,6 +85,9 @@ type runConfigJSON struct {
 		Passed int `json:"passed"`
 		Failed int `json:"failed"`
 	} `json:"test_counts,omitempty"`
+	Metadata *struct {
+		Labels map[string]string `json:"labels"`
+	} `json:"metadata,omitempty"`
 }
 
 // GenerateIndex scans the results directory and builds an index from all runs.
@@ -368,7 +372,7 @@ func BuildIndexEntryFromData(
 		testStats.TestsFailed = runConfig.TestCounts.Failed
 	}
 
-	return &IndexEntry{
+	entry := &IndexEntry{
 		RunID:             runID,
 		Timestamp:         runConfig.Timestamp,
 		TimestampEnd:      runConfig.TimestampEnd,
@@ -382,7 +386,13 @@ func BuildIndexEntryFromData(
 			RollbackStrategy: runConfig.Instance.RollbackStrategy,
 		},
 		Tests: testStats,
-	}, nil
+	}
+
+	if runConfig.Metadata != nil && len(runConfig.Metadata.Labels) > 0 {
+		entry.Metadata = runConfig.Metadata.Labels
+	}
+
+	return entry, nil
 }
 
 // WriteIndex writes the index to index.json in the runs subdirectory.

--- a/pkg/executor/index_test.go
+++ b/pkg/executor/index_test.go
@@ -1,0 +1,123 @@
+package executor
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildIndexEntryFromData(t *testing.T) {
+	t.Run("includes metadata labels", func(t *testing.T) {
+		configJSON := `{
+			"timestamp": 1700000000,
+			"suite_hash": "abc123",
+			"instance": {
+				"id": "geth-1",
+				"client": "geth",
+				"image": "ethereum/client-go:latest"
+			},
+			"metadata": {
+				"labels": {
+					"env": "production",
+					"team": "platform"
+				}
+			}
+		}`
+
+		entry, err := BuildIndexEntryFromData("run-1", []byte(configJSON), nil)
+		require.NoError(t, err)
+
+		require.NotNil(t, entry.Metadata)
+		assert.Equal(t, "production", entry.Metadata["env"])
+		assert.Equal(t, "platform", entry.Metadata["team"])
+	})
+
+	t.Run("no metadata when absent", func(t *testing.T) {
+		configJSON := `{
+			"timestamp": 1700000000,
+			"instance": {
+				"id": "geth-1",
+				"client": "geth",
+				"image": "ethereum/client-go:latest"
+			}
+		}`
+
+		entry, err := BuildIndexEntryFromData("run-1", []byte(configJSON), nil)
+		require.NoError(t, err)
+
+		assert.Nil(t, entry.Metadata)
+	})
+
+	t.Run("no metadata when labels empty", func(t *testing.T) {
+		configJSON := `{
+			"timestamp": 1700000000,
+			"instance": {
+				"id": "geth-1",
+				"client": "geth",
+				"image": "ethereum/client-go:latest"
+			},
+			"metadata": {
+				"labels": {}
+			}
+		}`
+
+		entry, err := BuildIndexEntryFromData("run-1", []byte(configJSON), nil)
+		require.NoError(t, err)
+
+		assert.Nil(t, entry.Metadata)
+	})
+
+	t.Run("metadata omitted from JSON when nil", func(t *testing.T) {
+		configJSON := `{
+			"timestamp": 1700000000,
+			"instance": {
+				"id": "geth-1",
+				"client": "geth",
+				"image": "ethereum/client-go:latest"
+			}
+		}`
+
+		entry, err := BuildIndexEntryFromData("run-1", []byte(configJSON), nil)
+		require.NoError(t, err)
+
+		data, err := json.Marshal(entry)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "metadata")
+	})
+
+	t.Run("parses basic fields", func(t *testing.T) {
+		configJSON := `{
+			"timestamp": 1700000000,
+			"timestamp_end": 1700003600,
+			"suite_hash": "abc123",
+			"status": "completed",
+			"instance": {
+				"id": "geth-1",
+				"client": "geth",
+				"image": "ethereum/client-go:latest",
+				"rollback_strategy": "rpc-debug-setHead"
+			},
+			"test_counts": {
+				"total": 10,
+				"passed": 8,
+				"failed": 2
+			}
+		}`
+
+		entry, err := BuildIndexEntryFromData("run-1", []byte(configJSON), nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, "run-1", entry.RunID)
+		assert.Equal(t, int64(1700000000), entry.Timestamp)
+		assert.Equal(t, int64(1700003600), entry.TimestampEnd)
+		assert.Equal(t, "abc123", entry.SuiteHash)
+		assert.Equal(t, "completed", entry.Status)
+		assert.Equal(t, "geth-1", entry.Instance.ID)
+		assert.Equal(t, "geth", entry.Instance.Client)
+		assert.Equal(t, 10, entry.Tests.TestsTotal)
+		assert.Equal(t, 8, entry.Tests.TestsPassed)
+		assert.Equal(t, 2, entry.Tests.TestsFailed)
+	})
+}

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -602,9 +602,11 @@ func (r *runner) runContainerLifecycle(
 		},
 	}
 
-	// Attach metadata labels if configured.
-	if r.cfg.FullConfig != nil && len(r.cfg.FullConfig.Runner.Metadata.Labels) > 0 {
-		runConfig.Metadata = &r.cfg.FullConfig.Runner.Metadata
+	// Attach metadata labels if configured (merged: client defaults + instance overrides).
+	if r.cfg.FullConfig != nil {
+		if labels := r.cfg.FullConfig.GetMetadataLabels(instance); len(labels) > 0 {
+			runConfig.Metadata = &config.MetadataConfig{Labels: labels}
+		}
 	}
 
 	if len(params.GenesisGroups) > 0 {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -30,6 +30,7 @@ export interface IndexEntry {
   }
   status?: RunStatus
   termination_reason?: string
+  metadata?: Record<string, string>
 }
 
 export interface IndexStepStats {

--- a/ui/src/components/compare/StickyRunBar.tsx
+++ b/ui/src/components/compare/StickyRunBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
-import { type CompareRun, type LabelMode, LABEL_MODE_OPTIONS, RUN_SLOTS, formatRunLabel } from './constants'
+import { type CompareRun, type LabelMode, buildLabelModeOptions, RUN_SLOTS, formatRunLabel } from './constants'
 import { FilterInput } from '@/components/shared/FilterInput'
 
 interface StickyRunBarProps {
@@ -49,7 +49,7 @@ export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, 
         <div className="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
           <span>Labels:</span>
           <div className="flex gap-1">
-            {LABEL_MODE_OPTIONS.map((opt) => (
+            {buildLabelModeOptions(runs).map((opt) => (
               <button
                 key={opt.value}
                 onClick={() => onLabelModeChange(opt.value)}

--- a/ui/src/components/compare/constants.ts
+++ b/ui/src/components/compare/constants.ts
@@ -86,7 +86,7 @@ export interface CompareRun {
   index: number
 }
 
-export type LabelMode = 'none' | 'instance-id'
+export type LabelMode = string
 
 export type ChartType = 'line' | 'bar' | 'dot'
 
@@ -96,14 +96,33 @@ export const CHART_TYPE_OPTIONS: { value: ChartType; label: string }[] = [
   { value: 'dot', label: 'Dot' },
 ]
 
-export const LABEL_MODE_OPTIONS: { value: LabelMode; label: string }[] = [
+export const LABEL_MODE_BASE_OPTIONS: { value: LabelMode; label: string }[] = [
   { value: 'none', label: 'None' },
   { value: 'instance-id', label: 'Instance ID' },
 ]
 
+/** Build the full label mode options from the base options + label keys found in runs. */
+export function buildLabelModeOptions(runs: CompareRun[]): { value: LabelMode; label: string }[] {
+  const keys = new Set<string>()
+  for (const run of runs) {
+    if (run.config.metadata?.labels) {
+      for (const key of Object.keys(run.config.metadata.labels)) {
+        if (!key.startsWith('github.') && key !== 'name') keys.add(key)
+      }
+    }
+  }
+  const labelOptions = Array.from(keys).sort().map((key) => ({ value: `label:${key}`, label: key }))
+  return [...LABEL_MODE_BASE_OPTIONS, ...labelOptions]
+}
+
 export function formatRunLabel(slot: RunSlot, run: CompareRun, labelMode: LabelMode): string {
   if (labelMode === 'instance-id' && run.config.instance.id) {
     return `${slot.label} (${run.config.instance.id})`
+  }
+  if (labelMode.startsWith('label:')) {
+    const key = labelMode.slice(6)
+    const value = run.config.metadata?.labels?.[key]
+    if (value) return `${slot.label} (${value})`
   }
   return slot.label
 }

--- a/ui/src/components/runs/LabelFilters.tsx
+++ b/ui/src/components/runs/LabelFilters.tsx
@@ -1,170 +1,206 @@
-import { useMemo } from 'react'
-import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react'
+import { useMemo, useState, useEffect, useRef } from 'react'
 import clsx from 'clsx'
 import { Plus, X } from 'lucide-react'
 import type { IndexEntry } from '@/api/types'
-import type { LabelFilter } from './labelFilterUtils'
+import type { LabelFilters as LabelFiltersType } from './labelFilterUtils'
 
 interface LabelFiltersProps {
   entries: IndexEntry[]
-  filters: LabelFilter[]
-  onChange: (filters: LabelFilter[]) => void
-}
-
-function ChevronIcon() {
-  return (
-    <svg className="size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
-      <path
-        fillRule="evenodd"
-        d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z"
-        clipRule="evenodd"
-      />
-    </svg>
-  )
+  filters: LabelFiltersType
+  onChange: (filters: LabelFiltersType) => void
 }
 
 export function LabelFilters({ entries, filters, onChange }: LabelFiltersProps) {
-  const allKeys = useMemo(() => {
-    const keySet = new Set<string>()
-    for (const entry of entries) {
-      if (entry.metadata) {
-        for (const key of Object.keys(entry.metadata)) {
-          keySet.add(key)
-        }
+  const [keyDropdownOpen, setKeyDropdownOpen] = useState(false)
+  const [valueDropdownKey, setValueDropdownKey] = useState<string | null>(null)
+  const keyRef = useRef<HTMLDivElement>(null)
+  const valueRef = useRef<HTMLDivElement>(null)
+
+  // Close dropdowns on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (keyDropdownOpen && keyRef.current && !keyRef.current.contains(e.target as Node)) {
+        setKeyDropdownOpen(false)
+      }
+      if (valueDropdownKey && valueRef.current && !valueRef.current.contains(e.target as Node)) {
+        setValueDropdownKey(null)
       }
     }
-    return Array.from(keySet).sort()
-  }, [entries])
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [keyDropdownOpen, valueDropdownKey])
 
-  const valuesForKey = useMemo(() => {
-    const map = new Map<string, Set<string>>()
+  const { allKeys, valuesForKey } = useMemo(() => {
+    const valMap = new Map<string, Set<string>>()
     for (const entry of entries) {
       if (entry.metadata) {
         for (const [key, value] of Object.entries(entry.metadata)) {
-          if (!map.has(key)) map.set(key, new Set())
-          map.get(key)!.add(value)
+          let set = valMap.get(key)
+          if (!set) {
+            set = new Set()
+            valMap.set(key, set)
+          }
+          set.add(value)
         }
       }
     }
-    const result = new Map<string, string[]>()
-    for (const [key, values] of map) {
-      result.set(key, Array.from(values).sort())
+    const keys = Array.from(valMap.keys()).sort()
+    const values = new Map<string, string[]>()
+    for (const [key, set] of valMap) {
+      values.set(key, Array.from(set).sort())
     }
-    return result
+    return { allKeys: keys, valuesForKey: values }
   }, [entries])
 
   if (allKeys.length === 0) return null
 
-  const usedKeys = new Set(filters.map((f) => f.key))
+  const availableKeys = allKeys.filter((k) => !filters.has(k) && k !== valueDropdownKey)
 
-  const handleAdd = () => {
-    const availableKey = allKeys.find((k) => !usedKeys.has(k))
-    if (!availableKey) return
-    const values = valuesForKey.get(availableKey) ?? []
-    onChange([...filters, { key: availableKey, value: values[0] ?? '' }])
+  const toggleValue = (key: string, value: string) => {
+    const next = new Map(filters)
+    const values = new Set(next.get(key) ?? [])
+    if (values.has(value)) {
+      values.delete(value)
+      if (values.size === 0) {
+        next.delete(key)
+      } else {
+        next.set(key, values)
+      }
+    } else {
+      values.add(value)
+      next.set(key, values)
+    }
+    onChange(next)
   }
 
-  const handleRemove = (index: number) => {
-    onChange(filters.filter((_, i) => i !== index))
+  const removeFilter = (key: string) => {
+    const next = new Map(filters)
+    next.delete(key)
+    onChange(next)
+    if (valueDropdownKey === key) setValueDropdownKey(null)
   }
 
-  const handleKeyChange = (index: number, newKey: string) => {
-    const values = valuesForKey.get(newKey) ?? []
-    const updated = filters.map((f, i) => (i === index ? { key: newKey, value: values[0] ?? '' } : f))
-    onChange(updated)
+  const addKey = (key: string) => {
+    setKeyDropdownOpen(false)
+    setValueDropdownKey(key)
   }
 
-  const handleValueChange = (index: number, newValue: string) => {
-    const updated = filters.map((f, i) => (i === index ? { ...f, value: newValue } : f))
-    onChange(updated)
+  // Build the list of chips: active filters + pending key (not yet in filters)
+  const chipKeys = Array.from(filters.keys())
+  if (valueDropdownKey && !filters.has(valueDropdownKey)) {
+    chipKeys.push(valueDropdownKey)
   }
-
-  const canAdd = allKeys.some((k) => !usedKeys.has(k))
 
   return (
-    <div className="flex flex-wrap items-end gap-2">
-      {filters.map((filter, index) => {
-        const availableKeys = allKeys.filter((k) => k === filter.key || !usedKeys.has(k))
-        const values = valuesForKey.get(filter.key) ?? []
-
+    <div className="flex flex-wrap items-center gap-2">
+      {chipKeys.map((key) => {
+        const values = filters.get(key)
+        const isPending = !values
         return (
-          <div key={index} className="flex items-end gap-1">
-            <div className="flex flex-col gap-1">
-              {index === 0 && <label className="text-sm/5 font-medium text-gray-700 dark:text-gray-300">Labels</label>}
-              <Listbox value={filter.key} onChange={(v: string) => handleKeyChange(index, v)}>
-                <div className="relative">
-                  <ListboxButton className="relative w-32 cursor-pointer rounded-xs bg-white py-2 pr-10 pl-3 text-left text-sm/6 text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset focus:outline-hidden focus:ring-2 focus:ring-blue-600 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-600 dark:focus:ring-blue-500">
-                    <span className="truncate">{filter.key}</span>
-                    <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                      <ChevronIcon />
-                    </span>
-                  </ListboxButton>
-                  <ListboxOptions className="absolute z-10 mt-1 max-h-60 w-full min-w-max overflow-auto rounded-xs bg-white py-1 text-base shadow-xs ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-gray-700">
-                    {availableKeys.map((key) => (
-                      <ListboxOption
-                        key={key}
-                        value={key}
-                        className={({ active }) =>
-                          clsx(
-                            'relative cursor-pointer py-2 pr-9 pl-3 select-none',
-                            active ? 'bg-blue-600 text-white' : 'text-gray-900 dark:text-gray-100',
-                          )
-                        }
-                      >
-                        {key}
-                      </ListboxOption>
-                    ))}
-                  </ListboxOptions>
-                </div>
-              </Listbox>
+          <div key={key} className="relative" ref={valueDropdownKey === key ? valueRef : undefined}>
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={() => setValueDropdownKey(valueDropdownKey === key ? null : key)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  setValueDropdownKey(valueDropdownKey === key ? null : key)
+                }
+              }}
+              className={clsx(
+                'flex cursor-pointer items-center gap-1.5 rounded-xs border px-2 py-1 text-xs/5 font-medium transition-colors',
+                isPending
+                  ? 'border-dashed border-blue-300 bg-blue-50/50 text-blue-500 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
+                  : 'border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50',
+              )}
+            >
+              <span className="font-semibold">{key}</span>
+              {values && values.size > 0 && (
+                <>
+                  <span>=</span>
+                  <span>{Array.from(values).join(', ')}</span>
+                </>
+              )}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  if (isPending) {
+                    setValueDropdownKey(null)
+                  } else {
+                    removeFilter(key)
+                  }
+                }}
+                className="ml-0.5 rounded-xs p-0.5 hover:bg-blue-200 dark:hover:bg-blue-800"
+              >
+                <X className="size-3" />
+              </button>
             </div>
 
-            <span className="py-2 text-sm/6 text-gray-400">=</span>
-
-            <Listbox value={filter.value} onChange={(v: string) => handleValueChange(index, v)}>
-              <div className="relative">
-                <ListboxButton className="relative w-36 cursor-pointer rounded-xs bg-white py-2 pr-10 pl-3 text-left text-sm/6 text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset focus:outline-hidden focus:ring-2 focus:ring-blue-600 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-600 dark:focus:ring-blue-500">
-                  <span className="truncate">{filter.value || '—'}</span>
-                  <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                    <ChevronIcon />
-                  </span>
-                </ListboxButton>
-                <ListboxOptions className="absolute z-10 mt-1 max-h-60 w-full min-w-max overflow-auto rounded-xs bg-white py-1 text-base shadow-xs ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-gray-700">
-                  {values.map((value) => (
-                    <ListboxOption
-                      key={value}
-                      value={value}
-                      className={({ active }) =>
-                        clsx(
-                          'relative cursor-pointer py-2 pr-9 pl-3 select-none',
-                          active ? 'bg-blue-600 text-white' : 'text-gray-900 dark:text-gray-100',
-                        )
-                      }
+            {/* Value multi-select dropdown */}
+            {valueDropdownKey === key && (
+              <div className="absolute top-full left-0 z-50 mt-1 max-h-64 min-w-48 overflow-y-auto rounded-xs border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+                {(valuesForKey.get(key) ?? []).map((val) => {
+                  const selected = values?.has(val) ?? false
+                  return (
+                    <button
+                      key={val}
+                      onClick={() => toggleValue(key, val)}
+                      className={clsx(
+                        'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm/6 transition-colors',
+                        selected
+                          ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+                          : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700',
+                      )}
                     >
-                      {value}
-                    </ListboxOption>
-                  ))}
-                </ListboxOptions>
+                      <span
+                        className={clsx(
+                          'flex size-4 shrink-0 items-center justify-center rounded-xs border text-xs/3',
+                          selected
+                            ? 'border-blue-500 bg-blue-500 text-white dark:border-blue-400 dark:bg-blue-400'
+                            : 'border-gray-300 dark:border-gray-600',
+                        )}
+                      >
+                        {selected && '✓'}
+                      </span>
+                      {val}
+                    </button>
+                  )
+                })}
               </div>
-            </Listbox>
-
-            <button
-              onClick={() => handleRemove(index)}
-              className="rounded-xs p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-            >
-              <X className="size-4" />
-            </button>
+            )}
           </div>
         )
       })}
-      {canAdd && (
-        <button
-          onClick={handleAdd}
-          className="flex items-center gap-1 rounded-xs px-2 py-2 text-sm/6 text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
-        >
-          <Plus className="size-4" />
-          {filters.length === 0 && <span>Label filter</span>}
-        </button>
+
+      {/* Add filter button */}
+      {availableKeys.length > 0 && (
+        <div className="relative" ref={keyRef}>
+          <button
+            onClick={() => {
+              setKeyDropdownOpen(!keyDropdownOpen)
+              setValueDropdownKey(null)
+            }}
+            className="flex items-center gap-1 rounded-xs border border-dashed border-gray-300 px-2 py-1 text-xs/5 text-gray-500 transition-colors hover:border-gray-400 hover:text-gray-700 dark:border-gray-600 dark:text-gray-400 dark:hover:border-gray-500 dark:hover:text-gray-300"
+          >
+            <Plus className="size-3" />
+            Label
+          </button>
+
+          {keyDropdownOpen && (
+            <div className="absolute top-full left-0 z-50 mt-1 min-w-36 overflow-hidden rounded-xs border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              {availableKeys.map((key) => (
+                <button
+                  key={key}
+                  onClick={() => addKey(key)}
+                  className="flex w-full px-3 py-1.5 text-left text-sm/6 text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                  {key}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
       )}
     </div>
   )

--- a/ui/src/components/runs/LabelFilters.tsx
+++ b/ui/src/components/runs/LabelFilters.tsx
@@ -1,0 +1,171 @@
+import { useMemo } from 'react'
+import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react'
+import clsx from 'clsx'
+import { Plus, X } from 'lucide-react'
+import type { IndexEntry } from '@/api/types'
+import type { LabelFilter } from './labelFilterUtils'
+
+interface LabelFiltersProps {
+  entries: IndexEntry[]
+  filters: LabelFilter[]
+  onChange: (filters: LabelFilter[]) => void
+}
+
+function ChevronIcon() {
+  return (
+    <svg className="size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
+      <path
+        fillRule="evenodd"
+        d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z"
+        clipRule="evenodd"
+      />
+    </svg>
+  )
+}
+
+export function LabelFilters({ entries, filters, onChange }: LabelFiltersProps) {
+  const allKeys = useMemo(() => {
+    const keySet = new Set<string>()
+    for (const entry of entries) {
+      if (entry.metadata) {
+        for (const key of Object.keys(entry.metadata)) {
+          keySet.add(key)
+        }
+      }
+    }
+    return Array.from(keySet).sort()
+  }, [entries])
+
+  const valuesForKey = useMemo(() => {
+    const map = new Map<string, Set<string>>()
+    for (const entry of entries) {
+      if (entry.metadata) {
+        for (const [key, value] of Object.entries(entry.metadata)) {
+          if (!map.has(key)) map.set(key, new Set())
+          map.get(key)!.add(value)
+        }
+      }
+    }
+    const result = new Map<string, string[]>()
+    for (const [key, values] of map) {
+      result.set(key, Array.from(values).sort())
+    }
+    return result
+  }, [entries])
+
+  if (allKeys.length === 0) return null
+
+  const usedKeys = new Set(filters.map((f) => f.key))
+
+  const handleAdd = () => {
+    const availableKey = allKeys.find((k) => !usedKeys.has(k))
+    if (!availableKey) return
+    const values = valuesForKey.get(availableKey) ?? []
+    onChange([...filters, { key: availableKey, value: values[0] ?? '' }])
+  }
+
+  const handleRemove = (index: number) => {
+    onChange(filters.filter((_, i) => i !== index))
+  }
+
+  const handleKeyChange = (index: number, newKey: string) => {
+    const values = valuesForKey.get(newKey) ?? []
+    const updated = filters.map((f, i) => (i === index ? { key: newKey, value: values[0] ?? '' } : f))
+    onChange(updated)
+  }
+
+  const handleValueChange = (index: number, newValue: string) => {
+    const updated = filters.map((f, i) => (i === index ? { ...f, value: newValue } : f))
+    onChange(updated)
+  }
+
+  const canAdd = allKeys.some((k) => !usedKeys.has(k))
+
+  return (
+    <div className="flex flex-wrap items-end gap-2">
+      {filters.map((filter, index) => {
+        const availableKeys = allKeys.filter((k) => k === filter.key || !usedKeys.has(k))
+        const values = valuesForKey.get(filter.key) ?? []
+
+        return (
+          <div key={index} className="flex items-end gap-1">
+            <div className="flex flex-col gap-1">
+              {index === 0 && <label className="text-sm/5 font-medium text-gray-700 dark:text-gray-300">Labels</label>}
+              <Listbox value={filter.key} onChange={(v: string) => handleKeyChange(index, v)}>
+                <div className="relative">
+                  <ListboxButton className="relative w-32 cursor-pointer rounded-xs bg-white py-2 pr-10 pl-3 text-left text-sm/6 text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset focus:outline-hidden focus:ring-2 focus:ring-blue-600 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-600 dark:focus:ring-blue-500">
+                    <span className="truncate">{filter.key}</span>
+                    <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                      <ChevronIcon />
+                    </span>
+                  </ListboxButton>
+                  <ListboxOptions className="absolute z-10 mt-1 max-h-60 w-full min-w-max overflow-auto rounded-xs bg-white py-1 text-base shadow-xs ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-gray-700">
+                    {availableKeys.map((key) => (
+                      <ListboxOption
+                        key={key}
+                        value={key}
+                        className={({ active }) =>
+                          clsx(
+                            'relative cursor-pointer py-2 pr-9 pl-3 select-none',
+                            active ? 'bg-blue-600 text-white' : 'text-gray-900 dark:text-gray-100',
+                          )
+                        }
+                      >
+                        {key}
+                      </ListboxOption>
+                    ))}
+                  </ListboxOptions>
+                </div>
+              </Listbox>
+            </div>
+
+            <span className="py-2 text-sm/6 text-gray-400">=</span>
+
+            <Listbox value={filter.value} onChange={(v: string) => handleValueChange(index, v)}>
+              <div className="relative">
+                <ListboxButton className="relative w-36 cursor-pointer rounded-xs bg-white py-2 pr-10 pl-3 text-left text-sm/6 text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset focus:outline-hidden focus:ring-2 focus:ring-blue-600 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-600 dark:focus:ring-blue-500">
+                  <span className="truncate">{filter.value || '—'}</span>
+                  <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                    <ChevronIcon />
+                  </span>
+                </ListboxButton>
+                <ListboxOptions className="absolute z-10 mt-1 max-h-60 w-full min-w-max overflow-auto rounded-xs bg-white py-1 text-base shadow-xs ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-gray-700">
+                  {values.map((value) => (
+                    <ListboxOption
+                      key={value}
+                      value={value}
+                      className={({ active }) =>
+                        clsx(
+                          'relative cursor-pointer py-2 pr-9 pl-3 select-none',
+                          active ? 'bg-blue-600 text-white' : 'text-gray-900 dark:text-gray-100',
+                        )
+                      }
+                    >
+                      {value}
+                    </ListboxOption>
+                  ))}
+                </ListboxOptions>
+              </div>
+            </Listbox>
+
+            <button
+              onClick={() => handleRemove(index)}
+              className="rounded-xs p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+        )
+      })}
+      {canAdd && (
+        <button
+          onClick={handleAdd}
+          className="flex items-center gap-1 rounded-xs px-2 py-2 text-sm/6 text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+        >
+          <Plus className="size-4" />
+          {filters.length === 0 && <span>Label filter</span>}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/runs/RunFilters.tsx
+++ b/ui/src/components/runs/RunFilters.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { StrategyIcon } from '@/components/shared/StrategyIcon'
 import { LabelFilters } from './LabelFilters'
-import type { LabelFilter } from './labelFilterUtils'
+import type { LabelFilters as LabelFiltersType } from './labelFilterUtils'
 import type { IndexEntry } from '@/api/types'
 
 export type TestStatusFilter = 'all' | 'passing' | 'failing' | 'timeout' | 'cancelled'
@@ -24,8 +24,8 @@ interface RunFiltersProps {
   selectedStrategy?: string | undefined
   onStrategyChange?: (strategy: string | undefined) => void
   entries?: IndexEntry[]
-  labelFilters?: LabelFilter[]
-  onLabelFiltersChange?: (filters: LabelFilter[]) => void
+  labelFilters?: LabelFiltersType
+  onLabelFiltersChange?: (filters: LabelFiltersType) => void
 }
 
 function ChevronIcon() {

--- a/ui/src/components/runs/RunFilters.tsx
+++ b/ui/src/components/runs/RunFilters.tsx
@@ -2,6 +2,9 @@ import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headless
 import clsx from 'clsx'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { StrategyIcon } from '@/components/shared/StrategyIcon'
+import { LabelFilters } from './LabelFilters'
+import type { LabelFilter } from './labelFilterUtils'
+import type { IndexEntry } from '@/api/types'
 
 export type TestStatusFilter = 'all' | 'passing' | 'failing' | 'timeout' | 'cancelled'
 
@@ -20,6 +23,9 @@ interface RunFiltersProps {
   strategies?: string[]
   selectedStrategy?: string | undefined
   onStrategyChange?: (strategy: string | undefined) => void
+  entries?: IndexEntry[]
+  labelFilters?: LabelFilter[]
+  onLabelFiltersChange?: (filters: LabelFilter[]) => void
 }
 
 function ChevronIcon() {
@@ -109,6 +115,9 @@ export function RunFilters({
   strategies,
   selectedStrategy,
   onStrategyChange,
+  entries,
+  labelFilters,
+  onLabelFiltersChange,
 }: RunFiltersProps) {
   const clientOptions = [{ value: '' as const, label: 'All clients' }, ...clients.map((c) => ({ value: c, label: c }))]
   const imageOptions = [{ value: '' as const, label: 'All images' }, ...images.map((i) => ({ value: i, label: i }))]
@@ -123,50 +132,55 @@ export function RunFilters({
   const strategyOptions = strategies ? [{ value: '' as const, label: 'All strategies' }, ...strategies.map((s) => ({ value: s, label: s, icon: <StrategyIcon strategy={s} /> }))] : []
 
   return (
-    <div className="flex flex-wrap items-center gap-4">
-      <FilterDropdown
-        label="Client"
-        value={selectedClient ?? ''}
-        onChange={(v) => onClientChange(v || undefined)}
-        options={clientOptions}
-        allLabel="All clients"
-      />
-      <FilterDropdown
-        label="Image"
-        value={selectedImage ?? ''}
-        onChange={(v) => onImageChange(v || undefined)}
-        options={imageOptions}
-        allLabel="All images"
-        width="w-64"
-      />
-      {suites && onSuiteChange && (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-4">
         <FilterDropdown
-          label="Suite"
-          value={selectedSuite ?? ''}
-          onChange={(v) => onSuiteChange(v || undefined)}
-          options={suiteOptions}
-          allLabel="All suites"
-          width="w-44"
+          label="Client"
+          value={selectedClient ?? ''}
+          onChange={(v) => onClientChange(v || undefined)}
+          options={clientOptions}
+          allLabel="All clients"
         />
-      )}
-      {strategies && strategies.length > 0 && onStrategyChange && (
         <FilterDropdown
-          label="Strategy"
-          value={selectedStrategy ?? ''}
-          onChange={(v) => onStrategyChange(v || undefined)}
-          options={strategyOptions}
-          allLabel="All strategies"
-          width="w-52"
+          label="Image"
+          value={selectedImage ?? ''}
+          onChange={(v) => onImageChange(v || undefined)}
+          options={imageOptions}
+          allLabel="All images"
+          width="w-64"
         />
+        {suites && onSuiteChange && (
+          <FilterDropdown
+            label="Suite"
+            value={selectedSuite ?? ''}
+            onChange={(v) => onSuiteChange(v || undefined)}
+            options={suiteOptions}
+            allLabel="All suites"
+            width="w-44"
+          />
+        )}
+        {strategies && strategies.length > 0 && onStrategyChange && (
+          <FilterDropdown
+            label="Strategy"
+            value={selectedStrategy ?? ''}
+            onChange={(v) => onStrategyChange(v || undefined)}
+            options={strategyOptions}
+            allLabel="All strategies"
+            width="w-52"
+          />
+        )}
+        <FilterDropdown
+          label="Status"
+          value={selectedStatus}
+          onChange={(v) => onStatusChange((v || 'all') as TestStatusFilter)}
+          options={statusOptions}
+          allLabel="All runs"
+          width="w-36"
+        />
+      </div>
+      {entries && labelFilters && onLabelFiltersChange && (
+        <LabelFilters entries={entries} filters={labelFilters} onChange={onLabelFiltersChange} />
       )}
-      <FilterDropdown
-        label="Status"
-        value={selectedStatus}
-        onChange={(v) => onStatusChange((v || 'all') as TestStatusFilter)}
-        options={statusOptions}
-        allLabel="All runs"
-        width="w-36"
-      />
     </div>
   )
 }

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -1,3 +1,4 @@
+import { Fragment, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import clsx from 'clsx'
 import { type IndexEntry, type IndexStepType, ALL_INDEX_STEP_TYPES, getIndexAggregatedStats } from '@/api/types'
@@ -7,6 +8,7 @@ import { Badge } from '@/components/shared/Badge'
 import { Duration } from '@/components/shared/Duration'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { StrategyIcon } from '@/components/shared/StrategyIcon'
+import { Tag } from 'lucide-react'
 import { formatTimestampDate, formatTimestampTime, formatRelativeTime } from '@/utils/date'
 import { formatDuration, formatNumber } from '@/utils/format'
 import { type SortColumn, type SortDirection } from './sortEntries'
@@ -113,6 +115,17 @@ export function RunsTable({
   onSelectionChange,
   selectionVariant = 'compare',
 }: RunsTableProps) {
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
+
+  const toggleExpanded = (runId: string) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev)
+      if (next.has(runId)) next.delete(runId)
+      else next.add(runId)
+      return next
+    })
+  }
+
   const handleSort = (column: SortColumn) => {
     if (onSortChange) {
       const newDirection = sortBy === column && sortDir === 'desc' ? 'asc' : 'desc'
@@ -135,14 +148,19 @@ export function RunsTable({
             <SortableHeader label="F" column="failed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-2" />
             <SortableHeader label="P" column="passed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-2" />
             <SortableHeader label="T" column="total" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-1.5 py-2 sm:px-2 sm:py-2" />
+            <th className="w-8 px-1 py-2" />
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
           {entries.map((entry) => {
             const hasFailures = entry.status !== 'container_died' && entry.status !== 'cancelled' && entry.status !== 'timeout' && entry.tests.tests_total - entry.tests.tests_passed > 0
+            const entryLabels = entry.metadata
+              ? Object.entries(entry.metadata).filter(([k]) => !k.startsWith('github.') && k !== 'name')
+              : []
+            const colSpan = (selectable ? 1 : 0) + 3 + (showSuite ? 1 : 0) + 6
             return (
+            <Fragment key={entry.run_id}>
             <tr
-              key={entry.run_id}
               onClick={selectable ? () => onSelectionChange?.(entry.run_id, !selectedRunIds?.has(entry.run_id)) : undefined}
               className={clsx(
                 'group relative cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50',
@@ -252,7 +270,53 @@ export function RunsTable({
                   </>
                 )
               })()}
+              <td className="relative z-10 px-1 py-2 text-center">
+                {entryLabels.length > 0 && (
+                  <div className="group/tag relative inline-block">
+                    <button
+                      onClick={(e) => { e.stopPropagation(); e.preventDefault(); toggleExpanded(entry.run_id) }}
+                      className={clsx(
+                        'rounded-xs p-0.5 transition-colors',
+                        expandedRows.has(entry.run_id)
+                          ? 'text-blue-600 dark:text-blue-400'
+                          : 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300',
+                      )}
+                    >
+                      <Tag className="size-3.5" />
+                    </button>
+                    <div className="pointer-events-none absolute right-0 bottom-full z-50 mb-1 hidden w-max max-w-xs rounded-sm bg-white px-3 py-2 text-xs/5 shadow-lg ring-1 ring-gray-200 group-hover/tag:block dark:bg-gray-800 dark:ring-gray-700">
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="text-gray-400 dark:text-gray-500">ID: {entry.instance.id}</span>
+                        {entryLabels.map(([k, v]) => (
+                          <span key={k} className="inline-flex items-center gap-1 rounded-xs border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-xs/4 font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                            <span className="font-semibold">{k}</span>={v}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </td>
             </tr>
+            {entryLabels.length > 0 && expandedRows.has(entry.run_id) && (
+              <tr>
+                <td colSpan={colSpan} className="bg-gray-50/50 px-3 py-1.5 sm:px-4 dark:bg-gray-900/30">
+                  <div className="flex flex-wrap items-center justify-end gap-1.5">
+                    <span className="text-xs/4 text-gray-400 dark:text-gray-500">
+                      ID: {entry.instance.id}
+                    </span>
+                    {entryLabels.map(([k, v]) => (
+                      <span key={k} className="inline-flex items-center gap-1 rounded-xs border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-xs/4 font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                        <span className="font-semibold">{k}</span>
+                        <span>=</span>
+                        <span>{v}</span>
+                      </span>
+                    ))}
+                  </div>
+                </td>
+              </tr>
+            )}
+            </Fragment>
           )})}
         </tbody>
       </table>

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -85,20 +85,42 @@ function SortableHeader({
 function SuiteCell({ suiteHash }: { suiteHash: string }) {
   const { data: suiteInfo } = useSuite(suiteHash)
   const name = suiteInfo?.metadata?.labels?.name
-  const tooltip = name ? `${name} (${suiteHash})` : suiteHash
+  const labels = suiteInfo?.metadata?.labels
+    ? Object.entries(suiteInfo.metadata.labels).filter(([k]) => k !== 'name')
+    : []
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="group/suite relative flex items-center gap-2">
       <JDenticon value={suiteHash} size={20} className="shrink-0 rounded-xs" />
       <Link
         to="/suites/$suiteHash"
         params={{ suiteHash }}
         onClick={(e) => e.stopPropagation()}
         className="text-blue-600 hover:text-blue-800 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
-        title={tooltip}
       >
         {suiteHash.slice(0, 4)}
       </Link>
+      <div className="pointer-events-none absolute top-full left-0 z-50 mt-1 hidden w-max max-w-xs rounded-sm bg-white px-3 py-2 text-xs/5 shadow-lg ring-1 ring-gray-200 group-hover/suite:block dark:bg-gray-800 dark:ring-gray-700">
+        <div className="flex flex-col gap-1.5">
+          {name && <div className="font-medium text-gray-900 dark:text-gray-100">{name}</div>}
+          <div className="font-mono text-gray-400 dark:text-gray-500">{suiteHash}</div>
+          {suiteInfo?.filter && (
+            <div className="text-gray-500 dark:text-gray-400">Filter: {suiteInfo.filter}</div>
+          )}
+          {suiteInfo && (
+            <div className="text-gray-500 dark:text-gray-400">{suiteInfo.tests.length} tests</div>
+          )}
+          {labels.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {labels.map(([k, v]) => (
+                <span key={k} className="inline-flex items-center gap-1 rounded-xs border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-xs/4 font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                  <span className="font-semibold">{k}</span>={v}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   )
 }
@@ -163,7 +185,7 @@ export function RunsTable({
             <tr
               onClick={selectable ? () => onSelectionChange?.(entry.run_id, !selectedRunIds?.has(entry.run_id)) : undefined}
               className={clsx(
-                'group relative cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                'group relative cursor-pointer transition-colors hover:z-20 hover:bg-gray-50 dark:hover:bg-gray-700/50',
                 entry.status === 'container_died' && 'bg-red-50/50 dark:bg-red-900/10',
                 entry.status === 'cancelled' && 'bg-yellow-50/50 dark:bg-yellow-900/10',
                 entry.status === 'timeout' && 'bg-orange-50/50 dark:bg-orange-900/10',
@@ -284,14 +306,16 @@ export function RunsTable({
                     >
                       <Tag className="size-3.5" />
                     </button>
-                    <div className="pointer-events-none absolute right-0 bottom-full z-50 mb-1 hidden w-max max-w-xs rounded-sm bg-white px-3 py-2 text-xs/5 shadow-lg ring-1 ring-gray-200 group-hover/tag:block dark:bg-gray-800 dark:ring-gray-700">
-                      <div className="flex flex-wrap items-center gap-1.5">
-                        <span className="text-gray-400 dark:text-gray-500">ID: {entry.instance.id}</span>
-                        {entryLabels.map(([k, v]) => (
-                          <span key={k} className="inline-flex items-center gap-1 rounded-xs border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-xs/4 font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
-                            <span className="font-semibold">{k}</span>={v}
-                          </span>
-                        ))}
+                    <div className="pointer-events-none absolute right-0 top-full z-50 mt-1 hidden w-max max-w-xs rounded-sm bg-white px-3 py-2 text-xs/5 shadow-lg ring-1 ring-gray-200 group-hover/tag:block dark:bg-gray-800 dark:ring-gray-700">
+                      <div className="flex flex-col gap-1.5">
+                        <div className="text-gray-400 dark:text-gray-500">Instance ID: {entry.instance.id}</div>
+                        <div className="flex flex-wrap gap-1">
+                          {entryLabels.map(([k, v]) => (
+                            <span key={k} className="inline-flex items-center gap-1 rounded-xs border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-xs/4 font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                              <span className="font-semibold">{k}</span>={v}
+                            </span>
+                          ))}
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/ui/src/components/runs/labelFilterUtils.ts
+++ b/ui/src/components/runs/labelFilterUtils.ts
@@ -1,21 +1,32 @@
-export interface LabelFilter {
-  key: string
-  value: string
+/** label filters: key → set of selected values (OR within key, AND across keys) */
+export type LabelFilters = Map<string, Set<string>>
+
+/** Parse URL param `key:val1|val2,key2:val3` into a Map */
+export function parseLabelFilters(raw: string | undefined): LabelFilters {
+  const filters: LabelFilters = new Map()
+  if (!raw) return filters
+  for (const segment of raw.split(',')) {
+    const idx = segment.indexOf(':')
+    if (idx < 1) continue
+    const key = decodeURIComponent(segment.slice(0, idx))
+    const values = segment
+      .slice(idx + 1)
+      .split('|')
+      .map(decodeURIComponent)
+      .filter(Boolean)
+    if (values.length > 0) filters.set(key, new Set(values))
+  }
+  return filters
 }
 
-export function parseLabelFilters(param: string | undefined): LabelFilter[] {
-  if (!param) return []
-  return param
-    .split(',')
-    .map((pair) => {
-      const idx = pair.indexOf(':')
-      if (idx < 1) return null
-      return { key: pair.slice(0, idx), value: pair.slice(idx + 1) }
-    })
-    .filter((f): f is LabelFilter => f !== null)
-}
-
-export function serializeLabelFilters(filters: LabelFilter[]): string | undefined {
-  if (filters.length === 0) return undefined
-  return filters.map((f) => `${f.key}:${f.value}`).join(',')
+export function serializeLabelFilters(filters: LabelFilters): string | undefined {
+  if (filters.size === 0) return undefined
+  const parts: string[] = []
+  for (const [key, values] of filters) {
+    if (values.size === 0) continue
+    parts.push(
+      `${encodeURIComponent(key)}:${Array.from(values).map(encodeURIComponent).join('|')}`,
+    )
+  }
+  return parts.length > 0 ? parts.join(',') : undefined
 }

--- a/ui/src/components/runs/labelFilterUtils.ts
+++ b/ui/src/components/runs/labelFilterUtils.ts
@@ -1,0 +1,21 @@
+export interface LabelFilter {
+  key: string
+  value: string
+}
+
+export function parseLabelFilters(param: string | undefined): LabelFilter[] {
+  if (!param) return []
+  return param
+    .split(',')
+    .map((pair) => {
+      const idx = pair.indexOf(':')
+      if (idx < 1) return null
+      return { key: pair.slice(0, idx), value: pair.slice(idx + 1) }
+    })
+    .filter((f): f is LabelFilter => f !== null)
+}
+
+export function serializeLabelFilters(filters: LabelFilter[]): string | undefined {
+  if (filters.length === 0) return undefined
+  return filters.map((f) => `${f.key}:${f.value}`).join(',')
+}

--- a/ui/src/components/shared/ClientBadge.tsx
+++ b/ui/src/components/shared/ClientBadge.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { getClientColors } from '@/utils/client-colors'
+import { getBaseClient, getClientColors } from '@/utils/client-colors'
 
 interface ClientBadgeProps {
   client: string
@@ -13,8 +13,9 @@ function capitalizeFirst(str: string): string {
 }
 
 export function ClientBadge({ client, className, hideLabel = false }: ClientBadgeProps) {
+  const base = getBaseClient(client)
   const colors = getClientColors(client)
-  const logoPath = `/img/clients/${client}.jpg`
+  const logoPath = `/img/clients/${base}.jpg`
 
   return (
     <span

--- a/ui/src/components/suite-detail/DurationChart.tsx
+++ b/ui/src/components/suite-detail/DurationChart.tsx
@@ -351,6 +351,7 @@ export function DurationChart({
       )}
       <ReactECharts
         option={option}
+        notMerge
         style={{ height: '250px', width: '100%' }}
         opts={{ renderer: 'svg' }}
         onEvents={{ click: handleChartClick, ...(isLargeDataset && { datazoom: handleDataZoom }) }}

--- a/ui/src/components/suite-detail/DurationChart.tsx
+++ b/ui/src/components/suite-detail/DurationChart.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import clsx from 'clsx'
 import { type IndexEntry, type IndexStepType, getIndexAggregatedStats, ALL_INDEX_STEP_TYPES } from '@/api/types'
+import { getClientChartColor } from '@/utils/client-colors'
 
 export type XAxisMode = 'time' | 'runCount'
 
@@ -25,16 +26,6 @@ interface DataPoint {
   image: string
 }
 
-const CLIENT_COLORS: Record<string, string> = {
-  geth: '#3b82f6',
-  reth: '#f97316',
-  nethermind: '#a855f7',
-  besu: '#22c55e',
-  erigon: '#ef4444',
-  nimbus: '#eab308',
-}
-
-const DEFAULT_COLOR = '#6b7280'
 
 function capitalizeFirst(str: string): string {
   if (!str) return str
@@ -128,7 +119,7 @@ export function DurationChart({
       },
       sampling: isLargeDataset ? ('lttb' as const) : undefined,
       itemStyle: {
-        color: CLIENT_COLORS[client] ?? DEFAULT_COLOR,
+        color: getClientChartColor(client),
       },
       emphasis: {
         itemStyle: {

--- a/ui/src/components/suite-detail/MGasChart.tsx
+++ b/ui/src/components/suite-detail/MGasChart.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import clsx from 'clsx'
 import { type IndexEntry, type IndexStepType, getIndexAggregatedStats, ALL_INDEX_STEP_TYPES } from '@/api/types'
+import { getClientChartColor } from '@/utils/client-colors'
 
 export type XAxisMode = 'time' | 'runCount'
 
@@ -25,16 +26,7 @@ interface DataPoint {
   image: string
 }
 
-const CLIENT_COLORS: Record<string, string> = {
-  geth: '#3b82f6',
-  reth: '#f97316',
-  nethermind: '#a855f7',
-  besu: '#22c55e',
-  erigon: '#ef4444',
-  nimbus: '#eab308',
-}
 
-const DEFAULT_COLOR = '#6b7280'
 
 function capitalizeFirst(str: string): string {
   if (!str) return str
@@ -127,7 +119,7 @@ export function MGasChart({
       },
       sampling: isLargeDataset ? ('lttb' as const) : undefined,
       itemStyle: {
-        color: CLIENT_COLORS[client] ?? DEFAULT_COLOR,
+        color: getClientChartColor(client),
       },
       emphasis: {
         itemStyle: {

--- a/ui/src/components/suite-detail/MGasChart.tsx
+++ b/ui/src/components/suite-detail/MGasChart.tsx
@@ -353,6 +353,7 @@ export function MGasChart({
       )}
       <ReactECharts
         option={option}
+        notMerge
         style={{ height: '250px', width: '100%' }}
         opts={{ renderer: 'svg' }}
         onEvents={{ click: handleChartClick, ...(isLargeDataset && { datazoom: handleDataZoom }) }}

--- a/ui/src/components/suite-detail/ResourceCharts.tsx
+++ b/ui/src/components/suite-detail/ResourceCharts.tsx
@@ -333,6 +333,7 @@ function SingleChart({ metric, runs, isDark, xAxisMode, onRunClick, isLargeDatas
       <h4 className="mb-2 text-xs font-medium text-gray-700 dark:text-gray-300">{metric.label}</h4>
       <ReactECharts
         option={option}
+        notMerge
         style={{ height: '250px', width: '100%' }}
         opts={{ renderer: 'svg' }}
         onEvents={{ click: handleChartClick, ...(isLargeDataset && { datazoom: handleDataZoom }) }}

--- a/ui/src/components/suite-detail/ResourceCharts.tsx
+++ b/ui/src/components/suite-detail/ResourceCharts.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import clsx from 'clsx'
 import type { IndexEntry, ResourceTotals } from '@/api/types'
+import { getClientChartColor } from '@/utils/client-colors'
 import { formatBytes } from '@/utils/format'
 
 export type XAxisMode = 'time' | 'runCount'
@@ -25,16 +26,6 @@ interface DataPoint {
   image: string
 }
 
-const CLIENT_COLORS: Record<string, string> = {
-  geth: '#3b82f6',
-  reth: '#f97316',
-  nethermind: '#a855f7',
-  besu: '#22c55e',
-  erigon: '#ef4444',
-  nimbus: '#eab308',
-}
-
-const DEFAULT_COLOR = '#6b7280'
 
 function capitalizeFirst(str: string): string {
   if (!str) return str
@@ -171,7 +162,7 @@ function SingleChart({ metric, runs, isDark, xAxisMode, onRunClick, isLargeDatas
       symbolSize: isLargeDataset ? 4 : 6,
       lineStyle: { width: isLargeDataset ? 1.5 : 2 },
       sampling: isLargeDataset ? ('lttb' as const) : undefined,
-      itemStyle: { color: CLIENT_COLORS[client] ?? DEFAULT_COLOR },
+      itemStyle: { color: getClientChartColor(client) },
       emphasis: {
         itemStyle: { borderWidth: 2, borderColor: '#fff' },
       },

--- a/ui/src/components/suite-detail/RunsHeatmap.tsx
+++ b/ui/src/components/suite-detail/RunsHeatmap.tsx
@@ -93,6 +93,8 @@ interface RunsHeatmapProps {
   groupBy?: string
   /** Called with the runs of a group when the per-group compare button is clicked. */
   onCompareGroup?: (runs: IndexEntry[]) => void
+  /** Called with a client name to compare its latest successful run across all groups. */
+  onCompareClientAcrossGroups?: (client: string) => void
   isDark: boolean
   colorNormalization?: ColorNormalization
   onColorNormalizationChange?: (mode: ColorNormalization) => void
@@ -124,6 +126,7 @@ export function RunsHeatmap({
   runs,
   groupBy,
   onCompareGroup,
+  onCompareClientAcrossGroups,
   isDark,
   colorNormalization = 'suite',
   onColorNormalizationChange,
@@ -466,7 +469,7 @@ export function RunsHeatmap({
             {/* Stats header */}
             {sectionIdx === 0 && (
               <div className="flex items-center gap-2 sm:gap-3">
-                <div className="hidden w-28 shrink-0 sm:block" />
+                <div className={clsx('hidden shrink-0 sm:block', onCompareClientAcrossGroups && groupSections ? 'w-32' : 'w-28')} />
                 <div className="flex-1" />
                 <div className="hidden shrink-0 gap-3 border-l border-transparent pl-3 font-mono text-xs/5 font-medium text-gray-400 md:flex dark:text-gray-500">
                   <span className="w-10 text-center">Min</span>
@@ -488,13 +491,22 @@ export function RunsHeatmap({
               }
               return (
                 <div key={`${section.label}-${client}`} className="flex items-center gap-2 sm:gap-3">
-                  <div className="shrink-0 sm:w-28">
+                  <div className={clsx('flex shrink-0 items-center gap-1', onCompareClientAcrossGroups && groupSections ? 'sm:w-32' : 'sm:w-28')}>
                     <span className="sm:hidden">
                       <ClientBadge client={client} hideLabel />
                     </span>
                     <span className="hidden sm:inline-flex">
                       <ClientBadge client={client} />
                     </span>
+                    {onCompareClientAcrossGroups && groupSections && (
+                      <button
+                        onClick={() => onCompareClientAcrossGroups(client)}
+                        className="flex shrink-0 items-center justify-center rounded-xs p-0.5 text-gray-400 transition-colors hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
+                        title={`Compare ${client} across groups`}
+                      >
+                        <GitCompareArrows className="size-3" />
+                      </button>
+                    )}
                   </div>
                   <div className="flex min-w-0 flex-1 flex-wrap gap-1">
                     {section.clientRuns[client].map((run) => {

--- a/ui/src/components/suite-detail/RunsHeatmap.tsx
+++ b/ui/src/components/suite-detail/RunsHeatmap.tsx
@@ -22,12 +22,27 @@ const COLORS = [
   '#ef4444', // red - worst
 ]
 
-function getColorByNormalizedValue(value: number, min: number, max: number, higherIsBetter: boolean): string {
-  if (max === min) return COLORS[2] // middle color if all same
-  let normalized = (value - min) / (max - min)
-  if (higherIsBetter) normalized = 1 - normalized // reverse for MGas/s (higher is better)
-  const level = Math.min(4, Math.floor(normalized * 5))
-  return COLORS[level]
+/**
+ * Create a percentile-based color mapper. Values are split into equal-sized
+ * quintiles so the color spread is balanced regardless of outliers.
+ */
+function createColorScale(values: number[], higherIsBetter: boolean): (value: number) => string {
+  if (values.length === 0) return () => COLORS[2]
+  const sorted = [...values].sort((a, b) => a - b)
+  return (value: number) => {
+    // Binary search for rank position
+    let lo = 0
+    let hi = sorted.length
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1
+      if (sorted[mid] < value) lo = mid + 1
+      else hi = mid
+    }
+    let percentile = lo / sorted.length
+    if (higherIsBetter) percentile = 1 - percentile
+    const level = Math.min(4, Math.floor(percentile * 5))
+    return COLORS[level]
+  }
 }
 
 function formatDurationMinSec(nanoseconds: number): string {
@@ -74,6 +89,8 @@ export type MetricMode = 'duration' | 'mgas'
 
 interface RunsHeatmapProps {
   runs: IndexEntry[]
+  /** When set, runs are grouped by this label key (or 'instance_id') before client grouping. */
+  groupBy?: string
   isDark: boolean
   colorNormalization?: ColorNormalization
   onColorNormalizationChange?: (mode: ColorNormalization) => void
@@ -85,6 +102,16 @@ interface RunsHeatmapProps {
   onSelectionChange?: (runId: string, selected: boolean) => void
 }
 
+interface GroupSection {
+  label: string
+  clients: string[]
+  clientRuns: Record<string, IndexEntry[]>
+  clientDurationStats: Record<string, ClientStats>
+  clientMgasStats: Record<string, ClientStats>
+  clientDurationScales: Record<string, (v: number) => string>
+  clientMgasScales: Record<string, (v: number) => string>
+}
+
 interface TooltipData {
   run: IndexEntry
   x: number
@@ -93,6 +120,7 @@ interface TooltipData {
 
 export function RunsHeatmap({
   runs,
+  groupBy,
   isDark,
   colorNormalization = 'suite',
   onColorNormalizationChange,
@@ -118,15 +146,13 @@ export function RunsHeatmap({
 
   const {
     clientRuns,
-    minDuration,
-    maxDuration,
-    minMgas,
-    maxMgas,
-    clientDurationMinMax,
-    clientMgasMinMax,
     clientDurationStats,
     clientMgasStats,
     clients,
+    suiteDurationScale,
+    suiteMgasScale,
+    clientDurationScales,
+    clientMgasScales,
   } = useMemo(() => {
     // Group runs by client
     const grouped: Record<string, IndexEntry[]> = {}
@@ -138,10 +164,13 @@ export function RunsHeatmap({
 
     // Sort each client's runs by timestamp (oldest first) and take last N
     const clientRuns: Record<string, IndexEntry[]> = {}
-    const clientDurationMinMax: Record<string, { min: number; max: number }> = {}
-    const clientMgasMinMax: Record<string, { min: number; max: number }> = {}
     const clientDurationStats: Record<string, ClientStats> = {}
     const clientMgasStats: Record<string, ClientStats> = {}
+    const clientDurationScales: Record<string, (v: number) => string> = {}
+    const clientMgasScales: Record<string, (v: number) => string> = {}
+
+    const allDurations: number[] = []
+    const allMgas: number[] = []
 
     for (const [client, clientRunsAll] of Object.entries(grouped)) {
       const sorted = [...clientRunsAll].sort((a, b) => b.timestamp - a.timestamp)
@@ -151,11 +180,7 @@ export function RunsHeatmap({
       const durations = clientRuns[client].map((r) => getIndexAggregatedStats(r, stepFilter).duration)
       const sortedDurations = [...durations].sort((a, b) => a - b)
       const durationSum = durations.reduce((acc, d) => acc + d, 0)
-
-      clientDurationMinMax[client] = {
-        min: sortedDurations[0],
-        max: sortedDurations[sortedDurations.length - 1],
-      }
+      allDurations.push(...durations)
 
       clientDurationStats[client] = {
         min: sortedDurations[0],
@@ -166,6 +191,8 @@ export function RunsHeatmap({
         last: durations[0],
       }
 
+      clientDurationScales[client] = createColorScale(durations, false)
+
       // Calculate MGas/s stats
       const mgasValues = clientRuns[client]
         .map((r) => {
@@ -173,15 +200,11 @@ export function RunsHeatmap({
           return calculateMGasPerSec(stats.gasUsed, stats.gasUsedDuration)
         })
         .filter((v): v is number => v !== undefined)
+      allMgas.push(...mgasValues)
 
       if (mgasValues.length > 0) {
         const sortedMgas = [...mgasValues].sort((a, b) => a - b)
         const mgasSum = mgasValues.reduce((acc, v) => acc + v, 0)
-
-        clientMgasMinMax[client] = {
-          min: sortedMgas[0],
-          max: sortedMgas[sortedMgas.length - 1],
-        }
 
         clientMgasStats[client] = {
           min: sortedMgas[0],
@@ -192,66 +215,130 @@ export function RunsHeatmap({
           last: mgasValues[0],
         }
       } else {
-        clientMgasMinMax[client] = { min: 0, max: 0 }
         clientMgasStats[client] = {}
       }
+
+      clientMgasScales[client] = createColorScale(mgasValues, true)
     }
-
-    // Calculate min/max across all runs
-    let minDuration = Infinity
-    let maxDuration = -Infinity
-    let minMgas = Infinity
-    let maxMgas = -Infinity
-
-    for (const run of runs) {
-      const stats = getIndexAggregatedStats(run, stepFilter)
-      minDuration = Math.min(minDuration, stats.duration)
-      maxDuration = Math.max(maxDuration, stats.duration)
-
-      const mgas = calculateMGasPerSec(stats.gasUsed, stats.gasUsedDuration)
-      if (mgas !== undefined) {
-        minMgas = Math.min(minMgas, mgas)
-        maxMgas = Math.max(maxMgas, mgas)
-      }
-    }
-
-    if (minMgas === Infinity) minMgas = 0
-    if (maxMgas === -Infinity) maxMgas = 0
 
     // Sort clients alphabetically
     const clients = Object.keys(clientRuns).sort()
 
     return {
       clientRuns,
-      minDuration,
-      maxDuration,
-      minMgas,
-      maxMgas,
-      clientDurationMinMax,
-      clientMgasMinMax,
       clientDurationStats,
       clientMgasStats,
       clients,
+      suiteDurationScale: createColorScale(allDurations, false),
+      suiteMgasScale: createColorScale(allMgas, true),
+      clientDurationScales,
+      clientMgasScales,
     }
   }, [runs, stepFilter])
 
-  const getColorForRun = (run: IndexEntry) => {
+  // When groupBy is set, split runs into sections by label value
+  const groupSections: GroupSection[] | null = useMemo(() => {
+    if (!groupBy) return null
+
+    // Partition runs by group value
+    const grouped = new Map<string, IndexEntry[]>()
+    for (const run of runs) {
+      const value = groupBy === 'instance_id'
+        ? run.instance.id
+        : (run.metadata?.[groupBy] ?? '(none)')
+      let list = grouped.get(value)
+      if (!list) {
+        list = []
+        grouped.set(value, list)
+      }
+      list.push(run)
+    }
+
+    const sections: GroupSection[] = []
+    for (const [label, groupRuns] of Array.from(grouped.entries()).sort(([a], [b]) => a.localeCompare(b))) {
+      const byClient: Record<string, IndexEntry[]> = {}
+      for (const run of groupRuns) {
+        const c = run.instance.client
+        if (!byClient[c]) byClient[c] = []
+        byClient[c].push(run)
+      }
+
+      const sectionClientRuns: Record<string, IndexEntry[]> = {}
+      const sectionDurationStats: Record<string, ClientStats> = {}
+      const sectionMgasStats: Record<string, ClientStats> = {}
+      const sectionDurationScales: Record<string, (v: number) => string> = {}
+      const sectionMgasScales: Record<string, (v: number) => string> = {}
+
+      for (const [c, cRuns] of Object.entries(byClient)) {
+        const sorted = [...cRuns].sort((a, b) => b.timestamp - a.timestamp)
+        sectionClientRuns[c] = sorted.slice(0, MAX_RUNS_PER_CLIENT)
+
+        const durations = sectionClientRuns[c].map((r) => getIndexAggregatedStats(r, stepFilter).duration)
+        const sortedD = [...durations].sort((a, b) => a - b)
+        const dSum = durations.reduce((acc, d) => acc + d, 0)
+        sectionDurationStats[c] = {
+          min: sortedD[0], max: sortedD[sortedD.length - 1],
+          mean: dSum / durations.length,
+          p95: calculatePercentile(sortedD, 95), p99: calculatePercentile(sortedD, 99),
+          last: durations[0],
+        }
+        sectionDurationScales[c] = createColorScale(durations, false)
+
+        const mgasVals = sectionClientRuns[c]
+          .map((r) => { const s = getIndexAggregatedStats(r, stepFilter); return calculateMGasPerSec(s.gasUsed, s.gasUsedDuration) })
+          .filter((v): v is number => v !== undefined)
+        if (mgasVals.length > 0) {
+          const sortedM = [...mgasVals].sort((a, b) => a - b)
+          const mSum = mgasVals.reduce((acc, v) => acc + v, 0)
+          sectionMgasStats[c] = {
+            min: sortedM[0], max: sortedM[sortedM.length - 1],
+            mean: mSum / mgasVals.length,
+            p95: calculatePercentile(sortedM, 95), p99: calculatePercentile(sortedM, 99),
+            last: mgasVals[0],
+          }
+        } else {
+          sectionMgasStats[c] = {}
+        }
+        sectionMgasScales[c] = createColorScale(mgasVals, true)
+      }
+
+      sections.push({
+        label,
+        clients: Object.keys(sectionClientRuns).sort(),
+        clientRuns: sectionClientRuns,
+        clientDurationStats: sectionDurationStats,
+        clientMgasStats: sectionMgasStats,
+        clientDurationScales: sectionDurationScales,
+        clientMgasScales: sectionMgasScales,
+      })
+    }
+
+    return sections
+  }, [groupBy, runs, stepFilter])
+
+  const getColorForRun = (
+    run: IndexEntry,
+    overrides?: {
+      mgasScales: Record<string, (v: number) => string>
+      durationScales: Record<string, (v: number) => string>
+    },
+  ) => {
     const stats = getIndexAggregatedStats(run, stepFilter)
     if (metricMode === 'mgas') {
       const mgas = calculateMGasPerSec(stats.gasUsed, stats.gasUsedDuration)
-      if (mgas === undefined) return COLORS[2] // middle color if no data
+      if (mgas === undefined) return COLORS[2]
 
       if (colorNormalization === 'client') {
-        const { min, max } = clientMgasMinMax[run.instance.client]
-        return getColorByNormalizedValue(mgas, min, max, true)
+        const scales = overrides?.mgasScales ?? clientMgasScales
+        return scales[run.instance.client]?.(mgas) ?? COLORS[2]
       }
-      return getColorByNormalizedValue(mgas, minMgas, maxMgas, true)
+      return suiteMgasScale(mgas)
     } else {
       if (colorNormalization === 'client') {
-        const { min, max } = clientDurationMinMax[run.instance.client]
-        return getColorByNormalizedValue(stats.duration, min, max, false)
+        const scales = overrides?.durationScales ?? clientDurationScales
+        return scales[run.instance.client]?.(stats.duration) ?? COLORS[2]
       }
-      return getColorByNormalizedValue(stats.duration, minDuration, maxDuration, false)
+      return suiteDurationScale(stats.duration)
     }
   }
 
@@ -347,122 +434,140 @@ export function RunsHeatmap({
         )}
       </div>
 
-      <div className="flex flex-col gap-2">
-        {/* Stats header */}
-        <div className="flex items-center gap-2 sm:gap-3">
-          <div className="hidden w-28 shrink-0 sm:block" />
-          <div className="flex-1" />
-          <div className="hidden shrink-0 gap-3 border-l border-transparent pl-3 font-mono text-xs/5 font-medium text-gray-400 md:flex dark:text-gray-500">
-            <span className="w-10 text-center">Min</span>
-            <span className="w-10 text-center">Max</span>
-            <span className="w-10 text-center">P95</span>
-            <span className="w-10 text-center">P99</span>
-            <span className="w-10 text-center">Mean</span>
-            <span className="w-10 text-center">Last</span>
-          </div>
-        </div>
-        {clients.map((client) => {
-          const stats = metricMode === 'mgas' ? clientMgasStats[client] : clientDurationStats[client]
-          const formatStatValue = (v?: number) => {
-            if (v === undefined) return '-'
-            if (metricMode === 'mgas') return v.toFixed(1)
-            return formatDurationCompact(v)
-          }
-          return (
-            <div key={client} className="flex items-center gap-2 sm:gap-3">
-              <div className="shrink-0 sm:w-28">
-                <span className="sm:hidden">
-                  <ClientBadge client={client} hideLabel />
-                </span>
-                <span className="hidden sm:inline-flex">
-                  <ClientBadge client={client} />
-                </span>
-              </div>
-              <div className="flex min-w-0 flex-1 flex-wrap gap-1">
-                {clientRuns[client].map((run) => {
-                  const runStats = getIndexAggregatedStats(run, stepFilter)
-                  const completed = isRunCompleted(run)
-                  return (
-                    <button
-                      key={run.run_id}
-                      onClick={() => handleRunClick(run)}
-                      onMouseEnter={(e) => handleMouseEnter(run, e)}
-                      onMouseLeave={handleMouseLeave}
-                      className={clsx(
-                        'relative size-5 shrink-0 cursor-pointer rounded-xs transition-all hover:scale-110 hover:ring-2 hover:ring-gray-400 dark:hover:ring-gray-500',
-                        selectable && selectedRunIds?.has(run.run_id) && 'scale-110 ring-2 ring-blue-500 dark:ring-blue-400',
-                        run.tests.tests_total - run.tests.tests_passed > 0 && completed && !selectedRunIds?.has(run.run_id) && 'ring-2 ring-inset ring-orange-500',
-                        !completed && !selectedRunIds?.has(run.run_id) && 'ring-2 ring-inset ring-red-600 dark:ring-red-500',
-                      )}
-                      style={{ backgroundColor: completed ? getColorForRun(run) : '#6b7280' }}
-                      title={`${formatTimestamp(run.timestamp)} - ${completed ? formatDurationMinSec(runStats.duration) : run.status}`}
-                    >
-                      {completed && run.tests.tests_total - run.tests.tests_passed > 0 && (
-                        <svg className="absolute inset-0 size-5" viewBox="0 0 20 20" fill="none">
-                          <text x="10" y="15" textAnchor="middle" fill="white" fontSize="13" fontWeight="bold" fontFamily="system-ui">!</text>
-                        </svg>
-                      )}
-                      {!completed && (
-                        <svg className="absolute inset-0 size-5 text-red-600 dark:text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                          <path d="M4 4l12 12M4 16L16 4" stroke="currentColor" strokeWidth="2" fill="none" />
-                        </svg>
-                      )}
-                    </button>
-                  )
-                })}
-              </div>
-              <div className="hidden shrink-0 gap-3 border-l border-gray-200 pl-3 font-mono text-xs/5 text-gray-500 md:flex dark:border-gray-700 dark:text-gray-400">
-                <span className="w-10 text-center">{formatStatValue(stats.min)}</span>
-                <span className="w-10 text-center">{formatStatValue(stats.max)}</span>
-                <span className="w-10 text-center">{formatStatValue(stats.p95)}</span>
-                <span className="w-10 text-center">{formatStatValue(stats.p99)}</span>
-                <span className="w-10 text-center">{formatStatValue(stats.mean)}</span>
-                <span className="w-10 text-center">{formatStatValue(stats.last)}</span>
-              </div>
+      {(groupSections ?? [{ label: '', clients, clientRuns, clientDurationStats, clientMgasStats, clientDurationScales, clientMgasScales }]).map((section, sectionIdx) => (
+        <div key={section.label || '_default'} className={clsx(sectionIdx > 0 && 'mt-4')}>
+          {section.label && (
+            <div className="mb-2 flex items-center gap-3">
+              <div className="h-px grow bg-gray-200 dark:bg-gray-700" />
+              <span className="inline-flex items-center gap-1.5 rounded-xs border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs/5 font-medium text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                <span className="font-semibold">{groupBy}</span>
+                <span>=</span>
+                <span>{section.label}</span>
+              </span>
+              <div className="h-px grow bg-gray-200 dark:bg-gray-700" />
             </div>
-          )
-        })}
-      </div>
-
-      {/* Mobile stats summary */}
-      <div className="mt-3 overflow-x-auto md:hidden">
-        <table className="w-full text-xs/5">
-          <thead>
-            <tr className="text-gray-400 dark:text-gray-500">
-              <th className="py-1 pr-3 text-left font-medium">Client</th>
-              <th className="px-2 py-1 text-center font-medium">Min</th>
-              <th className="px-2 py-1 text-center font-medium">Max</th>
-              <th className="px-2 py-1 text-center font-medium">P95</th>
-              <th className="px-2 py-1 text-center font-medium">P99</th>
-              <th className="px-2 py-1 text-center font-medium">Mean</th>
-              <th className="px-2 py-1 text-center font-medium">Last</th>
-            </tr>
-          </thead>
-          <tbody className="font-mono text-gray-500 dark:text-gray-400">
-            {clients.map((client) => {
-              const s = metricMode === 'mgas' ? clientMgasStats[client] : clientDurationStats[client]
-              const fmt = (v?: number) => {
+          )}
+          <div className="flex flex-col gap-2">
+            {/* Stats header */}
+            {sectionIdx === 0 && (
+              <div className="flex items-center gap-2 sm:gap-3">
+                <div className="hidden w-28 shrink-0 sm:block" />
+                <div className="flex-1" />
+                <div className="hidden shrink-0 gap-3 border-l border-transparent pl-3 font-mono text-xs/5 font-medium text-gray-400 md:flex dark:text-gray-500">
+                  <span className="w-10 text-center">Min</span>
+                  <span className="w-10 text-center">Max</span>
+                  <span className="w-10 text-center">P95</span>
+                  <span className="w-10 text-center">P99</span>
+                  <span className="w-10 text-center">Mean</span>
+                  <span className="w-10 text-center">Last</span>
+                </div>
+              </div>
+            )}
+            {section.clients.map((client) => {
+              const stats = metricMode === 'mgas' ? section.clientMgasStats[client] : section.clientDurationStats[client]
+              const colorOverrides = groupSections ? { mgasScales: section.clientMgasScales, durationScales: section.clientDurationScales } : undefined
+              const formatStatValue = (v?: number) => {
                 if (v === undefined) return '-'
                 if (metricMode === 'mgas') return v.toFixed(1)
                 return formatDurationCompact(v)
               }
               return (
-                <tr key={client} className="border-t border-gray-100 dark:border-gray-700">
-                  <td className="py-1 pr-3">
-                    <ClientBadge client={client} hideLabel />
-                  </td>
-                  <td className="px-2 py-1 text-center">{fmt(s.min)}</td>
-                  <td className="px-2 py-1 text-center">{fmt(s.max)}</td>
-                  <td className="px-2 py-1 text-center">{fmt(s.p95)}</td>
-                  <td className="px-2 py-1 text-center">{fmt(s.p99)}</td>
-                  <td className="px-2 py-1 text-center">{fmt(s.mean)}</td>
-                  <td className="px-2 py-1 text-center">{fmt(s.last)}</td>
-                </tr>
+                <div key={`${section.label}-${client}`} className="flex items-center gap-2 sm:gap-3">
+                  <div className="shrink-0 sm:w-28">
+                    <span className="sm:hidden">
+                      <ClientBadge client={client} hideLabel />
+                    </span>
+                    <span className="hidden sm:inline-flex">
+                      <ClientBadge client={client} />
+                    </span>
+                  </div>
+                  <div className="flex min-w-0 flex-1 flex-wrap gap-1">
+                    {section.clientRuns[client].map((run) => {
+                      const runStats = getIndexAggregatedStats(run, stepFilter)
+                      const completed = isRunCompleted(run)
+                      return (
+                        <button
+                          key={run.run_id}
+                          onClick={() => handleRunClick(run)}
+                          onMouseEnter={(e) => handleMouseEnter(run, e)}
+                          onMouseLeave={handleMouseLeave}
+                          className={clsx(
+                            'relative size-5 shrink-0 cursor-pointer rounded-xs transition-all hover:scale-110 hover:ring-2 hover:ring-gray-400 dark:hover:ring-gray-500',
+                            selectable && selectedRunIds?.has(run.run_id) && 'scale-110 ring-2 ring-blue-500 dark:ring-blue-400',
+                            run.tests.tests_total - run.tests.tests_passed > 0 && completed && !selectedRunIds?.has(run.run_id) && 'ring-2 ring-inset ring-orange-500',
+                            !completed && !selectedRunIds?.has(run.run_id) && 'ring-2 ring-inset ring-red-600 dark:ring-red-500',
+                          )}
+                          style={{ backgroundColor: completed ? getColorForRun(run, colorOverrides) : '#6b7280' }}
+                          title={`${formatTimestamp(run.timestamp)} - ${completed ? formatDurationMinSec(runStats.duration) : run.status}`}
+                        >
+                          {completed && run.tests.tests_total - run.tests.tests_passed > 0 && (
+                            <svg className="absolute inset-0 size-5" viewBox="0 0 20 20" fill="none">
+                              <text x="10" y="15" textAnchor="middle" fill="white" fontSize="13" fontWeight="bold" fontFamily="system-ui">!</text>
+                            </svg>
+                          )}
+                          {!completed && (
+                            <svg className="absolute inset-0 size-5 text-red-600 dark:text-red-400" viewBox="0 0 20 20" fill="currentColor">
+                              <path d="M4 4l12 12M4 16L16 4" stroke="currentColor" strokeWidth="2" fill="none" />
+                            </svg>
+                          )}
+                        </button>
+                      )
+                    })}
+                  </div>
+                  <div className="hidden shrink-0 gap-3 border-l border-gray-200 pl-3 font-mono text-xs/5 text-gray-500 md:flex dark:border-gray-700 dark:text-gray-400">
+                    <span className="w-10 text-center">{formatStatValue(stats.min)}</span>
+                    <span className="w-10 text-center">{formatStatValue(stats.max)}</span>
+                    <span className="w-10 text-center">{formatStatValue(stats.p95)}</span>
+                    <span className="w-10 text-center">{formatStatValue(stats.p99)}</span>
+                    <span className="w-10 text-center">{formatStatValue(stats.mean)}</span>
+                    <span className="w-10 text-center">{formatStatValue(stats.last)}</span>
+                  </div>
+                </div>
               )
             })}
-          </tbody>
-        </table>
-      </div>
+          </div>
+
+          {/* Mobile stats summary */}
+          <div className="mt-3 overflow-x-auto md:hidden">
+            <table className="w-full text-xs/5">
+              <thead>
+                <tr className="text-gray-400 dark:text-gray-500">
+                  <th className="py-1 pr-3 text-left font-medium">Client</th>
+                  <th className="px-2 py-1 text-center font-medium">Min</th>
+                  <th className="px-2 py-1 text-center font-medium">Max</th>
+                  <th className="px-2 py-1 text-center font-medium">P95</th>
+                  <th className="px-2 py-1 text-center font-medium">P99</th>
+                  <th className="px-2 py-1 text-center font-medium">Mean</th>
+                  <th className="px-2 py-1 text-center font-medium">Last</th>
+                </tr>
+              </thead>
+              <tbody className="font-mono text-gray-500 dark:text-gray-400">
+                {section.clients.map((client) => {
+                  const s = metricMode === 'mgas' ? section.clientMgasStats[client] : section.clientDurationStats[client]
+                  const fmt = (v?: number) => {
+                    if (v === undefined) return '-'
+                    if (metricMode === 'mgas') return v.toFixed(1)
+                    return formatDurationCompact(v)
+                  }
+                  return (
+                    <tr key={`${section.label}-${client}`} className="border-t border-gray-100 dark:border-gray-700">
+                      <td className="py-1 pr-3">
+                        <ClientBadge client={client} hideLabel />
+                      </td>
+                      <td className="px-2 py-1 text-center">{fmt(s.min)}</td>
+                      <td className="px-2 py-1 text-center">{fmt(s.max)}</td>
+                      <td className="px-2 py-1 text-center">{fmt(s.p95)}</td>
+                      <td className="px-2 py-1 text-center">{fmt(s.p99)}</td>
+                      <td className="px-2 py-1 text-center">{fmt(s.mean)}</td>
+                      <td className="px-2 py-1 text-center">{fmt(s.last)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
 
       {/* Legend */}
       <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs/5 text-gray-500 dark:text-gray-400">

--- a/ui/src/components/suite-detail/RunsHeatmap.tsx
+++ b/ui/src/components/suite-detail/RunsHeatmap.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import clsx from 'clsx'
-import { AlertTriangle } from 'lucide-react'
+import { AlertTriangle, GitCompareArrows } from 'lucide-react'
 import { type IndexEntry, type IndexStepType, getIndexAggregatedStats, ALL_INDEX_STEP_TYPES } from '@/api/types'
 import { formatTimestamp } from '@/utils/date'
 import { ClientBadge } from '@/components/shared/ClientBadge'
@@ -91,6 +91,8 @@ interface RunsHeatmapProps {
   runs: IndexEntry[]
   /** When set, runs are grouped by this label key (or 'instance_id') before client grouping. */
   groupBy?: string
+  /** Called with the runs of a group when the per-group compare button is clicked. */
+  onCompareGroup?: (runs: IndexEntry[]) => void
   isDark: boolean
   colorNormalization?: ColorNormalization
   onColorNormalizationChange?: (mode: ColorNormalization) => void
@@ -121,6 +123,7 @@ interface TooltipData {
 export function RunsHeatmap({
   runs,
   groupBy,
+  onCompareGroup,
   isDark,
   colorNormalization = 'suite',
   onColorNormalizationChange,
@@ -444,6 +447,18 @@ export function RunsHeatmap({
                 <span>=</span>
                 <span>{section.label}</span>
               </span>
+              {onCompareGroup && (
+                <button
+                  onClick={() => {
+                    const allGroupRuns = section.clients.flatMap((c) => section.clientRuns[c])
+                    onCompareGroup(allGroupRuns)
+                  }}
+                  className="flex shrink-0 cursor-pointer items-center justify-center rounded-xs p-1 shadow-xs ring-1 ring-inset transition-colors bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                  title="Compare latest successful run per client in this group"
+                >
+                  <GitCompareArrows className="size-3.5" />
+                </button>
+              )}
               <div className="h-px grow bg-gray-200 dark:bg-gray-700" />
             </div>
           )}

--- a/ui/src/components/suite-detail/RunsHeatmap.tsx
+++ b/ui/src/components/suite-detail/RunsHeatmap.tsx
@@ -635,9 +635,26 @@ export function RunsHeatmap({
                   const mgas = calculateMGasPerSec(tooltipStats.gasUsed, tooltipStats.gasUsedDuration)
                   return mgas !== undefined ? <div>MGas/s: {mgas.toFixed(2)}</div> : null
                 })()}
+                <div className="text-gray-500 dark:text-gray-400">
+                  Instance ID: {tooltip.run.instance.id}
+                </div>
                 <div className="truncate text-gray-500 dark:text-gray-400" style={{ maxWidth: '200px' }}>
                   {tooltip.run.instance.image}
                 </div>
+                {tooltip.run.metadata && (() => {
+                  const labels = Object.entries(tooltip.run.metadata!)
+                    .filter(([k]) => !k.startsWith('github.') && k !== 'name')
+                  if (labels.length === 0) return null
+                  return (
+                    <div className="flex flex-wrap gap-1">
+                      {labels.map(([k, v]) => (
+                        <span key={k} className="rounded-xs bg-gray-100 px-1.5 py-0.5 text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+                          {k}={v}
+                        </span>
+                      ))}
+                    </div>
+                  )
+                })()}
                 <div className="flex gap-2">
                   <span className="text-green-600 dark:text-green-400">
                     {tooltip.run.tests.tests_passed} passed

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -21,7 +21,7 @@ import { ResourceComparisonCharts } from '@/components/compare/ResourceCompariso
 import { BlockLogsComparison } from '@/components/compare/BlockLogsComparison'
 import { ConfigDiff } from '@/components/compare/ConfigDiff'
 import { type StepTypeOption, ALL_STEP_TYPES, DEFAULT_STEP_FILTER } from '@/pages/RunDetailPage'
-import { MIN_COMPARE_RUNS, MAX_COMPARE_RUNS, LABEL_MODE_OPTIONS, type CompareRun, type LabelMode } from '@/components/compare/constants'
+import { MIN_COMPARE_RUNS, MAX_COMPARE_RUNS, buildLabelModeOptions, type CompareRun, type LabelMode } from '@/components/compare/constants'
 
 function parseStepFilter(param: string | undefined): StepTypeOption[] {
   if (!param) return DEFAULT_STEP_FILTER
@@ -113,7 +113,7 @@ export function ComparePage() {
   const { data: suite } = useSuite(suiteHash)
   const headerRef = useRef<HTMLDivElement>(null)
   const baselineIdx = Math.min(Math.max(parseInt(search.baseline ?? '0', 10) || 0, 0), runIds.length - 1)
-  const labelMode: LabelMode = search.labels === 'instance-id' ? 'instance-id' : 'none'
+  const labelMode: LabelMode = search.labels ?? 'none'
   const tableBaseline: 'best' | 'worst' | number = search.tableBase === 'worst'
     ? 'worst'
     : search.tableBase !== undefined && search.tableBase !== 'best'
@@ -206,6 +206,8 @@ export function ComparePage() {
     index: i,
   }))
 
+  const labelModeOptions = buildLabelModeOptions(runs)
+
   // Suite mismatch: check if all hashes are the same
   const uniqueHashes = new Set(runs.map((r) => r.config.suite_hash).filter(Boolean))
   const suiteMismatch = uniqueHashes.size > 1
@@ -242,7 +244,7 @@ export function ComparePage() {
         <div className="flex items-center gap-1.5">
           <span>Labels:</span>
           <div className="flex gap-1">
-            {LABEL_MODE_OPTIONS.map((opt) => (
+            {labelModeOptions.map((opt) => (
               <button
                 key={opt.value}
                 onClick={() => setLabelMode(opt.value)}

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -613,6 +613,26 @@ export function RunDetailPage() {
       </div>
 
       {config.metadata?.labels && (() => {
+        const userLabels = Object.entries(config.metadata.labels)
+          .filter(([k]) => !k.startsWith('github.') && k !== 'name')
+        if (userLabels.length === 0) return null
+        return (
+          <div className="flex flex-wrap items-center gap-2">
+            {userLabels.map(([key, value]) => (
+              <span
+                key={key}
+                className="inline-flex items-center gap-1.5 rounded-xs border border-blue-200 bg-blue-50 px-2 py-1 text-xs/5 font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+              >
+                <span className="font-semibold">{key}</span>
+                <span>=</span>
+                <span>{value}</span>
+              </span>
+            ))}
+          </div>
+        )
+      })()}
+
+      {config.metadata?.labels && (() => {
         const gh = Object.entries(config.metadata.labels)
           .filter(([k]) => k.startsWith('github.'))
           .reduce<Record<string, string>>((acc, [k, v]) => { acc[k.replace('github.', '')] = v; return acc }, {})

--- a/ui/src/pages/RunsPage.tsx
+++ b/ui/src/pages/RunsPage.tsx
@@ -10,6 +10,7 @@ import { type IndexStepType, ALL_INDEX_STEP_TYPES, DEFAULT_INDEX_STEP_FILTER } f
 import { RunsTable } from '@/components/runs/RunsTable'
 import { sortIndexEntries, type SortColumn, type SortDirection } from '@/components/runs/sortEntries'
 import { RunFilters, type TestStatusFilter } from '@/components/runs/RunFilters'
+import { parseLabelFilters, serializeLabelFilters, type LabelFilter } from '@/components/runs/labelFilterUtils'
 import { Pagination } from '@/components/shared/Pagination'
 import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
@@ -35,8 +36,10 @@ export function RunsPage() {
     sortBy?: SortColumn
     sortDir?: SortDirection
     steps?: string
+    labels?: string
   }
-  const { page = 1, pageSize = DEFAULT_PAGE_SIZE, client, image, suite, strategy, status = 'all', sortBy = 'timestamp', sortDir = 'desc', steps } = search
+  const { page = 1, pageSize = DEFAULT_PAGE_SIZE, client, image, suite, strategy, status = 'all', sortBy = 'timestamp', sortDir = 'desc', steps, labels } = search
+  const labelFilters = parseLabelFilters(labels)
 
   // Parse step filter from URL
   const parseStepFilter = (stepsParam: string | undefined): IndexStepType[] => {
@@ -111,9 +114,12 @@ export function RunsPage() {
       if (status === 'failing' && e.tests.tests_total - e.tests.tests_passed === 0) return false
       if (status === 'timeout' && e.status !== 'timeout') return false
       if (status === 'cancelled' && e.status !== 'cancelled') return false
+      for (const lf of labelFilters) {
+        if (e.metadata?.[lf.key] !== lf.value) return false
+      }
       return true
     })
-  }, [index, client, image, suite, strategy, status])
+  }, [index, client, image, suite, strategy, status, labelFilters])
 
   const sortedEntries = useMemo(() => sortIndexEntries(filteredEntries, sortBy, sortDir, stepFilter), [filteredEntries, sortBy, sortDir, stepFilter])
   const totalPages = Math.ceil(sortedEntries.length / localPageSize)
@@ -121,49 +127,54 @@ export function RunsPage() {
 
   const handlePageChange = (newPage: number) => {
     setLocalPage(newPage)
-    navigate({ to: '/runs', search: { page: newPage, pageSize: localPageSize, client, image, suite, strategy, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: newPage, pageSize: localPageSize, client, image, suite, strategy, status, sortBy, sortDir, steps, labels } })
   }
 
   const handlePageSizeChange = (newSize: number) => {
     setLocalPageSize(newSize)
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: newSize, client, image, suite, strategy, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: newSize, client, image, suite, strategy, status, sortBy, sortDir, steps, labels } })
   }
 
   const handleClientChange = (newClient: string | undefined) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client: newClient, image, suite, strategy, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client: newClient, image, suite, strategy, status, sortBy, sortDir, steps, labels } })
   }
 
   const handleImageChange = (newImage: string | undefined) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image: newImage, suite, strategy, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image: newImage, suite, strategy, status, sortBy, sortDir, steps, labels } })
   }
 
   const handleSuiteChange = (newSuite: string | undefined) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite: newSuite, strategy, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite: newSuite, strategy, status, sortBy, sortDir, steps, labels } })
   }
 
   const handleStrategyChange = (newStrategy: string | undefined) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy: newStrategy, status, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy: newStrategy, status, sortBy, sortDir, steps, labels } })
   }
 
   const handleStatusChange = (newStatus: TestStatusFilter) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status: newStatus, sortBy, sortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status: newStatus, sortBy, sortDir, steps, labels } })
   }
 
   const handleSortChange = (newSortBy: SortColumn, newSortDir: SortDirection) => {
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status, sortBy: newSortBy, sortDir: newSortDir, steps } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status, sortBy: newSortBy, sortDir: newSortDir, steps, labels } })
   }
 
   const handleStepFilterChange = (newFilter: IndexStepType[]) => {
     const stepsParam = newFilter.length === ALL_INDEX_STEP_TYPES.length ? undefined : newFilter.join(',')
     setLocalPage(1)
-    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status, sortBy, sortDir, steps: stepsParam } })
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status, sortBy, sortDir, steps: stepsParam, labels } })
+  }
+
+  const handleLabelFiltersChange = (newFilters: LabelFilter[]) => {
+    setLocalPage(1)
+    navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status, sortBy, sortDir, steps, labels: serializeLabelFilters(newFilters) } })
   }
 
   // Compare mode state
@@ -302,6 +313,9 @@ export function RunsPage() {
               onStrategyChange={handleStrategyChange}
               selectedStatus={status}
               onStatusChange={handleStatusChange}
+              entries={index?.entries}
+              labelFilters={labelFilters}
+              onLabelFiltersChange={handleLabelFiltersChange}
             />
           </div>
         </div>

--- a/ui/src/pages/RunsPage.tsx
+++ b/ui/src/pages/RunsPage.tsx
@@ -10,7 +10,7 @@ import { type IndexStepType, ALL_INDEX_STEP_TYPES, DEFAULT_INDEX_STEP_FILTER } f
 import { RunsTable } from '@/components/runs/RunsTable'
 import { sortIndexEntries, type SortColumn, type SortDirection } from '@/components/runs/sortEntries'
 import { RunFilters, type TestStatusFilter } from '@/components/runs/RunFilters'
-import { parseLabelFilters, serializeLabelFilters, type LabelFilter } from '@/components/runs/labelFilterUtils'
+import { parseLabelFilters, serializeLabelFilters, type LabelFilters } from '@/components/runs/labelFilterUtils'
 import { Pagination } from '@/components/shared/Pagination'
 import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
@@ -114,8 +114,9 @@ export function RunsPage() {
       if (status === 'failing' && e.tests.tests_total - e.tests.tests_passed === 0) return false
       if (status === 'timeout' && e.status !== 'timeout') return false
       if (status === 'cancelled' && e.status !== 'cancelled') return false
-      for (const lf of labelFilters) {
-        if (e.metadata?.[lf.key] !== lf.value) return false
+      for (const [key, allowedValues] of labelFilters) {
+        const actual = e.metadata?.[key]
+        if (!actual || !allowedValues.has(actual)) return false
       }
       return true
     })
@@ -172,7 +173,7 @@ export function RunsPage() {
     navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status, sortBy, sortDir, steps: stepsParam, labels } })
   }
 
-  const handleLabelFiltersChange = (newFilters: LabelFilter[]) => {
+  const handleLabelFiltersChange = (newFilters: LabelFilters) => {
     setLocalPage(1)
     navigate({ to: '/runs', search: { page: 1, pageSize: localPageSize, client, image, suite, strategy, status, sortBy, sortDir, steps, labels: serializeLabelFilters(newFilters) } })
   }

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useMemo, useState, useEffect } from 'react'
+import { useCallback, useMemo, useState, useEffect, useRef } from 'react'
 import { Link, useParams, useNavigate, useSearch } from '@tanstack/react-router'
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
 import clsx from 'clsx'
-import { ChevronRight, SquareStack, GitCompareArrows, LayoutGrid, Clock, Grid3X3, Trash2 } from 'lucide-react'
+import { ChevronRight, SquareStack, GitCompareArrows, LayoutGrid, Clock, Grid3X3, Trash2, Plus, X } from 'lucide-react'
 import { type IndexEntry, type IndexStepType, ALL_INDEX_STEP_TYPES, DEFAULT_INDEX_STEP_FILTER, type SuiteTest } from '@/api/types'
 import { useSuite } from '@/api/hooks/useSuite'
 import { useSuiteStats } from '@/api/hooks/useSuiteStats'
@@ -20,6 +20,8 @@ import { RunsTable } from '@/components/runs/RunsTable'
 import { sortIndexEntries, type SortColumn, type SortDirection } from '@/components/runs/sortEntries'
 import { RunFilters, type TestStatusFilter } from '@/components/runs/RunFilters'
 import { parseLabelFilters, serializeLabelFilters, type LabelFilters } from '@/components/runs/labelFilterUtils'
+import { ClientBadge } from '@/components/shared/ClientBadge'
+import { getBaseClient } from '@/utils/client-colors'
 import { LoadingState, Spinner } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { Badge } from '@/components/shared/Badge'
@@ -66,6 +68,183 @@ function OpcodeHeatmapSection({ tests, onTestClick }: { tests: SuiteTest[]; onTe
         </div>
       )}
     </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ChartFilters — client toggles + label chip filters for the Run Charts
+// ---------------------------------------------------------------------------
+
+interface ChartFiltersProps {
+  clients: string[]
+  clientFilter: Set<string>
+  onClientFilterChange: (filter: Set<string>) => void
+  labelKeys: string[]
+  labelValues: Map<string, string[]>
+  labelFilters: Map<string, Set<string>>
+  onLabelFiltersChange: (filters: Map<string, Set<string>>) => void
+}
+
+function ChartFilters({
+  clients, clientFilter, onClientFilterChange,
+  labelKeys, labelValues, labelFilters, onLabelFiltersChange,
+}: ChartFiltersProps) {
+  const [keyDropdownOpen, setKeyDropdownOpen] = useState(false)
+  const [valueDropdownKey, setValueDropdownKey] = useState<string | null>(null)
+  const keyRef = useRef<HTMLDivElement>(null)
+  const valueRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (keyDropdownOpen && keyRef.current && !keyRef.current.contains(e.target as Node)) setKeyDropdownOpen(false)
+      if (valueDropdownKey && valueRef.current && !valueRef.current.contains(e.target as Node)) setValueDropdownKey(null)
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [keyDropdownOpen, valueDropdownKey])
+
+  const toggleClient = (c: string) => {
+    const next = new Set(clientFilter)
+    if (next.has(c)) { next.delete(c) } else { next.add(c) }
+    onClientFilterChange(next)
+  }
+
+  const availableLabelKeys = labelKeys.filter((k) => !labelFilters.has(k) && k !== valueDropdownKey)
+
+  const toggleLabelValue = (key: string, value: string) => {
+    const next = new Map(labelFilters)
+    const values = new Set(next.get(key) ?? [])
+    if (values.has(value)) {
+      values.delete(value)
+      if (values.size === 0) next.delete(key)
+      else next.set(key, values)
+    } else {
+      values.add(value)
+      next.set(key, values)
+    }
+    onLabelFiltersChange(next)
+  }
+
+  const removeLabelFilter = (key: string) => {
+    const next = new Map(labelFilters)
+    next.delete(key)
+    onLabelFiltersChange(next)
+    if (valueDropdownKey === key) setValueDropdownKey(null)
+  }
+
+  const chipKeys = Array.from(labelFilters.keys())
+  if (valueDropdownKey && !labelFilters.has(valueDropdownKey)) chipKeys.push(valueDropdownKey)
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {/* Client toggles */}
+      {clients.map((c) => {
+        const active = clientFilter.size === 0 || clientFilter.has(c)
+        return (
+          <button
+            key={c}
+            onClick={() => toggleClient(c)}
+            className={clsx(
+              'transition-opacity',
+              !active && 'opacity-30 hover:opacity-60',
+            )}
+          >
+            <ClientBadge client={c} />
+          </button>
+        )
+      })}
+
+      {/* Label filter chips */}
+      {chipKeys.map((key) => {
+        const values = labelFilters.get(key)
+        const isPending = !values
+        return (
+          <div key={key} className="relative" ref={valueDropdownKey === key ? valueRef : undefined}>
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={() => setValueDropdownKey(valueDropdownKey === key ? null : key)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setValueDropdownKey(valueDropdownKey === key ? null : key) } }}
+              className={clsx(
+                'flex cursor-pointer items-center gap-1.5 rounded-xs border px-2 py-1 text-xs/5 font-medium transition-colors',
+                isPending
+                  ? 'border-dashed border-blue-300 bg-blue-50/50 text-blue-500 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
+                  : 'border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50',
+              )}
+            >
+              <span className="font-semibold">{key}</span>
+              {values && values.size > 0 && (
+                <>
+                  <span>=</span>
+                  <span>{Array.from(values).join(', ')}</span>
+                </>
+              )}
+              <button
+                onClick={(e) => { e.stopPropagation(); if (isPending) setValueDropdownKey(null); else removeLabelFilter(key) }}
+                className="ml-0.5 rounded-xs p-0.5 hover:bg-blue-200 dark:hover:bg-blue-800"
+              >
+                <X className="size-3" />
+              </button>
+            </div>
+            {valueDropdownKey === key && (
+              <div className="absolute top-full left-0 z-50 mt-1 max-h-64 min-w-48 overflow-y-auto rounded-xs border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+                {(labelValues.get(key) ?? []).map((val) => {
+                  const selected = values?.has(val) ?? false
+                  return (
+                    <button
+                      key={val}
+                      onClick={() => toggleLabelValue(key, val)}
+                      className={clsx(
+                        'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm/6 transition-colors',
+                        selected
+                          ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+                          : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700',
+                      )}
+                    >
+                      <span className={clsx(
+                        'flex size-4 shrink-0 items-center justify-center rounded-xs border text-xs/3',
+                        selected
+                          ? 'border-blue-500 bg-blue-500 text-white dark:border-blue-400 dark:bg-blue-400'
+                          : 'border-gray-300 dark:border-gray-600',
+                      )}>
+                        {selected && '✓'}
+                      </span>
+                      {val}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )
+      })}
+
+      {/* Add label filter button */}
+      {availableLabelKeys.length > 0 && (
+        <div className="relative" ref={keyRef}>
+          <button
+            onClick={() => { setKeyDropdownOpen(!keyDropdownOpen); setValueDropdownKey(null) }}
+            className="flex items-center gap-1 rounded-xs border border-dashed border-gray-300 px-2 py-1 text-xs/5 text-gray-500 transition-colors hover:border-gray-400 hover:text-gray-700 dark:border-gray-600 dark:text-gray-400 dark:hover:border-gray-500 dark:hover:text-gray-300"
+          >
+            <Plus className="size-3" />
+            Label
+          </button>
+          {keyDropdownOpen && (
+            <div className="absolute top-full left-0 z-50 mt-1 min-w-36 overflow-hidden rounded-xs border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              {availableLabelKeys.map((key) => (
+                <button
+                  key={key}
+                  onClick={() => { setKeyDropdownOpen(false); setValueDropdownKey(key) }}
+                  className="flex w-full px-3 py-1.5 text-left text-sm/6 text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                  {key}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -177,6 +356,8 @@ export function SuiteDetailPage() {
   const [heatmapExpanded, setHeatmapExpanded] = useState(true)
   const [chartExpanded, setChartExpanded] = useState(true)
   const [chartZoomRange, setChartZoomRange] = useState({ start: 0, end: 100 })
+  const [chartClientFilter, setChartClientFilter] = useState<Set<string>>(new Set())
+  const [chartLabelFilters, setChartLabelFilters] = useState<Map<string, Set<string>>>(new Map())
   const handleChartZoomChange = useCallback((range: { start: number; end: number }) => {
     setChartZoomRange(range)
   }, [])
@@ -237,10 +418,48 @@ export function SuiteDetailPage() {
     return groupedRunsAll.filter((entry) => !entry.status || entry.status === 'completed')
   }, [groupedRunsAll])
 
-  const chartRuns = useMemo(() => {
+  const chartRunsBase = useMemo(() => {
     if (!chartPassingOnly) return completedRuns
     return completedRuns.filter((entry) => entry.tests.tests_total === entry.tests.tests_passed)
   }, [completedRuns, chartPassingOnly])
+
+  // Derive available base clients and label keys/values for chart filtering
+  const { chartClients, chartLabelKeys, chartLabelValues } = useMemo(() => {
+    const clientSet = new Set<string>()
+    const valMap = new Map<string, Set<string>>()
+    for (const run of chartRunsBase) {
+      clientSet.add(getBaseClient(run.instance.client))
+      if (run.metadata) {
+        for (const [key, value] of Object.entries(run.metadata)) {
+          if (key.startsWith('github.') || key === 'name') continue
+          let set = valMap.get(key)
+          if (!set) { set = new Set(); valMap.set(key, set) }
+          set.add(value)
+        }
+      }
+    }
+    const keys = Array.from(valMap.keys()).sort()
+    const values = new Map<string, string[]>()
+    for (const [key, set] of valMap) values.set(key, Array.from(set).sort())
+    return { chartClients: Array.from(clientSet).sort(), chartLabelKeys: keys, chartLabelValues: values }
+  }, [chartRunsBase])
+
+  const chartRuns = useMemo(() => {
+    let runs = chartRunsBase
+    if (chartClientFilter.size > 0) {
+      runs = runs.filter((r) => chartClientFilter.has(getBaseClient(r.instance.client)))
+    }
+    if (chartLabelFilters.size > 0) {
+      runs = runs.filter((r) => {
+        for (const [key, allowed] of chartLabelFilters) {
+          const actual = r.metadata?.[key]
+          if (!actual || !allowed.has(actual)) return false
+        }
+        return true
+      })
+    }
+    return runs
+  }, [chartRunsBase, chartClientFilter, chartLabelFilters])
 
   const clients = useMemo(() => {
     const clientSet = new Set(suiteRunsAll.map((e) => e.instance.client))
@@ -814,6 +1033,18 @@ export function SuiteDetailPage() {
                           </button>
                         </div>
                       </div>
+                      {/* Chart filters: client toggles + label chips */}
+                      {(chartClients.length > 1 || chartLabelKeys.length > 0) && (
+                        <ChartFilters
+                          clients={chartClients}
+                          clientFilter={chartClientFilter}
+                          onClientFilterChange={setChartClientFilter}
+                          labelKeys={chartLabelKeys}
+                          labelValues={chartLabelValues}
+                          labelFilters={chartLabelFilters}
+                          onLabelFiltersChange={setChartLabelFilters}
+                        />
+                      )}
                       <div className="flex items-center gap-3">
                         <div className="h-px grow bg-gray-200 dark:bg-gray-700" />
                         <span className="text-xs font-medium text-gray-400 dark:text-gray-500">Performance</span>

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -19,7 +19,7 @@ import { OpcodeHeatmap } from '@/components/suite-detail/OpcodeHeatmap'
 import { RunsTable } from '@/components/runs/RunsTable'
 import { sortIndexEntries, type SortColumn, type SortDirection } from '@/components/runs/sortEntries'
 import { RunFilters, type TestStatusFilter } from '@/components/runs/RunFilters'
-import { parseLabelFilters, serializeLabelFilters, type LabelFilter } from '@/components/runs/labelFilterUtils'
+import { parseLabelFilters, serializeLabelFilters, type LabelFilters } from '@/components/runs/labelFilterUtils'
 import { LoadingState, Spinner } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { Badge } from '@/components/shared/Badge'
@@ -245,8 +245,9 @@ export function SuiteDetailPage() {
       if (status === 'failing' && e.tests.tests_total - e.tests.tests_passed === 0) return false
       if (status === 'timeout' && e.status !== 'timeout') return false
       if (status === 'cancelled' && e.status !== 'cancelled') return false
-      for (const lf of labelFilters) {
-        if (e.metadata?.[lf.key] !== lf.value) return false
+      for (const [key, allowedValues] of labelFilters) {
+        const actual = e.metadata?.[key]
+        if (!actual || !allowedValues.has(actual)) return false
       }
       return true
     })
@@ -288,7 +289,7 @@ export function SuiteDetailPage() {
     })
   }
 
-  const handleLabelFiltersChange = (newFilters: LabelFilter[]) => {
+  const handleLabelFiltersChange = (newFilters: LabelFilters) => {
     setRunsPage(1)
     navigate({
       to: '/suites/$suiteHash',

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -1011,7 +1011,8 @@ export function SuiteDetailPage() {
                             if (ids.length >= MAX_COMPARE_RUNS) break
                           }
                           if (ids.length >= MIN_COMPARE_RUNS) {
-                            navigate({ to: '/compare', search: { runs: ids.join(',') } })
+                            const labels = groupBy === 'instance_id' ? 'instance-id' : `label:${groupBy}`
+                            navigate({ to: '/compare', search: { runs: ids.join(','), labels } })
                           }
                         } : undefined}
                         isDark={isDark}

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -3,7 +3,7 @@ import { Link, useParams, useNavigate, useSearch } from '@tanstack/react-router'
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
 import clsx from 'clsx'
 import { ChevronRight, SquareStack, GitCompareArrows, LayoutGrid, Clock, Grid3X3, Trash2 } from 'lucide-react'
-import { type IndexStepType, ALL_INDEX_STEP_TYPES, DEFAULT_INDEX_STEP_FILTER, type SuiteTest } from '@/api/types'
+import { type IndexEntry, type IndexStepType, ALL_INDEX_STEP_TYPES, DEFAULT_INDEX_STEP_FILTER, type SuiteTest } from '@/api/types'
 import { useSuite } from '@/api/hooks/useSuite'
 import { useSuiteStats } from '@/api/hooks/useSuiteStats'
 import { useIndex } from '@/api/hooks/useIndex'
@@ -99,8 +99,9 @@ export function SuiteDetailPage() {
     hTh?: string
     hRpc?: string
     hPs?: string
+    groupBy?: string
   }
-  const { tab, client, image, status = 'all', sortBy = 'timestamp', sortDir = 'desc', filesPage, detail, opcodeSort, q, chartMode = 'runCount', heatmapColor = 'suite', hq, hn, hr, hFs, hStat, hCs, hTh, hRpc, hPs } = search
+  const { tab, client, image, status = 'all', sortBy = 'timestamp', sortDir = 'desc', filesPage, detail, opcodeSort, q, chartMode = 'runCount', heatmapColor = 'suite', hq, hn, hr, hFs, hStat, hCs, hTh, hRpc, hPs, groupBy } = search
   const chartPassingOnly = search.chartPassingOnly !== 'false'
   const stepFilter = parseStepFilter(search.steps)
   const labelFilters = parseLabelFilters(search.labels)
@@ -198,11 +199,43 @@ export function SuiteDetailPage() {
     return index.entries.filter((entry) => entry.suite_hash === suiteHash)
   }, [index, suiteHash])
 
+  // Collect available label keys for the group-by selector
+  const groupByLabelKeys = useMemo(() => {
+    const keys = new Set<string>()
+    for (const run of suiteRunsAll) {
+      if (run.metadata) {
+        for (const key of Object.keys(run.metadata)) {
+          if (!key.startsWith('github.') && key !== 'name') keys.add(key)
+        }
+      }
+    }
+    return Array.from(keys).sort()
+  }, [suiteRunsAll])
+
+  // Apply grouping: transforms client name to include the group suffix
+  const applyGrouping = useCallback((runs: IndexEntry[]): IndexEntry[] => {
+    if (!groupBy) return runs
+    return runs.map((run) => {
+      let suffix: string
+      if (groupBy === 'instance_id') {
+        suffix = run.instance.id
+      } else {
+        suffix = run.metadata?.[groupBy] ?? '(none)'
+      }
+      return {
+        ...run,
+        instance: { ...run.instance, client: `${run.instance.client} / ${suffix}` },
+      }
+    })
+  }, [groupBy])
+
+  const groupedRunsAll = useMemo(() => applyGrouping(suiteRunsAll), [suiteRunsAll, applyGrouping])
+
   // Filter to only completed runs for metrics (exclude container_died, cancelled)
   // Runs without status are considered completed (backward compatibility)
   const completedRuns = useMemo(() => {
-    return suiteRunsAll.filter((entry) => !entry.status || entry.status === 'completed')
-  }, [suiteRunsAll])
+    return groupedRunsAll.filter((entry) => !entry.status || entry.status === 'completed')
+  }, [groupedRunsAll])
 
   const chartRuns = useMemo(() => {
     if (!chartPassingOnly) return completedRuns
@@ -267,7 +300,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client: newClient, image, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client: newClient, image, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -276,7 +309,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image: newImage, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image: newImage, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -285,7 +318,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status: newStatus, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image, status: newStatus, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -294,7 +327,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(newFilters) },
+      search: { tab, client, image, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(newFilters), groupBy },
     })
   }
 
@@ -336,7 +369,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab: newTab, client, image, status, sortBy, sortDir, filesPage: undefined, detail: undefined, opcodeSort: undefined, q: undefined },
+      search: { tab: newTab, client, image, status, sortBy, sortDir, filesPage: undefined, detail: undefined, opcodeSort: undefined, q: undefined, groupBy },
     })
   }
 
@@ -345,7 +378,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy: newSortBy, sortDir: newSortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image, status, sortBy: newSortBy, sortDir: newSortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -353,7 +386,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, filesPage: page, q, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image, status, sortBy, sortDir, filesPage: page, q, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -361,7 +394,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, filesPage: 1, q: query || undefined, chartMode, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image, status, sortBy, sortDir, filesPage: 1, q: query || undefined, chartMode, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -369,7 +402,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, filesPage, detail: index, opcodeSort, q, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image, status, sortBy, sortDir, filesPage, detail: index, opcodeSort, q, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -377,7 +410,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, filesPage, detail, opcodeSort: sort === 'name' ? undefined : sort, q, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image, status, sortBy, sortDir, filesPage, detail, opcodeSort: sort === 'name' ? undefined : sort, q, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -387,7 +420,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode: mode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode: mode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -395,7 +428,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: passingOnly ? undefined : 'false', heatmapColor, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: passingOnly ? undefined : 'false', heatmapColor, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -403,7 +436,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor: mode, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor: mode, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -411,7 +444,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq: query || undefined, hn, hr, hFs, hStat, hCs, hTh, hRpc, hPs },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq: query || undefined, hn, hr, hFs, hStat, hCs, hTh, hRpc, hPs, groupBy },
     })
   }
 
@@ -419,7 +452,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn: show ? '1' : undefined, hr, hFs, hStat, hCs, hTh, hRpc, hPs },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn: show ? '1' : undefined, hr, hFs, hStat, hCs, hTh, hRpc, hPs, groupBy },
     })
   }
 
@@ -427,7 +460,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr: useRegex ? '1' : undefined, hFs, hStat, hCs, hTh, hRpc, hPs },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr: useRegex ? '1' : undefined, hFs, hStat, hCs, hTh, hRpc, hPs, groupBy },
     })
   }
 
@@ -435,7 +468,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs: fs ? '1' : undefined, hStat, hCs, hTh, hRpc, hPs },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs: fs ? '1' : undefined, hStat, hCs, hTh, hRpc, hPs, groupBy },
     })
   }
 
@@ -443,7 +476,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs, hStat: stat === 'avgMgas' ? undefined : stat, hCs, hTh, hRpc, hPs },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs, hStat: stat === 'avgMgas' ? undefined : stat, hCs, hTh, hRpc, hPs, groupBy },
     })
   }
 
@@ -451,7 +484,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs, hStat, hCs: show ? '1' : undefined, hTh, hRpc, hPs },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs, hStat, hCs: show ? '1' : undefined, hTh, hRpc, hPs, groupBy },
     })
   }
 
@@ -459,7 +492,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs, hStat, hCs, hTh: th === 60 ? undefined : String(th), hRpc, hPs },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs, hStat, hCs, hTh: th === 60 ? undefined : String(th), hRpc, hPs, groupBy },
     })
   }
 
@@ -467,7 +500,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs, hStat, hCs, hTh, hRpc: count === 5 ? undefined : String(count), hPs },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs, hStat, hCs, hTh, hRpc: count === 5 ? undefined : String(count), hPs, groupBy },
     })
   }
 
@@ -475,7 +508,15 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs, hStat, hCs, hTh, hRpc, hPs: size === 20 ? undefined : String(size) },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), hq, hn, hr, hFs, hStat, hCs, hTh, hRpc, hPs: size === 20 ? undefined : String(size), groupBy },
+    })
+  }
+
+  const handleGroupByChange = (key: string | undefined) => {
+    navigate({
+      to: '/suites/$suiteHash',
+      params: { suiteHash },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters), groupBy: key },
     })
   }
 
@@ -483,7 +524,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(steps), labels: serializeLabelFilters(labelFilters) },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(steps), labels: serializeLabelFilters(labelFilters), groupBy },
     })
   }
 
@@ -606,35 +647,74 @@ export function SuiteDetailPage() {
               </p>
             ) : (
               <div className="flex flex-col gap-4">
-                {/* Step Filter Control */}
-                <div className="flex flex-wrap items-center gap-2 rounded-xs bg-white p-2 shadow-xs sm:gap-3 sm:p-3 dark:bg-gray-800">
-                  <span className="text-xs/5 font-medium text-gray-700 sm:text-sm/6 dark:text-gray-300">Metric steps:</span>
-                  <div className="flex items-center gap-1">
-                    {ALL_INDEX_STEP_TYPES.map((step) => (
-                      <button
-                        key={step}
-                        onClick={() => {
-                          const newFilter = stepFilter.includes(step)
-                            ? stepFilter.filter((s) => s !== step)
-                            : [...stepFilter, step]
-                          if (newFilter.length > 0) {
-                            handleStepFilterChange(newFilter)
-                          }
-                        }}
-                        className={`rounded-xs px-2 py-0.5 text-xs font-medium capitalize transition-colors sm:px-2.5 sm:py-1 ${
-                          stepFilter.includes(step)
-                            ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300'
-                            : 'bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
-                        }`}
-                        title={`${stepFilter.includes(step) ? 'Exclude' : 'Include'} ${step} step in metric calculations`}
-                      >
-                        {step}
-                      </button>
-                    ))}
+                {/* Step Filter & Group By Controls */}
+                <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-xs bg-white p-2 shadow-xs sm:p-3 dark:bg-gray-800">
+                  <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+                    <span className="text-xs/5 font-medium text-gray-700 sm:text-sm/6 dark:text-gray-300">Metric steps:</span>
+                    <div className="flex items-center gap-1">
+                      {ALL_INDEX_STEP_TYPES.map((step) => (
+                        <button
+                          key={step}
+                          onClick={() => {
+                            const newFilter = stepFilter.includes(step)
+                              ? stepFilter.filter((s) => s !== step)
+                              : [...stepFilter, step]
+                            if (newFilter.length > 0) {
+                              handleStepFilterChange(newFilter)
+                            }
+                          }}
+                          className={`rounded-xs px-2 py-0.5 text-xs font-medium capitalize transition-colors sm:px-2.5 sm:py-1 ${
+                            stepFilter.includes(step)
+                              ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300'
+                              : 'bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
+                          }`}
+                          title={`${stepFilter.includes(step) ? 'Exclude' : 'Include'} ${step} step in metric calculations`}
+                        >
+                          {step}
+                        </button>
+                      ))}
+                    </div>
                   </div>
-                  <span className="hidden text-xs text-gray-500 sm:inline dark:text-gray-400">
-                    (affects Duration, MGas/s calculations)
-                  </span>
+                  {groupByLabelKeys.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+                      <span className="text-xs/5 font-medium text-gray-700 sm:text-sm/6 dark:text-gray-300">Group by:</span>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => handleGroupByChange(undefined)}
+                          className={`rounded-xs px-2 py-0.5 text-xs font-medium transition-colors sm:px-2.5 sm:py-1 ${
+                            !groupBy
+                              ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                              : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                          }`}
+                        >
+                          None
+                        </button>
+                        {groupByLabelKeys.map((key) => (
+                          <button
+                            key={key}
+                            onClick={() => handleGroupByChange(key)}
+                            className={`rounded-xs px-2 py-0.5 text-xs font-medium transition-colors sm:px-2.5 sm:py-1 ${
+                              groupBy === key
+                                ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                                : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                            }`}
+                          >
+                            {key}
+                          </button>
+                        ))}
+                        <button
+                          onClick={() => handleGroupByChange('instance_id')}
+                          className={`rounded-xs px-2 py-0.5 text-xs font-medium transition-colors sm:px-2.5 sm:py-1 ${
+                            groupBy === 'instance_id'
+                              ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                              : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                          }`}
+                        >
+                          instance id
+                        </button>
+                      </div>
+                    </div>
+                  )}
                 </div>
                 <div className="overflow-hidden rounded-xs border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
                   <div className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 sm:px-4 sm:py-3">
@@ -674,7 +754,7 @@ export function SuiteDetailPage() {
                   </div>
                   {heatmapExpanded && (
                     <div className="border-t border-gray-200 p-3 sm:p-4 dark:border-gray-700">
-                      <RunsHeatmap runs={suiteRunsAll} isDark={isDark} colorNormalization={heatmapColor} onColorNormalizationChange={handleHeatmapColorChange} stepFilter={stepFilter} selectable={compareMode} selectedRunIds={selectedRunIds} onSelectionChange={handleSelectionChange} />
+                      <RunsHeatmap runs={suiteRunsAll} groupBy={groupBy} isDark={isDark} colorNormalization={heatmapColor} onColorNormalizationChange={handleHeatmapColorChange} stepFilter={stepFilter} selectable={compareMode} selectedRunIds={selectedRunIds} onSelectionChange={handleSelectionChange} />
                     </div>
                   )}
                 </div>

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -992,6 +992,28 @@ export function SuiteDetailPage() {
                             navigate({ to: '/compare', search: { runs: ids.join(',') } })
                           }
                         } : undefined}
+                        onCompareClientAcrossGroups={groupBy ? (client) => {
+                          // Find the latest successful run for this client in each group
+                          const sorted = [...suiteRunsAll]
+                            .filter((r) => r.instance.client === client)
+                            .sort((a, b) => b.timestamp - a.timestamp)
+                          const seenGroups = new Set<string>()
+                          const ids: string[] = []
+                          for (const run of sorted) {
+                            const groupValue = groupBy === 'instance_id'
+                              ? run.instance.id
+                              : (run.metadata?.[groupBy] ?? '(none)')
+                            if (seenGroups.has(groupValue)) continue
+                            if (run.tests.tests_total > 0 && run.tests.tests_passed === run.tests.tests_total) {
+                              seenGroups.add(groupValue)
+                              ids.push(run.run_id)
+                            }
+                            if (ids.length >= MAX_COMPARE_RUNS) break
+                          }
+                          if (ids.length >= MIN_COMPARE_RUNS) {
+                            navigate({ to: '/compare', search: { runs: ids.join(',') } })
+                          }
+                        } : undefined}
                         isDark={isDark}
                         colorNormalization={heatmapColor}
                         onColorNormalizationChange={handleHeatmapColorChange}

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -973,7 +973,33 @@ export function SuiteDetailPage() {
                   </div>
                   {heatmapExpanded && (
                     <div className="border-t border-gray-200 p-3 sm:p-4 dark:border-gray-700">
-                      <RunsHeatmap runs={suiteRunsAll} groupBy={groupBy} isDark={isDark} colorNormalization={heatmapColor} onColorNormalizationChange={handleHeatmapColorChange} stepFilter={stepFilter} selectable={compareMode} selectedRunIds={selectedRunIds} onSelectionChange={handleSelectionChange} />
+                      <RunsHeatmap
+                        runs={suiteRunsAll}
+                        groupBy={groupBy}
+                        onCompareGroup={groupBy ? (groupRuns) => {
+                          const sorted = [...groupRuns].sort((a, b) => b.timestamp - a.timestamp)
+                          const seen = new Set<string>()
+                          const ids: string[] = []
+                          for (const run of sorted) {
+                            if (seen.has(run.instance.client)) continue
+                            if (run.tests.tests_total > 0 && run.tests.tests_passed === run.tests.tests_total) {
+                              seen.add(run.instance.client)
+                              ids.push(run.run_id)
+                            }
+                            if (ids.length >= MAX_COMPARE_RUNS) break
+                          }
+                          if (ids.length >= MIN_COMPARE_RUNS) {
+                            navigate({ to: '/compare', search: { runs: ids.join(',') } })
+                          }
+                        } : undefined}
+                        isDark={isDark}
+                        colorNormalization={heatmapColor}
+                        onColorNormalizationChange={handleHeatmapColorChange}
+                        stepFilter={stepFilter}
+                        selectable={compareMode}
+                        selectedRunIds={selectedRunIds}
+                        onSelectionChange={handleSelectionChange}
+                      />
                     </div>
                   )}
                 </div>

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -19,6 +19,7 @@ import { OpcodeHeatmap } from '@/components/suite-detail/OpcodeHeatmap'
 import { RunsTable } from '@/components/runs/RunsTable'
 import { sortIndexEntries, type SortColumn, type SortDirection } from '@/components/runs/sortEntries'
 import { RunFilters, type TestStatusFilter } from '@/components/runs/RunFilters'
+import { parseLabelFilters, serializeLabelFilters, type LabelFilter } from '@/components/runs/labelFilterUtils'
 import { LoadingState, Spinner } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { Badge } from '@/components/shared/Badge'
@@ -88,6 +89,7 @@ export function SuiteDetailPage() {
     chartPassingOnly?: string
     heatmapColor?: ColorNormalization
     steps?: string
+    labels?: string
     hq?: string
     hn?: string
     hr?: string
@@ -101,6 +103,7 @@ export function SuiteDetailPage() {
   const { tab, client, image, status = 'all', sortBy = 'timestamp', sortDir = 'desc', filesPage, detail, opcodeSort, q, chartMode = 'runCount', heatmapColor = 'suite', hq, hn, hr, hFs, hStat, hCs, hTh, hRpc, hPs } = search
   const chartPassingOnly = search.chartPassingOnly !== 'false'
   const stepFilter = parseStepFilter(search.steps)
+  const labelFilters = parseLabelFilters(search.labels)
   const { data: suite, isLoading, error, refetch } = useSuite(suiteHash)
   const { data: suiteStats, isLoading: suiteStatsLoading } = useSuiteStats(suiteHash)
   const { data: index } = useIndex()
@@ -242,9 +245,12 @@ export function SuiteDetailPage() {
       if (status === 'failing' && e.tests.tests_total - e.tests.tests_passed === 0) return false
       if (status === 'timeout' && e.status !== 'timeout') return false
       if (status === 'cancelled' && e.status !== 'cancelled') return false
+      for (const lf of labelFilters) {
+        if (e.metadata?.[lf.key] !== lf.value) return false
+      }
       return true
     })
-  }, [suiteRunsAll, client, image, status])
+  }, [suiteRunsAll, client, image, status, labelFilters])
 
   const sortedRuns = useMemo(() => sortIndexEntries(filteredRuns, sortBy, sortDir, stepFilter), [filteredRuns, sortBy, sortDir, stepFilter])
   const totalRunsPages = Math.ceil(sortedRuns.length / runsPageSize)
@@ -260,7 +266,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client: newClient, image, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client: newClient, image, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -269,7 +275,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image: newImage, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client, image: newImage, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -278,7 +284,16 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status: newStatus, sortBy, sortDir, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client, image, status: newStatus, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
+    })
+  }
+
+  const handleLabelFiltersChange = (newFilters: LabelFilter[]) => {
+    setRunsPage(1)
+    navigate({
+      to: '/suites/$suiteHash',
+      params: { suiteHash },
+      search: { tab, client, image, status, sortBy, sortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(newFilters) },
     })
   }
 
@@ -329,7 +344,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy: newSortBy, sortDir: newSortDir, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client, image, status, sortBy: newSortBy, sortDir: newSortDir, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -337,7 +352,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, filesPage: page, q, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client, image, status, sortBy, sortDir, filesPage: page, q, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -345,7 +360,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, filesPage: 1, q: query || undefined, chartMode, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client, image, status, sortBy, sortDir, filesPage: 1, q: query || undefined, chartMode, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -353,7 +368,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, filesPage, detail: index, opcodeSort, q, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client, image, status, sortBy, sortDir, filesPage, detail: index, opcodeSort, q, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -361,7 +376,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, filesPage, detail, opcodeSort: sort === 'name' ? undefined : sort, q, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client, image, status, sortBy, sortDir, filesPage, detail, opcodeSort: sort === 'name' ? undefined : sort, q, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -371,7 +386,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode: mode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode: mode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -379,7 +394,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: passingOnly ? undefined : 'false', heatmapColor, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: passingOnly ? undefined : 'false', heatmapColor, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -387,7 +402,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor: mode, steps: serializeStepFilter(stepFilter) },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor: mode, steps: serializeStepFilter(stepFilter), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -467,7 +482,7 @@ export function SuiteDetailPage() {
     navigate({
       to: '/suites/$suiteHash',
       params: { suiteHash },
-      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(steps) },
+      search: { tab, client, image, status, sortBy, sortDir, chartMode, chartPassingOnly: chartPassingOnlyParam, heatmapColor, steps: serializeStepFilter(steps), labels: serializeLabelFilters(labelFilters) },
     })
   }
 
@@ -784,6 +799,9 @@ export function SuiteDetailPage() {
                     onImageChange={handleImageChange}
                     selectedStatus={status}
                     onStatusChange={handleStatusChange}
+                    entries={suiteRunsAll}
+                    labelFilters={labelFilters}
+                    onLabelFiltersChange={handleLabelFiltersChange}
                   />
                 </div>
                 {filteredRuns.length === 0 ? (

--- a/ui/src/utils/client-colors.ts
+++ b/ui/src/utils/client-colors.ts
@@ -37,13 +37,34 @@ export const clientColors: Record<string, { bg: string; text: string; darkBg: st
   },
 }
 
+/** Extract the base client name from a potentially grouped name like "geth / mainnet". */
+export function getBaseClient(client: string): string {
+  return client.includes(' / ') ? client.slice(0, client.indexOf(' / ')) : client
+}
+
 export function getClientColors(client: string) {
   return (
-    clientColors[client] ?? {
+    clientColors[getBaseClient(client)] ?? {
       bg: 'bg-gray-100',
       text: 'text-gray-800',
       darkBg: 'dark:bg-gray-700',
       darkText: 'dark:text-gray-200',
     }
   )
+}
+
+/** Chart hex colors per client (used by ECharts series). */
+const clientChartColors: Record<string, string> = {
+  geth: '#3b82f6',
+  reth: '#f97316',
+  nethermind: '#a855f7',
+  besu: '#22c55e',
+  erigon: '#ef4444',
+  nimbus: '#eab308',
+}
+
+const DEFAULT_CHART_COLOR = '#6b7280'
+
+export function getClientChartColor(client: string): string {
+  return clientChartColors[getBaseClient(client)] ?? DEFAULT_CHART_COLOR
 }


### PR DESCRIPTION
## Summary
Comprehensive metadata labels support across the UI, building on the backend label infrastructure.

### Label Filtering
- Replace single-value label filters with multi-value chip UI (OR within key, AND across keys) on the runs table, suite detail page, and suites page — consistent Grafana-style filter chips everywhere
- URL format: `key1:val1|val2,key2:val3`

### Label Visibility
- **Run detail page**: show metadata labels as blue chips between stats cards and GitHub section
- **Runs table**: expandable row via tag icon (rightmost column) with label chips and instance ID; hover popover on the tag icon; suite hash hover popover showing suite name, hash, filter, test count, and labels
- **Heatmap tooltip**: show instance ID and labels when hovering over run squares

### Suite Detail — Group By
- Add group-by selector (label key or instance ID) to the suite detail Runs tab
- **Heatmap**: renders grouped sections with headers, each containing per-client rows with independent stats
- **Charts**: separate series per client+group combo via client name suffixing
- **Chart filters**: client toggle badges and label chip filters for the Run Charts section, using base client names so they work correctly with group-by active
- Fix ECharts `notMerge` so filtered-out series actually disappear

### Suite Detail — Compare Buttons
- Per-group compare button in heatmap headers (compare latest successful run per client within a group)
- Cross-group compare button per client badge (compare a client's latest successful run across all groups)
- Cross-group compare defaults the compare page label mode to the group-by key

### Compare Page
- Dynamic label mode options built from runs' metadata (in addition to None and Instance ID)
- Label mode stored in URL as `label:{key}` for metadata labels

### Infrastructure
- Centralize client chart colors in `client-colors.ts` with `getBaseClient()` extraction so grouped names like "geth / mainnet" resolve to correct colors in badges, charts, and logos

## Test plan
- [x] Verify label filter chips work on /runs, suite detail runs tab, and /suites pages
- [x] Verify labels show on run detail page, runs table (tag icon + popover), and heatmap tooltip
- [x] Test group-by on suite detail: heatmap sections, chart series, chart filters
- [x] Test per-group and cross-group compare buttons navigate correctly
- [x] Verify compare page shows dynamic label options and defaults from group-by
- [x] Verify client colors are correct across all views when group-by is active