### PR TITLE
feat(ui): shared zoom and table separators on compare page

### DIFF
--- a/ui/src/components/compare/MGasComparisonChart.tsx
+++ b/ui/src/components/compare/MGasComparisonChart.tsx
@@ -5,12 +5,19 @@ import type { RunResult, SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
+export interface ZoomRange {
+  start: number
+  end: number
+}
+
 interface MGasComparisonChartProps {
   runs: CompareRun[]
   suiteTests?: SuiteTest[]
   stepFilter: StepTypeOption[]
   labelMode: LabelMode
   testNameFilter?: (name: string) => boolean
+  zoomRange?: ZoomRange
+  onZoomChange?: (range: ZoomRange) => void
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -64,9 +71,10 @@ function buildMGasData(
   return entries.map((e, i) => ({ testIndex: i + 1, testOrder: e.order, testName: e.name, mgas: e.mgas }))
 }
 
-export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, testNameFilter }: MGasComparisonChartProps) {
+export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, testNameFilter, zoomRange: externalZoom, onZoomChange }: MGasComparisonChartProps) {
   const isDark = useDarkMode()
-  const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
+  const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
+  const zoomRange = externalZoom ?? internalZoom
   const prevZoomRef = useRef(zoomRange)
 
   const handleZoom = useCallback((params: { start?: number; end?: number; batch?: Array<{ start: number; end: number }> }) => {
@@ -80,10 +88,12 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
       end = params.end
     }
     if (start !== undefined && end !== undefined && (prevZoomRef.current.start !== start || prevZoomRef.current.end !== end)) {
-      prevZoomRef.current = { start, end }
-      setZoomRange({ start, end })
+      const newRange = { start, end }
+      prevZoomRef.current = newRange
+      setInternalZoom(newRange)
+      onZoomChange?.(newRange)
     }
-  }, [])
+  }, [onZoomChange])
 
   const onEvents = useMemo(() => ({ datazoom: handleZoom }), [handleZoom])
 

--- a/ui/src/components/compare/MGasComparisonChart.tsx
+++ b/ui/src/components/compare/MGasComparisonChart.tsx
@@ -3,7 +3,7 @@ import ReactECharts from 'echarts-for-react'
 import { Flame } from 'lucide-react'
 import type { RunResult, SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
-import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
+import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 export interface ZoomRange {
   start: number
@@ -18,6 +18,7 @@ interface MGasComparisonChartProps {
   testNameFilter?: (name: string) => boolean
   zoomRange?: ZoomRange
   onZoomChange?: (range: ZoomRange) => void
+  chartType?: ChartType
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -71,7 +72,7 @@ function buildMGasData(
   return entries.map((e, i) => ({ testIndex: i + 1, testOrder: e.order, testName: e.name, mgas: e.mgas }))
 }
 
-export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, testNameFilter, zoomRange: externalZoom, onZoomChange }: MGasComparisonChartProps) {
+export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line' }: MGasComparisonChartProps) {
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -212,20 +213,30 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
       series: runs.map((_run, i) => {
         const slot = RUN_SLOTS[i]
         const points = pointsPerRun[i]
-        return {
+        const data = points.map((d) => [d.testIndex, d.mgas, d.testName, d.testOrder])
+        const base = {
           name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
+          data,
+          itemStyle: { color: slot.color },
+        }
+        if (chartType === 'bar') {
+          return { ...base, type: 'bar' as const, barMaxWidth: 6 }
+        }
+        if (chartType === 'dot') {
+          return { ...base, type: 'scatter' as const, symbolSize: 4 }
+        }
+        return {
+          ...base,
           type: 'line' as const,
           smooth: maxLen <= 100,
           showSymbol: maxLen <= 100,
           symbolSize: 4,
           lineStyle: { width: 2 },
-          data: points.map((d) => [d.testIndex, d.mgas, d.testName, d.testOrder]),
-          itemStyle: { color: slot.color },
           areaStyle: { opacity: 0.08, color: slot.color },
         }
       }),
     }
-  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, testNameFilter])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType])
 
   if (pointsPerRun.every((p) => p.length === 0)) return null
 

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -4,6 +4,7 @@ import { ArrowRightLeft } from 'lucide-react'
 import type { SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
+import type { ZoomRange } from './MGasComparisonChart'
 
 interface PercentageDiffChartProps {
   runs: CompareRun[]
@@ -15,6 +16,8 @@ interface PercentageDiffChartProps {
   diffFilter: 'all' | 'faster' | 'slower'
   onDiffFilterChange: (val: 'all' | 'faster' | 'slower') => void
   testNameFilter?: (name: string) => boolean
+  zoomRange?: ZoomRange
+  onZoomChange?: (range: ZoomRange) => void
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -109,9 +112,10 @@ function buildDiffData(
   }))
 }
 
