### PR TITLE
fix(ui): prevent cursor jump in filter inputs

### DIFF
--- a/ui/src/components/compare/StickyRunBar.tsx
+++ b/ui/src/components/compare/StickyRunBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
 import { type CompareRun, type LabelMode, LABEL_MODE_OPTIONS, RUN_SLOTS, formatRunLabel } from './constants'
+import { FilterInput } from '@/components/shared/FilterInput'
 
 interface StickyRunBarProps {
   runs: CompareRun[]
@@ -65,11 +66,10 @@ export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, 
         </div>
         <div className="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
           <span>Filter:</span>
-          <input
-            type="text"
+          <FilterInput
             placeholder={testFilterRegex ? 'Regex...' : 'Filter...'}
             value={testFilter}
-            onChange={(e) => onTestFilterChange(e.target.value)}
+            onValueChange={onTestFilterChange}
             className={clsx(
               'w-36 rounded-xs border bg-white px-2 py-0.5 text-xs/5 placeholder-gray-400 focus:outline-hidden focus:ring-1 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
               testFilterRegex && testFilter && (() => { try { new RegExp(testFilter); return false } catch { return true } })()

--- a/ui/src/components/run-detail/block-logs-dashboard/BlockLogsDashboard.tsx
+++ b/ui/src/components/run-detail/block-logs-dashboard/BlockLogsDashboard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { TabPanel } from '@headlessui/react'
 import { Blocks, CircleHelp, X, Maximize2 } from 'lucide-react'
 import type { BlockLogs, SuiteTest } from '@/api/types'
+import { FilterInput } from '@/components/shared/FilterInput'
 import { useDashboardState } from './hooks/useDashboardState'
 import { useProcessedData } from './hooks/useProcessedData'
 import { DashboardFilters } from './components/DashboardFilters'
@@ -102,11 +103,10 @@ export function BlockLogsDashboard({ blockLogs, runId, suiteTests, onTestClick, 
       </div>
       <div className="flex items-center gap-2">
         {onSearchChange && (
-          <input
-            type="text"
+          <FilterInput
             placeholder="Filter tests..."
             value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
+            onValueChange={onSearchChange}
             className="rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
           />
         )}

--- a/ui/src/components/shared/FilterInput.tsx
+++ b/ui/src/components/shared/FilterInput.tsx
@@ -1,0 +1,40 @@
+import { useState, type InputHTMLAttributes } from 'react'
+
+type FilterInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> & {
+  value: string
+  onValueChange: (value: string) => void
+}
+
+/**
+ * A controlled text input that keeps local state to avoid cursor-jump issues
+ * when the canonical value lives in URL search params or other async state.
+ *
+ * Tracks the last-seen prop value as state. When the prop changes from an
+ * external source (e.g. browser back/forward), local state re-syncs. During
+ * typing, the prop echoes back our own value so the condition is false and
+ * local state is left untouched — preserving the cursor position.
+ */
+export function FilterInput({ value, onValueChange, ...rest }: FilterInputProps) {
+  const [local, setLocal] = useState(value)
+  const [prevValue, setPrevValue] = useState(value)
+
+  if (value !== prevValue) {
+    setPrevValue(value)
+
+    if (value !== local) {
+      setLocal(value)
+    }
+  }
+
+  return (
+    <input
+      {...rest}
+      type="text"
+      value={local}
+      onChange={(e) => {
+        setLocal(e.target.value)
+        onValueChange(e.target.value)
+      }}
+    />
+  )
+}

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -9,6 +9,7 @@ import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { JDenticon } from '@/components/shared/JDenticon'
+import { FilterInput } from '@/components/shared/FilterInput'
 import { CompareHeader } from '@/components/compare/CompareHeader'
 import { StickyRunBar } from '@/components/compare/StickyRunBar'
 import { MetricsComparison } from '@/components/compare/MetricsComparison'
@@ -289,11 +290,10 @@ export function ComparePage() {
         </div>
         <div className="flex items-center gap-1.5">
           <span>Filter:</span>
-          <input
-            type="text"
+          <FilterInput
             placeholder={testFilterRegex ? 'Regex pattern...' : 'Filter tests...'}
             value={testFilter}
-            onChange={(e) => setTestFilter(e.target.value)}
+            onValueChange={setTestFilter}
             className={clsx(
               'rounded-xs border bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:outline-hidden focus:ring-1 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
               testFilterRegex && testFilter && (() => { try { new RegExp(testFilter); return false } catch { return true } })()

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -19,6 +19,7 @@ import { ClientStat } from '@/components/shared/ClientStat'
 import { Duration } from '@/components/shared/Duration'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { StatusAlert } from '@/components/shared/StatusBadge'
+import { FilterInput } from '@/components/shared/FilterInput'
 import { formatTimestamp, formatDurationSeconds } from '@/utils/date'
 import { formatNumber, formatBytes } from '@/utils/format'
 import { useIndex } from '@/api/hooks/useIndex'
@@ -717,11 +718,10 @@ export function RunDetailPage() {
                 <Flame className="size-4 text-gray-400 dark:text-gray-500" />
                 Performance Heatmap
               </h3>
-              <input
-                type="text"
+              <FilterInput
                 placeholder="Filter tests..."
                 value={q}
-                onChange={(e) => handleSearchChange(e.target.value)}
+                onValueChange={handleSearchChange}
                 className="rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
               />
             </div>


### PR DESCRIPTION
## Summary
- Typing into "Filter tests..." inputs on the run detail and compare pages caused the cursor to jump to the end after every keystroke, making it impossible to edit the middle of the query.
- Root cause: input value was derived directly from URL search params, and the async round-trip (onChange → navigate → re-render from URL) overwrote the input on each character.
- Adds a `FilterInput` component that keeps local state during typing and only re-syncs from the prop when the change originates externally (e.g. browser back/forward).
- Replaces all 4 affected filter inputs: RunDetailPage heatmap, ComparePage, StickyRunBar, and BlockLogsDashboard.

## Test plan
- [x] On the run detail page, type into "Filter tests..." — verify cursor stays in place when editing the middle of the query
- [x] On the compare page, same test for both the inline filter and the sticky bar filter
- [x] Use browser back/forward after filtering — verify the input value updates correctly