### PR TITLE
feat(ui): handle large files in executions table and file viewer

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -151,3 +151,92 @@ export async function fetchText(path: string): Promise<FetchResult<string>> {
 
   return { data, status: response.status }
 }
+
+/**
+ * Fetch only the first `bytes` of a text file (using Range header).
+ * Falls back to a full fetch + truncation if the server doesn't support Range.
+ */
+export async function fetchPartialText(path: string, bytes: number): Promise<FetchResult<string>> {
+  const config = await loadRuntimeConfig()
+  const url = getDataUrl(path, config)
+
+  let response: Response
+
+  const headers: HeadersInit = { Range: `bytes=0-${bytes - 1}` }
+
+  if (isS3Mode(config)) {
+    response = await fetchViaS3(url)
+  } else if (isLocalMode(config)) {
+    response = await fetch(cacheBustUrl(url), { credentials: 'include', headers })
+  } else {
+    response = await fetch(cacheBustUrl(url), { headers })
+  }
+
+  if (!response.ok && response.status !== 206) {
+    return { data: null, status: response.status }
+  }
+
+  const data = await response.text()
+  return { data: data.slice(0, bytes), status: response.status }
+}
+
+export interface LineSummary {
+  size: number
+  /** First N bytes of the line (UTF-8 decoded), for extracting metadata like method names. */
+  head: string
+}
+
+/**
+ * Stream a text file and return per-line byte sizes and the first
+ * `headBytes` characters of each line. The file content is never
+ * held in memory — only the lightweight summaries are kept.
+ */
+const LINE_HEAD_BYTES = 256
+
+export async function fetchLineSummaries(path: string): Promise<FetchResult<LineSummary[]>> {
+  const config = await loadRuntimeConfig()
+  const url = getDataUrl(path, config)
+
+  let response: Response
+
+  if (isS3Mode(config)) {
+    response = await fetchViaS3(url)
+  } else if (isLocalMode(config)) {
+    response = await fetch(cacheBustUrl(url), { credentials: 'include' })
+  } else {
+    response = await fetch(cacheBustUrl(url))
+  }
+
+  if (!response.ok || !response.body) {
+    return { data: null, status: response.status }
+  }
+
+  const lines: LineSummary[] = []
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  const newline = 10 // '\n'
+  let lineSize = 0
+  const headBuf: number[] = []
+
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    for (let i = 0; i < value.length; i++) {
+      if (value[i] === newline) {
+        lines.push({ size: lineSize, head: decoder.decode(new Uint8Array(headBuf)) })
+        lineSize = 0
+        headBuf.length = 0
+      } else {
+        lineSize++
+        if (headBuf.length < LINE_HEAD_BYTES) headBuf.push(value[i])
+      }
+    }
+  }
+
+  // Last line (if no trailing newline)
+  if (lineSize > 0) {
+    lines.push({ size: lineSize, head: decoder.decode(new Uint8Array(headBuf)) })
+  }
+
+  return { data: lines, status: response.status }
+}

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -124,18 +124,19 @@ export async function fetchHead(path: string): Promise<HeadResult> {
   })
 }
 