-export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode, diffFilter, onDiffFilterChange, testNameFilter }: PercentageDiffChartProps) {
+export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode, diffFilter, onDiffFilterChange, testNameFilter, zoomRange: externalZoom, onZoomChange }: PercentageDiffChartProps) {
   const isDark = useDarkMode()
-  const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
+  const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
+  const zoomRange = externalZoom ?? internalZoom
   const prevZoomRef = useRef(zoomRange)
 
   const handleZoom = useCallback((params: { start?: number; end?: number; batch?: Array<{ start: number; end: number }> }) => {
@@ -125,10 +129,12 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
       end = params.end
     }
     if (start !== undefined && end !== undefined && (prevZoomRef.current.start !== start || prevZoomRef.current.end !== end)) {
-      prevZoomRef.current = { start, end }
-      setZoomRange({ start, end })
+      const newRange = { start, end }
+      prevZoomRef.current = newRange
+      setInternalZoom(newRange)
+      onZoomChange?.(newRange)
     }
-  }, [])
+  }, [onZoomChange])
 
   const onEvents = useMemo(() => ({ datazoom: handleZoom }), [handleZoom])
 

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -3,7 +3,7 @@ import ReactECharts from 'echarts-for-react'
 import { ArrowRightLeft } from 'lucide-react'
 import type { SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
-import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
+import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 import type { ZoomRange } from './MGasComparisonChart'
 
 interface PercentageDiffChartProps {
@@ -18,6 +18,7 @@ interface PercentageDiffChartProps {
   testNameFilter?: (name: string) => boolean
   zoomRange?: ZoomRange
   onZoomChange?: (range: ZoomRange) => void
+  chartType?: ChartType
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -112,7 +113,7 @@ function buildDiffData(
   }))
 }
 
-export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode, diffFilter, onDiffFilterChange, testNameFilter, zoomRange: externalZoom, onZoomChange }: PercentageDiffChartProps) {
+export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode, diffFilter, onDiffFilterChange, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line' }: PercentageDiffChartProps) {
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -283,30 +284,40 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
         },
         ...otherRunIndices.map((runIdx, seriesIdx) => {
           const slot = RUN_SLOTS[runIdx]
-          return {
+          const data = diffData.map((d) => {
+            const diff = d.diffs[seriesIdx]
+            const absMGas = d.values[seriesIdx]
+            if (diff === null || absMGas === null) return null
+            if (diffFilter === 'faster' && diff < 0) return null
+            if (diffFilter === 'slower' && diff > 0) return null
+            return {
+              value: [d.testIndex, diff, d.testName, d.baselineValue, absMGas, d.testOrder],
+            }
+          }).filter(Boolean)
+          const base = {
             name: `vs ${formatRunLabel(slot, runs[runIdx], labelMode)}`,
+            data,
+            itemStyle: { color: slot.color },
+          }
+          if (chartType === 'bar') {
+            return { ...base, type: 'bar' as const, barMaxWidth: 6 }
+          }
+          if (chartType === 'dot') {
+            return { ...base, type: 'scatter' as const, symbolSize: 4 }
+          }
+          return {
+            ...base,
             type: 'line' as const,
             smooth: diffData.length <= 100,
             showSymbol: diffData.length <= 100,
             symbolSize: 4,
             lineStyle: { width: 2 },
-            data: diffData.map((d) => {
-              const diff = d.diffs[seriesIdx]
-              const absMGas = d.values[seriesIdx]
-              if (diff === null || absMGas === null) return null
-              if (diffFilter === 'faster' && diff < 0) return null
-              if (diffFilter === 'slower' && diff > 0) return null
-              return {
-                value: [d.testIndex, diff, d.testName, d.baselineValue, absMGas, d.testOrder],
-              }
-            }).filter(Boolean),
-            itemStyle: { color: slot.color },
             areaStyle: { opacity: 0.08, color: slot.color },
           }
         }),
       ],
     }
