### PR TITLE
feat: add archive test source for ZIP and tar.gz files

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -203,6 +203,7 @@ runs:
         DOCKER_CMD="$DOCKER_CMD -v /proc/sys/vm/drop_caches:/host_drop_caches"
         DOCKER_CMD="$DOCKER_CMD -v /sys/devices/system/cpu:/host_sys_cpu"
         DOCKER_CMD="$DOCKER_CMD -v /sys/fs/cgroup:/sys/fs/cgroup:ro"
+        DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_GITHUB_TOKEN=${{ inputs.github-token }}"
         DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_DROP_CACHES_PATH=/host_drop_caches"
         DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_CPU_SYSFS_PATH=/host_sys_cpu"
         DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_DIR=/app/results"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -148,9 +148,10 @@ type TestsConfig struct {
 // SourceConfig defines where to find test files.
 type SourceConfig struct {
 	// New unified source options.
-	Git          *GitSourceV2        `yaml:"git,omitempty" mapstructure:"git"`
-	Local        *LocalSourceV2      `yaml:"local,omitempty" mapstructure:"local"`
-	EESTFixtures *EESTFixturesSource `yaml:"eest_fixtures,omitempty" mapstructure:"eest_fixtures"`
+	Git          *GitSourceV2         `yaml:"git,omitempty" mapstructure:"git"`
+	Local        *LocalSourceV2       `yaml:"local,omitempty" mapstructure:"local"`
+	Archive      *ArchiveSourceConfig `yaml:"archive,omitempty" mapstructure:"archive"`
+	EESTFixtures *EESTFixturesSource  `yaml:"eest_fixtures,omitempty" mapstructure:"eest_fixtures"`
 }
 
 // EESTFixturesSource defines an EEST fixtures source from GitHub releases, artifacts,
@@ -330,6 +331,14 @@ type LocalSourceV2 struct {
 	Steps       *StepsConfig `yaml:"steps,omitempty" mapstructure:"steps"`
 }
 
