### PR TITLE
fix(api): limit suite stats to recent runs and add gzip

### DIFF
--- a/pkg/api/handlers_index.go
+++ b/pkg/api/handlers_index.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -96,8 +97,18 @@ func (s *server) handleSuiteStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	durations, err := s.indexStore.ListTestStatsBySuite(
-		r.Context(), suiteHash,
+	// Parse max_runs_per_client: default 30, clamp to [1, 200].
+	maxRuns := 30
+	if v := r.URL.Query().Get("max_runs_per_client"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			maxRuns = n
+		}
+	}
+
+	maxRuns = max(1, min(200, maxRuns))
+
+	durations, err := s.indexStore.ListTestStatsBySuiteRecent(
+		r.Context(), suiteHash, maxRuns,
 	)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError,

--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -36,6 +36,9 @@ type Store interface {
 	ListTestStatsBySuite(
 		ctx context.Context, suiteHash string,
 	) ([]TestStat, error)
+	ListTestStatsBySuiteRecent(
+		ctx context.Context, suiteHash string, maxRunsPerClient int,
+	) ([]TestStat, error)
 	DeleteTestStatsForRun(ctx context.Context, runID string) error
 
 	ListAllRuns(ctx context.Context) ([]Run, error)
@@ -464,6 +467,78 @@ func (s *store) ListTestStatsBySuite(
 		Where("suite_hash = ?", suiteHash).
 		Find(&stats).Error; err != nil {
 		return nil, fmt.Errorf("listing test stats: %w", err)
+	}
+
+	return stats, nil
+}
+
+// clientRunRow holds the lightweight result of the distinct client/run_id
+// query used by ListTestStatsBySuiteRecent.
+type clientRunRow struct {
+	Client   string
+	RunID    string
+	RunStart int64
+}
+
+// ListTestStatsBySuiteRecent returns test stats for the N most recent runs
+// per client within a suite. This avoids fetching the entire suite history
+// which can be millions of rows for large suites.
+func (s *store) ListTestStatsBySuiteRecent(
+	ctx context.Context, suiteHash string, maxRunsPerClient int,
+) ([]TestStat, error) {
+	// Step 1: lightweight query to get distinct client/run combos.
+	var rows []clientRunRow
+	if err := s.readDB.WithContext(ctx).
+		Model(&TestStat{}).
+		Select("DISTINCT client, run_id, run_start").
+		Where("suite_hash = ?", suiteHash).
+		Order("run_start DESC").
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf(
+			"listing recent client runs: %w", err,
+		)
+	}
+
+	// Step 2: group by client, take top N run_ids per client.
+	clientRuns := make(map[string]int, 8)
+	runIDs := make([]string, 0, maxRunsPerClient*4)
+
+	for i := range rows {
+		client := rows[i].Client
+		if clientRuns[client] >= maxRunsPerClient {
+			continue
+		}
+
+		clientRuns[client]++
+
+		runIDs = append(runIDs, rows[i].RunID)
+	}
+
+	if len(runIDs) == 0 {
+		return nil, nil
+	}
+
+	// Step 3: fetch full test_stats for the selected run_ids.
+	// Batch the IN clause to stay within SQLite's bind variable limit.
+	const batchSize = 500
+
+	stats := make([]TestStat, 0, len(runIDs)*100)
+
+	for i := 0; i < len(runIDs); i += batchSize {
+		end := min(i+batchSize, len(runIDs))
+		batch := runIDs[i:end]
+
+		var batchStats []TestStat
+		if err := s.readDB.WithContext(ctx).
+			Where("suite_hash = ? AND run_id IN ?",
+				suiteHash, batch).
+			Find(&batchStats).Error; err != nil {
+			return nil, fmt.Errorf(
+				"listing test stats for recent runs: %w", err,
+			)
+		}
+
+		stats = append(stats, batchStats...)
 	}
 
 	return stats, nil

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -16,6 +16,7 @@ func (s *server) buildRouter() http.Handler {
 	r.Use(chimw.Recoverer)
 	r.Use(s.requestLogger)
 	r.Use(s.corsMiddleware())
+	r.Use(chimw.Compress(5))
 
 	r.Route("/api/v1", func(r chi.Router) {
 		// Public endpoints.

--- a/ui/src/api/hooks/useSuiteStats.ts
+++ b/ui/src/api/hooks/useSuiteStats.ts
@@ -11,7 +11,7 @@ export function useSuiteStats(suiteHash: string | undefined) {
 
       if (isIndexingEnabled(config) && config.api?.baseUrl) {
         const response = await fetch(
-          `${config.api.baseUrl}/api/v1/index/suites/${suiteHash}/stats`,
+          `${config.api.baseUrl}/api/v1/index/suites/${suiteHash}/stats?max_runs_per_client=25`,
           { credentials: 'include' },
         )
 


### PR DESCRIPTION
## Summary
- Add `ListTestStatsBySuiteRecent` to indexstore that fetches only the N most recent runs per client instead of all rows. Uses a two-step query (lightweight distinct client/run_id lookup, then batched IN clause) to stay SQLite-compatible.
- `handleSuiteStats` now parses `max_runs_per_client` query param (default 30, clamped 1–200) and calls the new method.
- Add `chimw.Compress(5)` global middleware for gzip compression (~10-20x on JSON).
- UI passes `?max_runs_per_client=25` (matching its max slider value).

**Before:** 300+ runs × 4000 tests = ~1.2M rows, ~800MB JSON, no compression.  
**After (25 runs/client, 3 clients):** ~300K rows, ~200MB uncompressed, ~10-20MB gzipped.

## Test plan
- [x] `go build ./pkg/api/...` / `go vet` / `golangci-lint` all pass
- [x] Load a large suite (300+ runs) — verify response is small and fast
- [x] Verify `Content-Encoding: gzip` header in response
- [x] Verify UI Tests tab loads and displays correctly
- [x] Verify `max_runs_per_client` param works with different values