-  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange, labelMode, diffFilter])
+  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange, labelMode, diffFilter, chartType])
 
   if (runs.every((r) => r.result === null)) return null
 

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -399,12 +399,12 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
               <th className="pb-1 text-right font-medium">Faster</th>
               <th className="pb-1 text-right font-medium">Avg %</th>
               <th className="pb-1 text-right font-medium">P95 %</th>
-              <th className="pb-1 text-right font-medium">P99 %</th>
-              <th className="pb-1 text-right font-medium">Slower</th>
+              <th className="pb-1 pr-3 text-right font-medium">P99 %</th>
+              <th className="border-l border-gray-200 pb-1 pl-3 text-right font-medium dark:border-gray-600">Slower</th>
               <th className="pb-1 text-right font-medium">Avg %</th>
               <th className="pb-1 text-right font-medium">P95 %</th>
-              <th className="pb-1 text-right font-medium">P99 %</th>
-              <th className="pb-1 text-right font-medium">Equal</th>
+              <th className="pb-1 pr-3 text-right font-medium">P99 %</th>
+              <th className="border-l border-gray-200 pb-1 pl-3 text-right font-medium dark:border-gray-600">Equal</th>
               <th className="pb-1 text-right font-medium">Total</th>
             </tr>
           </thead>
@@ -441,12 +441,12 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
                   <td className="py-1 text-right font-medium text-green-600 dark:text-green-400">{fasterPcts.length}</td>
                   <td className="py-1 text-right text-green-600 dark:text-green-400">{fasterPcts.length > 0 ? `+${avg(fasterPcts).toFixed(1)}%` : '-'}</td>
                   <td className="py-1 text-right text-green-600 dark:text-green-400">{fasterPcts.length > 0 ? `+${percentile(fasterPcts, 95).toFixed(1)}%` : '-'}</td>
-                  <td className="py-1 text-right text-green-600 dark:text-green-400">{fasterPcts.length > 0 ? `+${percentile(fasterPcts, 99).toFixed(1)}%` : '-'}</td>
-                  <td className="py-1 text-right font-medium text-red-600 dark:text-red-400">{slowerPcts.length}</td>
+                  <td className="py-1 pr-3 text-right text-green-600 dark:text-green-400">{fasterPcts.length > 0 ? `+${percentile(fasterPcts, 99).toFixed(1)}%` : '-'}</td>
+                  <td className="border-l border-gray-200 py-1 pl-3 text-right font-medium text-red-600 dark:border-gray-600 dark:text-red-400">{slowerPcts.length}</td>
                   <td className="py-1 text-right text-red-600 dark:text-red-400">{slowerPcts.length > 0 ? `-${avg(slowerPcts).toFixed(1)}%` : '-'}</td>
                   <td className="py-1 text-right text-red-600 dark:text-red-400">{slowerPcts.length > 0 ? `-${percentile(slowerPcts, 95).toFixed(1)}%` : '-'}</td>