+// ArchiveSourceConfig defines an archive file source for tests.
+// The file can be a local path or a URL (HTTP/HTTPS) to a ZIP or tar.gz archive.
+type ArchiveSourceConfig struct {
+	File        string       `yaml:"file" mapstructure:"file"`
+	PreRunSteps []string     `yaml:"pre_run_steps,omitempty" mapstructure:"pre_run_steps"`
+	Steps       *StepsConfig `yaml:"steps,omitempty" mapstructure:"steps"`
+}
+
 // StepsConfig defines glob patterns for each step type.
 type StepsConfig struct {
 	Setup   []string `yaml:"setup,omitempty" mapstructure:"setup"`
@@ -339,7 +348,7 @@ type StepsConfig struct {
 
 // IsConfigured returns true if any test source is configured.
 func (s *SourceConfig) IsConfigured() bool {
-	return s.Git != nil || s.Local != nil || s.EESTFixtures != nil
+	return s.Git != nil || s.Local != nil || s.Archive != nil || s.EESTFixtures != nil
 }
 
 // DefaultContainerDir is the default container mount path for data directories.
@@ -1096,12 +1105,16 @@ func (s *SourceConfig) Validate() error {
 		count++
 	}
 
+	if s.Archive != nil {
+		count++
+	}
+
 	if s.EESTFixtures != nil {
 		count++
 	}
 
 	if count > 1 {
-		return fmt.Errorf("cannot specify multiple sources (git, local, eest_fixtures)")
+		return fmt.Errorf("cannot specify multiple sources (git, local, archive, eest_fixtures)")
 	}
 
 	if s.Git != nil {
@@ -1121,6 +1134,12 @@ func (s *SourceConfig) Validate() error {
 
 		if _, err := os.Stat(s.Local.BaseDir); os.IsNotExist(err) {
 			return fmt.Errorf("local.base_dir %q does not exist", s.Local.BaseDir)
+		}
+	}
+
+	if s.Archive != nil {
+		if s.Archive.File == "" {
+			return fmt.Errorf("archive.file is required")
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -609,6 +609,46 @@ func TestSourceConfig_Validate(t *testing.T) {
 			wantErr:   true,
 			errSubstr: "does not exist",
 		},
+		{
+			name: "valid archive source with URL",
+			source: SourceConfig{
+				Archive: &ArchiveSourceConfig{
+					File: "https://example.com/fixtures.zip",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid archive source with local file",
+			source: SourceConfig{
+				Archive: &ArchiveSourceConfig{
+					File: fixturesTarball,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "archive missing file",
+			source: SourceConfig{
+				Archive: &ArchiveSourceConfig{},
+			},
+			wantErr:   true,
+			errSubstr: "archive.file is required",
+		},
+		{
+			name: "multiple sources not allowed - archive and git",
+			source: SourceConfig{
+				Archive: &ArchiveSourceConfig{
+					File: "https://example.com/fixtures.zip",
+				},
+				Git: &GitSourceV2{
+					Repo:    "https://github.com/test/repo",
+					Version: "v1.0.0",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "cannot specify multiple sources",
+		},
 	}
 
 	for _, tt := range tests {
@@ -923,6 +963,15 @@ func TestSourceConfig_IsConfigured(t *testing.T) {
 				EESTFixtures: &EESTFixturesSource{
 					GitHubRepo:    "test/repo",
 					GitHubRelease: "v1",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "archive source",
+			source: SourceConfig{
+				Archive: &ArchiveSourceConfig{
+					File: "https://example.com/fixtures.zip",
 				},
 			},
 			expected: true,

--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -1,0 +1,151 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+// ArchiveSource downloads and extracts an archive file, then discovers tests
+// from the extracted contents using glob patterns.
+type ArchiveSource struct {
+	log      logrus.FieldLogger
+	cfg      *config.ArchiveSourceConfig
+	cacheDir string
+	filter   string
+	basePath string // temp directory where archive was extracted
+}
+
+// Prepare downloads (if URL) and extracts the archive, then discovers tests.
+func (s *ArchiveSource) Prepare(ctx context.Context) (*PreparedSource, error) {
+	// Create temp directory for extraction.
+	parentDir := s.cacheDir
+	if parentDir == "" {
+		parentDir = os.TempDir()
+	}
+
+	tmpDir, err := os.MkdirTemp(parentDir, "archive-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp directory: %w", err)
+	}
+
+	s.basePath = tmpDir
+
+	// Determine the archive file path.
+	archivePath, err := s.resolveFile(ctx)
+	if err != nil {
+		_ = os.RemoveAll(s.basePath)
+		s.basePath = ""
+
+		return nil, fmt.Errorf("resolving archive file: %w", err)
+	}
+
+	// Detect format and extract.
+	if err := s.extractArchive(archivePath); err != nil {
+		_ = os.RemoveAll(s.basePath)
+		s.basePath = ""
+
+		return nil, fmt.Errorf("extracting archive: %w", err)
+	}
+
+	s.log.WithField("path", s.basePath).Info("Extracted archive")
+
+	return discoverTestsFromConfig(
+		s.basePath, s.cfg.PreRunSteps, s.cfg.Steps, s.filter, s.log,
+	)
+}
+
+// Cleanup removes the temporary extraction directory.
+func (s *ArchiveSource) Cleanup() error {
+	if s.basePath != "" {
+		return os.RemoveAll(s.basePath)
+	}
+
+	return nil
+}
+
+// GetSourceInfo returns source information for the suite summary.
+func (s *ArchiveSource) GetSourceInfo() (*SuiteSource, error) {
+	info := &ArchiveSourceInfo{
+		File:        s.cfg.File,
+		PreRunSteps: s.cfg.PreRunSteps,
+	}
+
+	if s.cfg.Steps != nil {
+		info.Steps = &SourceStepsGlobs{
+			Setup:   s.cfg.Steps.Setup,
+			Test:    s.cfg.Steps.Test,
+			Cleanup: s.cfg.Steps.Cleanup,
+		}
+	}
+
+	return &SuiteSource{Archive: info}, nil
+}
+
+// resolveFile returns the local path to the archive file, downloading it first
+// if the configured file is a URL.
+func (s *ArchiveSource) resolveFile(ctx context.Context) (string, error) {
+	file := s.cfg.File
+
+	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
+		s.log.WithField("url", file).Info("Downloading archive")
+
+		destPath := filepath.Join(s.basePath, "archive-download")
+
+		if err := downloadToFile(ctx, file, destPath); err != nil {
+			return "", err
+		}
+
+		return destPath, nil
+	}
+
+	// Local file path — resolve relative paths.
+	if !filepath.IsAbs(file) {
+		absPath, err := filepath.Abs(file)
+		if err != nil {
+			return "", fmt.Errorf("resolving path %q: %w", file, err)
+		}
+
+		file = absPath
+	}
+
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return "", fmt.Errorf("archive file %q does not exist", file)
+	}
+
+	return file, nil
+}
+
+// extractArchive detects the archive format and extracts it to the base path.
+// For ZIP archives, inner tarballs are also extracted automatically.
+func (s *ArchiveSource) extractArchive(archivePath string) error {
+	format, err := detectArchiveFormat(archivePath)
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case archiveFormatZip:
+		if err := extractZipFile(archivePath, s.basePath); err != nil {
+			return fmt.Errorf("extracting zip: %w", err)
+		}
+
+		// Auto-extract inner tarballs (e.g. GitHub Actions artifacts).
+		if err := extractInnerTarballs(s.basePath, s.log); err != nil {
+			return fmt.Errorf("extracting inner tarballs: %w", err)
+		}
+	case archiveFormatTarGz:
+		if err := extractTarGzFile(archivePath, s.basePath); err != nil {
+			return fmt.Errorf("extracting tar.gz: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported archive format: %s", format)
+	}
+
+	return nil
+}

--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -5,20 +5,28 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
 	"github.com/sirupsen/logrus"
 )
 
+// ghArtifactURLPattern matches GitHub Actions artifact browser URLs:
+// https://github.com/{owner}/{repo}/actions/runs/{run_id}/artifacts/{artifact_id}
+var ghArtifactURLPattern = regexp.MustCompile(
+	`^https://github\.com/([^/]+/[^/]+)/actions/runs/\d+/artifacts/(\d+)$`,
+)
+
 // ArchiveSource downloads and extracts an archive file, then discovers tests
 // from the extracted contents using glob patterns.
 type ArchiveSource struct {
-	log      logrus.FieldLogger
-	cfg      *config.ArchiveSourceConfig
-	cacheDir string
-	filter   string
-	basePath string // temp directory where archive was extracted
+	log         logrus.FieldLogger
+	cfg         *config.ArchiveSourceConfig
+	cacheDir    string
+	filter      string
+	githubToken string
+	basePath    string // temp directory where archive was extracted
 }
 
 // Prepare downloads (if URL) and extracts the archive, then discovers tests.
@@ -97,7 +105,9 @@ func (s *ArchiveSource) resolveFile(ctx context.Context) (string, error) {
 
 		destPath := filepath.Join(s.basePath, "archive-download")
 
-		if err := downloadToFile(ctx, file, destPath); err != nil {
+		downloadURL, token := s.resolveDownloadURL(file)
+
+		if err := downloadToFile(ctx, downloadURL, destPath, token); err != nil {
 			return "", err
 		}
 
@@ -119,6 +129,30 @@ func (s *ArchiveSource) resolveFile(ctx context.Context) (string, error) {
 	}
 
 	return file, nil
+}
+
+// resolveDownloadURL converts browser URLs to API URLs where needed and returns
+// the appropriate auth token. For GitHub Actions artifact URLs, it converts to
+// the GitHub API download endpoint with bearer token auth.
+func (s *ArchiveSource) resolveDownloadURL(rawURL string) (string, string) {
+	matches := ghArtifactURLPattern.FindStringSubmatch(rawURL)
+	if matches != nil {
+		repo := matches[1]
+		artifactID := matches[2]
+		apiURL := fmt.Sprintf(
+			"https://api.github.com/repos/%s/actions/artifacts/%s/zip",
+			repo, artifactID,
+		)
+
+		s.log.WithFields(logrus.Fields{
+			"repo":        repo,
+			"artifact_id": artifactID,
+		}).Info("Detected GitHub artifact URL, using API endpoint")
+
+		return apiURL, s.githubToken
+	}
+
+	return rawURL, ""
 }
 
 // extractArchive detects the archive format and extracts it to the base path.

--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -95,23 +97,49 @@ func (s *ArchiveSource) GetSourceInfo() (*SuiteSource, error) {
 	return &SuiteSource{Archive: info}, nil
 }
 
-// resolveFile returns the local path to the archive file, downloading it first
-// if the configured file is a URL.
+// resolveFile returns the local path to the archive file. For URLs, it checks
+// the cache directory first and only downloads if the file is not already cached.
 func (s *ArchiveSource) resolveFile(ctx context.Context) (string, error) {
 	file := s.cfg.File
 
 	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
-		s.log.WithField("url", file).Info("Downloading archive")
+		cachedPath := s.cachedArchivePath()
 
-		destPath := filepath.Join(s.basePath, "archive-download")
+		if _, err := os.Stat(cachedPath); err == nil {
+			s.log.WithFields(logrus.Fields{
+				"url":  file,
+				"path": cachedPath,
+			}).Info("Using cached archive")
+
+			return cachedPath, nil
+		}
+
+		s.log.WithField("url", file).Info("Downloading archive")
 
 		downloadURL, token := s.resolveDownloadURL(file)
 
-		if err := downloadToFile(ctx, downloadURL, destPath, token, s.log); err != nil {
+		// Download to a temp file first, then rename for atomic cache writes.
+		tmpPath := cachedPath + ".tmp"
+
+		if err := os.MkdirAll(filepath.Dir(cachedPath), 0755); err != nil {
+			return "", fmt.Errorf("creating cache directory: %w", err)
+		}
+
+		if err := downloadToFile(ctx, downloadURL, tmpPath, token, s.log); err != nil {
+			_ = os.Remove(tmpPath)
+
 			return "", err
 		}
 
-		return destPath, nil
+		if err := os.Rename(tmpPath, cachedPath); err != nil {
+			_ = os.Remove(tmpPath)
+
+			return "", fmt.Errorf("caching archive: %w", err)
+		}
+
+		s.log.WithField("path", cachedPath).Info("Archive cached")
+
+		return cachedPath, nil
 	}
 
 	// Local file path — resolve relative paths.
@@ -129,6 +157,20 @@ func (s *ArchiveSource) resolveFile(ctx context.Context) (string, error) {
 	}
 
 	return file, nil
+}
+
+// cachedArchivePath returns a stable file path in the cache directory derived
+// from the configured URL, so repeated runs reuse the same downloaded file.
+func (s *ArchiveSource) cachedArchivePath() string {
+	hash := sha256.Sum256([]byte(s.cfg.File))
+	name := "archive-" + hex.EncodeToString(hash[:8])
+
+	cacheDir := s.cacheDir
+	if cacheDir == "" {
+		cacheDir = os.TempDir()
+	}
+
+	return filepath.Join(cacheDir, name)
 }
 
 // resolveDownloadURL converts browser URLs to API URLs where needed and returns

--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -107,7 +107,7 @@ func (s *ArchiveSource) resolveFile(ctx context.Context) (string, error) {
 
 		downloadURL, token := s.resolveDownloadURL(file)
 
-		if err := downloadToFile(ctx, downloadURL, destPath, token); err != nil {
+		if err := downloadToFile(ctx, downloadURL, destPath, token, s.log); err != nil {
 			return "", err
 		}
 
@@ -148,6 +148,14 @@ func (s *ArchiveSource) resolveDownloadURL(rawURL string) (string, string) {
 			"repo":        repo,
 			"artifact_id": artifactID,
 		}).Info("Detected GitHub artifact URL, using API endpoint")
+
+		if s.githubToken == "" {
+			s.log.Warn(
+				"GitHub token is required for artifact downloads. " +
+					"Set runner.github_token in config or " +
+					"BENCHMARKOOR_RUNNER_GITHUB_TOKEN env var",
+			)
+		}
 
 		return apiURL, s.githubToken
 	}

--- a/pkg/executor/archive_source_test.go
+++ b/pkg/executor/archive_source_test.go
@@ -5,9 +5,15 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
 	"github.com/sirupsen/logrus"
@@ -275,6 +281,113 @@ func TestDetectArchiveFormat(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDownloadToFile_Parallel(t *testing.T) {
+	// Create a test payload large enough to trigger parallel downloads.
+	payload := make([]byte, minParallelSize+1024)
+	_, err := rand.Read(payload)
+	require.NoError(t, err)
+
+	// Serve with Accept-Ranges support (Go's http.ServeContent does this).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeContent(w, r, "test.bin", timeZero, newByteReadSeeker(payload))
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "downloaded")
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	err = downloadToFile(context.Background(), srv.URL, destPath, "", log)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}
+
+func TestDownloadToFile_SequentialFallback(t *testing.T) {
+	payload := []byte("small-content-no-parallel")
+
+	// Server that does NOT support range requests.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "downloaded")
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	err := downloadToFile(context.Background(), srv.URL, destPath, "", log)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}
+
+func TestDownloadToFile_BearerToken(t *testing.T) {
+	var receivedAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data"))
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "downloaded")
+	log := logrus.New()
+
+	err := downloadToFile(context.Background(), srv.URL, destPath, "my-token", log)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer my-token", receivedAuth)
+}
+
+// byteReadSeeker wraps a byte slice to implement io.ReadSeeker for
+// http.ServeContent (which enables Accept-Ranges support).
+type byteReadSeeker struct {
+	data   []byte
+	offset int64
+}
+
+// timeZero is used as the modtime for http.ServeContent so it doesn't
+// generate Last-Modified headers that interfere with tests.
+var timeZero = time.Time{}
+
+func newByteReadSeeker(data []byte) *byteReadSeeker {
+	return &byteReadSeeker{data: data}
+}
+
+func (b *byteReadSeeker) Read(p []byte) (int, error) {
+	if b.offset >= int64(len(b.data)) {
+		return 0, io.EOF
+	}
+
+	n := copy(p, b.data[b.offset:])
+	b.offset += int64(n)
+
+	return n, nil
+}
+
+func (b *byteReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		b.offset = offset
+	case io.SeekCurrent:
+		b.offset += offset
+	case io.SeekEnd:
+		b.offset = int64(len(b.data)) + offset
+	}
+
+	return b.offset, nil
 }
 
 // createTestZip creates a zip file with the given text files.

--- a/pkg/executor/archive_source_test.go
+++ b/pkg/executor/archive_source_test.go
@@ -170,6 +170,50 @@ func TestArchiveSource_PrepareFileNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not exist")
 }
 
+func TestArchiveSource_ResolveDownloadURL(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	source := &ArchiveSource{
+		log:         log.WithField("source", "archive"),
+		githubToken: "gh-test-token",
+	}
+
+	tests := []struct {
+		name          string
+		input         string
+		expectedURL   string
+		expectedToken string
+	}{
+		{
+			name:          "GitHub artifact URL",
+			input:         "https://github.com/NethermindEth/gas-benchmarks/actions/runs/23847558369/artifacts/6222084759",
+			expectedURL:   "https://api.github.com/repos/NethermindEth/gas-benchmarks/actions/artifacts/6222084759/zip",
+			expectedToken: "gh-test-token",
+		},
+		{
+			name:          "regular URL unchanged",
+			input:         "https://example.com/fixtures.zip",
+			expectedURL:   "https://example.com/fixtures.zip",
+			expectedToken: "",
+		},
+		{
+			name:          "GitHub non-artifact URL unchanged",
+			input:         "https://github.com/owner/repo/releases/download/v1/file.zip",
+			expectedURL:   "https://github.com/owner/repo/releases/download/v1/file.zip",
+			expectedToken: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, token := source.resolveDownloadURL(tt.input)
+			assert.Equal(t, tt.expectedURL, url)
+			assert.Equal(t, tt.expectedToken, token)
+		})
+	}
+}
+
 func TestDetectArchiveFormat(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/executor/archive_source_test.go
+++ b/pkg/executor/archive_source_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"archive/tar"
 	"archive/zip"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/rand"
@@ -283,6 +284,63 @@ func TestDetectArchiveFormat(t *testing.T) {
 	}
 }
 
+func TestArchiveSource_CachesDownload(t *testing.T) {
+	var requestCount int
+
+	// Serve a zip file and count requests.
+	zipBuf := createTestZipBytes(t, map[string]string{
+		"tests/test/001.txt": "content",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", strconv.Itoa(len(zipBuf)))
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		requestCount++
+		w.Header().Set("Content-Length", strconv.Itoa(len(zipBuf)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(zipBuf)
+	}))
+	defer srv.Close()
+
+	cacheDir := t.TempDir()
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	makeSrc := func() *ArchiveSource {
+		return &ArchiveSource{
+			log:      log.WithField("source", "archive"),
+			cacheDir: cacheDir,
+			cfg: &config.ArchiveSourceConfig{
+				File: srv.URL + "/tests.zip",
+				Steps: &config.StepsConfig{
+					Test: []string{"tests/test/*"},
+				},
+			},
+		}
+	}
+
+	// First run: downloads the file.
+	s1 := makeSrc()
+	result, err := s1.Prepare(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(result.Tests))
+	assert.Equal(t, 1, requestCount)
+	require.NoError(t, s1.Cleanup())
+
+	// Second run: uses cached file, no new download.
+	s2 := makeSrc()
+	result, err = s2.Prepare(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(result.Tests))
+	assert.Equal(t, 1, requestCount, "expected no additional download request")
+	require.NoError(t, s2.Cleanup())
+}
+
 func TestDownloadToFile_Parallel(t *testing.T) {
 	// Create a test payload large enough to trigger parallel downloads.
 	payload := make([]byte, minParallelSize+1024)
@@ -458,4 +516,25 @@ func createTestTarGz(t *testing.T, path string, files map[string]string) {
 	require.NoError(t, tw.Close())
 	require.NoError(t, gw.Close())
 	require.NoError(t, f.Close())
+}
+
+// createTestZipBytes creates a zip in memory and returns its bytes.
+func createTestZipBytes(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	w := zip.NewWriter(&buf)
+
+	for name, content := range files {
+		fw, err := w.Create(name)
+		require.NoError(t, err)
+
+		_, err = fw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, w.Close())
+
+	return buf.Bytes()
 }

--- a/pkg/executor/archive_source_test.go
+++ b/pkg/executor/archive_source_test.go
@@ -1,0 +1,304 @@
+package executor
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveSource_PrepareWithLocalZip(t *testing.T) {
+	// Create a zip with test files.
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "tests.zip")
+	createTestZip(t, zipPath, map[string]string{
+		"tests/test/001.txt":    "test-line-1",
+		"tests/setup/001.txt":   "setup-line-1",
+		"tests/cleanup/001.txt": "cleanup-line-1",
+	})
+
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	source := &ArchiveSource{
+		log:      log.WithField("source", "archive"),
+		cacheDir: tmpDir,
+		cfg: &config.ArchiveSourceConfig{
+			File: zipPath,
+			Steps: &config.StepsConfig{
+				Setup:   []string{"tests/setup/*"},
+				Test:    []string{"tests/test/*"},
+				Cleanup: []string{"tests/cleanup/*"},
+			},
+		},
+	}
+
+	result, err := source.Prepare(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.Tests)
+	assert.Equal(t, 1, len(result.Tests))
+
+	// Verify cleanup removes the temp dir.
+	basePath := source.basePath
+	require.DirExists(t, basePath)
+	require.NoError(t, source.Cleanup())
+	assert.NoDirExists(t, basePath)
+}
+
+func TestArchiveSource_PrepareWithLocalTarGz(t *testing.T) {
+	tmpDir := t.TempDir()
+	tarPath := filepath.Join(tmpDir, "tests.tar.gz")
+	createTestTarGz(t, tarPath, map[string]string{
+		"mytest/test/abc.txt": "test-content",
+	})
+
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	source := &ArchiveSource{
+		log:      log.WithField("source", "archive"),
+		cacheDir: tmpDir,
+		cfg: &config.ArchiveSourceConfig{
+			File: tarPath,
+			Steps: &config.StepsConfig{
+				Test: []string{"mytest/test/*"},
+			},
+		},
+	}
+
+	result, err := source.Prepare(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, len(result.Tests))
+
+	require.NoError(t, source.Cleanup())
+}
+
+func TestArchiveSource_PrepareWithInnerTarballs(t *testing.T) {
+	// Create a zip containing an inner tar.gz (like GitHub Actions artifacts).
+	tmpDir := t.TempDir()
+
+	// First create the inner tar.gz.
+	innerTarPath := filepath.Join(tmpDir, "inner.tar.gz")
+	createTestTarGz(t, innerTarPath, map[string]string{
+		"data/test/001.txt": "inner-content",
+	})
+
+	innerData, err := os.ReadFile(innerTarPath)
+	require.NoError(t, err)
+
+	// Create a zip containing the inner tar.gz.
+	zipPath := filepath.Join(tmpDir, "artifact.zip")
+	createTestZip(t, zipPath, map[string]string{})
+	// Re-create with the binary tar.gz inside.
+	createTestZipWithBinary(t, zipPath, map[string][]byte{
+		"inner.tar.gz": innerData,
+	})
+
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	source := &ArchiveSource{
+		log:      log.WithField("source", "archive"),
+		cacheDir: tmpDir,
+		cfg: &config.ArchiveSourceConfig{
+			File: zipPath,
+			Steps: &config.StepsConfig{
+				Test: []string{"data/test/*"},
+			},
+		},
+	}
+
+	result, err := source.Prepare(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, len(result.Tests))
+
+	require.NoError(t, source.Cleanup())
+}
+
+func TestArchiveSource_GetSourceInfo(t *testing.T) {
+	source := &ArchiveSource{
+		cfg: &config.ArchiveSourceConfig{
+			File:        "https://example.com/tests.zip",
+			PreRunSteps: []string{"pre/step.txt"},
+			Steps: &config.StepsConfig{
+				Setup:   []string{"setup/*"},
+				Test:    []string{"test/*"},
+				Cleanup: []string{"cleanup/*"},
+			},
+		},
+	}
+
+	info, err := source.GetSourceInfo()
+	require.NoError(t, err)
+	require.NotNil(t, info.Archive)
+	assert.Equal(t, "https://example.com/tests.zip", info.Archive.File)
+	assert.Equal(t, []string{"pre/step.txt"}, info.Archive.PreRunSteps)
+	assert.Equal(t, []string{"setup/*"}, info.Archive.Steps.Setup)
+	assert.Equal(t, []string{"test/*"}, info.Archive.Steps.Test)
+	assert.Equal(t, []string{"cleanup/*"}, info.Archive.Steps.Cleanup)
+}
+
+func TestArchiveSource_CleanupNoBasePath(t *testing.T) {
+	source := &ArchiveSource{}
+	require.NoError(t, source.Cleanup())
+}
+
+func TestArchiveSource_PrepareFileNotFound(t *testing.T) {
+	log := logrus.New()
+
+	source := &ArchiveSource{
+		log:      log.WithField("source", "archive"),
+		cacheDir: t.TempDir(),
+		cfg: &config.ArchiveSourceConfig{
+			File: "/nonexistent/file.zip",
+		},
+	}
+
+	_, err := source.Prepare(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestDetectArchiveFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		content  []byte
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "zip by extension",
+			filename: "test.zip",
+			content:  []byte{0x50, 0x4B, 0x03, 0x04, 0x00},
+			expected: archiveFormatZip,
+		},
+		{
+			name:     "tar.gz by extension",
+			filename: "test.tar.gz",
+			content:  []byte{0x1F, 0x8B, 0x08, 0x00, 0x00},
+			expected: archiveFormatTarGz,
+		},
+		{
+			name:     "tgz by extension",
+			filename: "test.tgz",
+			content:  []byte{0x1F, 0x8B, 0x08, 0x00, 0x00},
+			expected: archiveFormatTarGz,
+		},
+		{
+			name:     "zip by magic bytes",
+			filename: "archive",
+			content:  []byte{0x50, 0x4B, 0x03, 0x04, 0x00},
+			expected: archiveFormatZip,
+		},
+		{
+			name:     "gzip by magic bytes",
+			filename: "archive",
+			content:  []byte{0x1F, 0x8B, 0x08, 0x00, 0x00},
+			expected: archiveFormatTarGz,
+		},
+		{
+			name:     "unknown format",
+			filename: "archive",
+			content:  []byte{0x00, 0x00, 0x00, 0x00, 0x00},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			path := filepath.Join(tmpDir, tt.filename)
+			require.NoError(t, os.WriteFile(path, tt.content, 0644))
+
+			format, err := detectArchiveFormat(path)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, format)
+			}
+		})
+	}
+}
+
+// createTestZip creates a zip file with the given text files.
+func createTestZip(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+
+	w := zip.NewWriter(f)
+
+	for name, content := range files {
+		fw, err := w.Create(name)
+		require.NoError(t, err)
+
+		_, err = fw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+}
+
+// createTestZipWithBinary creates a zip file with binary content entries.
+func createTestZipWithBinary(t *testing.T, path string, files map[string][]byte) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+
+	w := zip.NewWriter(f)
+
+	for name, content := range files {
+		fw, err := w.Create(name)
+		require.NoError(t, err)
+
+		_, err = fw.Write(content)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+}
+
+// createTestTarGz creates a tar.gz file with the given text files.
+func createTestTarGz(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0644,
+			Size: int64(len(content)),
+		}
+
+		require.NoError(t, tw.WriteHeader(hdr))
+
+		_, err = tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	require.NoError(t, f.Close())
+}

--- a/pkg/executor/eest_source.go
+++ b/pkg/executor/eest_source.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"archive/tar"
-	"archive/zip"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -466,152 +465,19 @@ func (s *EESTSource) downloadGitHubArtifact(ctx context.Context, artifactName, r
 
 // extractZip extracts a zip archive to the target directory.
 func (s *EESTSource) extractZip(zipPath, targetDir string) error {
-	r, err := zip.OpenReader(zipPath)
-	if err != nil {
-		return fmt.Errorf("opening zip: %w", err)
-	}
-
-	defer func() { _ = r.Close() }()
-
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		return fmt.Errorf("creating target directory: %w", err)
-	}
-
-	for _, f := range r.File {
-		target := filepath.Join(targetDir, filepath.Clean(f.Name))
-		if !strings.HasPrefix(target, filepath.Clean(targetDir)+string(os.PathSeparator)) {
-			return fmt.Errorf("invalid zip entry: %s", f.Name)
-		}
-
-		if f.FileInfo().IsDir() {
-			if err := os.MkdirAll(target, 0755); err != nil {
-				return fmt.Errorf("creating directory: %w", err)
-			}
-
-			continue
-		}
-
-		// Ensure parent directory exists.
-		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-			return fmt.Errorf("creating parent directory: %w", err)
-		}
-
-		outFile, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return fmt.Errorf("creating file: %w", err)
-		}
-
-		rc, err := f.Open()
-		if err != nil {
-			_ = outFile.Close()
-
-			return fmt.Errorf("opening zip entry: %w", err)
-		}
-
-		if _, err := io.Copy(outFile, rc); err != nil {
-			_ = rc.Close()
-			_ = outFile.Close()
-
-			return fmt.Errorf("extracting file: %w", err)
-		}
-
-		_ = rc.Close()
-		_ = outFile.Close()
-	}
-
-	return nil
+	return extractZipFile(zipPath, targetDir)
 }
 
-// extractInnerTarballs finds .tar.gz files in the directory, extracts them in-place,
-// and removes the original tarball. GitHub Actions artifacts contain .tar.gz files
-// inside the outer zip.
+// extractInnerTarballs finds .tar.gz files in the directory, extracts them
+// in-place, and removes the original tarball. GitHub Actions artifacts contain
+// .tar.gz files inside the outer zip.
 func (s *EESTSource) extractInnerTarballs(_ context.Context, dir string) error {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return fmt.Errorf("reading directory %s: %w", dir, err)
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tar.gz") {
-			continue
-		}
-
-		tarballPath := filepath.Join(dir, entry.Name())
-
-		s.log.WithField("file", tarballPath).Debug("Extracting inner tarball")
-
-		if err := s.extractLocalTarball(tarballPath, dir); err != nil {
-			return fmt.Errorf("extracting %s: %w", entry.Name(), err)
-		}
-
-		// Remove the tarball after successful extraction.
-		if err := os.Remove(tarballPath); err != nil {
-			s.log.WithError(err).WithField("file", tarballPath).Warn("Failed to remove extracted tarball")
-		}
-	}
-
-	return nil
+	return extractInnerTarballs(dir, s.log)
 }
 
 // extractLocalTarball extracts a local .tar.gz file to the target directory.
 func (s *EESTSource) extractLocalTarball(tarballPath, targetDir string) error {
-	f, err := os.Open(tarballPath)
-	if err != nil {
-		return fmt.Errorf("opening tarball: %w", err)
-	}
-
-	defer func() { _ = f.Close() }()
-
-	gzr, err := gzip.NewReader(f)
-	if err != nil {
-		return fmt.Errorf("creating gzip reader: %w", err)
-	}
-
-	defer func() { _ = gzr.Close() }()
-
-	tr := tar.NewReader(gzr)
-
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-
-		if err != nil {
-			return fmt.Errorf("reading tar: %w", err)
-		}
-
-		target := filepath.Join(targetDir, filepath.Clean(header.Name))
-		if !strings.HasPrefix(target, filepath.Clean(targetDir)+string(os.PathSeparator)) {
-			return fmt.Errorf("invalid tar entry: %s", header.Name)
-		}
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0755); err != nil {
-				return fmt.Errorf("creating directory: %w", err)
-			}
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-				return fmt.Errorf("creating parent directory: %w", err)
-			}
-
-			outFile, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
-			if err != nil {
-				return fmt.Errorf("creating file: %w", err)
-			}
-
-			if _, err := io.Copy(outFile, tr); err != nil {
-				_ = outFile.Close()
-
-				return fmt.Errorf("extracting file: %w", err)
-			}
-
-			_ = outFile.Close()
-		}
-	}
-
-	return nil
+	return extractTarGzFile(tarballPath, targetDir)
 }
 
 // downloadAndExtractTarball downloads a tarball and extracts it to the target directory.

