### PR TITLE
fix: flush page cache before ZFS rollback in container-recreate strategy

### DIFF
--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -287,6 +287,31 @@ func (r *runner) runTestsWithContainerStrategy(
 				)
 
 				waitForLogDrain(logDone, logCancel, logDrainTimeout)
+
+				// Flush dirty pages and drop caches BEFORE rollback.
+				// The killed container's MAP_SHARED mmap writes leave
+				// dirty pages in the page cache. Writing to drop_caches
+				// triggers a sync first, which would write those stale
+				// pages onto the rolled-back dataset — effectively
+				// undoing the rollback for recently-written blocks
+				// (e.g. MDBX meta-pages). By syncing and dropping
+				// caches before the rollback, we ensure no dirty pages
+				// survive to corrupt the post-rollback state.
+				if dropCachesPath != "" {
+					if syncErr := exec.Command("sync").Run(); syncErr != nil {
+						testLog.WithError(syncErr).Warn(
+							"Failed to sync before rollback",
+						)
+					}
+
+					if cacheErr := os.WriteFile(
+						dropCachesPath, []byte("3"), 0,
+					); cacheErr != nil {
+						testLog.WithError(cacheErr).Warn(
+							"Failed to drop page caches before rollback",
+						)
+					}
+				}
 			}
 
 			// Rollback the ZFS dataset to the ready-state snapshot.


### PR DESCRIPTION
## Summary
- After force-killing a container, dirty pages from MDBX's `MAP_SHARED` mmap writes remain in the Linux page cache. When `zfs rollback` reverts the on-disk data, those stale cached pages survive and get served to the new container — creating a mismatch between the rolled-back static files and the stale MDBX pages. Reth detects this inconsistency and crashes during unwind on the second test.
- Adds `sync` + `drop_caches` before ZFS rollback in the container-recreate strategy, matching the existing logic in the checkpoint-restore path (`strategy_checkpoint.go:403-419`).

## Test plan
- [x] `go build` and `go vet` pass
- [x] Run a reth benchmark with `container-recreate` + ZFS rollback strategy and verify the second test no longer crashes with a database integrity error