-                  <td className="py-1 text-right text-red-600 dark:text-red-400">{slowerPcts.length > 0 ? `-${percentile(slowerPcts, 99).toFixed(1)}%` : '-'}</td>
-                  <td className="py-1 text-right text-gray-400 dark:text-gray-500">{equal}</td>
+                  <td className="py-1 pr-3 text-right text-red-600 dark:text-red-400">{slowerPcts.length > 0 ? `-${percentile(slowerPcts, 99).toFixed(1)}%` : '-'}</td>
+                  <td className="border-l border-gray-200 py-1 pl-3 text-right text-gray-400 dark:border-gray-600 dark:text-gray-500">{equal}</td>
                   <td className="py-1 text-right text-gray-500 dark:text-gray-400">{total}</td>
                 </tr>
               )

--- a/ui/src/components/compare/ResourceComparisonCharts.tsx
+++ b/ui/src/components/compare/ResourceComparisonCharts.tsx
@@ -3,7 +3,7 @@ import ReactECharts from 'echarts-for-react'
 import { Cpu } from 'lucide-react'
 import type { TestEntry, ResourceTotals, SuiteTest } from '@/api/types'
 import { formatBytes } from '@/utils/format'
-import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
+import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 import type { ZoomRange } from './MGasComparisonChart'
 
 interface AggregatedResourceData {
@@ -81,6 +81,7 @@ interface ResourceComparisonChartsProps {
   suiteTests?: SuiteTest[]
   zoomRange?: ZoomRange
   onZoomChange?: (range: ZoomRange) => void
+  chartType?: ChartType
 }
 
 interface ResourceDataPoint {
@@ -183,7 +184,7 @@ function ChartSection({ title, option, onZoom }: ChartSectionProps) {
   )
 }
 
-export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suiteTests, zoomRange: externalZoom, onZoomChange }: ResourceComparisonChartsProps) {
+export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suiteTests, zoomRange: externalZoom, onZoomChange, chartType = 'line' }: ResourceComparisonChartsProps) {
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -274,13 +275,17 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suit
       ],
     }
 
-    const createLineSeries = () => ({
-      type: 'line' as const,
-      smooth: maxLen <= 100,
-      showSymbol: maxLen <= 100,
-      symbolSize: 4,
-      lineStyle: { width: 2 },
-    })
+    const createSeriesStyle = () => {
+      if (chartType === 'bar') return { type: 'bar' as const, barMaxWidth: 6 }
+      if (chartType === 'dot') return { type: 'scatter' as const, symbolSize: 4 }
+      return {
+        type: 'line' as const,
+        smooth: maxLen <= 100,
+        showSymbol: maxLen <= 100,
+        symbolSize: 4,
+        lineStyle: { width: 2 },
+      }
+    }
 
     // Map series names to client: "Run A" → client, "A Read" → client, "A Write" → client
     const clientBySeriesName = new Map<string, string>()
@@ -335,10 +340,10 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suit
         const points = pointsPerRun[i]
         return {
           name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
-          ...createLineSeries(),
+          ...createSeriesStyle(),
           data: points.map((d) => [d.testIndex, d[field], d.testName, d.testOrder]),
           itemStyle: { color: slot.color },
-          areaStyle: { opacity: 0.08, color: slot.color },
+          ...(chartType === 'line' ? { areaStyle: { opacity: 0.08, color: slot.color } } : {}),
         }
       })
 
@@ -399,7 +404,7 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suit
     }
 
     return { cpuPercentOption, memoryMBOption, cpuTimeOption, memoryDeltaOption, diskReadBytesOption, diskWriteBytesOption, diskReadOpsOption, diskWriteOpsOption }
-  }, [pointsPerRun, runs, isDark, zoomRange, labelMode])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType])
 
   if (!hasData) return null
 

--- a/ui/src/components/compare/ResourceComparisonCharts.tsx
+++ b/ui/src/components/compare/ResourceComparisonCharts.tsx
@@ -4,6 +4,7 @@ import { Cpu } from 'lucide-react'
 import type { TestEntry, ResourceTotals, SuiteTest } from '@/api/types'
 import { formatBytes } from '@/utils/format'
 import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