--- a/pkg/executor/extract.go
+++ b/pkg/executor/extract.go
@@ -173,11 +173,17 @@ func extractInnerTarballs(dir string, log logrus.FieldLogger) error {
 }
 
 // downloadToFile downloads a URL to a local file path using plain HTTP with
-// redirect following.
-func downloadToFile(ctx context.Context, url, destPath string) error {
+// redirect following. If bearerToken is non-empty, it is sent as an
+// Authorization header.
+func downloadToFile(ctx context.Context, url, destPath, bearerToken string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
+	}
+
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+		req.Header.Set("Accept", "application/vnd.github+json")
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/pkg/executor/extract.go
+++ b/pkg/executor/extract.go
@@ -1,0 +1,256 @@
+package executor
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	archiveFormatZip   = "zip"
+	archiveFormatTarGz = "targz"
+)
+
+// extractZipFile extracts a zip archive to the target directory.
+func extractZipFile(zipPath, targetDir string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("opening zip: %w", err)
+	}
+
+	defer func() { _ = r.Close() }()
+
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("creating target directory: %w", err)
+	}
+
+	for _, f := range r.File {
+		target := filepath.Join(targetDir, filepath.Clean(f.Name))
+		if !strings.HasPrefix(target, filepath.Clean(targetDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid zip entry: %s", f.Name)
+		}
+
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return fmt.Errorf("creating directory: %w", err)
+			}
+
+			continue
+		}
+
+		// Ensure parent directory exists.
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return fmt.Errorf("creating parent directory: %w", err)
+		}
+
+		outFile, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return fmt.Errorf("creating file: %w", err)
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			_ = outFile.Close()
+
+			return fmt.Errorf("opening zip entry: %w", err)
+		}
+
+		if _, err := io.Copy(outFile, rc); err != nil {
+			_ = rc.Close()
+			_ = outFile.Close()
+
+			return fmt.Errorf("extracting file: %w", err)
+		}
+
+		_ = rc.Close()
+		_ = outFile.Close()
+	}
+
+	return nil
+}
+
+// extractTarGzFile extracts a .tar.gz file to the target directory.
+func extractTarGzFile(tarballPath, targetDir string) error {
+	f, err := os.Open(tarballPath)
+	if err != nil {
+		return fmt.Errorf("opening tarball: %w", err)
+	}
+
+	defer func() { _ = f.Close() }()
+
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("creating gzip reader: %w", err)
+	}
+
+	defer func() { _ = gzr.Close() }()
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return fmt.Errorf("reading tar: %w", err)
+		}
+
+		target := filepath.Join(targetDir, filepath.Clean(header.Name))
+		if !strings.HasPrefix(target, filepath.Clean(targetDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid tar entry: %s", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return fmt.Errorf("creating directory: %w", err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return fmt.Errorf("creating parent directory: %w", err)
+			}
+
+			outFile, err := os.OpenFile(
+				target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode),
+			)
+			if err != nil {
+				return fmt.Errorf("creating file: %w", err)
+			}
+
+			if _, err := io.Copy(outFile, tr); err != nil {
+				_ = outFile.Close()
+
+				return fmt.Errorf("extracting file: %w", err)
+			}
+
+			_ = outFile.Close()
+		}
+	}
+
+	return nil
+}
+
+// extractInnerTarballs finds .tar.gz files in the directory, extracts them
+// in-place, and removes the original tarball.
+func extractInnerTarballs(dir string, log logrus.FieldLogger) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("reading directory %s: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tar.gz") {
+			continue
+		}
+
+		tarballPath := filepath.Join(dir, entry.Name())
+
+		log.WithField("file", tarballPath).Debug("Extracting inner tarball")
+
+		if err := extractTarGzFile(tarballPath, dir); err != nil {
+			return fmt.Errorf("extracting %s: %w", entry.Name(), err)
+		}
+
+		// Remove the tarball after successful extraction.
+		if err := os.Remove(tarballPath); err != nil {
+			log.WithError(err).WithField("file", tarballPath).
+				Warn("Failed to remove extracted tarball")
+		}
+	}
+
+	return nil
+}
+
+// downloadToFile downloads a URL to a local file path using plain HTTP with
+// redirect following.
+func downloadToFile(ctx context.Context, url, destPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("downloading %s: %w", url, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	out, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("creating file %s: %w", destPath, err)
+	}
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		_ = out.Close()
+		_ = os.Remove(destPath)
+
+		return fmt.Errorf("writing file %s: %w", destPath, err)
+	}
+
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("closing file %s: %w", destPath, err)
+	}
+
+	return nil
+}
+
+// detectArchiveFormat determines the archive format from file extension,
+// falling back to magic bytes detection.
+func detectArchiveFormat(filePath string) (string, error) {
+	lower := strings.ToLower(filePath)
+
+	switch {
+	case strings.HasSuffix(lower, ".zip"):
+		return archiveFormatZip, nil
+	case strings.HasSuffix(lower, ".tar.gz"), strings.HasSuffix(lower, ".tgz"):
+		return archiveFormatTarGz, nil
+	}
+
+	// Fall back to magic bytes.
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("opening file for format detection: %w", err)
+	}
+
+	defer func() { _ = f.Close() }()
+
+	header := make([]byte, 4)
+
+	n, err := f.Read(header)
+	if err != nil {
+		return "", fmt.Errorf("reading file header: %w", err)
+	}
+
+	if n < 2 {
+		return "", fmt.Errorf("file too small to detect format")
+	}
+
+	// ZIP magic: PK\x03\x04
+	if n >= 4 && header[0] == 0x50 && header[1] == 0x4B &&
+		header[2] == 0x03 && header[3] == 0x04 {
+		return archiveFormatZip, nil
+	}
+
+	// Gzip magic: \x1f\x8b
+	if header[0] == 0x1F && header[1] == 0x8B {
+		return archiveFormatTarGz, nil
+	}
+
+	return "", fmt.Errorf("unrecognized archive format for %s", filePath)
+}