-export async function fetchText(path: string): Promise<FetchResult<string>> {
+export async function fetchText(path: string, opts?: { cacheBust?: boolean }): Promise<FetchResult<string>> {
   const config = await loadRuntimeConfig()
   const url = getDataUrl(path, config)
+  const bust = opts?.cacheBust !== false
 
   let response: Response
 
   if (isS3Mode(config)) {
     response = await fetchViaS3(url)
   } else if (isLocalMode(config)) {
-    response = await fetch(cacheBustUrl(url), { credentials: 'include' })
+    response = await fetch(bust ? cacheBustUrl(url) : url, { credentials: 'include' })
   } else {
-    response = await fetch(cacheBustUrl(url))
+    response = await fetch(bust ? cacheBustUrl(url) : url)
   }
 
   if (!response.ok) {
@@ -167,9 +168,9 @@ export async function fetchPartialText(path: string, bytes: number, offset = 0):
   if (isS3Mode(config)) {
     response = await fetchViaS3(url)
   } else if (isLocalMode(config)) {
-    response = await fetch(cacheBustUrl(url), { credentials: 'include', headers })
+    response = await fetch(url, { credentials: 'include', headers })
   } else {
-    response = await fetch(cacheBustUrl(url), { headers })
+    response = await fetch(url, { headers })
   }
 
   if (!response.ok && response.status !== 206) {
@@ -202,9 +203,9 @@ export async function fetchLineSummaries(path: string): Promise<FetchResult<Line
   if (isS3Mode(config)) {
     response = await fetchViaS3(url)
   } else if (isLocalMode(config)) {
-    response = await fetch(cacheBustUrl(url), { credentials: 'include' })
+    response = await fetch(url, { credentials: 'include' })
   } else {
-    response = await fetch(cacheBustUrl(url))
+    response = await fetch(url)
   }
 
   if (!response.ok || !response.body) {
@@ -239,4 +240,55 @@ export async function fetchLineSummaries(path: string): Promise<FetchResult<Line
   }
 
   return { data: lines, status: response.status }
+}
+
+/**
+ * Stream a text file and call `onLine` for each completed line.
+ * Returns a promise that resolves when the stream is complete.
+ */
+export async function streamLineSummaries(
+  path: string,
+  onLine: (summary: LineSummary, index: number) => void,
+): Promise<void> {
+  const config = await loadRuntimeConfig()
+  const url = getDataUrl(path, config)
+
+  let response: Response
+
+  if (isS3Mode(config)) {
+    response = await fetchViaS3(url)
+  } else if (isLocalMode(config)) {
+    response = await fetch(url, { credentials: 'include' })
+  } else {
+    response = await fetch(url)
+  }
+
+  if (!response.ok || !response.body) return
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  const newline = 10
+  let lineSize = 0
+  const headBuf: number[] = []
+  let lineIndex = 0
+
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    for (let i = 0; i < value.length; i++) {
+      if (value[i] === newline) {
+        onLine({ size: lineSize, head: decoder.decode(new Uint8Array(headBuf)) }, lineIndex)
+        lineSize = 0
+        headBuf.length = 0
+        lineIndex++
+      } else {
+        lineSize++
+        if (headBuf.length < LINE_HEAD_BYTES) headBuf.push(value[i])
+      }
+    }
+  }
+
+  if (lineSize > 0) {
+    onLine({ size: lineSize, head: decoder.decode(new Uint8Array(headBuf)) }, lineIndex)
+  }
 }

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -153,16 +153,16 @@ export async function fetchText(path: string): Promise<FetchResult<string>> {
 }
 
 /**
- * Fetch only the first `bytes` of a text file (using Range header).
+ * Fetch a byte range of a text file (using Range header).
  * Falls back to a full fetch + truncation if the server doesn't support Range.
  */
-export async function fetchPartialText(path: string, bytes: number): Promise<FetchResult<string>> {
+export async function fetchPartialText(path: string, bytes: number, offset = 0): Promise<FetchResult<string>> {
   const config = await loadRuntimeConfig()
   const url = getDataUrl(path, config)
 
   let response: Response
 
-  const headers: HeadersInit = { Range: `bytes=0-${bytes - 1}` }
+  const headers: HeadersInit = { Range: `bytes=${offset}-${offset + bytes - 1}` }
 
   if (isS3Mode(config)) {
     response = await fetchViaS3(url)

--- a/ui/src/api/hooks/useTestDetails.ts
+++ b/ui/src/api/hooks/useTestDetails.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchText, fetchData, fetchHead, fetchLineSummaries } from '../client'
 import type { AggregatedStats, ResultDetails } from '../types'
 
-const MAX_REQUEST_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+const MAX_INLINE_FILE_SIZE = 50 * 1024 * 1024 // 50MB — skip full fetch above this
 
 // Step types for test execution
 export type StepType = 'setup' | 'test' | 'cleanup' | 'pre_run'
@@ -31,11 +31,33 @@ export function useTestResponses(runId: string, testName: string, stepType: Step
   return useQuery({
     queryKey: ['run', runId, 'test', testName, 'step', stepType, 'responses'],
     queryFn: async () => {
+      const head = await fetchHead(path)
+      if (head.exists && head.size !== null && head.size > MAX_INLINE_FILE_SIZE) {
+        return null
+      }
+
       const { data, status } = await fetchText(path)
       if (!data) {
         throw new Error(`Failed to fetch responses: ${status}`)
       }
       return data.trim().split('\n')
+    },
+    enabled: !!runId && !!testName,
+  })
+}
+
+/** Stream response file for per-line summaries (works for any file size). */
+export function useTestResponseSummaries(runId: string, testName: string, stepType: StepType) {
+  const path = `runs/${runId}/${testName}/${stepType}.response`
+
+  return useQuery({
+    queryKey: ['run', runId, 'test', testName, 'step', stepType, 'response-summaries'],
+    queryFn: async () => {
+      const { data, status } = await fetchLineSummaries(path)
+      if (!data) {
+        throw new Error(`Failed to stream response file: ${status}`)
+      }
+      return data
     },
     enabled: !!runId && !!testName,
   })
@@ -65,13 +87,10 @@ export function useTestRequests(suiteHash: string, testName: string, stepType: S
   return useQuery({
     queryKey: ['suite', suiteHash, 'test', testName, 'step', stepType, 'requests'],
     queryFn: async () => {
-      // Check file size first to avoid crashing on huge request files
+      // Skip full fetch for very large files — streaming summaries handle the rest
       const head = await fetchHead(path)
-      if (head.exists && head.size !== null && head.size > MAX_REQUEST_FILE_SIZE) {
-        throw new Error(
-          `Request file too large (${(head.size / 1024 / 1024).toFixed(0)}MB). ` +
-          `Execution details cannot be displayed.`,
-        )
+      if (head.exists && head.size !== null && head.size > MAX_INLINE_FILE_SIZE) {
+        return null
       }
 
       const { data, status } = await fetchText(path)

--- a/ui/src/api/hooks/useTestDetails.ts
+++ b/ui/src/api/hooks/useTestDetails.ts
@@ -1,5 +1,6 @@
+import { useEffect, useReducer } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { fetchText, fetchData, fetchHead, fetchLineSummaries } from '../client'
+import { fetchText, fetchData, fetchHead, streamLineSummaries, type LineSummary } from '../client'
 import type { AggregatedStats, ResultDetails } from '../types'
 
 const MAX_INLINE_FILE_SIZE = 50 * 1024 * 1024 // 50MB — skip full fetch above this
@@ -36,7 +37,7 @@ export function useTestResponses(runId: string, testName: string, stepType: Step
         return null
       }
 
-      const { data, status } = await fetchText(path)
+      const { data, status } = await fetchText(path, { cacheBust: false })
       if (!data) {
         throw new Error(`Failed to fetch responses: ${status}`)
       }
@@ -46,21 +47,59 @@ export function useTestResponses(runId: string, testName: string, stepType: Step
   })
 }
 
-/** Stream response file for per-line summaries (works for any file size). */
+/** Stream response file and return per-line summaries progressively. */
 export function useTestResponseSummaries(runId: string, testName: string, stepType: StepType) {
   const path = `runs/${runId}/${testName}/${stepType}.response`
+  return useStreamingSummaries(path, !!runId && !!testName)
+}
 
-  return useQuery({
-    queryKey: ['run', runId, 'test', testName, 'step', stepType, 'response-summaries'],
-    queryFn: async () => {
-      const { data, status } = await fetchLineSummaries(path)
-      if (!data) {
-        throw new Error(`Failed to stream response file: ${status}`)
-      }
-      return data
-    },
-    enabled: !!runId && !!testName,
-  })
+/**
+ * Progressive streaming hook — streams a newline-delimited file and
+ * updates state as each line is scanned so UI rows appear one by one.
+ */
+
+type StreamAction =
+  | { type: 'reset'; path: string }
+  | { type: 'line'; summary: LineSummary }
+  | { type: 'done' }
+
+interface StreamState {
+  data: LineSummary[] | undefined
+  isStreaming: boolean
+  path: string
+}
+
+function streamReducer(state: StreamState, action: StreamAction): StreamState {
+  switch (action.type) {
+    case 'reset':
+      return { data: undefined, isStreaming: true, path: action.path }
+    case 'line':
+      return { ...state, data: state.data ? [...state.data, action.summary] : [action.summary] }
+    case 'done':
+      return { ...state, isStreaming: false }
+  }
+}
+
+function useStreamingSummaries(path: string, enabled: boolean) {
+  const [state, dispatch] = useReducer(streamReducer, { data: undefined, isStreaming: false, path: '' })
+
+  useEffect(() => {
+    if (!enabled) return
+
+    let cancelled = false
+    dispatch({ type: 'reset', path })
+
+    streamLineSummaries(path, (summary) => {
+      if (!cancelled) dispatch({ type: 'line', summary })
+    }).finally(() => {
+      if (!cancelled) dispatch({ type: 'done' })
+    })
+
+    return () => { cancelled = true }
+  }, [path, enabled])
+
+  const current = state.path === path ? state : { data: undefined, isStreaming: enabled }
+  return { data: current.data, isStreaming: current.isStreaming }
 }
 
 export function useTestAggregated(runId: string, testName: string, stepType: StepType) {
@@ -93,7 +132,7 @@ export function useTestRequests(suiteHash: string, testName: string, stepType: S
         return null
       }
 
-      const { data, status } = await fetchText(path)
+      const { data, status } = await fetchText(path, { cacheBust: false })
       if (!data) {
         throw new Error(`Failed to fetch requests: ${status}`)
       }
@@ -104,22 +143,10 @@ export function useTestRequests(suiteHash: string, testName: string, stepType: S
 }
 
 /**
- * Stream the request file and return per-line summaries (byte size +
- * first 256 bytes for method extraction). Works for any file size since
- * the full content is never held in memory.
+ * Stream the request file and return per-line summaries progressively.
+ * Updates state as each line is scanned so early rows appear immediately.
  */
 export function useTestRequestSummaries(suiteHash: string, testName: string, stepType: StepType) {
   const path = `suites/${suiteHash}/${testName}/${stepType}.request`
-
-  return useQuery({
-    queryKey: ['suite', suiteHash, 'test', testName, 'step', stepType, 'request-summaries'],
-    queryFn: async () => {
-      const { data, status } = await fetchLineSummaries(path)
-      if (!data) {
-        throw new Error(`Failed to stream request file: ${status}`)
-      }
-      return data
-    },
-    enabled: !!suiteHash && !!testName,
-  })
+  return useStreamingSummaries(path, !!suiteHash && !!testName)
 }

--- a/ui/src/api/hooks/useTestDetails.ts
+++ b/ui/src/api/hooks/useTestDetails.ts
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchText, fetchData } from '../client'
+import { fetchText, fetchData, fetchHead, fetchLineSummaries } from '../client'
 import type { AggregatedStats, ResultDetails } from '../types'
+
+const MAX_REQUEST_FILE_SIZE = 10 * 1024 * 1024 // 10MB
 
 // Step types for test execution
 export type StepType = 'setup' | 'test' | 'cleanup' | 'pre_run'
@@ -63,11 +65,41 @@ export function useTestRequests(suiteHash: string, testName: string, stepType: S
   return useQuery({
     queryKey: ['suite', suiteHash, 'test', testName, 'step', stepType, 'requests'],
     queryFn: async () => {
+      // Check file size first to avoid crashing on huge request files
+      const head = await fetchHead(path)
+      if (head.exists && head.size !== null && head.size > MAX_REQUEST_FILE_SIZE) {
+        throw new Error(
+          `Request file too large (${(head.size / 1024 / 1024).toFixed(0)}MB). ` +
+          `Execution details cannot be displayed.`,
+        )
+      }
+
       const { data, status } = await fetchText(path)
       if (!data) {
         throw new Error(`Failed to fetch requests: ${status}`)
       }
       return data.trim().split('\n')
+    },
+    enabled: !!suiteHash && !!testName,
+  })
+}
+
+/**
+ * Stream the request file and return per-line summaries (byte size +
+ * first 256 bytes for method extraction). Works for any file size since
+ * the full content is never held in memory.
+ */
+export function useTestRequestSummaries(suiteHash: string, testName: string, stepType: StepType) {
+  const path = `suites/${suiteHash}/${testName}/${stepType}.request`
+
+  return useQuery({
+    queryKey: ['suite', suiteHash, 'test', testName, 'step', stepType, 'request-summaries'],
+    queryFn: async () => {
+      const { data, status } = await fetchLineSummaries(path)
+      if (!data) {
+        throw new Error(`Failed to stream request file: ${status}`)
+      }
+      return data
     },
     enabled: !!suiteHash && !!testName,
   })

--- a/ui/src/components/run-detail/ExecutionsList.tsx
+++ b/ui/src/components/run-detail/ExecutionsList.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import { ChevronRight } from 'lucide-react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import { useTestRequests, useTestResponses, useTestResultDetails, type StepType } from '@/api/hooks/useTestDetails'
+import { useTestRequests, useTestResponses, useTestResultDetails, useTestRequestSummaries, type StepType } from '@/api/hooks/useTestDetails'
 import { Duration } from '@/components/shared/Duration'
 
 function useDarkMode() {
@@ -84,9 +84,18 @@ function formatJson(json: string): string {
   }
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
 interface ExecutionRowProps {
   index: number
-  request: string
+  request?: string
+  requestSize?: number
+  /** Method name from partial fetch (used when full request is unavailable). */
+  methodName?: string
   response?: string
   time?: number
   status?: number // 0=success, 1=fail
@@ -113,22 +122,28 @@ function StatusIndicator({ status }: { status?: number }) {
   )
 }
 
-function ExecutionRow({ index, request, response, time, status, mgasPerSec, gasUsed }: ExecutionRowProps) {
+function ExecutionRow({ index, request, requestSize, methodName, response, time, status, mgasPerSec, gasUsed }: ExecutionRowProps) {
   const [expanded, setExpanded] = useState(false)
-  const method = parseMethod(request)
+  const method = request ? parseMethod(request) : methodName
+  const canExpand = !!request || !!response
 
   return (
     <div className="max-w-full overflow-hidden border-b border-gray-200 last:border-b-0 dark:border-gray-700">
       <button
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => canExpand && setExpanded(!expanded)}
         className={clsx(
-          'flex w-full cursor-pointer items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-gray-100 dark:hover:bg-gray-800',
+          'flex w-full items-center gap-3 px-3 py-2 text-left transition-colors',
+          canExpand ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800' : 'cursor-default',
           expanded && 'bg-gray-100 dark:bg-gray-800',
         )}
       >
-        <ChevronRight className={clsx('size-4 shrink-0 text-gray-400 transition-transform', expanded && 'rotate-90')} />
+        {canExpand ? (
+          <ChevronRight className={clsx('size-4 shrink-0 text-gray-400 transition-transform', expanded && 'rotate-90')} />
+        ) : (
+          <span className="size-4 shrink-0" />
+        )}
         <span className="w-10 shrink-0 font-mono text-sm/6 text-gray-500 dark:text-gray-400">#{index}</span>
-        <span className="min-w-0 flex-1 truncate font-mono text-sm/6 text-gray-900 dark:text-gray-100">{method}</span>
+        <span className="min-w-0 flex-1 truncate font-mono text-sm/6 text-gray-900 dark:text-gray-100">{method ?? '-'}</span>
         {mgasPerSec !== undefined && (
           <span className="shrink-0 text-sm/6 font-medium text-blue-600 dark:text-blue-400">
             {mgasPerSec.toFixed(2)} MGas/s
@@ -137,6 +152,17 @@ function ExecutionRow({ index, request, response, time, status, mgasPerSec, gasU
                 ({(gasUsed / 1e6).toFixed(2)}M gas)
               </span>
             )}
+          </span>
+        )}
+        {(requestSize !== undefined || request || response) && (
+          <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+            {(requestSize !== undefined || request) && (
+              <span title="Request size">
+                {formatBytes(requestSize ?? new Blob([request!]).size)}
+              </span>
+            )}
+            {(requestSize !== undefined || request) && response && ' / '}
+            {response && <span title="Response size">{formatBytes(new Blob([response]).size)}</span>}
           </span>
         )}
         {time !== undefined && (
@@ -150,17 +176,19 @@ function ExecutionRow({ index, request, response, time, status, mgasPerSec, gasU
       {expanded && (
         <div className="bg-gray-50 px-4 py-3 dark:bg-gray-900/50">
           <div className="flex flex-col gap-3">
-            <div>
-              <div className="mb-1 flex items-center justify-between">
-                <h5 className="text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                  Request
-                </h5>
-                <CopyButton text={formatJson(request)} />
+            {request && (
+              <div>
+                <div className="mb-1 flex items-center justify-between">
+                  <h5 className="text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Request
+                  </h5>
+                  <CopyButton text={formatJson(request)} />
+                </div>
+                <div className="w-0 min-w-full overflow-x-auto rounded-xs bg-gray-100 dark:bg-gray-800">
+                  <JsonBlock code={formatJson(request)} />
+                </div>
               </div>
-              <div className="w-0 min-w-full overflow-x-auto rounded-xs bg-gray-100 dark:bg-gray-800">
-                <JsonBlock code={formatJson(request)} />
-              </div>
-            </div>
+            )}
             {response && (
               <div>
                 <div className="mb-1 flex items-center justify-between">
@@ -181,12 +209,22 @@ function ExecutionRow({ index, request, response, time, status, mgasPerSec, gasU
   )
 }
 
+const EXECUTIONS_PAGE_SIZE = 100
+
 export function ExecutionsList({ runId, suiteHash, testName, stepType }: ExecutionsListProps) {
   const { data: requests, isLoading: requestsLoading, error: requestsError } = useTestRequests(suiteHash, testName, stepType)
-  const { data: responses, isLoading: responsesLoading } = useTestResponses(runId, testName, stepType)
-  const { data: resultDetails, isLoading: detailsLoading } = useTestResultDetails(runId, testName, stepType)
+  const { data: responses, error: responsesError } = useTestResponses(runId, testName, stepType)
+  const { data: resultDetails, isLoading: detailsLoading, error: detailsError } = useTestResultDetails(runId, testName, stepType)
+  const { data: requestSummaries } = useTestRequestSummaries(suiteHash, testName, stepType)
+  const [page, setPage] = useState(1)
 
-  const isLoading = requestsLoading || responsesLoading || detailsLoading
+  // Treat response/detail fetch errors as missing data (not all steps have responses)
+  const safeRequests = requestsError ? undefined : requests
+  const safeResponses = responsesError ? undefined : responses
+  const safeDetails = detailsError ? undefined : resultDetails
+
+  // Wait for at least one data source (details or requests) to be ready
+  const isLoading = (!requestsError && requestsLoading) && (!detailsError && detailsLoading)
 
   if (isLoading) {
     return (
@@ -197,20 +235,29 @@ export function ExecutionsList({ runId, suiteHash, testName, stepType }: Executi
     )
   }
 
-  if (requestsError || !requests) {
+  // Derive execution count from whichever source is available
+  const executionCount = safeDetails?.duration_ns.length ?? safeRequests?.length ?? requestSummaries?.length ?? 0
+
+  if (executionCount === 0) {
     return <p className="py-2 text-sm/6 text-gray-500 dark:text-gray-400">No execution data available</p>
   }
 
-  const totalDurationNs = resultDetails?.duration_ns.reduce((sum, ns) => sum + ns, 0) ?? 0
-  const totalGasUsed = resultDetails?.gas_used
-    ? Object.values(resultDetails.gas_used).reduce((sum, g) => sum + g, 0)
+  const totalDurationNs = Array.isArray(safeDetails?.duration_ns)
+    ? safeDetails.duration_ns.reduce((sum, ns) => sum + ns, 0)
     : 0
+  const totalGasUsed = safeDetails?.gas_used
+    ? Object.values(safeDetails.gas_used).reduce((sum, g) => sum + g, 0)
+    : 0
+
+  const totalPages = Math.ceil(executionCount / EXECUTIONS_PAGE_SIZE)
+  const startIdx = (page - 1) * EXECUTIONS_PAGE_SIZE
+  const endIdx = Math.min(startIdx + EXECUTIONS_PAGE_SIZE, executionCount)
 
   return (
     <div className="mt-4 max-w-full overflow-hidden">
       <div className="mb-2 flex items-center justify-between">
         <h4 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
-          Executions ({requests.length})
+          Executions ({executionCount})
         </h4>
         {totalDurationNs > 0 && (
           <span className="text-sm/6 text-gray-500 dark:text-gray-400">
@@ -224,19 +271,45 @@ export function ExecutionsList({ runId, suiteHash, testName, stepType }: Executi
         )}
       </div>
       <div className="overflow-hidden rounded-xs border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-        {requests.map((request, index) => (
-          <ExecutionRow
-            key={index}
-            index={index}
-            request={request}
-            response={responses?.[index]}
-            time={resultDetails?.duration_ns[index]}
-            status={resultDetails?.status[index]}
-            mgasPerSec={resultDetails?.mgas_s[String(index)]}
-            gasUsed={resultDetails?.gas_used[String(index)]}
-          />
-        ))}
+        {Array.from({ length: endIdx - startIdx }, (_, i) => {
+          const index = startIdx + i
+          return (
+            <ExecutionRow
+              key={index}
+              index={index}
+              request={safeRequests?.[index]}
+              requestSize={requestSummaries?.[index]?.size}
+              methodName={requestSummaries?.[index]?.head.match(/"method"\s*:\s*"([^"]+)"/)?.[1]}
+              response={safeResponses?.[index]}
+              time={safeDetails?.duration_ns[index]}
+              status={safeDetails?.status[index]}
+              mgasPerSec={safeDetails?.mgas_s[String(index)]}
+              gasUsed={safeDetails?.gas_used[String(index)]}
+            />
+          )
+        })}
       </div>
+      {totalPages > 1 && (
+        <div className="mt-2 flex items-center justify-between text-xs/5 text-gray-500 dark:text-gray-400">
+          <span>Showing {startIdx + 1}–{endIdx} of {executionCount}</span>
+          <div className="flex gap-1">
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage(page - 1)}
+              className="rounded-xs px-2 py-0.5 transition-colors hover:bg-gray-100 disabled:opacity-40 dark:hover:bg-gray-700"
+            >
+              Prev
+            </button>
+            <button
+              disabled={page >= totalPages}
+              onClick={() => setPage(page + 1)}
+              className="rounded-xs px-2 py-0.5 transition-colors hover:bg-gray-100 disabled:opacity-40 dark:hover:bg-gray-700"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/ui/src/components/run-detail/ExecutionsList.tsx
+++ b/ui/src/components/run-detail/ExecutionsList.tsx
@@ -196,6 +196,9 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
             </>
           ) : ''}
         </span>
+        <span className="w-16 shrink-0 text-right text-sm/6 text-gray-500 dark:text-gray-400">
+          {time !== undefined ? <Duration nanoseconds={time} /> : ''}
+        </span>
         <span className="w-28 shrink-0 text-right text-xs text-gray-400 dark:text-gray-500">
           {requestSize !== undefined || request ? (
             <span title="Request size">
@@ -212,9 +215,6 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
           ) : (
             <span className="inline-block size-2.5 animate-spin rounded-full border border-gray-300 border-t-gray-500" />
           )}
-        </span>
-        <span className="w-16 shrink-0 text-right text-sm/6 text-gray-500 dark:text-gray-400">
-          {time !== undefined ? <Duration nanoseconds={time} /> : ''}
         </span>
         <span className="w-12 shrink-0 text-right">
           <StatusIndicator status={status} />

--- a/ui/src/components/run-detail/ExecutionsList.tsx
+++ b/ui/src/components/run-detail/ExecutionsList.tsx
@@ -1,9 +1,11 @@
 import { useState, useCallback, useEffect } from 'react'
 import clsx from 'clsx'
+import { useQuery } from '@tanstack/react-query'
 import { ChevronRight } from 'lucide-react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import { useTestRequests, useTestResponses, useTestResultDetails, useTestRequestSummaries, type StepType } from '@/api/hooks/useTestDetails'
+import { useTestRequests, useTestResponses, useTestResultDetails, useTestRequestSummaries, useTestResponseSummaries, type StepType } from '@/api/hooks/useTestDetails'
+import { fetchPartialText } from '@/api/client'
 import { Duration } from '@/components/shared/Duration'
 
 function useDarkMode() {
@@ -90,17 +92,33 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
+interface LazyLineInfo {
+  /** Full path to the file (e.g. "suites/{hash}/{test}/setup.request") */
+  filePath: string
+  /** Byte offset of this line within the file */
+  byteOffset: number
+  /** Byte size of this line */
+  byteSize: number
+}
+
 interface ExecutionRowProps {
   index: number
   request?: string
   requestSize?: number
   /** Method name from partial fetch (used when full request is unavailable). */
   methodName?: string
+  /** Info for lazy-loading request content on expand (when full file was too large). */
+  requestLineInfo?: LazyLineInfo
   response?: string
+  responseSize?: number
   time?: number
   status?: number // 0=success, 1=fail
   mgasPerSec?: number
   gasUsed?: number
+  /** File viewer link for the response file at this line. */
+  responseViewerUrl?: string
+  /** File viewer link for the request file at this line. */
+  requestViewerUrl?: string
 }
 
 function StatusIndicator({ status }: { status?: number }) {
@@ -122,10 +140,26 @@ function StatusIndicator({ status }: { status?: number }) {
   )
 }
 
-function ExecutionRow({ index, request, requestSize, methodName, response, time, status, mgasPerSec, gasUsed }: ExecutionRowProps) {
+const MAX_LAZY_LINE_SIZE = 1_000_000 // 1MB — lazy-load lines up to this size
+
+function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo, response, responseSize, time, status, mgasPerSec, gasUsed, responseViewerUrl, requestViewerUrl }: ExecutionRowProps) {
   const [expanded, setExpanded] = useState(false)
   const method = request ? parseMethod(request) : methodName
-  const canExpand = !!request || !!response
+
+  // Lazy-load request content for lines that are small enough but weren't in the full fetch
+  const canLazyLoad = !request && !!requestLineInfo && requestLineInfo.byteSize <= MAX_LAZY_LINE_SIZE
+  const { data: lazyRequest } = useQuery({
+    queryKey: ['lazy-line', requestLineInfo?.filePath, requestLineInfo?.byteOffset, requestLineInfo?.byteSize],
+    queryFn: async () => {
+      if (!requestLineInfo) return null
+      const { data } = await fetchPartialText(requestLineInfo.filePath, requestLineInfo.byteSize, requestLineInfo.byteOffset)
+      return data
+    },
+    enabled: expanded && canLazyLoad,
+  })
+
+  const effectiveRequest = request ?? lazyRequest ?? undefined
+  const canExpand = !!effectiveRequest || !!response || !!responseViewerUrl || !!requestViewerUrl || canLazyLoad
 
   return (
     <div className="max-w-full overflow-hidden border-b border-gray-200 last:border-b-0 dark:border-gray-700">
@@ -154,15 +188,19 @@ function ExecutionRow({ index, request, requestSize, methodName, response, time,
             )}
           </span>
         )}
-        {(requestSize !== undefined || request || response) && (
+        {(requestSize !== undefined || request || responseSize !== undefined || response) && (
           <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
             {(requestSize !== undefined || request) && (
               <span title="Request size">
                 {formatBytes(requestSize ?? new Blob([request!]).size)}
               </span>
             )}
-            {(requestSize !== undefined || request) && response && ' / '}
-            {response && <span title="Response size">{formatBytes(new Blob([response]).size)}</span>}
+            {(requestSize !== undefined || request) && (responseSize !== undefined || response) && ' / '}
+            {(responseSize !== undefined || response) && (
+              <span title="Response size">
+                {formatBytes(responseSize ?? new Blob([response!]).size)}
+              </span>
+            )}
           </span>
         )}
         {time !== undefined && (
@@ -176,16 +214,45 @@ function ExecutionRow({ index, request, requestSize, methodName, response, time,
       {expanded && (
         <div className="bg-gray-50 px-4 py-3 dark:bg-gray-900/50">
           <div className="flex flex-col gap-3">
-            {request && (
+            {effectiveRequest && (
               <div>
                 <div className="mb-1 flex items-center justify-between">
                   <h5 className="text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
                     Request
                   </h5>
-                  <CopyButton text={formatJson(request)} />
+                  <CopyButton text={formatJson(effectiveRequest)} />
                 </div>
                 <div className="w-0 min-w-full overflow-x-auto rounded-xs bg-gray-100 dark:bg-gray-800">
-                  <JsonBlock code={formatJson(request)} />
+                  <JsonBlock code={formatJson(effectiveRequest)} />
+                </div>
+              </div>
+            )}
+            {!effectiveRequest && canLazyLoad && expanded && (
+              <div>
+                <h5 className="mb-1 text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  Request
+                </h5>
+                <div className="flex items-center gap-2 py-2 text-sm/6 text-gray-500 dark:text-gray-400">
+                  <div className="size-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600" />
+                  Loading...
+                </div>
+              </div>
+            )}
+            {!effectiveRequest && !canLazyLoad && requestViewerUrl && (
+              <div>
+                <h5 className="mb-1 text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  Request
+                </h5>
+                <div className="rounded-xs bg-gray-100 px-3 py-2 text-sm/6 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                  This file is too large to display here{requestSize !== undefined ? ` (${formatBytes(requestSize)})` : ''}.{' '}
+                  <a
+                    href={requestViewerUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium text-blue-600 hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
+                  >
+                    View request in file viewer →
+                  </a>
                 </div>
               </div>
             )}
@@ -199,6 +266,24 @@ function ExecutionRow({ index, request, requestSize, methodName, response, time,
                 </div>
                 <div className="w-0 min-w-full overflow-x-auto rounded-xs bg-gray-100 dark:bg-gray-800">
                   <JsonBlock code={formatJson(response)} />
+                </div>
+              </div>
+            )}
+            {!response && responseViewerUrl && (
+              <div>
+                <h5 className="mb-1 text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  Response
+                </h5>
+                <div className="rounded-xs bg-gray-100 px-3 py-2 text-sm/6 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                  This file is too large to display here{responseSize !== undefined ? ` (${formatBytes(responseSize)})` : ''}.{' '}
+                  <a
+                    href={responseViewerUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium text-blue-600 hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
+                  >
+                    View response in file viewer →
+                  </a>
                 </div>
               </div>
             )}
@@ -216,7 +301,22 @@ export function ExecutionsList({ runId, suiteHash, testName, stepType }: Executi
   const { data: responses, error: responsesError } = useTestResponses(runId, testName, stepType)
   const { data: resultDetails, isLoading: detailsLoading, error: detailsError } = useTestResultDetails(runId, testName, stepType)
   const { data: requestSummaries } = useTestRequestSummaries(suiteHash, testName, stepType)
+  const { data: responseSummaries } = useTestResponseSummaries(runId, testName, stepType)
   const [page, setPage] = useState(1)
+
+  // Compute byte offsets for each request line (for lazy Range fetches)
+  const requestFilePath = `suites/${suiteHash}/${testName}/${stepType}.request`
+  const requestByteOffsets = requestSummaries
+    ? (() => {
+        const offsets: number[] = []
+        let offset = 0
+        for (const s of requestSummaries) {
+          offsets.push(offset)
+          offset += s.size + 1 // +1 for the newline
+        }
+        return offsets
+      })()
+    : undefined
 
   // Treat response/detail fetch errors as missing data (not all steps have responses)
   const safeRequests = requestsError ? undefined : requests
@@ -280,11 +380,21 @@ export function ExecutionsList({ runId, suiteHash, testName, stepType }: Executi
               request={safeRequests?.[index]}
               requestSize={requestSummaries?.[index]?.size}
               methodName={requestSummaries?.[index]?.head.match(/"method"\s*:\s*"([^"]+)"/)?.[1]}
+              requestLineInfo={!safeRequests?.[index] && requestSummaries?.[index] && requestByteOffsets
+                ? { filePath: requestFilePath, byteOffset: requestByteOffsets[index], byteSize: requestSummaries[index].size }
+                : undefined}
               response={safeResponses?.[index]}
+              responseSize={responseSummaries?.[index]?.size}
               time={safeDetails?.duration_ns[index]}
               status={safeDetails?.status[index]}
               mgasPerSec={safeDetails?.mgas_s[String(index)]}
               gasUsed={safeDetails?.gas_used[String(index)]}
+              responseViewerUrl={!safeResponses?.[index] && responseSummaries?.[index] && responseSummaries[index].size > 1_000_000
+                ? `/runs/${runId}/fileviewer?file=${encodeURIComponent(`${testName}/${stepType}.response`)}&lines=${index + 1}`
+                : undefined}
+              requestViewerUrl={!safeRequests?.[index] && requestSummaries?.[index] && requestSummaries[index].size > 1_000_000
+                ? `/runs/${runId}/fileviewer?base=${encodeURIComponent(`suites/${suiteHash}`)}&file=${encodeURIComponent(`${testName}/${stepType}.request`)}&lines=${index + 1}`
+                : undefined}
             />
           )
         })}

--- a/ui/src/components/run-detail/ExecutionsList.tsx
+++ b/ui/src/components/run-detail/ExecutionsList.tsx
@@ -184,17 +184,19 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
             ? <span className="inline-block size-3 animate-spin rounded-full border border-gray-300 border-t-gray-600" />
             : '-')}
         </span>
-        {mgasPerSec !== undefined && (
-          <span className="shrink-0 text-sm/6 font-medium text-blue-600 dark:text-blue-400">
-            {mgasPerSec.toFixed(2)} MGas/s
-            {gasUsed !== undefined && (
-              <span className="ml-1 font-normal text-gray-500 dark:text-gray-400">
-                ({(gasUsed / 1e6).toFixed(2)}M gas)
-              </span>
-            )}
-          </span>
-        )}
-        <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+        <span className="w-44 shrink-0 text-right text-sm/6 font-medium text-blue-600 dark:text-blue-400">
+          {mgasPerSec !== undefined ? (
+            <>
+              {mgasPerSec.toFixed(2)} MGas/s
+              {gasUsed !== undefined && (
+                <span className="ml-1 font-normal text-gray-500 dark:text-gray-400">
+                  ({(gasUsed / 1e6).toFixed(2)}M)
+                </span>
+              )}
+            </>
+          ) : ''}
+        </span>
+        <span className="w-28 shrink-0 text-right text-xs text-gray-400 dark:text-gray-500">
           {requestSize !== undefined || request ? (
             <span title="Request size">
               {formatBytes(requestSize ?? new Blob([request!]).size)}
@@ -211,12 +213,12 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
             <span className="inline-block size-2.5 animate-spin rounded-full border border-gray-300 border-t-gray-500" />
           )}
         </span>
-        {time !== undefined && (
-          <span className="shrink-0 text-sm/6 text-gray-500 dark:text-gray-400">
-            <Duration nanoseconds={time} />
-          </span>
-        )}
-        <StatusIndicator status={status} />
+        <span className="w-16 shrink-0 text-right text-sm/6 text-gray-500 dark:text-gray-400">
+          {time !== undefined ? <Duration nanoseconds={time} /> : ''}
+        </span>
+        <span className="w-12 shrink-0 text-right">
+          <StatusIndicator status={status} />
+        </span>
       </button>
 
       {expanded && (

--- a/ui/src/components/run-detail/ExecutionsList.tsx
+++ b/ui/src/components/run-detail/ExecutionsList.tsx
@@ -159,6 +159,8 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
   })
 
   const effectiveRequest = request ?? lazyRequest ?? undefined
+  const effectiveRequestSize = requestSize ?? (request ? new Blob([request]).size : undefined)
+  const effectiveResponseSize = responseSize ?? (response ? new Blob([response]).size : undefined)
   const canExpand = !!effectiveRequest || !!response || !!responseViewerUrl || !!requestViewerUrl || canLazyLoad
 
   return (
@@ -177,7 +179,11 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
           <span className="size-4 shrink-0" />
         )}
         <span className="w-10 shrink-0 font-mono text-sm/6 text-gray-500 dark:text-gray-400">#{index}</span>
-        <span className="min-w-0 flex-1 truncate font-mono text-sm/6 text-gray-900 dark:text-gray-100">{method ?? '-'}</span>
+        <span className="min-w-0 flex-1 truncate font-mono text-sm/6 text-gray-900 dark:text-gray-100">
+          {method ?? (requestSize === undefined
+            ? <span className="inline-block size-3 animate-spin rounded-full border border-gray-300 border-t-gray-600" />
+            : '-')}
+        </span>
         {mgasPerSec !== undefined && (
           <span className="shrink-0 text-sm/6 font-medium text-blue-600 dark:text-blue-400">
             {mgasPerSec.toFixed(2)} MGas/s
@@ -188,21 +194,23 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
             )}
           </span>
         )}
-        {(requestSize !== undefined || request || responseSize !== undefined || response) && (
-          <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
-            {(requestSize !== undefined || request) && (
-              <span title="Request size">
-                {formatBytes(requestSize ?? new Blob([request!]).size)}
-              </span>
-            )}
-            {(requestSize !== undefined || request) && (responseSize !== undefined || response) && ' / '}
-            {(responseSize !== undefined || response) && (
-              <span title="Response size">
-                {formatBytes(responseSize ?? new Blob([response!]).size)}
-              </span>
-            )}
-          </span>
-        )}
+        <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+          {requestSize !== undefined || request ? (
+            <span title="Request size">
+              {formatBytes(requestSize ?? new Blob([request!]).size)}
+            </span>
+          ) : (
+            <span className="inline-block size-2.5 animate-spin rounded-full border border-gray-300 border-t-gray-500" />
+          )}
+          {' / '}
+          {responseSize !== undefined || response ? (
+            <span title="Response size">
+              {formatBytes(responseSize ?? new Blob([response!]).size)}
+            </span>
+          ) : (
+            <span className="inline-block size-2.5 animate-spin rounded-full border border-gray-300 border-t-gray-500" />
+          )}
+        </span>
         {time !== undefined && (
           <span className="shrink-0 text-sm/6 text-gray-500 dark:text-gray-400">
             <Duration nanoseconds={time} />
@@ -218,7 +226,7 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
               <div>
                 <div className="mb-1 flex items-center justify-between">
                   <h5 className="text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                    Request
+                    Request{effectiveRequestSize !== undefined && <span className="ml-1 normal-case tracking-normal">({formatBytes(effectiveRequestSize)})</span>}
                   </h5>
                   <CopyButton text={formatJson(effectiveRequest)} />
                 </div>
@@ -241,10 +249,10 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
             {!effectiveRequest && !canLazyLoad && requestViewerUrl && (
               <div>
                 <h5 className="mb-1 text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                  Request
+                  Request{effectiveRequestSize !== undefined && <span className="ml-1 normal-case tracking-normal">({formatBytes(effectiveRequestSize)})</span>}
                 </h5>
                 <div className="rounded-xs bg-gray-100 px-3 py-2 text-sm/6 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
-                  This file is too large to display here{requestSize !== undefined ? ` (${formatBytes(requestSize)})` : ''}.{' '}
+                  This file is too large to display here.{' '}
                   <a
                     href={requestViewerUrl}
                     target="_blank"
@@ -260,7 +268,7 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
               <div>
                 <div className="mb-1 flex items-center justify-between">
                   <h5 className="text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                    Response
+                    Response{effectiveResponseSize !== undefined && <span className="ml-1 normal-case tracking-normal">({formatBytes(effectiveResponseSize)})</span>}
                   </h5>
                   <CopyButton text={formatJson(response)} />
                 </div>
@@ -272,10 +280,10 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
             {!response && responseViewerUrl && (
               <div>
                 <h5 className="mb-1 text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                  Response
+                  Response{effectiveResponseSize !== undefined && <span className="ml-1 normal-case tracking-normal">({formatBytes(effectiveResponseSize)})</span>}
                 </h5>
                 <div className="rounded-xs bg-gray-100 px-3 py-2 text-sm/6 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
-                  This file is too large to display here{responseSize !== undefined ? ` (${formatBytes(responseSize)})` : ''}.{' '}
+                  This file is too large to display here.{' '}
                   <a
                     href={responseViewerUrl}
                     target="_blank"

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -491,6 +491,9 @@ export function FileViewerPage() {
     })
   }, [isLargeFile, totalSize, loadedBytes, chunkLoading, filePath])
 
+  // Auto-load chunks until the target selected line is available
+  const targetLine = selectedLines.size > 0 ? Math.max(...selectedLines) : 0
+
   const isLoading = headLoading || fullLoading || (isLargeFile && chunks.length === 0 && chunkLoading)
   const error = fullError
 
@@ -504,6 +507,14 @@ export function FileViewerPage() {
   }, [])
 
   const lines = useMemo(() => fileContent?.split('\n') ?? [], [fileContent])
+
+  // Keep loading chunks until the target line from the URL is reachable
+  useEffect(() => {
+    if (!isLargeFile || !hasMoreChunks || chunkLoading || targetLine === 0) return
+    if (lines.length < targetLine) {
+      loadNextChunk()
+    }
+  }, [isLargeFile, hasMoreChunks, chunkLoading, targetLine, lines.length, loadNextChunk])
   const useAnsi = useMemo(() => fileContent ? hasAnsiCodes(fileContent) : false, [fileContent])
   const language = useMemo(() => fileContent ? detectLanguage(fileContent) : 'bash', [fileContent])
   const useSyntax = useMemo(() => !useAnsi && lines.length <= SYNTAX_HIGHLIGHT_LINE_LIMIT, [useAnsi, lines.length])
@@ -569,12 +580,15 @@ export function FileViewerPage() {
     [selectedLines, lastClickedLine, updateSelectedLines]
   )
 
-  // Scroll to first selected line on initial load
+  // Scroll to first selected line once it's available
   useEffect(() => {
     if (lines.length > 0 && selectedLines.size > 0 && !hasScrolledRef.current) {
       const firstLine = Math.min(...selectedLines)
-      virtualizer.scrollToIndex(firstLine - 1, { align: 'center' })
-      hasScrolledRef.current = true
+      // Wait until the target line is loaded before scrolling
+      if (firstLine <= lines.length) {
+        virtualizer.scrollToIndex(firstLine - 1, { align: 'center' })
+        hasScrolledRef.current = true
+      }
     }
   }, [lines.length, selectedLines, virtualizer])
 
@@ -654,8 +668,14 @@ export function FileViewerPage() {
           </div>
         </div>
         {isLargeFile && totalSize !== null && (
-          <div className="border-b border-blue-200 bg-blue-50 px-4 py-1.5 text-xs/5 text-blue-700 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-300">
-            Large file ({(totalSize / 1024 / 1024).toFixed(1)} MB) — loaded {(loadedBytes / 1024 / 1024).toFixed(1)} MB ({lines.length} lines)
+          <div className="flex items-center gap-2 border-b border-blue-200 bg-blue-50 px-4 py-1.5 text-xs/5 text-blue-700 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-300">
+            {chunkLoading && (
+              <div className="size-3.5 shrink-0 animate-spin rounded-full border-2 border-blue-300 border-t-blue-600" />
+            )}
+            <span>
+              Large file ({(totalSize / 1024 / 1024).toFixed(1)} MB) — loaded {(loadedBytes / 1024 / 1024).toFixed(1)} MB ({lines.length} lines)
+              {chunkLoading && targetLine > lines.length && ` — loading to line ${targetLine}...`}
+            </span>
           </div>
         )}
         <div ref={scrollContainerRef} className="max-h-[80vh] overflow-auto">

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -15,10 +15,10 @@ import { JDenticon } from '@/components/shared/JDenticon'
 const ESTIMATED_LINE_HEIGHT = 20
 const SYNTAX_HIGHLIGHT_LINE_LIMIT = 5_000
 
-function parseLineSelection(linesParam: string | undefined): Set<number> {
-  if (!linesParam) return new Set()
+function parseLineSelection(linesParam: string | number | undefined): Set<number> {
+  if (linesParam === undefined || linesParam === null) return new Set()
   const selected = new Set<number>()
-  const parts = linesParam.split(',')
+  const parts = String(linesParam).split(',')
   for (const part of parts) {
     if (part.includes('-')) {
       const [start, end] = part.split('-').map(Number)
@@ -368,7 +368,7 @@ const VirtualLineRow = memo(function VirtualLineRow({
 export function FileViewerPage() {
   const { runId } = useParams({ from: '/runs/$runId/fileviewer' })
   const navigate = useNavigate()
-  const search = useSearch({ from: '/runs/$runId/fileviewer' }) as { file?: string; lines?: string }
+  const search = useSearch({ from: '/runs/$runId/fileviewer' }) as { file?: string; lines?: string; base?: string }
   const filename = search.file
   const selectedLines = parseLineSelection(search.lines)
 
@@ -387,7 +387,8 @@ export function FileViewerPage() {
   } = useQuery({
     queryKey: ['run', runId, 'file', filename],
     queryFn: async () => {
-      const { data, status } = await fetchText(`runs/${runId}/${filename}`)
+      const basePath = search.base ?? `runs/${runId}`
+      const { data, status } = await fetchText(`${basePath}/${filename}`)
       if (!data) {
         throw new Error(`Failed to fetch log: ${status}`)
       }

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import { fetchText } from '@/api/client'
+import { fetchText, fetchHead, fetchPartialText } from '@/api/client'
 import { useRunConfig } from '@/api/hooks/useRunConfig'
 import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
@@ -365,6 +365,40 @@ const VirtualLineRow = memo(function VirtualLineRow({
   )
 })
 
+const MAX_FULL_LOAD = 10 * 1024 * 1024 // 10MB — load whole file below this (chunked above)
+const CHUNK_SIZE = 10 * 1024 * 1024 // 10MB per chunk
+
+function LoadMoreSentinel({ loading, onVisible }: { loading: boolean; onVisible: () => void }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const onVisibleRef = useRef(onVisible)
+
+  useEffect(() => {
+    onVisibleRef.current = onVisible
+  }, [onVisible])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) onVisibleRef.current() },
+      { threshold: 0 },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div ref={ref} className="flex justify-center py-3">
+      {loading && (
+        <div className="flex items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
+          <div className="size-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600" />
+          Loading more...
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function FileViewerPage() {
   const { runId } = useParams({ from: '/runs/$runId/fileviewer' })
   const navigate = useNavigate()
@@ -379,23 +413,95 @@ export function FileViewerPage() {
   const { data: config } = useRunConfig(runId)
   const { data: suite } = useSuite(config?.suite_hash ?? '')
 
-  const {
-    data: fileContent,
-    isLoading,
-    error,
-    refetch,
-  } = useQuery({
-    queryKey: ['run', runId, 'file', filename],
-    queryFn: async () => {
-      const basePath = search.base ?? `runs/${runId}`
-      const { data, status } = await fetchText(`${basePath}/${filename}`)
-      if (!data) {
-        throw new Error(`Failed to fetch log: ${status}`)
-      }
-      return data
-    },
+  const filePath = useMemo(() => {
+    const basePath = search.base ?? `runs/${runId}`
+    return `${basePath}/${filename}`
+  }, [search.base, runId, filename])
+
+  // Step 1: HEAD to get file size
+  const { data: headResult, isLoading: headLoading } = useQuery({
+    queryKey: ['fileviewer-head', filePath],
+    queryFn: () => fetchHead(filePath),
     enabled: !!runId && !!filename,
   })
+
+  const totalSize = headResult?.exists && headResult.size !== null ? headResult.size : null
+  const isLargeFile = totalSize !== null && totalSize > MAX_FULL_LOAD
+
+  // Step 2a: Small files — load fully
+  const { data: fullContent, isLoading: fullLoading, error: fullError } = useQuery({
+    queryKey: ['fileviewer-full', filePath],
+    queryFn: async () => {
+      const { data, status } = await fetchText(filePath, { cacheBust: false })
+      if (!data) throw new Error(`Failed to fetch file: ${status}`)
+      return data
+    },
+    enabled: !!runId && !!filename && headResult !== undefined && !isLargeFile,
+  })
+
+  // Step 2b: Large files — chunk-based loading from the start
+  const [chunks, setChunks] = useState<string[]>([])
+  const [loadedBytes, setLoadedBytes] = useState(0) // how many bytes loaded so far
+  const [chunkLoading, setChunkLoading] = useState(false)
+  const hasMoreChunks = isLargeFile && totalSize !== null && loadedBytes < totalSize
+
+  // Reset chunks when file changes
+  useEffect(() => {
+    setChunks([])
+    setLoadedBytes(0)
+  }, [filePath])
+
+  // Load initial chunk for large files
+  useEffect(() => {
+    if (!isLargeFile || totalSize === null || chunks.length > 0 || chunkLoading) return
+    setChunkLoading(true)
+    const size = Math.min(CHUNK_SIZE, totalSize)
+    fetchPartialText(filePath, size, 0).then(({ data }) => {
+      if (!data) { setChunkLoading(false); return }
+      // Drop the last partial line (save the byte count before trimming)
+      const lastNl = data.lastIndexOf('\n')
+      const text = lastNl >= 0 ? data.slice(0, lastNl) : data
+      const bytesConsumed = lastNl >= 0 ? lastNl + 1 : data.length
+      setChunks([text])
+      setLoadedBytes(bytesConsumed)
+      setChunkLoading(false)
+    })
+  }, [isLargeFile, totalSize, filePath, chunks.length, chunkLoading])
+
+  const loadNextChunk = useCallback(() => {
+    if (!isLargeFile || totalSize === null || loadedBytes >= totalSize || chunkLoading) return
+    setChunkLoading(true)
+    const size = Math.min(CHUNK_SIZE, totalSize - loadedBytes)
+    fetchPartialText(filePath, size, loadedBytes).then(({ data }) => {
+      if (!data) { setChunkLoading(false); return }
+      // Drop the last partial line unless we reached the end
+      const atEnd = loadedBytes + size >= totalSize
+      let text = data
+      let bytesConsumed = data.length
+      if (!atEnd) {
+        const lastNl = data.lastIndexOf('\n')
+        if (lastNl >= 0) {
+          text = data.slice(0, lastNl)
+          bytesConsumed = lastNl + 1
+        }
+      }
+      setChunks((prev) => [...prev, text])
+      setLoadedBytes((prev) => prev + bytesConsumed)
+      setChunkLoading(false)
+    })
+  }, [isLargeFile, totalSize, loadedBytes, chunkLoading, filePath])
+
+  const isLoading = headLoading || fullLoading || (isLargeFile && chunks.length === 0 && chunkLoading)
+  const error = fullError
+
+  const fileContent = isLargeFile
+    ? (chunks.length > 0 ? chunks.join('\n') : undefined)
+    : fullContent
+
+  const refetch = useCallback(() => {
+    setChunks([])
+    setLoadedBytes(0)
+  }, [])
 
   const lines = useMemo(() => fileContent?.split('\n') ?? [], [fileContent])
   const useAnsi = useMemo(() => fileContent ? hasAnsiCodes(fileContent) : false, [fileContent])
@@ -547,6 +653,11 @@ export function FileViewerPage() {
             <DownloadButton content={fileContent} filename={filename} />
           </div>
         </div>
+        {isLargeFile && totalSize !== null && (
+          <div className="border-b border-blue-200 bg-blue-50 px-4 py-1.5 text-xs/5 text-blue-700 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-300">
+            Large file ({(totalSize / 1024 / 1024).toFixed(1)} MB) — loaded {(loadedBytes / 1024 / 1024).toFixed(1)} MB ({lines.length} lines)
+          </div>
+        )}
         <div ref={scrollContainerRef} className="max-h-[80vh] overflow-auto">
           <div
             className="relative w-full"
@@ -577,6 +688,9 @@ export function FileViewerPage() {
               )
             })}
           </div>
+          {hasMoreChunks && (
+            <LoadMoreSentinel loading={chunkLoading} onVisible={loadNextChunk} />
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Handle large request/response files gracefully across the executions table and file viewer.

### Executions Table
- Stream request files to extract per-line byte sizes and method names (first 256 bytes) without loading full content into memory — updates progressively with loading spinners per row
- Skip full file fetch for files >50MB, use streaming summaries for metadata
- Lazy-load individual line content via Range requests when expanding a row (<1MB lines)
- Show "too large to display" with file viewer link for lines >1MB
- Display per-line request/response sizes on each row and in expanded section headers
- Add pagination (100 per page) as safety net
- Align execution row columns (MGas/s, Duration, Sizes, Status) with fixed widths
- Remove cache-buster from immutable .request/.response file fetches

### File Viewer
- Chunked loading for large files (>10MB): loads from top in 10MB chunks with correct line numbers
- Auto-load next chunk via IntersectionObserver when scrolling near the bottom
- Auto-load chunks to reach a URL-specified line selection, then scroll to it
- Info banner with spinner showing total size, loaded bytes, and line count
- Support `base` query param for viewing suite-level files (not just run-level)
- Fix `parseLineSelection` to handle numeric URL params

## Test plan
- [x] Open a run with large setup request files (>50MB total) — verify table renders with method names, sizes, and durations without crashing
- [x] Expand a small execution row — verify request JSON loads lazily
- [x] Expand a large execution row (>1MB) — verify "too large" message with file viewer link
- [x] Open a large log file in file viewer — verify chunked loading with auto-scroll
- [x] Share a URL with `?lines=100000` on a large file — verify it auto-loads and scrolls to the line
- [x] Verify no `?_t=` cache buster on .request/.response fetches