### PR TITLE
feat(ui): suites page grouping, filtering, and inactive marking

### DIFF
--- a/ui/src/components/suites/SuitesTable.tsx
+++ b/ui/src/components/suites/SuitesTable.tsx
@@ -87,9 +87,9 @@ function SuiteRow({ suite }: { suite: SuiteEntry }) {
           <span className="text-xs/4 text-gray-400 dark:text-gray-500">{formatTimestampTime(suite.lastRun)}</span>
         </span>
       </td>
-      <td className="whitespace-nowrap px-3 py-2 sm:px-4 sm:py-2.5">
+      <td className="px-3 py-2 sm:px-4 sm:py-2.5">
         <div className="flex items-center gap-2">
-          <JDenticon value={suite.hash} size={24} className="shrink-0 rounded-xs" />
+          <JDenticon value={suite.hash} size={24} className="shrink-0 self-start rounded-xs" />
           <div className="flex flex-col">
             <Link
               to="/suites/$suiteHash"
@@ -101,6 +101,21 @@ function SuiteRow({ suite }: { suite: SuiteEntry }) {
             </Link>
             {suiteInfo?.metadata?.labels?.name && (
               <span className="font-mono text-xs text-gray-500 dark:text-gray-400">{suite.hash}</span>
+            )}
+            {suiteInfo?.metadata?.labels && Object.keys(suiteInfo.metadata.labels).some((k) => k !== 'name') && (
+              <div className="flex flex-wrap gap-1">
+                {Object.entries(suiteInfo.metadata.labels)
+                  .filter(([key]) => key !== 'name')
+                  .map(([key, value]) => (
+                    <span
+                      key={key}
+                      className="inline-flex items-center gap-1 rounded-xs bg-gray-100 px-1.5 py-0.5 text-xs/4 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+                    >
+                      <span className="font-medium text-gray-500 dark:text-gray-500">{key}:</span>
+                      {value}
+                    </span>
+                  ))}
+              </div>
             )}
           </div>
         </div>
@@ -169,7 +184,15 @@ export function SuitesTable({
 
   return (
     <div className="overflow-x-auto rounded-xs bg-white shadow-xs dark:bg-gray-800">
-      <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <table className="min-w-full table-fixed divide-y divide-gray-200 dark:divide-gray-700">
+        <colgroup>
+          <col className="w-28" />      {/* Last Run */}
+          <col />                        {/* Suite (takes remaining space) */}
+          <col className="w-32" />       {/* Source */}
+          <col className="w-28" />       {/* Pre-Run Steps */}
+          <col className="w-32" />       {/* Filter */}
+          <col className="w-24" />       {/* Runs */}
+        </colgroup>
         <thead className="bg-gray-50 dark:bg-gray-900">
           <tr>
             <SortableHeader label="Last Run" column="lastRun" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />

--- a/ui/src/components/suites/SuitesTable.tsx
+++ b/ui/src/components/suites/SuitesTable.tsx
@@ -151,8 +151,8 @@ function SuiteRow({ suite, isInactive, hidden }: { suite: SuiteEntry; isInactive
           <span className="text-gray-400 dark:text-gray-500">-</span>
         )}
       </td>
-      <td className="whitespace-nowrap px-3 py-2 sm:px-4 sm:py-2.5">
-        <Badge variant="info">{suite.runCount} runs</Badge>
+      <td className="whitespace-nowrap px-3 py-2 text-right sm:px-4 sm:py-2.5">
+        <Badge variant="info">{suite.runCount}</Badge>
       </td>
     </tr>
   )

--- a/ui/src/components/suites/SuitesTable.tsx
+++ b/ui/src/components/suites/SuitesTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Link, useNavigate } from '@tanstack/react-router'
 import clsx from 'clsx'
 import { useSuite } from '@/api/hooks/useSuite'
@@ -21,6 +21,8 @@ interface SuitesTableProps {
   sortBy?: SuiteSortColumn
   sortDir?: SuiteSortDirection
   onSortChange?: (column: SuiteSortColumn, direction: SuiteSortDirection) => void
+  hideInactive?: boolean
+  inactiveThresholdMs?: number
 }
 
 function SortIcon({ direction, active }: { direction: SuiteSortDirection; active: boolean }) {
@@ -72,14 +74,19 @@ function StaticHeader({ label }: { label: string }) {
   )
 }
 
-function SuiteRow({ suite }: { suite: SuiteEntry }) {
+function SuiteRow({ suite, isInactive, hidden }: { suite: SuiteEntry; isInactive?: boolean; hidden?: boolean }) {
   const navigate = useNavigate()
   const { data: suiteInfo } = useSuite(suite.hash)
+
+  if (hidden) return null
 
   return (
     <tr
       onClick={() => navigate({ to: '/suites/$suiteHash', params: { suiteHash: suite.hash } })}
-      className="cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
+      className={clsx(
+        'cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50',
+        isInactive && 'opacity-40',
+      )}
     >
       <td className="whitespace-nowrap px-3 py-2 text-sm/6 text-gray-500 sm:px-4 sm:py-2.5 dark:text-gray-400">
         <span className="flex flex-col" title={formatRelativeTime(suite.lastRun)}>
@@ -151,12 +158,22 @@ function SuiteRow({ suite }: { suite: SuiteEntry }) {
   )
 }
 
+const DEFAULT_INACTIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000
+
+function useNow() {
+  const [now] = useState(() => Date.now())
+  return now
+}
+
 export function SuitesTable({
   suites,
   sortBy = 'lastRun',
   sortDir = 'desc',
   onSortChange,
+  hideInactive,
+  inactiveThresholdMs = DEFAULT_INACTIVE_THRESHOLD_MS,
 }: SuitesTableProps) {
+  const now = useNow()
   const handleSort = (column: SuiteSortColumn) => {
     if (onSortChange) {
       const newDirection = sortBy === column && sortDir === 'desc' ? 'asc' : 'desc'
@@ -185,14 +202,7 @@ export function SuitesTable({
   return (
     <div className="overflow-x-auto rounded-xs bg-white shadow-xs dark:bg-gray-800">
       <table className="min-w-full table-fixed divide-y divide-gray-200 dark:divide-gray-700">
-        <colgroup>
-          <col className="w-28" />      {/* Last Run */}
-          <col />                        {/* Suite (takes remaining space) */}
-          <col className="w-32" />       {/* Source */}
-          <col className="w-28" />       {/* Pre-Run Steps */}
-          <col className="w-32" />       {/* Filter */}
-          <col className="w-24" />       {/* Runs */}
-        </colgroup>
+        <colgroup><col className="w-28" /><col /><col className="w-32" /><col className="w-28" /><col className="w-32" /><col className="w-24" /></colgroup>
         <thead className="bg-gray-50 dark:bg-gray-900">
           <tr>
             <SortableHeader label="Last Run" column="lastRun" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
@@ -205,7 +215,12 @@ export function SuitesTable({
         </thead>
         <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
           {sortedSuites.map((suite) => (
-            <SuiteRow key={suite.hash} suite={suite} />
+            <SuiteRow
+              key={suite.hash}
+              suite={suite}
+              isInactive={(now - suite.lastRun * 1000) > inactiveThresholdMs}
+              hidden={hideInactive && (now - suite.lastRun * 1000) > inactiveThresholdMs}
+            />
           ))}
         </tbody>
       </table>

--- a/ui/src/pages/SuitesPage.tsx
+++ b/ui/src/pages/SuitesPage.tsx
@@ -1,5 +1,9 @@
-import { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, useCallback } from 'react'
 import { useNavigate, useSearch } from '@tanstack/react-router'
+import { useQueries } from '@tanstack/react-query'
+import clsx from 'clsx'
+import { fetchData } from '@/api/client'
+import type { SuiteInfo } from '@/api/types'
 import { useIndex } from '@/api/hooks/useIndex'
 import { SuitesTable, type SuiteSortColumn, type SuiteSortDirection } from '@/components/suites/SuitesTable'
 import { Pagination } from '@/components/shared/Pagination'
@@ -8,6 +12,28 @@ import { ErrorState } from '@/components/shared/ErrorState'
 import { EmptyState } from '@/components/shared/EmptyState'
 
 const PAGE_SIZE = 20
+const NO_VALUE = '(no value)'
+
+interface SuiteEntry {
+  hash: string
+  runCount: number
+  lastRun: number
+}
+
+interface GroupEntry {
+  /** Per-key label values, e.g. { context: "ABC", network: "mainnet" } */
+  labels: Record<string, string>
+  suites: SuiteEntry[]
+}
+
+function parseGroupBy(raw: string | undefined): string[] {
+  if (!raw) return []
+  return raw.split(',').filter(Boolean)
+}
+
+function serializeGroupBy(keys: string[]): string | undefined {
+  return keys.length > 0 ? keys.join(',') : undefined
+}
 
 export function SuitesPage() {
   const navigate = useNavigate()
@@ -15,8 +41,10 @@ export function SuitesPage() {
     page?: number
     sortBy?: SuiteSortColumn
     sortDir?: SuiteSortDirection
+    groupBy?: string
   }
   const { page = 1, sortBy = 'lastRun', sortDir = 'desc' } = search
+  const groupByKeys = useMemo(() => parseGroupBy(search.groupBy), [search.groupBy])
   const { data: index, isLoading, error, refetch } = useIndex()
   const [currentPage, setCurrentPage] = useState(page)
 
@@ -43,16 +71,103 @@ export function SuitesPage() {
     return Array.from(suiteMap.entries()).map(([hash, { runCount, lastRun }]) => ({ hash, runCount, lastRun }))
   }, [index])
 
-  const totalPages = Math.ceil(suites.length / PAGE_SIZE)
-  const paginatedSuites = suites.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+  // Fetch all suite infos to extract label keys and group
+  const suiteQueries = useQueries({
+    queries: suites.map((s) => ({
+      queryKey: ['suite', s.hash],
+      queryFn: async () => {
+        const { data } = await fetchData<SuiteInfo>(`suites/${s.hash}/summary.json`, { cacheBustInterval: 3600 })
+        return data
+      },
+    })),
+  })
+
+  const suiteInfoMap = useMemo(() => {
+    const map = new Map<string, SuiteInfo>()
+    for (let i = 0; i < suites.length; i++) {
+      const info = suiteQueries[i]?.data
+      if (info) map.set(suites[i].hash, info)
+    }
+    return map
+  }, [suites, suiteQueries])
+
+  // Collect all unique label keys across suites
+  const labelKeys = useMemo(() => {
+    const keys = new Set<string>()
+    for (const info of suiteInfoMap.values()) {
+      if (info.metadata?.labels) {
+        for (const key of Object.keys(info.metadata.labels)) {
+          keys.add(key)
+        }
+      }
+    }
+    keys.delete('name')
+    return Array.from(keys).sort()
+  }, [suiteInfoMap])
+
+  // Group suites by the selected label keys (supports multi-key combos)
+  const groups = useMemo((): GroupEntry[] | null => {
+    if (groupByKeys.length === 0) return null
+
+    const grouped = new Map<string, GroupEntry>()
+    for (const suite of suites) {
+      const info = suiteInfoMap.get(suite.hash)
+      const labels: Record<string, string> = {}
+      for (const key of groupByKeys) {
+        labels[key] = info?.metadata?.labels?.[key] ?? NO_VALUE
+      }
+      // Stable composite key from sorted key=value pairs
+      const compositeKey = groupByKeys.map((k) => `${k}=${labels[k]}`).join('\0')
+      const existing = grouped.get(compositeKey)
+      if (existing) {
+        existing.suites.push(suite)
+      } else {
+        grouped.set(compositeKey, { labels, suites: [suite] })
+      }
+    }
+
+    return Array.from(grouped.values()).sort((a, b) => {
+      // Groups where ALL keys have real values sort first;
+      // any group containing a NO_VALUE sorts to the end.
+      const aHasNoValue = Object.values(a.labels).some((v) => v === NO_VALUE)
+      const bHasNoValue = Object.values(b.labels).some((v) => v === NO_VALUE)
+      if (aHasNoValue !== bHasNoValue) return aHasNoValue ? 1 : -1
+
+      // Within the same tier, sort alphabetically by each key's value
+      for (const key of groupByKeys) {
+        const cmp = a.labels[key].localeCompare(b.labels[key])
+        if (cmp !== 0) return cmp
+      }
+      return 0
+    })
+  }, [groupByKeys, suites, suiteInfoMap])
+
+  const updateSearch = useCallback(
+    (patch: Record<string, string | number | undefined>) => {
+      navigate({
+        to: '/suites',
+        search: { page: search.page, sortBy: search.sortBy, sortDir: search.sortDir, groupBy: search.groupBy, ...patch },
+        replace: true,
+      })
+    },
+    [navigate, search.page, search.sortBy, search.sortDir, search.groupBy],
+  )
 
   const handlePageChange = (newPage: number) => {
     setCurrentPage(newPage)
-    navigate({ to: '/suites', search: { page: newPage, sortBy, sortDir } })
+    updateSearch({ page: newPage })
   }
 
   const handleSortChange = (newSortBy: SuiteSortColumn, newSortDir: SuiteSortDirection) => {
-    navigate({ to: '/suites', search: { page: currentPage, sortBy: newSortBy, sortDir: newSortDir } })
+    updateSearch({ sortBy: newSortBy, sortDir: newSortDir })
+  }
+
+  const toggleGroupByKey = (key: string) => {
+    const next = groupByKeys.includes(key)
+      ? groupByKeys.filter((k) => k !== key)
+      : [...groupByKeys, key]
+    updateSearch({ groupBy: serializeGroupBy(next), page: 1 })
+    setCurrentPage(1)
   }
 
   if (isLoading) {
@@ -67,16 +182,70 @@ export function SuitesPage() {
     return <EmptyState title="No suites found" message="No test suites have been used yet." />
   }
 
+  const totalPages = groups ? 0 : Math.ceil(suites.length / PAGE_SIZE)
+  const paginatedSuites = groups ? [] : suites.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+
   return (
     <div className="flex flex-col gap-6">
-      <h1 className="text-2xl/8 font-bold text-gray-900 dark:text-gray-100">Test Suites ({suites.length})</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl/8 font-bold text-gray-900 dark:text-gray-100">Test Suites ({suites.length})</h1>
+        {labelKeys.length > 0 && (
+          <div className="flex items-center gap-2 text-sm/6 text-gray-600 dark:text-gray-400">
+            <span>Group by:</span>
+            <div className="flex gap-1">
+              {labelKeys.map((key) => (
+                <button
+                  key={key}
+                  onClick={() => toggleGroupByKey(key)}
+                  className={clsx(
+                    'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                    groupByKeys.includes(key)
+                      ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                  )}
+                >
+                  {key}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
 
-      <SuitesTable suites={paginatedSuites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} />
-
-      {totalPages > 1 && (
-        <div className="flex justify-center">
-          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+      {groups ? (
+        <div className="flex flex-col gap-8">
+          {groups.map((group) => {
+            const groupKey = groupByKeys.map((k) => `${k}=${group.labels[k]}`).join(', ')
+            return (
+              <div key={groupKey} className="flex flex-col gap-3">
+                <h2 className="flex flex-wrap items-center gap-2 text-lg/7 font-semibold text-gray-900 dark:text-gray-100">
+                  {groupByKeys.map((key) => (
+                    <span key={key} className="flex items-center gap-1">
+                      <span className="rounded-xs bg-gray-100 px-2 py-0.5 text-sm/6 font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+                        {key}
+                      </span>
+                      <span>{group.labels[key]}</span>
+                    </span>
+                  ))}
+                  <span className="text-sm/6 font-normal text-gray-500 dark:text-gray-400">
+                    ({group.suites.length})
+                  </span>
+                </h2>
+                <SuitesTable suites={group.suites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} />
+              </div>
+            )
+          })}
         </div>
+      ) : (
+        <>
+          <SuitesTable suites={paginatedSuites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} />
+
+          {totalPages > 1 && (
+            <div className="flex justify-center">
+              <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/ui/src/pages/SuitesPage.tsx
+++ b/ui/src/pages/SuitesPage.tsx
@@ -1,7 +1,8 @@
-import { useMemo, useState, useEffect, useCallback } from 'react'
+import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useQueries } from '@tanstack/react-query'
 import clsx from 'clsx'
+import { Plus, X } from 'lucide-react'
 import { fetchData } from '@/api/client'
 import type { SuiteInfo } from '@/api/types'
 import { useIndex } from '@/api/hooks/useIndex'
@@ -21,10 +22,12 @@ interface SuiteEntry {
 }
 
 interface GroupEntry {
-  /** Per-key label values, e.g. { context: "ABC", network: "mainnet" } */
   labels: Record<string, string>
   suites: SuiteEntry[]
 }
+
+/** label filters: key → set of selected values (OR within key, AND across keys) */
+type LabelFilters = Map<string, Set<string>>
 
 function parseGroupBy(raw: string | undefined): string[] {
   if (!raw) return []
@@ -35,6 +38,209 @@ function serializeGroupBy(keys: string[]): string | undefined {
   return keys.length > 0 ? keys.join(',') : undefined
 }
 
+/** Parse URL param `key:val1|val2,key2:val3` into a Map */
+function parseLabelFilters(raw: string | undefined): LabelFilters {
+  const filters: LabelFilters = new Map()
+  if (!raw) return filters
+  for (const segment of raw.split(',')) {
+    const idx = segment.indexOf(':')
+    if (idx < 1) continue
+    const key = decodeURIComponent(segment.slice(0, idx))
+    const values = segment.slice(idx + 1).split('|').map(decodeURIComponent).filter(Boolean)
+    if (values.length > 0) filters.set(key, new Set(values))
+  }
+  return filters
+}
+
+function serializeLabelFilters(filters: LabelFilters): string | undefined {
+  if (filters.size === 0) return undefined
+  const parts: string[] = []
+  for (const [key, values] of filters) {
+    if (values.size === 0) continue
+    parts.push(`${encodeURIComponent(key)}:${Array.from(values).map(encodeURIComponent).join('|')}`)
+  }
+  return parts.length > 0 ? parts.join(',') : undefined
+}
+
+// ---------------------------------------------------------------------------
+// LabelFilterBar — Grafana-style dynamic filter chips with dropdowns
+// ---------------------------------------------------------------------------
+
+interface LabelFilterBarProps {
+  labelKeys: string[]
+  /** All known values per label key */
+  labelValues: Map<string, string[]>
+  filters: LabelFilters
+  onFiltersChange: (filters: LabelFilters) => void
+}
+
+function LabelFilterBar({ labelKeys, labelValues, filters, onFiltersChange }: LabelFilterBarProps) {
+  const [keyDropdownOpen, setKeyDropdownOpen] = useState(false)
+  const [valueDropdownKey, setValueDropdownKey] = useState<string | null>(null)
+  const keyRef = useRef<HTMLDivElement>(null)
+  const valueRef = useRef<HTMLDivElement>(null)
+
+  // Close dropdowns on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (keyDropdownOpen && keyRef.current && !keyRef.current.contains(e.target as Node)) {
+        setKeyDropdownOpen(false)
+      }
+      if (valueDropdownKey && valueRef.current && !valueRef.current.contains(e.target as Node)) {
+        setValueDropdownKey(null)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [keyDropdownOpen, valueDropdownKey])
+
+  const availableKeys = labelKeys.filter((k) => !filters.has(k) && k !== valueDropdownKey)
+
+  const toggleValue = (key: string, value: string) => {
+    const next = new Map(filters)
+    const values = new Set(next.get(key) ?? [])
+    if (values.has(value)) {
+      values.delete(value)
+      if (values.size === 0) {
+        next.delete(key)
+      } else {
+        next.set(key, values)
+      }
+    } else {
+      values.add(value)
+      next.set(key, values)
+    }
+    onFiltersChange(next)
+  }
+
+  const removeFilter = (key: string) => {
+    const next = new Map(filters)
+    next.delete(key)
+    onFiltersChange(next)
+    if (valueDropdownKey === key) setValueDropdownKey(null)
+  }
+
+  const addKey = (key: string) => {
+    setKeyDropdownOpen(false)
+    // Open value picker immediately for the new key
+    setValueDropdownKey(key)
+  }
+
+  // Build the list of chips: active filters + pending key (not yet in filters)
+  const chipKeys = useMemo(() => {
+    const keys = Array.from(filters.keys())
+    if (valueDropdownKey && !filters.has(valueDropdownKey)) {
+      keys.push(valueDropdownKey)
+    }
+    return keys
+  }, [filters, valueDropdownKey])
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {/* Filter chips (active + pending) */}
+      {chipKeys.map((key) => {
+        const values = filters.get(key)
+        const isPending = !values
+        return (
+          <div key={key} className="relative" ref={valueDropdownKey === key ? valueRef : undefined}>
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={() => setValueDropdownKey(valueDropdownKey === key ? null : key)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setValueDropdownKey(valueDropdownKey === key ? null : key) } }}
+              className={clsx(
+                'flex cursor-pointer items-center gap-1.5 rounded-xs border px-2 py-1 text-xs/5 font-medium transition-colors',
+                isPending
+                  ? 'border-dashed border-blue-300 bg-blue-50/50 text-blue-500 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
+                  : 'border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50',
+              )}
+            >
+              <span className="font-semibold">{key}</span>
+              {values && values.size > 0 && (
+                <>
+                  <span>=</span>
+                  <span>{Array.from(values).join(', ')}</span>
+                </>
+              )}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  if (isPending) { setValueDropdownKey(null) } else { removeFilter(key) }
+                }}
+                className="ml-0.5 rounded-xs p-0.5 hover:bg-blue-200 dark:hover:bg-blue-800"
+              >
+                <X className="size-3" />
+              </button>
+            </div>
+
+            {/* Value multi-select dropdown */}
+            {valueDropdownKey === key && (
+              <div className="absolute top-full left-0 z-50 mt-1 max-h-64 min-w-48 overflow-y-auto rounded-xs border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+                {(labelValues.get(key) ?? []).map((val) => {
+                  const selected = values?.has(val) ?? false
+                  return (
+                    <button
+                      key={val}
+                      onClick={() => toggleValue(key, val)}
+                      className={clsx(
+                        'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm/6 transition-colors',
+                        selected
+                          ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+                          : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700',
+                      )}
+                    >
+                      <span className={clsx(
+                        'flex size-4 shrink-0 items-center justify-center rounded-xs border text-xs/3',
+                        selected
+                          ? 'border-blue-500 bg-blue-500 text-white dark:border-blue-400 dark:bg-blue-400'
+                          : 'border-gray-300 dark:border-gray-600',
+                      )}>
+                        {selected && '✓'}
+                      </span>
+                      {val}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )
+      })}
+
+      {/* Add filter button */}
+      {availableKeys.length > 0 && (
+        <div className="relative" ref={keyRef}>
+          <button
+            onClick={() => { setKeyDropdownOpen(!keyDropdownOpen); setValueDropdownKey(null) }}
+            className="flex items-center gap-1 rounded-xs border border-dashed border-gray-300 px-2 py-1 text-xs/5 text-gray-500 transition-colors hover:border-gray-400 hover:text-gray-700 dark:border-gray-600 dark:text-gray-400 dark:hover:border-gray-500 dark:hover:text-gray-300"
+          >
+            <Plus className="size-3" />
+            Filter
+          </button>
+
+          {keyDropdownOpen && (
+            <div className="absolute top-full left-0 z-50 mt-1 min-w-36 overflow-hidden rounded-xs border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              {availableKeys.map((key) => (
+                <button
+                  key={key}
+                  onClick={() => addKey(key)}
+                  className="flex w-full px-3 py-1.5 text-left text-sm/6 text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                  {key}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// SuitesPage
+// ---------------------------------------------------------------------------
+
 export function SuitesPage() {
   const navigate = useNavigate()
   const search = useSearch({ from: '/suites' }) as {
@@ -42,9 +248,11 @@ export function SuitesPage() {
     sortBy?: SuiteSortColumn
     sortDir?: SuiteSortDirection
     groupBy?: string
+    labels?: string
   }
   const { page = 1, sortBy = 'lastRun', sortDir = 'desc' } = search
   const groupByKeys = useMemo(() => parseGroupBy(search.groupBy), [search.groupBy])
+  const labelFilters = useMemo(() => parseLabelFilters(search.labels), [search.labels])
   const { data: index, isLoading, error, refetch } = useIndex()
   const [currentPage, setCurrentPage] = useState(page)
 
@@ -91,32 +299,55 @@ export function SuitesPage() {
     return map
   }, [suites, suiteQueries])
 
-  // Collect all unique label keys across suites
-  const labelKeys = useMemo(() => {
-    const keys = new Set<string>()
+  // Collect all unique label keys and per-key values across suites
+  const { labelKeys, labelValues } = useMemo(() => {
+    const valuesMap = new Map<string, Set<string>>()
     for (const info of suiteInfoMap.values()) {
       if (info.metadata?.labels) {
-        for (const key of Object.keys(info.metadata.labels)) {
-          keys.add(key)
+        for (const [key, value] of Object.entries(info.metadata.labels)) {
+          if (key === 'name') continue
+          let set = valuesMap.get(key)
+          if (!set) {
+            set = new Set()
+            valuesMap.set(key, set)
+          }
+          set.add(value)
         }
       }
     }
-    keys.delete('name')
-    return Array.from(keys).sort()
+    const keys = Array.from(valuesMap.keys()).sort()
+    const values = new Map<string, string[]>()
+    for (const [key, set] of valuesMap) {
+      values.set(key, Array.from(set).sort())
+    }
+    return { labelKeys: keys, labelValues: values }
   }, [suiteInfoMap])
 
-  // Group suites by the selected label keys (supports multi-key combos)
+  // Apply label filters to suites
+  const filteredSuites = useMemo(() => {
+    if (labelFilters.size === 0) return suites
+    return suites.filter((suite) => {
+      const info = suiteInfoMap.get(suite.hash)
+      const labels = info?.metadata?.labels
+      for (const [key, allowedValues] of labelFilters) {
+        const actual = labels?.[key]
+        if (!actual || !allowedValues.has(actual)) return false
+      }
+      return true
+    })
+  }, [suites, suiteInfoMap, labelFilters])
+
+  // Group filtered suites by the selected label keys
   const groups = useMemo((): GroupEntry[] | null => {
     if (groupByKeys.length === 0) return null
 
     const grouped = new Map<string, GroupEntry>()
-    for (const suite of suites) {
+    for (const suite of filteredSuites) {
       const info = suiteInfoMap.get(suite.hash)
       const labels: Record<string, string> = {}
       for (const key of groupByKeys) {
         labels[key] = info?.metadata?.labels?.[key] ?? NO_VALUE
       }
-      // Stable composite key from sorted key=value pairs
       const compositeKey = groupByKeys.map((k) => `${k}=${labels[k]}`).join('\0')
       const existing = grouped.get(compositeKey)
       if (existing) {
@@ -127,30 +358,29 @@ export function SuitesPage() {
     }
 
     return Array.from(grouped.values()).sort((a, b) => {
-      // Groups where ALL keys have real values sort first;
-      // any group containing a NO_VALUE sorts to the end.
       const aHasNoValue = Object.values(a.labels).some((v) => v === NO_VALUE)
       const bHasNoValue = Object.values(b.labels).some((v) => v === NO_VALUE)
       if (aHasNoValue !== bHasNoValue) return aHasNoValue ? 1 : -1
-
-      // Within the same tier, sort alphabetically by each key's value
       for (const key of groupByKeys) {
         const cmp = a.labels[key].localeCompare(b.labels[key])
         if (cmp !== 0) return cmp
       }
       return 0
     })
-  }, [groupByKeys, suites, suiteInfoMap])
+  }, [groupByKeys, filteredSuites, suiteInfoMap])
 
   const updateSearch = useCallback(
     (patch: Record<string, string | number | undefined>) => {
       navigate({
         to: '/suites',
-        search: { page: search.page, sortBy: search.sortBy, sortDir: search.sortDir, groupBy: search.groupBy, ...patch },
+        search: {
+          page: search.page, sortBy: search.sortBy, sortDir: search.sortDir,
+          groupBy: search.groupBy, labels: search.labels, ...patch,
+        },
         replace: true,
       })
     },
-    [navigate, search.page, search.sortBy, search.sortDir, search.groupBy],
+    [navigate, search.page, search.sortBy, search.sortDir, search.groupBy, search.labels],
   )
 
   const handlePageChange = (newPage: number) => {
@@ -170,6 +400,11 @@ export function SuitesPage() {
     setCurrentPage(1)
   }
 
+  const handleLabelFiltersChange = (next: LabelFilters) => {
+    updateSearch({ labels: serializeLabelFilters(next), page: 1 })
+    setCurrentPage(1)
+  }
+
   if (isLoading) {
     return <LoadingState message="Loading suites..." />
   }
@@ -182,13 +417,15 @@ export function SuitesPage() {
     return <EmptyState title="No suites found" message="No test suites have been used yet." />
   }
 
-  const totalPages = groups ? 0 : Math.ceil(suites.length / PAGE_SIZE)
-  const paginatedSuites = groups ? [] : suites.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+  const totalPages = groups ? 0 : Math.ceil(filteredSuites.length / PAGE_SIZE)
+  const paginatedSuites = groups ? [] : filteredSuites.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
 
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl/8 font-bold text-gray-900 dark:text-gray-100">Test Suites ({suites.length})</h1>
+        <h1 className="text-2xl/8 font-bold text-gray-900 dark:text-gray-100">
+          Test Suites ({filteredSuites.length}{labelFilters.size > 0 && ` / ${suites.length}`})
+        </h1>
         {labelKeys.length > 0 && (
           <div className="flex items-center gap-2 text-sm/6 text-gray-600 dark:text-gray-400">
             <span>Group by:</span>
@@ -211,6 +448,15 @@ export function SuitesPage() {
           </div>
         )}
       </div>
+
+      {labelKeys.length > 0 && (
+        <LabelFilterBar
+          labelKeys={labelKeys}
+          labelValues={labelValues}
+          filters={labelFilters}
+          onFiltersChange={handleLabelFiltersChange}
+        />
+      )}
 
       {groups ? (
         <div className="flex flex-col gap-8">

--- a/ui/src/pages/SuitesPage.tsx
+++ b/ui/src/pages/SuitesPage.tsx
@@ -251,7 +251,7 @@ export function SuitesPage() {
     labels?: string
   }
   const { page = 1, sortBy = 'lastRun', sortDir = 'desc' } = search
-  const groupByKeys = useMemo(() => parseGroupBy(search.groupBy), [search.groupBy])
+  const groupByKeys = useMemo(() => parseGroupBy(search.groupBy ?? 'context'), [search.groupBy])
   const labelFilters = useMemo(() => parseLabelFilters(search.labels), [search.labels])
   const { data: index, isLoading, error, refetch } = useIndex()
   const [currentPage, setCurrentPage] = useState(page)

--- a/ui/src/pages/SuitesPage.tsx
+++ b/ui/src/pages/SuitesPage.tsx
@@ -14,6 +14,14 @@ import { EmptyState } from '@/components/shared/EmptyState'
 
 const PAGE_SIZE = 20
 const NO_VALUE = '(no value)'
+const DAY_MS = 24 * 60 * 60 * 1000
+const INACTIVE_OPTIONS = [
+  { label: '7d', days: 7 },
+  { label: '14d', days: 14 },
+  { label: '30d', days: 30 },
+  { label: '90d', days: 90 },
+] as const
+const DEFAULT_INACTIVE_DAYS = 7
 
 interface SuiteEntry {
   hash: string
@@ -34,8 +42,8 @@ function parseGroupBy(raw: string | undefined): string[] {
   return raw.split(',').filter(Boolean)
 }
 
-function serializeGroupBy(keys: string[]): string | undefined {
-  return keys.length > 0 ? keys.join(',') : undefined
+function serializeGroupBy(keys: string[]): string {
+  return keys.length > 0 ? keys.join(',') : 'none'
 }
 
 /** Parse URL param `key:val1|val2,key2:val3` into a Map */
@@ -249,9 +257,18 @@ export function SuitesPage() {
     sortDir?: SuiteSortDirection
     groupBy?: string
     labels?: string
+    hideInactive?: string
+    inactiveDays?: string
   }
   const { page = 1, sortBy = 'lastRun', sortDir = 'desc' } = search
-  const groupByKeys = useMemo(() => parseGroupBy(search.groupBy ?? 'context'), [search.groupBy])
+  const hideInactive = search.hideInactive === '1'
+  const inactiveDays = Number(search.inactiveDays) || DEFAULT_INACTIVE_DAYS
+  const inactiveThresholdMs = inactiveDays * DAY_MS
+  const [now] = useState(() => Date.now())
+  const groupByKeys = useMemo(
+    () => parseGroupBy(search.groupBy === 'none' ? undefined : (search.groupBy ?? 'context')),
+    [search.groupBy],
+  )
   const labelFilters = useMemo(() => parseLabelFilters(search.labels), [search.labels])
   const { data: index, isLoading, error, refetch } = useIndex()
   const [currentPage, setCurrentPage] = useState(page)
@@ -357,7 +374,15 @@ export function SuitesPage() {
       }
     }
 
+    const isAllInactive = (group: GroupEntry) =>
+      group.suites.every((s) => (now - s.lastRun * 1000) > inactiveThresholdMs)
+
     return Array.from(grouped.values()).sort((a, b) => {
+      // Groups where all suites are inactive sort to the bottom
+      const aAllInactive = isAllInactive(a)
+      const bAllInactive = isAllInactive(b)
+      if (aAllInactive !== bAllInactive) return aAllInactive ? 1 : -1
+
       const aHasNoValue = Object.values(a.labels).some((v) => v === NO_VALUE)
       const bHasNoValue = Object.values(b.labels).some((v) => v === NO_VALUE)
       if (aHasNoValue !== bHasNoValue) return aHasNoValue ? 1 : -1
@@ -367,7 +392,7 @@ export function SuitesPage() {
       }
       return 0
     })
-  }, [groupByKeys, filteredSuites, suiteInfoMap])
+  }, [groupByKeys, filteredSuites, suiteInfoMap, now, inactiveThresholdMs])
 
   const updateSearch = useCallback(
     (patch: Record<string, string | number | undefined>) => {
@@ -375,12 +400,12 @@ export function SuitesPage() {
         to: '/suites',
         search: {
           page: search.page, sortBy: search.sortBy, sortDir: search.sortDir,
-          groupBy: search.groupBy, labels: search.labels, ...patch,
+          groupBy: search.groupBy, labels: search.labels, hideInactive: search.hideInactive, inactiveDays: search.inactiveDays, ...patch,
         },
         replace: true,
       })
     },
-    [navigate, search.page, search.sortBy, search.sortDir, search.groupBy, search.labels],
+    [navigate, search.page, search.sortBy, search.sortDir, search.groupBy, search.labels, search.hideInactive, search.inactiveDays],
   )
 
   const handlePageChange = (newPage: number) => {
@@ -426,7 +451,38 @@ export function SuitesPage() {
         <h1 className="text-2xl/8 font-bold text-gray-900 dark:text-gray-100">
           Test Suites ({filteredSuites.length}{labelFilters.size > 0 && ` / ${suites.length}`})
         </h1>
-        {labelKeys.length > 0 && (
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 text-sm/6 text-gray-600 dark:text-gray-400">
+            <span>Inactive:</span>
+            <div className="flex gap-1">
+              {INACTIVE_OPTIONS.map((opt) => (
+                <button
+                  key={opt.days}
+                  onClick={() => updateSearch({ inactiveDays: opt.days === DEFAULT_INACTIVE_DAYS ? undefined : String(opt.days) })}
+                  className={clsx(
+                    'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                    inactiveDays === opt.days
+                      ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={() => updateSearch({ hideInactive: hideInactive ? undefined : '1' })}
+              className={clsx(
+                'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                hideInactive
+                  ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+              )}
+            >
+              Hide
+            </button>
+          </div>
+          {labelKeys.length > 0 && (
           <div className="flex items-center gap-2 text-sm/6 text-gray-600 dark:text-gray-400">
             <span>Group by:</span>
             <div className="flex gap-1">
@@ -447,6 +503,7 @@ export function SuitesPage() {
             </div>
           </div>
         )}
+        </div>
       </div>
 
       {labelKeys.length > 0 && (
@@ -462,6 +519,7 @@ export function SuitesPage() {
         <div className="flex flex-col gap-8">
           {groups.map((group) => {
             const groupKey = groupByKeys.map((k) => `${k}=${group.labels[k]}`).join(', ')
+            const inactiveCount = group.suites.filter((s) => (now - s.lastRun * 1000) > inactiveThresholdMs).length
             return (
               <div key={groupKey} className="flex flex-col gap-3">
                 <h2 className="flex flex-wrap items-center gap-2 text-lg/7 font-semibold text-gray-900 dark:text-gray-100">
@@ -474,17 +532,17 @@ export function SuitesPage() {
                     </span>
                   ))}
                   <span className="text-sm/6 font-normal text-gray-500 dark:text-gray-400">
-                    ({group.suites.length})
+                    ({group.suites.length}{inactiveCount > 0 && `, ${inactiveCount} inactive`})
                   </span>
                 </h2>
-                <SuitesTable suites={group.suites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} />
+                <SuitesTable suites={group.suites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} hideInactive={hideInactive} inactiveThresholdMs={inactiveThresholdMs} />
               </div>
             )
           })}
         </div>
       ) : (
         <>
-          <SuitesTable suites={paginatedSuites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} />
+          <SuitesTable suites={paginatedSuites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} hideInactive={hideInactive} inactiveThresholdMs={inactiveThresholdMs} />
 
           {totalPages > 1 && (
             <div className="flex justify-center">


### PR DESCRIPTION
## Summary
- **Group by labels**: Toggle pill buttons to group suites by one or more label keys (defaults to `context`). Supports composite grouping. Groups with `(no value)` sort to the bottom.
- **Dynamic label filters**: Grafana-style filter bar — click `+ Filter` to pick a label key, then multi-select values. Multiple values per key are OR'd, multiple keys are AND'd. Persisted in URL.
- **Inactive suite marking**: Suites with no runs in the last N days are dimmed (40% opacity). Configurable threshold (7d/14d/30d/90d). "Hide" toggle removes them entirely. All-inactive groups sort to the bottom, group headers show inactive count.
- **Labels in table**: Suite labels (excluding `name`) shown as badges below the suite name in the Suite column.
- **Fixed column alignment**: `table-fixed` layout with explicit column widths ensures consistent alignment across grouped tables.

## Test plan
- [x] Visit `/suites` — verify default grouping by `context` label
- [x] Toggle group-by pills on/off, verify grouping updates and URL persists
- [x] Deselect all group-by pills — verify flat table view
- [x] Click `+ Filter`, pick a label key, select values — verify suites are filtered
- [x] Verify inactive suites are dimmed, "Hide" removes them, threshold selector works
- [x] Verify groups with all-inactive suites appear at the bottom
- [x] Verify column alignment is consistent across groups