--- a/pkg/executor/extract.go
+++ b/pkg/executor/extract.go
@@ -177,7 +177,7 @@ func extractInnerTarballs(dir string, log logrus.FieldLogger) error {
 const (
 	progressLogInterval = 10 * 1024 * 1024 // 10 MiB between progress logs
 	defaultChunkSize    = 25 * 1024 * 1024 // 25 MiB per chunk
-	defaultParallelism  = 4                // number of parallel download workers
+	defaultParallelism  = 8                // number of parallel download workers
 	minParallelSize     = 10 * 1024 * 1024 // don't parallelize below 10 MiB
 )
 

--- a/pkg/executor/extract.go
+++ b/pkg/executor/extract.go
@@ -172,10 +172,14 @@ func extractInnerTarballs(dir string, log logrus.FieldLogger) error {
 	return nil
 }
 
+const progressLogInterval = 10 * 1024 * 1024 // 10 MiB between progress logs
+
 // downloadToFile downloads a URL to a local file path using plain HTTP with
 // redirect following. If bearerToken is non-empty, it is sent as an
-// Authorization header.
-func downloadToFile(ctx context.Context, url, destPath, bearerToken string) error {
+// Authorization header. Download progress is logged periodically.
+func downloadToFile(
+	ctx context.Context, url, destPath, bearerToken string, log logrus.FieldLogger,
+) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
@@ -197,12 +201,25 @@ func downloadToFile(ctx context.Context, url, destPath, bearerToken string) erro
 		return fmt.Errorf("downloading %s: HTTP %d", url, resp.StatusCode)
 	}
 
+	totalSize := resp.ContentLength
+	if totalSize > 0 {
+		log.WithField("size", formatBytes(totalSize)).Info("Download starting")
+	} else {
+		log.Info("Download starting (unknown size)")
+	}
+
 	out, err := os.Create(destPath)
 	if err != nil {
 		return fmt.Errorf("creating file %s: %w", destPath, err)
 	}
 
-	if _, err := io.Copy(out, resp.Body); err != nil {
+	pw := &progressWriter{
+		log:       log,
+		total:     totalSize,
+		nextLogAt: progressLogInterval,
+	}
+
+	if _, err := io.Copy(out, io.TeeReader(resp.Body, pw)); err != nil {
 		_ = out.Close()
 		_ = os.Remove(destPath)
 
@@ -213,7 +230,58 @@ func downloadToFile(ctx context.Context, url, destPath, bearerToken string) erro
 		return fmt.Errorf("closing file %s: %w", destPath, err)
 	}
 
+	log.WithField("size", formatBytes(pw.written)).Info("Download complete")
+
 	return nil
+}
+
+// progressWriter tracks bytes written and logs progress periodically.
+type progressWriter struct {
+	log       logrus.FieldLogger
+	total     int64
+	written   int64
+	nextLogAt int64
+}
+
+func (pw *progressWriter) Write(p []byte) (int, error) {
+	n := len(p)
+	pw.written += int64(n)
+
+	if pw.written >= pw.nextLogAt {
+		fields := logrus.Fields{
+			"downloaded": formatBytes(pw.written),
+		}
+
+		if pw.total > 0 {
+			pct := float64(pw.written) / float64(pw.total) * 100
+			fields["total"] = formatBytes(pw.total)
+			fields["progress"] = fmt.Sprintf("%.0f%%", pct)
+		}
+
+		pw.log.WithFields(fields).Info("Downloading")
+		pw.nextLogAt = pw.written + progressLogInterval
+	}
+
+	return n, nil
+}
+
+// formatBytes returns a human-readable byte size string.
+func formatBytes(b int64) string {
+	const (
+		mib = 1024 * 1024
+		gib = 1024 * mib
+	)
+
+	switch {
+	case b >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(b)/float64(gib))
+	case b >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(b)/float64(mib))
+	case b >= 1024:
+		return fmt.Sprintf("%.1f KiB", float64(b)/1024)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
 }
 
 // detectArchiveFormat determines the archive format from file extension,