+import type { ZoomRange } from './MGasComparisonChart'
 
 interface AggregatedResourceData {
   totals: ResourceTotals
@@ -78,6 +79,8 @@ interface ResourceComparisonChartsProps {
   labelMode: LabelMode
   testNameFilter?: (name: string) => boolean
   suiteTests?: SuiteTest[]
+  zoomRange?: ZoomRange
+  onZoomChange?: (range: ZoomRange) => void
 }
 
 interface ResourceDataPoint {
@@ -180,17 +183,20 @@ function ChartSection({ title, option, onZoom }: ChartSectionProps) {
   )
 }
 
-export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suiteTests }: ResourceComparisonChartsProps) {
+export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suiteTests, zoomRange: externalZoom, onZoomChange }: ResourceComparisonChartsProps) {
   const isDark = useDarkMode()
-  const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
+  const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
+  const zoomRange = externalZoom ?? internalZoom
   const prevZoomRef = useRef(zoomRange)
 
   const handleZoom = useCallback((start: number, end: number) => {
     if (prevZoomRef.current.start !== start || prevZoomRef.current.end !== end) {
-      prevZoomRef.current = { start, end }
-      setZoomRange({ start, end })
+      const newRange = { start, end }
+      prevZoomRef.current = newRange
+      setInternalZoom(newRange)
+      onZoomChange?.(newRange)
     }
-  }, [])
+  }, [onZoomChange])
 
   const pointsPerRun = useMemo(
     () => runs.map((r) => r.result ? buildDataPoints(r.result.tests, testNameFilter, suiteTests) : []),

--- a/ui/src/components/compare/constants.ts
+++ b/ui/src/components/compare/constants.ts
@@ -88,6 +88,14 @@ export interface CompareRun {
 
 export type LabelMode = 'none' | 'instance-id'
 
+export type ChartType = 'line' | 'bar' | 'dot'
+
+export const CHART_TYPE_OPTIONS: { value: ChartType; label: string }[] = [
+  { value: 'line', label: 'Line' },
+  { value: 'bar', label: 'Bar' },
+  { value: 'dot', label: 'Dot' },
+]
+
 export const LABEL_MODE_OPTIONS: { value: LabelMode; label: string }[] = [
   { value: 'none', label: 'None' },
   { value: 'instance-id', label: 'Instance ID' },

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -13,6 +13,7 @@ import { CompareHeader } from '@/components/compare/CompareHeader'
 import { StickyRunBar } from '@/components/compare/StickyRunBar'
 import { MetricsComparison } from '@/components/compare/MetricsComparison'
 import { MGasComparisonChart } from '@/components/compare/MGasComparisonChart'
+import { type ChartType, CHART_TYPE_OPTIONS } from '@/components/compare/constants'
 import { PercentageDiffChart } from '@/components/compare/PercentageDiffChart'
 import { TestComparisonTable } from '@/components/compare/TestComparisonTable'
 import { ResourceComparisonCharts } from '@/components/compare/ResourceComparisonCharts'
@@ -125,6 +126,7 @@ export function ComparePage() {
   const testFilterRegex = search.filterRegex === '1'
   const [sharedZoom, setSharedZoom] = useState(true)
   const [chartZoom, setChartZoom] = useState({ start: 0, end: 100 })
+  const [chartType, setChartType] = useState<ChartType>('line')
 
   const testNameFilter = useMemo(() => {
     if (!testFilter) return undefined
@@ -255,6 +257,24 @@ export function ComparePage() {
           </div>
         </div>
         <div className="flex items-center gap-1.5">
+          <span>Chart:</span>
+          <div className="flex gap-1">
+            {CHART_TYPE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => setChartType(opt.value)}
+                className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+                  chartType === opt.value
+                    ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5">
           <span>Shared Zoom:</span>
           <button
             onClick={() => setSharedZoom(!sharedZoom)}
@@ -317,16 +337,16 @@ export function ComparePage() {
       <MetricsComparison runs={runs} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} />
 
       {allResults && (
-        <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} labelMode={labelMode} testNameFilter={testNameFilter} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} />
+        <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} labelMode={labelMode} testNameFilter={testNameFilter} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} chartType={chartType} />
       )}
 
       {allResults && (
-        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} diffFilter={diffFilter} onDiffFilterChange={setDiffFilter} testNameFilter={testNameFilter} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} />
+        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} diffFilter={diffFilter} onDiffFilterChange={setDiffFilter} testNameFilter={testNameFilter} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} chartType={chartType} />
       )}
 
       <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} labelMode={labelMode} testNameFilter={testNameFilter} />
 
