### PR TITLE
feat: skip graceful stop for ZFS-based rollback strategies

### DIFF
--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -734,7 +734,7 @@ func (r *runner) runContainerLifecycle(
 
 		stopCancel()
 
-		log.WithField("duration", time.Since(stopStart)).Debug(
+		log.WithField("duration", time.Since(stopStart)).Info(
 			"Container stopped",
 		)
 
@@ -751,7 +751,7 @@ func (r *runner) runContainerLifecycle(
 			log.WithError(rmErr).Warn("Failed to remove container")
 		}
 
-		log.WithField("duration", time.Since(rmStart)).Debug(
+		log.WithField("duration", time.Since(rmStart)).Info(
 			"Container removed",
 		)
 

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -723,23 +723,37 @@ func (r *runner) runContainerLifecycle(
 		stopCtx, stopCancel := context.WithTimeout(
 			context.Background(), 30*time.Second,
 		)
+
+		stopStart := time.Now()
+
 		if stopErr := r.containerMgr.StopContainer(
 			stopCtx, containerID,
 		); stopErr != nil {
 			log.WithError(stopErr).Debug("Failed to stop container")
 		}
+
 		stopCancel()
+
+		log.WithField("duration", time.Since(stopStart)).Debug(
+			"Container stopped",
+		)
 
 		// Now that the container is stopped, the log-streaming
 		// goroutine should return quickly.
 		waitForLogDrain(&logDone, &logCancel, logDrainTimeout)
 
 		// Remove the stopped container.
+		rmStart := time.Now()
+
 		if rmErr := r.containerMgr.RemoveContainer(
 			context.Background(), containerID,
 		); rmErr != nil {
 			log.WithError(rmErr).Warn("Failed to remove container")
 		}
+
+		log.WithField("duration", time.Since(rmStart)).Debug(
+			"Container removed",
+		)
 
 		_ = logFile.Close()
 	})

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -102,9 +102,15 @@ func (r *runner) runTestsWithCheckpointRestore(
 	if r.cfg.FullConfig.GetCheckpointRestartContainer(params.Instance) {
 		log.Info("Restarting container before checkpoint for clean process state")
 
+		stopStart := time.Now()
+
 		if err := r.containerMgr.StopContainer(ctx, containerID); err != nil {
 			return nil, fmt.Errorf("stopping container before checkpoint restart: %w", err)
 		}
+
+		log.WithField("duration", time.Since(stopStart)).Debug(
+			"Container stopped for checkpoint restart",
+		)
 
 		// Drain logs from the stopped container.
 		waitForLogDrain(logDone, logCancel, logDrainTimeout)
@@ -275,9 +281,17 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 	waitAfterTCPDrop := r.cfg.FullConfig.GetCheckpointWaitAfterTCPDropConns(params.Instance)
 
+	log.Info("Checkpointing container")
+
+	cpStart := time.Now()
+
 	if err := cpMgr.CheckpointContainer(ctx, containerID, exportPath, waitAfterTCPDrop); err != nil {
 		return nil, fmt.Errorf("checkpointing container: %w", err)
 	}
+
+	log.WithField("duration", time.Since(cpStart)).Info(
+		"Container checkpointed",
+	)
 
 	defer func() {
 		_ = os.Remove(exportPath)
@@ -414,6 +428,9 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 		// Restore container from checkpoint.
 		restoreName := fmt.Sprintf("%s-restore-%d", params.ContainerSpec.Name, i)
+		testLog.Debug("Restoring container from checkpoint")
+
+		restoreStart := time.Now()
 
 		restoredID, err := cpMgr.RestoreContainer(ctx, exportPath, &podman.RestoreOptions{
 			Name:        restoreName,
@@ -424,6 +441,10 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 			return combined, fmt.Errorf("restoring container for test %d: %w", i, err)
 		}
+
+		testLog.WithField("duration", time.Since(restoreStart)).Debug(
+			"Container restored from checkpoint",
+		)
 
 		// Register cleanup for this iteration.
 		iterID := restoredID
@@ -499,9 +520,13 @@ func (r *runner) runTestsWithCheckpointRestore(
 		// Force-remove the container (no graceful stop needed — ZFS
 		// rollback discards the datadir anyway). Use a fresh context
 		// so this succeeds even if the parent was cancelled (CTRL+C).
+		testLog.Debug("Force-removing restored container")
+
+		rmStart := time.Now()
 		rmCtx, rmCancel := context.WithTimeout(
 			context.Background(), 30*time.Second,
 		)
+
 		if rmErr := r.containerMgr.RemoveContainer(
 			rmCtx, restoredID,
 		); rmErr != nil && !isContainerNotFound(rmErr) {
@@ -509,7 +534,12 @@ func (r *runner) runTestsWithCheckpointRestore(
 				"Failed to remove restored container",
 			)
 		}
+
 		rmCancel()
+
+		testLog.WithField("duration", time.Since(rmStart)).Debug(
+			"Restored container removed",
+		)
 
 		waitForLogDrain(logDone, logCancel, logDrainTimeout)
 

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -108,7 +108,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 			return nil, fmt.Errorf("stopping container before checkpoint restart: %w", err)
 		}
 
-		log.WithField("duration", time.Since(stopStart)).Debug(
+		log.WithField("duration", time.Since(stopStart)).Info(
 			"Container stopped for checkpoint restart",
 		)
 
@@ -428,7 +428,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 		// Restore container from checkpoint.
 		restoreName := fmt.Sprintf("%s-restore-%d", params.ContainerSpec.Name, i)
-		testLog.Debug("Restoring container from checkpoint")
+		testLog.Info("Restoring container from checkpoint")
 
 		restoreStart := time.Now()
 
@@ -442,7 +442,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 			return combined, fmt.Errorf("restoring container for test %d: %w", i, err)
 		}
 
-		testLog.WithField("duration", time.Since(restoreStart)).Debug(
+		testLog.WithField("duration", time.Since(restoreStart)).Info(
 			"Container restored from checkpoint",
 		)
 
@@ -520,7 +520,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 		// Force-remove the container (no graceful stop needed — ZFS
 		// rollback discards the datadir anyway). Use a fresh context
 		// so this succeeds even if the parent was cancelled (CTRL+C).
-		testLog.Debug("Force-removing restored container")
+		testLog.Info("Force-removing restored container")
 
 		rmStart := time.Now()
 		rmCtx, rmCancel := context.WithTimeout(
@@ -537,7 +537,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 		rmCancel()
 
-		testLog.WithField("duration", time.Since(rmStart)).Debug(
+		testLog.WithField("duration", time.Since(rmStart)).Info(
 			"Restored container removed",
 		)
 

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -496,23 +496,9 @@ func (r *runner) runTestsWithCheckpointRestore(
 			testLog.WithError(execErr).Error("Test execution failed")
 		}
 
-		// Stop the container first so the attach connection closes,
-		// then remove it. Use a fresh context so this succeeds even
-		// if the parent context was cancelled (e.g., CTRL+C).
-		stopCtx, stopCancel := context.WithTimeout(
-			context.Background(), 30*time.Second,
-		)
-		if stopErr := r.containerMgr.StopContainer(
-			stopCtx, restoredID,
-		); stopErr != nil {
-			testLog.WithError(stopErr).Debug(
-				"Failed to stop restored container",
-			)
-		}
-		stopCancel()
-
-		waitForLogDrain(logDone, logCancel, logDrainTimeout)
-
+		// Force-remove the container (no graceful stop needed — ZFS
+		// rollback discards the datadir anyway). Use a fresh context
+		// so this succeeds even if the parent was cancelled (CTRL+C).
 		rmCtx, rmCancel := context.WithTimeout(
 			context.Background(), 30*time.Second,
 		)
@@ -524,6 +510,8 @@ func (r *runner) runTestsWithCheckpointRestore(
 			)
 		}
 		rmCancel()
+
+		waitForLogDrain(logDone, logCancel, logDrainTimeout)
 
 		// Aggregate results.
 		if result != nil {

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -102,9 +102,17 @@ func (r *runner) runTestsWithContainerStrategy(
 		}
 
 		// Stop the initial container so writes are flushed to disk.
+		log.Debug("Stopping container for ZFS snapshot")
+
+		stopStart := time.Now()
+
 		if err := r.containerMgr.StopContainer(ctx, containerID); err != nil {
 			return nil, fmt.Errorf("stopping container for ZFS snapshot: %w", err)
 		}
+
+		log.WithField("duration", time.Since(stopStart)).Debug(
+			"Container stopped for ZFS snapshot",
+		)
 
 		waitForLogDrain(logDone, logCancel, logDrainTimeout)
 
@@ -169,11 +177,19 @@ func (r *runner) runTestsWithContainerStrategy(
 		defer sr.cleanup()
 
 		// Remove the initial container (we'll create fresh ones per test).
+		log.Debug("Removing initial container")
+
+		rmStart := time.Now()
+
 		if err := r.containerMgr.RemoveContainer(
 			ctx, containerID,
 		); err != nil {
 			log.WithError(err).Warn("Failed to remove initial container")
 		}
+
+		log.WithField("duration", time.Since(rmStart)).Debug(
+			"Initial container removed",
+		)
 	}
 
 	combined := &executor.ExecutionResult{}
@@ -194,6 +210,8 @@ func (r *runner) runTestsWithContainerStrategy(
 				context.Background(), 30*time.Second,
 			)
 
+			stopStart := time.Now()
+
 			if err := r.containerMgr.StopContainer(
 				stopCtx, currentContainerID,
 			); err != nil {
@@ -204,12 +222,18 @@ func (r *runner) runTestsWithContainerStrategy(
 
 			stopCancel()
 
+			log.WithField("duration", time.Since(stopStart)).Debug(
+				"Container stopped on cancellation",
+			)
+
 			waitForLogDrain(logDone, logCancel, logDrainTimeout)
 
 			// Remove the stopped container.
 			rmCtx, rmCancel := context.WithTimeout(
 				context.Background(), 30*time.Second,
 			)
+
+			rmStart := time.Now()
 
 			if err := r.containerMgr.RemoveContainer(
 				rmCtx, currentContainerID,
@@ -220,6 +244,10 @@ func (r *runner) runTestsWithContainerStrategy(
 			}
 
 			rmCancel()
+
+			log.WithField("duration", time.Since(rmStart)).Debug(
+				"Container removed on cancellation",
+			)
 
 			combined.TotalDuration = time.Since(startTime)
 
@@ -244,6 +272,8 @@ func (r *runner) runTestsWithContainerStrategy(
 				// stop needed — ZFS rollback discards the datadir anyway).
 				testLog.Debug("Force-removing container before ZFS rollback")
 
+				rmStart := time.Now()
+
 				if err := r.containerMgr.RemoveContainer(
 					ctx, currentContainerID,
 				); err != nil {
@@ -251,6 +281,10 @@ func (r *runner) runTestsWithContainerStrategy(
 						"Failed to remove container",
 					)
 				}
+
+				testLog.WithField("duration", time.Since(rmStart)).Debug(
+					"Container removed before ZFS rollback",
+				)
 
 				waitForLogDrain(logDone, logCancel, logDrainTimeout)
 			}
@@ -434,21 +468,37 @@ func (r *runner) runTestsWithContainerStrategy(
 			testLog.Info("Recreating container for next test")
 
 			// Stop container first so Docker flushes remaining logs.
+			testLog.Debug("Stopping container for recreate")
+
+			stopStart := time.Now()
+
 			if err := r.containerMgr.StopContainer(
 				ctx, currentContainerID,
 			); err != nil {
 				testLog.WithError(err).Warn("Failed to stop container")
 			}
 
+			testLog.WithField("duration", time.Since(stopStart)).Debug(
+				"Container stopped for recreate",
+			)
+
 			// Wait for the log-streaming goroutine to finish.
 			waitForLogDrain(logDone, logCancel, logDrainTimeout)
 
 			// Remove the stopped container.
+			testLog.Debug("Removing stopped container")
+
+			rmStart := time.Now()
+
 			if err := r.containerMgr.RemoveContainer(
 				ctx, currentContainerID,
 			); err != nil {
 				testLog.WithError(err).Warn("Failed to remove container")
 			}
+
+			testLog.WithField("duration", time.Since(rmStart)).Debug(
+				"Container removed for recreate",
+			)
 
 			// Create a fresh data volume/datadir for the new container.
 			newSpec := *params.ContainerSpec
@@ -717,6 +767,9 @@ func (r *runner) runTestsWithContainerStrategy(
 			stopCtx, stopCancel := context.WithTimeout(
 				context.Background(), 30*time.Second,
 			)
+
+			stopStart := time.Now()
+
 			if stopErr := r.containerMgr.StopContainer(
 				stopCtx, currentContainerID,
 			); stopErr != nil {
@@ -724,7 +777,12 @@ func (r *runner) runTestsWithContainerStrategy(
 					"Failed to stop container after death/interruption",
 				)
 			}
+
 			stopCancel()
+
+			log.WithField("duration", time.Since(stopStart)).Debug(
+				"Container stopped after death/interruption",
+			)
 
 			waitForLogDrain(logDone, logCancel, logDrainTimeout)
 

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -240,16 +240,9 @@ func (r *runner) runTestsWithContainerStrategy(
 			testLog.Info("Rolling back ZFS snapshot for next test")
 
 			if i > 0 {
-				// Stop and remove container from previous test.
-				if err := r.containerMgr.StopContainer(
-					ctx, currentContainerID,
-				); err != nil {
-					testLog.WithError(err).Warn(
-						"Failed to stop container",
-					)
-				}
-
-				waitForLogDrain(logDone, logCancel, logDrainTimeout)
+				// Force-remove container from previous test (no graceful
+				// stop needed — ZFS rollback discards the datadir anyway).
+				testLog.Debug("Force-removing container before ZFS rollback")
 
 				if err := r.containerMgr.RemoveContainer(
 					ctx, currentContainerID,
@@ -258,6 +251,8 @@ func (r *runner) runTestsWithContainerStrategy(
 						"Failed to remove container",
 					)
 				}
+
+				waitForLogDrain(logDone, logCancel, logDrainTimeout)
 			}
 
 			// Rollback the ZFS dataset to the ready-state snapshot.

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -102,7 +102,7 @@ func (r *runner) runTestsWithContainerStrategy(
 		}
 
 		// Stop the initial container so writes are flushed to disk.
-		log.Debug("Stopping container for ZFS snapshot")
+		log.Info("Stopping container for ZFS snapshot")
 
 		stopStart := time.Now()
 
@@ -110,7 +110,7 @@ func (r *runner) runTestsWithContainerStrategy(
 			return nil, fmt.Errorf("stopping container for ZFS snapshot: %w", err)
 		}
 
-		log.WithField("duration", time.Since(stopStart)).Debug(
+		log.WithField("duration", time.Since(stopStart)).Info(
 			"Container stopped for ZFS snapshot",
 		)
 
@@ -177,7 +177,7 @@ func (r *runner) runTestsWithContainerStrategy(
 		defer sr.cleanup()
 
 		// Remove the initial container (we'll create fresh ones per test).
-		log.Debug("Removing initial container")
+		log.Info("Removing initial container")
 
 		rmStart := time.Now()
 
@@ -187,7 +187,7 @@ func (r *runner) runTestsWithContainerStrategy(
 			log.WithError(err).Warn("Failed to remove initial container")
 		}
 
-		log.WithField("duration", time.Since(rmStart)).Debug(
+		log.WithField("duration", time.Since(rmStart)).Info(
 			"Initial container removed",
 		)
 	}
@@ -222,7 +222,7 @@ func (r *runner) runTestsWithContainerStrategy(
 
 			stopCancel()
 
-			log.WithField("duration", time.Since(stopStart)).Debug(
+			log.WithField("duration", time.Since(stopStart)).Info(
 				"Container stopped on cancellation",
 			)
 
@@ -245,7 +245,7 @@ func (r *runner) runTestsWithContainerStrategy(
 
 			rmCancel()
 
-			log.WithField("duration", time.Since(rmStart)).Debug(
+			log.WithField("duration", time.Since(rmStart)).Info(
 				"Container removed on cancellation",
 			)
 
@@ -270,7 +270,7 @@ func (r *runner) runTestsWithContainerStrategy(
 			if i > 0 {
 				// Force-remove container from previous test (no graceful
 				// stop needed — ZFS rollback discards the datadir anyway).
-				testLog.Debug("Force-removing container before ZFS rollback")
+				testLog.Info("Force-removing container before ZFS rollback")
 
 				rmStart := time.Now()
 
@@ -282,7 +282,7 @@ func (r *runner) runTestsWithContainerStrategy(
 					)
 				}
 
-				testLog.WithField("duration", time.Since(rmStart)).Debug(
+				testLog.WithField("duration", time.Since(rmStart)).Info(
 					"Container removed before ZFS rollback",
 				)
 
@@ -468,7 +468,7 @@ func (r *runner) runTestsWithContainerStrategy(
 			testLog.Info("Recreating container for next test")
 
 			// Stop container first so Docker flushes remaining logs.
-			testLog.Debug("Stopping container for recreate")
+			testLog.Info("Stopping container for recreate")
 
 			stopStart := time.Now()
 
@@ -478,7 +478,7 @@ func (r *runner) runTestsWithContainerStrategy(
 				testLog.WithError(err).Warn("Failed to stop container")
 			}
 
-			testLog.WithField("duration", time.Since(stopStart)).Debug(
+			testLog.WithField("duration", time.Since(stopStart)).Info(
 				"Container stopped for recreate",
 			)
 
@@ -486,7 +486,7 @@ func (r *runner) runTestsWithContainerStrategy(
 			waitForLogDrain(logDone, logCancel, logDrainTimeout)
 
 			// Remove the stopped container.
-			testLog.Debug("Removing stopped container")
+			testLog.Info("Removing stopped container")
 
 			rmStart := time.Now()
 
@@ -496,7 +496,7 @@ func (r *runner) runTestsWithContainerStrategy(
 				testLog.WithError(err).Warn("Failed to remove container")
 			}
 
-			testLog.WithField("duration", time.Since(rmStart)).Debug(
+			testLog.WithField("duration", time.Since(rmStart)).Info(
 				"Container removed for recreate",
 			)
 
@@ -780,7 +780,7 @@ func (r *runner) runTestsWithContainerStrategy(
 
 			stopCancel()
 
-			log.WithField("duration", time.Since(stopStart)).Debug(
+			log.WithField("duration", time.Since(stopStart)).Info(
 				"Container stopped after death/interruption",
 			)
 


### PR DESCRIPTION
## Summary
- Skip `StopContainer` (SIGTERM + grace period) in ZFS-based rollback paths (`container-recreate` and `checkpoint-restore` strategies)
- Go straight to `RemoveContainer` (SIGKILL) since the datadir is rolled back from a ZFS snapshot anyway, making graceful shutdown unnecessary
- Reduces per-test turnaround time by eliminating the wait for graceful client shutdown

## Test plan
- [x] `go build ./pkg/runner/` and `go vet ./pkg/runner/` pass
- [x] Run a benchmark with `container-recreate` + ZFS rollback and verify containers are force-removed between tests
- [x] Run a benchmark with `checkpoint-restore` and verify containers are force-removed between tests
- [x] Verify non-ZFS `container-recreate` path still uses graceful stop
- [x] Verify initial container setup stops (before test loop) still use graceful stop