--- a/pkg/executor/extract.go
+++ b/pkg/executor/extract.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 )
@@ -172,23 +174,83 @@ func extractInnerTarballs(dir string, log logrus.FieldLogger) error {
 	return nil
 }
 
-const progressLogInterval = 10 * 1024 * 1024 // 10 MiB between progress logs
+const (
+	progressLogInterval = 10 * 1024 * 1024 // 10 MiB between progress logs
+	defaultChunkSize    = 25 * 1024 * 1024 // 25 MiB per chunk
+	defaultParallelism  = 4                // number of parallel download workers
+	minParallelSize     = 10 * 1024 * 1024 // don't parallelize below 10 MiB
+)
 
-// downloadToFile downloads a URL to a local file path using plain HTTP with
-// redirect following. If bearerToken is non-empty, it is sent as an
-// Authorization header. Download progress is logged periodically.
+// downloadToFile downloads a URL to a local file. It probes for range request
+// support and downloads chunks in parallel when the server supports it,
+// falling back to a single sequential download otherwise.
 func downloadToFile(
 	ctx context.Context, url, destPath, bearerToken string, log logrus.FieldLogger,
+) error {
+	totalSize, supportsRange, err := probeDownload(ctx, url, bearerToken)
+	if err != nil {
+		return err
+	}
+
+	if supportsRange && totalSize >= minParallelSize {
+		log.WithFields(logrus.Fields{
+			"size":    formatBytes(totalSize),
+			"workers": defaultParallelism,
+		}).Info("Downloading with parallel range requests")
+
+		return downloadParallel(ctx, url, destPath, bearerToken, totalSize, log)
+	}
+
+	if totalSize > 0 {
+		log.WithField("size", formatBytes(totalSize)).
+			Info("Downloading (server does not support range requests)")
+	} else {
+		log.Info("Downloading (unknown size)")
+	}
+
+	return downloadSequential(ctx, url, destPath, bearerToken, totalSize, log)
+}
+
+// probeDownload sends a HEAD request to determine file size and range support.
+func probeDownload(
+	ctx context.Context, url, bearerToken string,
+) (totalSize int64, supportsRange bool, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return 0, false, fmt.Errorf("creating HEAD request: %w", err)
+	}
+
+	applyAuth(req, bearerToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, false, fmt.Errorf("probing %s: %w", url, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, false, fmt.Errorf("probing %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	acceptRanges := resp.Header.Get("Accept-Ranges")
+	supportsRange = acceptRanges == "bytes" && resp.ContentLength > 0
+
+	return resp.ContentLength, supportsRange, nil
+}
+
+// downloadSequential downloads the file in a single GET request with progress
+// logging.
+func downloadSequential(
+	ctx context.Context, url, destPath, bearerToken string,
+	totalSize int64, log logrus.FieldLogger,
 ) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
 
-	if bearerToken != "" {
-		req.Header.Set("Authorization", "Bearer "+bearerToken)
-		req.Header.Set("Accept", "application/vnd.github+json")
-	}
+	applyAuth(req, bearerToken)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -201,23 +263,12 @@ func downloadToFile(
 		return fmt.Errorf("downloading %s: HTTP %d", url, resp.StatusCode)
 	}
 
-	totalSize := resp.ContentLength
-	if totalSize > 0 {
-		log.WithField("size", formatBytes(totalSize)).Info("Download starting")
-	} else {
-		log.Info("Download starting (unknown size)")
-	}
-
 	out, err := os.Create(destPath)
 	if err != nil {
 		return fmt.Errorf("creating file %s: %w", destPath, err)
 	}
 
-	pw := &progressWriter{
-		log:       log,
-		total:     totalSize,
-		nextLogAt: progressLogInterval,
-	}
+	pw := newProgressLogger(log, totalSize)
 
 	if _, err := io.Copy(out, io.TeeReader(resp.Body, pw)); err != nil {
 		_ = out.Close()
@@ -230,36 +281,202 @@ func downloadToFile(
 		return fmt.Errorf("closing file %s: %w", destPath, err)
 	}
 
-	log.WithField("size", formatBytes(pw.written)).Info("Download complete")
+	log.WithField("size", formatBytes(pw.Written())).Info("Download complete")
 
 	return nil
 }
 
-// progressWriter tracks bytes written and logs progress periodically.
-type progressWriter struct {
-	log       logrus.FieldLogger
-	total     int64
-	written   int64
-	nextLogAt int64
+// downloadParallel downloads the file using multiple concurrent range requests
+// and assembles the chunks into the destination file.
+func downloadParallel(
+	ctx context.Context, url, destPath, bearerToken string,
+	totalSize int64, log logrus.FieldLogger,
+) error {
+	// Pre-allocate the output file.
+	out, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("creating file %s: %w", destPath, err)
+	}
+
+	if err := out.Truncate(totalSize); err != nil {
+		_ = out.Close()
+
+		return fmt.Errorf("pre-allocating file: %w", err)
+	}
+
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("closing pre-allocated file: %w", err)
+	}
+
+	// Build chunk list.
+	type chunk struct {
+		index      int
+		start, end int64 // inclusive byte range
+	}
+
+	chunks := make([]chunk, 0, (totalSize/defaultChunkSize)+1)
+
+	for start := int64(0); start < totalSize; start += defaultChunkSize {
+		end := start + defaultChunkSize - 1
+		if end >= totalSize {
+			end = totalSize - 1
+		}
+
+		chunks = append(chunks, chunk{
+			index: len(chunks),
+			start: start,
+			end:   end,
+		})
+	}
+
+	pw := newProgressLogger(log, totalSize)
+
+	// Download chunks in parallel.
+	var (
+		wg      sync.WaitGroup
+		errOnce sync.Once
+		dlErr   error
+		sem     = make(chan struct{}, defaultParallelism)
+	)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, c := range chunks {
+		wg.Add(1)
+
+		go func(c chunk) {
+			defer wg.Done()
+
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				errOnce.Do(func() { dlErr = ctx.Err() })
+
+				return
+			}
+
+			if err := downloadChunk(ctx, url, destPath, bearerToken, c.start, c.end, pw); err != nil {
+				errOnce.Do(func() {
+					dlErr = fmt.Errorf("chunk %d (%s-%s): %w",
+						c.index, formatBytes(c.start), formatBytes(c.end), err,
+					)
+					cancel()
+				})
+			}
+		}(c)
+	}
+
+	wg.Wait()
+
+	if dlErr != nil {
+		_ = os.Remove(destPath)
+
+		return fmt.Errorf("parallel download failed: %w", dlErr)
+	}
+
+	log.WithField("size", formatBytes(totalSize)).Info("Download complete")
+
+	return nil
 }
 