-      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} suiteTests={suite?.tests} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} />}
+      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} suiteTests={suite?.tests} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} chartType={chartType} />}
 
       {allResults && (
         <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} tableBaseline={tableBaseline} onTableBaselineChange={setTableBaseline} sortBy={tableSortBy} sortDir={tableSortDir} onSortChange={setTableSort} testNameFilter={testNameFilter} />

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import clsx from 'clsx'
 import { Link, useSearch, useNavigate } from '@tanstack/react-router'
 import { useQueries } from '@tanstack/react-query'
@@ -123,6 +123,8 @@ export function ComparePage() {
   const diffFilter = (search.diffFilter === 'faster' || search.diffFilter === 'slower' ? search.diffFilter : 'all') as 'all' | 'faster' | 'slower'
   const testFilter = search.filter ?? ''
   const testFilterRegex = search.filterRegex === '1'
+  const [sharedZoom, setSharedZoom] = useState(true)
+  const [chartZoom, setChartZoom] = useState({ start: 0, end: 100 })
 
   const testNameFilter = useMemo(() => {
     if (!testFilter) return undefined
@@ -253,6 +255,19 @@ export function ComparePage() {
           </div>
         </div>
         <div className="flex items-center gap-1.5">
+          <span>Shared Zoom:</span>
+          <button
+            onClick={() => setSharedZoom(!sharedZoom)}
+            className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+              sharedZoom
+                ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+            }`}
+          >
+            {sharedZoom ? 'On' : 'Off'}
+          </button>
+        </div>
+        <div className="flex items-center gap-1.5">
           <span>Filter:</span>
           <input
             type="text"
@@ -302,16 +317,16 @@ export function ComparePage() {
       <MetricsComparison runs={runs} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} />
 
       {allResults && (
-        <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} labelMode={labelMode} testNameFilter={testNameFilter} />
+        <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} labelMode={labelMode} testNameFilter={testNameFilter} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} />
       )}
 
       {allResults && (
-        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} diffFilter={diffFilter} onDiffFilterChange={setDiffFilter} testNameFilter={testNameFilter} />
+        <PercentageDiffChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} diffFilter={diffFilter} onDiffFilterChange={setDiffFilter} testNameFilter={testNameFilter} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} />
       )}
 
       <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} labelMode={labelMode} testNameFilter={testNameFilter} />
 
-      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} suiteTests={suite?.tests} />}
+      {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} suiteTests={suite?.tests} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} />}
 
       {allResults && (
         <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} tableBaseline={tableBaseline} onTableBaselineChange={setTableBaseline} sortBy={tableSortBy} sortDir={tableSortDir} onSortChange={setTableSort} testNameFilter={testNameFilter} />


### PR DESCRIPTION
## Summary
- Add shared zoom across MGas/s, % Difference, and Resource Usage charts — zooming one chart syncs all others
- Add a "Shared Zoom" toggle (enabled by default) next to the Labels selector
- Add a "Chart" type selector (Line / Bar / Dot) that switches all charts between line, bar, and scatter rendering
- Add visual border separators between Faster/Slower/Equal groups in the % Difference summary table

## Test plan
- [x] Zoom in one chart and verify all charts sync when Shared Zoom is On
- [x] Toggle Shared Zoom Off and verify charts zoom independently
- [x] Switch between Line, Bar, and Dot modes and verify all charts update
- [x] Verify table separators have proper spacing in both light and dark mode