### PR TITLE
feat: mount geth config TOML with increased HTTP timeouts

### DIFF
--- a/pkg/client/besu.go
+++ b/pkg/client/besu.go
@@ -99,3 +99,7 @@ func (s *besuSpec) RPCRollbackSpec() *RPCRollbackSpec {
 		RPCMethod: "debug_setHead",
 	}
 }
+
+func (s *besuSpec) DefaultConfigFiles() map[string]string {
+	return nil
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -82,6 +82,11 @@ type Spec interface {
 	// RPCRollbackSpec returns the client's rollback RPC method and parameter format.
 	// Returns nil if the client does not support rollback.
 	RPCRollbackSpec() *RPCRollbackSpec
+
+	// DefaultConfigFiles returns config files to mount into the container.
+	// Keys are target paths inside the container, values are file contents.
+	// Returns nil if no config files are needed.
+	DefaultConfigFiles() map[string]string
 }
 
 // Registry manages client specifications.

--- a/pkg/client/erigon.go
+++ b/pkg/client/erigon.go
@@ -105,3 +105,7 @@ func (s *erigonSpec) DefaultEnvironment() map[string]string {
 func (s *erigonSpec) RPCRollbackSpec() *RPCRollbackSpec {
 	return nil
 }
+
+func (s *erigonSpec) DefaultConfigFiles() map[string]string {
+	return nil
+}

--- a/pkg/client/geth.go
+++ b/pkg/client/geth.go
@@ -20,6 +20,8 @@ func (s *gethSpec) DefaultImage() string {
 
 func (s *gethSpec) DefaultCommand() []string {
 	return []string{
+		// Config file with HTTP timeout overrides.
+		"--config=/tmp/config.toml",
 		// Data directory - should always point to /data
 		"--datadir=/data",
 		// Peering / Syncing
@@ -93,5 +95,16 @@ func (s *gethSpec) RPCRollbackSpec() *RPCRollbackSpec {
 	return &RPCRollbackSpec{
 		Method:    RollbackMethodSetHeadHex,
 		RPCMethod: "debug_setHead",
+	}
+}
+
+func (s *gethSpec) DefaultConfigFiles() map[string]string {
+	return map[string]string{
+		"/tmp/config.toml": `[Node.HTTPTimeouts]
+ReadTimeout = 300000000000 # 300s
+ReadHeaderTimeout = 300000000000 # 300s
+WriteTimeout = 300000000000 # 300s
+IdleTimeout = 120000000000 # 120s
+`,
 	}
 }

--- a/pkg/client/nethermind.go
+++ b/pkg/client/nethermind.go
@@ -96,3 +96,7 @@ func (s *nethermindSpec) RPCRollbackSpec() *RPCRollbackSpec {
 		RPCMethod: "debug_resetHead",
 	}
 }
+
+func (s *nethermindSpec) DefaultConfigFiles() map[string]string {
+	return nil
+}

--- a/pkg/client/nimbus.go
+++ b/pkg/client/nimbus.go
@@ -84,3 +84,7 @@ func (s *nimbusSpec) DefaultEnvironment() map[string]string {
 func (s *nimbusSpec) RPCRollbackSpec() *RPCRollbackSpec {
 	return nil
 }
+
+func (s *nimbusSpec) DefaultConfigFiles() map[string]string {
+	return nil
+}

--- a/pkg/client/reth.go
+++ b/pkg/client/reth.go
@@ -86,3 +86,7 @@ func (s *rethSpec) DefaultEnvironment() map[string]string {
 func (s *rethSpec) RPCRollbackSpec() *RPCRollbackSpec {
 	return nil
 }
+
+func (s *rethSpec) DefaultConfigFiles() map[string]string {
+	return nil
+}

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -248,6 +248,21 @@ func (r *runner) runContainerLifecycle(
 		})
 	}
 
+	// Mount default config files from the client spec.
+	for target, content := range spec.DefaultConfigFiles() {
+		cfgFile := filepath.Join(tempDir, filepath.Base(target))
+		if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+			return fmt.Errorf("writing config file %s: %w", target, err)
+		}
+
+		mounts = append(mounts, docker.Mount{
+			Type:     "bind",
+			Source:   cfgFile,
+			Target:   target,
+			ReadOnly: true,
+		})
+	}
+
 	// Run init container if required (skip when using datadir or no genesis).
 	if spec.RequiresInit() && !useDataDir && genesisSource != "" {
 		log.Info("Running init container")


### PR DESCRIPTION
Some tests needed longer than the default 30s timeout. Increasing it to 300s.

## Summary
- Adds `DefaultConfigFiles()` to the client `Spec` interface, allowing clients to declare config files that get bind-mounted into their containers
- For geth, mounts a TOML config at `/tmp/config.toml` with increased `Node.HTTPTimeouts` (300s read/readheader/write, 120s idle) to prevent timeouts during long-running benchmark RPC calls
- In `lifecycle.go`, writes spec config files to the temp dir and adds them as read-only bind mounts

## Test plan
- [x] Run a benchmark with geth and verify the config.toml is mounted and timeouts are applied
- [x] Verify other clients (besu, nethermind, erigon, nimbus, reth) are unaffected