-func (pw *progressWriter) Write(p []byte) (int, error) {
+// downloadChunk downloads a single byte range and writes it at the correct
+// offset in the destination file.
+func downloadChunk(
+	ctx context.Context, url, destPath, bearerToken string,
+	start, end int64, pw *progressLogger,
+) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	applyAuth(req, bearerToken)
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("expected HTTP 206, got %d", resp.StatusCode)
+	}
+
+	f, err := os.OpenFile(destPath, os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("opening file for writing: %w", err)
+	}
+
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return fmt.Errorf("seeking to offset %d: %w", start, err)
+	}
+
+	if _, err := io.Copy(f, io.TeeReader(resp.Body, pw)); err != nil {
+		return fmt.Errorf("writing chunk: %w", err)
+	}
+
+	return nil
+}
+
+// applyAuth sets bearer token authentication headers on a request.
+func applyAuth(req *http.Request, bearerToken string) {
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+		req.Header.Set("Accept", "application/vnd.github+json")
+	}
+}
+
+// progressLogger tracks total bytes downloaded across concurrent workers and
+// logs progress periodically. Safe for concurrent use.
+type progressLogger struct {
+	log       logrus.FieldLogger
+	total     int64
+	written   atomic.Int64
+	nextLogAt atomic.Int64
+}
+
+// newProgressLogger creates a progress logger for the given total size.
+func newProgressLogger(log logrus.FieldLogger, total int64) *progressLogger {
+	pl := &progressLogger{
+		log:   log,
+		total: total,
+	}
+	pl.nextLogAt.Store(progressLogInterval)
+
+	return pl
+}
+
+// Written returns the total bytes written so far.
+func (pl *progressLogger) Written() int64 {
+	return pl.written.Load()
+}
+
+func (pl *progressLogger) Write(p []byte) (int, error) {
 	n := len(p)
-	pw.written += int64(n)
+	current := pl.written.Add(int64(n))
 
-	if pw.written >= pw.nextLogAt {
-		fields := logrus.Fields{
-			"downloaded": formatBytes(pw.written),
+	threshold := pl.nextLogAt.Load()
+	if current >= threshold {
+		// CAS to avoid duplicate log lines from concurrent writers.
+		if pl.nextLogAt.CompareAndSwap(threshold, current+progressLogInterval) {
+			fields := logrus.Fields{
+				"downloaded": formatBytes(current),
+			}
+
+			if pl.total > 0 {
+				pct := float64(current) / float64(pl.total) * 100
+				fields["total"] = formatBytes(pl.total)
+				fields["progress"] = fmt.Sprintf("%.0f%%", pct)
+			}
+
+			pl.log.WithFields(fields).Info("Downloading")
 		}
-
-		if pw.total > 0 {
-			pct := float64(pw.written) / float64(pw.total) * 100
-			fields["total"] = formatBytes(pw.total)
-			fields["progress"] = fmt.Sprintf("%.0f%%", pct)
-		}
-
-		pw.log.WithFields(fields).Info("Downloading")
-		pw.nextLogAt = pw.written + progressLogInterval
 	}
 
 	return n, nil

--- a/pkg/executor/source.go
+++ b/pkg/executor/source.go
@@ -112,6 +112,15 @@ func NewSource(log logrus.FieldLogger, cfg *config.SourceConfig, cacheDir, filte
 		}
 	}
 
+	if cfg.Archive != nil {
+		return &ArchiveSource{
+			log:      log.WithField("source", "archive"),
+			cfg:      cfg.Archive,
+			cacheDir: cacheDir,
+			filter:   filter,
+		}
+	}
+
 	if cfg.EESTFixtures != nil {
 		return NewEESTSource(log, cfg.EESTFixtures, cacheDir, filter, githubToken)
 	}

--- a/pkg/executor/source.go
+++ b/pkg/executor/source.go
@@ -114,10 +114,11 @@ func NewSource(log logrus.FieldLogger, cfg *config.SourceConfig, cacheDir, filte
 
 	if cfg.Archive != nil {
 		return &ArchiveSource{
-			log:      log.WithField("source", "archive"),
-			cfg:      cfg.Archive,
-			cacheDir: cacheDir,
-			filter:   filter,
+			log:         log.WithField("source", "archive"),
+			cfg:         cfg.Archive,
+			cacheDir:    cacheDir,
+			filter:      filter,
+			githubToken: githubToken,
 		}
 	}
 

--- a/pkg/executor/suite.go
+++ b/pkg/executor/suite.go
@@ -27,9 +27,10 @@ type SuiteInfo struct {
 
 // SuiteSource contains source information for the suite.
 type SuiteSource struct {
-	Git   *GitSourceInfo   `json:"git,omitempty"`
-	Local *LocalSourceInfo `json:"local,omitempty"`
-	EEST  *EESTSourceInfo  `json:"eest,omitempty"`
+	Git     *GitSourceInfo     `json:"git,omitempty"`
+	Local   *LocalSourceInfo   `json:"local,omitempty"`
+	Archive *ArchiveSourceInfo `json:"archive,omitempty"`
+	EEST    *EESTSourceInfo    `json:"eest,omitempty"`
 }
 
 // GitSourceInfo contains git repository source information.
@@ -44,6 +45,13 @@ type GitSourceInfo struct {
 // LocalSourceInfo contains local directory source information.
 type LocalSourceInfo struct {
 	BaseDir     string            `json:"base_dir"`
+	PreRunSteps []string          `json:"pre_run_steps,omitempty"`
+	Steps       *SourceStepsGlobs `json:"steps,omitempty"`
+}
+
+// ArchiveSourceInfo contains archive file source information.
+type ArchiveSourceInfo struct {
+	File        string            `json:"file"`
 	PreRunSteps []string          `json:"pre_run_steps,omitempty"`
 	Steps       *SourceStepsGlobs `json:"steps,omitempty"`
 }

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -420,6 +420,15 @@ export interface SourceInfo {
       cleanup?: string[]
     }
   }
+  archive?: {
+    file: string
+    pre_run_steps?: string[]
+    steps?: {
+      setup?: string[]
+      test?: string[]
+      cleanup?: string[]
+    }
+  }
   eest?: {
     github_repo: string
     github_release?: string

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -108,7 +108,7 @@ function SuiteCell({ suiteHash }: { suiteHash: string }) {
             <div className="text-gray-500 dark:text-gray-400">Filter: {suiteInfo.filter}</div>
           )}
           {suiteInfo && (
-            <div className="text-gray-500 dark:text-gray-400">{suiteInfo.tests.length} tests</div>
+            <div className="text-gray-500 dark:text-gray-400">{suiteInfo.tests?.length ?? 0} tests</div>
           )}
           {labels.length > 0 && (
             <div className="flex flex-wrap gap-1">

--- a/ui/src/components/shared/SourceBadge.tsx
+++ b/ui/src/components/shared/SourceBadge.tsx
@@ -13,6 +13,14 @@ function GitHubIcon({ className }: { className?: string }) {
   )
 }
 
+function ArchiveIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-2 6h-2v2h-2v-2h-2v-2h2v-2h2v2h2v2z" />
+    </svg>
+  )
+}
+
 function FolderIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor">
@@ -55,6 +63,35 @@ export function SourceBadge({ source, label }: SourceBadgeProps) {
         <GitHubIcon className="size-4" />
         {label && <span className="text-xs/5">{label}</span>}
       </a>
+    )
+  }
+
+  if (source.archive) {
+    const isUrl = source.archive.file.startsWith('http://') || source.archive.file.startsWith('https://')
+
+    if (isUrl) {
+      return (
+        <a
+          href={source.archive.file}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={source.archive.file}
+          className="inline-flex items-center gap-1.5 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          <ArchiveIcon className="size-4" />
+          {label && <span className="text-xs/5">{label}</span>}
+        </a>
+      )
+    }
+
+    return (
+      <span
+        title={source.archive.file}
+        className="inline-flex items-center gap-1.5 text-gray-600 dark:text-gray-400"
+      >
+        <ArchiveIcon className="size-4" />
+        {label && <span className="text-xs/5">{label}</span>}
+      </span>
     )
   }
 

--- a/ui/src/components/suite-detail/SuiteSource.tsx
+++ b/ui/src/components/suite-detail/SuiteSource.tsx
@@ -188,28 +188,58 @@ export function SuiteSource({ title, source }: SuiteSourceProps) {
 
   if (source.archive) {
     const isUrl = source.archive.file.startsWith('http://') || source.archive.file.startsWith('https://')
+    const ghRunMatch = source.archive.file.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/actions\/runs\/(\d+)\/artifacts\/\d+$/)
+    const ghRunUrl = ghRunMatch ? `https://github.com/${ghRunMatch[1]}/actions/runs/${ghRunMatch[2]}` : null
 
     return (
       <Card title={<span className="flex items-center gap-2">{title}<SourceTypeBadge source={source} /></span>} collapsible>
         <div className="flex flex-col gap-4">
-          <div>
-            <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Archive File</dt>
-            <dd className="mt-1 break-all font-mono text-sm/6 text-gray-900 dark:text-gray-100">
-              {isUrl ? (
-                <a
-                  href={source.archive.file}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 hover:underline dark:text-blue-400"
-                >
-                  {source.archive.file}
-                </a>
-              ) : (
-                source.archive.file
-              )}
-            </dd>
-          </div>
+          <dl className="grid grid-cols-1 gap-4">
+            <div>
+              <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Archive File</dt>
+              <dd className="mt-1 break-all font-mono text-sm/6 text-gray-900 dark:text-gray-100">
+                {isUrl ? (
+                  <a
+                    href={source.archive.file}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {source.archive.file}
+                  </a>
+                ) : (
+                  source.archive.file
+                )}
+              </dd>
+            </div>
+            {ghRunUrl && (
+              <div>
+                <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">GitHub Actions Run</dt>
+                <dd className="mt-1 break-all text-sm/6">
+                  <a
+                    href={ghRunUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {ghRunUrl}
+                  </a>
+                </dd>
+              </div>
+            )}
+          </dl>
           <StepsInfo steps={source.archive.steps} preRunSteps={source.archive.pre_run_steps} />
+          {ghRunUrl && (
+            <a
+              href={ghRunUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-fit items-center gap-2 rounded-sm bg-gray-900 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-gray-700 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-300"
+            >
+              <GitHubIcon className="size-4" />
+              View Actions Run
+            </a>
+          )}
         </div>
       </Card>
     )

--- a/ui/src/components/suite-detail/SuiteSource.tsx
+++ b/ui/src/components/suite-detail/SuiteSource.tsx
@@ -123,6 +123,10 @@ function SourceTypeBadge({ source }: { source: SourceInfo }) {
     return <Badge variant="warning">Local</Badge>
   }
 
+  if (source.archive) {
+    return <Badge variant="info">Archive</Badge>
+  }
+
   if (source.eest) {
     const hasArtifacts =
       source.eest.fixtures_artifact_name || source.eest.genesis_artifact_name
@@ -177,6 +181,35 @@ export function SuiteSource({ title, source }: SuiteSourceProps) {
             <dd className="mt-1 font-mono text-sm/6 text-gray-900 dark:text-gray-100">{source.local.base_dir}</dd>
           </div>
           <StepsInfo steps={source.local.steps} preRunSteps={source.local.pre_run_steps} />
+        </div>
+      </Card>
+    )
+  }
+
+  if (source.archive) {
+    const isUrl = source.archive.file.startsWith('http://') || source.archive.file.startsWith('https://')
+
+    return (
+      <Card title={<span className="flex items-center gap-2">{title}<SourceTypeBadge source={source} /></span>} collapsible>
+        <div className="flex flex-col gap-4">
+          <div>
+            <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Archive File</dt>
+            <dd className="mt-1 break-all font-mono text-sm/6 text-gray-900 dark:text-gray-100">
+              {isUrl ? (
+                <a
+                  href={source.archive.file}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {source.archive.file}
+                </a>
+              ) : (
+                source.archive.file
+              )}
+            </dd>
+          </div>
+          <StepsInfo steps={source.archive.steps} preRunSteps={source.archive.pre_run_steps} />
         </div>
       </Card>
     )


### PR DESCRIPTION
## Summary

- Add new `archive` source type under `tests.source` that downloads and extracts ZIP or tar.gz archives from URLs or local paths, then discovers tests via glob patterns within extracted contents
- Automatically detect and convert GitHub Actions artifact browser URLs to API calls with bearer token auth
- Support parallel range-request downloads (8 workers, 25 MiB chunks) with automatic fallback to sequential when the server doesn't support range requests
- Cache downloaded archives locally so repeated runs with the same URL skip the download
- Auto-extract inner tarballs found inside ZIP files (e.g. GitHub Actions artifacts)
- Pass `BENCHMARKOOR_RUNNER_GITHUB_TOKEN` into the Docker container in the GitHub Action
- Fix null `tests` array crash in UI suite cell tooltip

## Example config

```yaml
tests:
  source:
    archive:
      file: https://github.com/NethermindEth/gas-benchmarks/actions/runs/123/artifacts/456
      pre_run_steps:
        - "perf-devnet-3/gas-bump.txt"
      steps:
        setup:
          - "perf-devnet-3/tests/setup/*.txt"
        test:
          - "perf-devnet-3/tests/test/*.txt"
        cleanup:
          - "perf-devnet-3/tests/cleanup/*.txt"
```

## Test plan

- [x] Config validation tests (valid archive, missing file, multiple sources)
- [x] `IsConfigured()` test for archive source
- [x] Local ZIP and tar.gz extraction tests
- [x] Inner tarball auto-extraction test
- [x] GitHub artifact URL detection and conversion test
- [x] Download caching test (second run skips download)
- [x] Parallel range-request download test with httptest server
- [x] Sequential fallback test
- [x] Bearer token forwarding test
- [x] Format detection by extension and magic bytes
- [x] Race detector clean on parallel download