### PR TITLE
feat: show post_test_sleep_duration in UI and promote log to info

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -538,7 +538,7 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 		}
 
 		if opts.PostTestSleepDuration > 0 {
-			log.WithField("duration", opts.PostTestSleepDuration).Debug("Sleeping after test")
+			log.WithField("duration", opts.PostTestSleepDuration).Info("Sleeping after test")
 			time.Sleep(opts.PostTestSleepDuration)
 		}
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -239,6 +239,7 @@ export interface InstanceConfig {
   retry_new_payloads_syncing_state?: RetryNewPayloadsSyncingConfig
   resource_limits?: ResourceLimitsConfig
   post_test_rpc_calls?: PostTestRPCCallConfig[]
+  post_test_sleep_duration?: string
   checkpoint_restore_strategy_options?: CheckpointRestoreStrategyOptions
 }
 

--- a/ui/src/components/run-detail/RunConfiguration.tsx
+++ b/ui/src/components/run-detail/RunConfiguration.tsx
@@ -380,6 +380,23 @@ export function RunConfiguration({ instance, system, startBlock, metadata }: Run
                 </div>
               )}
 
+              {instance.post_test_sleep_duration && (
+                <div>
+                  <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Post-Test Sleep Duration</dt>
+                  <dd className="mt-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-sm/6 text-gray-900 dark:text-gray-100">
+                        {instance.post_test_sleep_duration}
+                      </span>
+                      <CopyButton text={instance.post_test_sleep_duration} />
+                    </div>
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      Sleep duration after each test, allowing clients time for internal cleanup.
+                    </p>
+                  </dd>
+                </div>
+              )}
+
               {instance.genesis && (
                 <div>
                   <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Genesis</dt>


### PR DESCRIPTION
## Summary
- Add `post_test_sleep_duration` to the TypeScript `InstanceConfig` type and render it on the run details configuration page
- Promote the post-test sleep log in the executor from `Debug` to `Info` for better observability

## Test plan
- [x] Verify `post_test_sleep_duration` appears in the config section on the run details page when set
- [x] Verify it is hidden when not configured (omitempty)
- [x] Verify the executor logs the sleep at info level