### PR TITLE
feat: external opcode metadata for archive sources

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -129,7 +129,27 @@ runner:
     #     #     cleanup:
     #     #       - "tests/cleanup/*.txt"
     #
-    #     # Option 3: EEST (Ethereum Execution Spec Tests) fixtures from GitHub releases.
+    #     # Option 3: Archive source (ZIP or tar.gz, local or remote URL).
+    #     # Downloads (if URL), extracts, and discovers tests from the archive contents.
+    #     # GitHub Actions artifact URLs are auto-converted to API download endpoints.
+    #     # archive:
+    #     #   file: https://github.com/NethermindEth/gas-benchmarks/actions/runs/23847558369/artifacts/6222084759
+    #     #   pre_run_steps:
+    #     #     - "perf-devnet-3/gas-bump.txt"
+    #     #     - "perf-devnet-3/funding.txt"
+    #     #   steps:
+    #     #     setup:
+    #     #       - "perf-devnet-3/setup/*.txt"
+    #     #     test:
+    #     #       - "perf-devnet-3/testing/*.txt"
+    #     #   # Optional: External opcode metadata file within the archive.
+    #     #   # JSON mapping test names to opcode counts: {"test_name": {"OPCODE": count}}
+    #     #   # opcodes: "opcodes_tracing.json"
+    #     #   # Optional: Separate archive containing the opcodes file.
+    #     #   # If not set, the opcodes file is searched in the main archive.
+    #     #   # opcodes_file: https://github.com/.../artifacts/6222074312
+    #
+    #     # Option 4: EEST (Ethereum Execution Spec Tests) fixtures from GitHub releases.
     #     # Downloads fixtures directly from ethereum/execution-spec-tests releases.
     #     # Genesis files are auto-resolved per client type from the release.
     #     # eest_fixtures:
@@ -141,7 +161,7 @@ runner:
     #     #   # fixtures_url: https://example.com/fixtures_benchmark.tar.gz
     #     #   # genesis_url: https://example.com/benchmark_genesis.tar.gz
     #
-    #     # Option 3b: EEST fixtures from GitHub Actions artifacts.
+    #     # Option 4b: EEST fixtures from GitHub Actions artifacts.
     #     # Alternative to releases - downloads from workflow run artifacts.
     #     # Uses the gh CLI if available, otherwise falls back to the GitHub REST API
     #     # (requires runner.github_token or BENCHMARKOOR_RUNNER_GITHUB_TOKEN).
@@ -154,7 +174,7 @@ runner:
     #     #   # genesis_artifact_run_id: "12345678901"
     #     #   # fixtures_subdir also works with artifacts
     #
-    #     # Option 3c: EEST fixtures from local directories.
+    #     # Option 4c: EEST fixtures from local directories.
     #     # Points directly at already-extracted fixtures and genesis directories.
     #     # No downloading or caching — useful for local development with locally-built EEST fixtures.
     #     # eest_fixtures:
@@ -163,7 +183,7 @@ runner:
     #     #   # fixtures_subdir also works with local directories
     #     #   # fixtures_subdir: fixtures/blockchain_tests_engine_x  # default
     #
-    #     # Option 3d: EEST fixtures from local .tar.gz tarballs.
+    #     # Option 4d: EEST fixtures from local .tar.gz tarballs.
     #     # Extracts tarballs to a cache directory (keyed by content hash, re-extraction skipped
     #     # if already cached). Useful when you have locally-built tarballs but haven't extracted them.
     #     # eest_fixtures:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,7 +243,7 @@ runner:
 
 #### Test Sources
 
-Tests can be loaded from a local directory, a git repository, or EEST (Ethereum Execution Spec Tests) fixtures. Only one source type can be configured.
+Tests can be loaded from a local directory, a git repository, an archive file, or EEST (Ethereum Execution Spec Tests) fixtures. Only one source type can be configured.
 
 ##### Local Source
 
@@ -298,6 +298,46 @@ tests:
 | `steps.setup` | []string | No | Glob patterns for setup phase files |
 | `steps.test` | []string | No | Glob patterns for test phase files |
 | `steps.cleanup` | []string | No | Glob patterns for cleanup phase files |
+
+##### Archive Source
+
+Tests can be loaded from a ZIP or tar.gz archive file, either from a local path or a URL (including GitHub Actions artifacts).
+
+```yaml
+tests:
+  source:
+    archive:
+      file: https://github.com/NethermindEth/gas-benchmarks/actions/runs/23847558369/artifacts/6222084759
+      pre_run_steps:
+        - "perf-devnet-3/gas-bump.txt"
+        - "perf-devnet-3/funding.txt"
+      steps:
+        setup:
+          - "perf-devnet-3/setup/*.txt"
+        test:
+          - "perf-devnet-3/testing/*.txt"
+      # Optional: External opcode metadata for the test suite.
+      # When provided, opcode counts are included in the suite summary.json
+      # and displayed in the UI opcode heatmap.
+      opcodes: "opcodes_tracing.json"
+      # Optional: Separate archive containing the opcodes file.
+      # If not set, the opcodes file is searched in the main archive.
+      # opcodes_file: https://github.com/NethermindEth/gas-benchmarks/actions/runs/23847558369/artifacts/6222074312
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `file` | string | Yes | Local path or URL to a ZIP or tar.gz archive. GitHub Actions artifact URLs are auto-converted to API endpoints |
+| `pre_run_steps` | []string | No | Glob patterns for steps executed once before all tests |
+| `steps.setup` | []string | No | Glob patterns for setup phase files |
+| `steps.test` | []string | No | Glob patterns for test phase files |
+| `steps.cleanup` | []string | No | Glob patterns for cleanup phase files |
+| `opcodes` | string | No | Filename within the archive containing opcode count metadata (e.g., `opcodes_tracing.json`). The file must be a JSON object mapping test names to opcode counts: `{"test_name": {"OPCODE": count, ...}}` |
+| `opcodes_file` | string | No | Separate archive URL/path containing the opcodes file. If not set, the opcodes file is searched in the main `file` archive |
+
+**GitHub Actions artifacts:** Browser URLs like `https://github.com/{owner}/{repo}/actions/runs/{run_id}/artifacts/{artifact_id}` are automatically converted to the GitHub API download endpoint. A GitHub token is required for artifact downloads (set via `runner.github_token` or `BENCHMARKOOR_RUNNER_GITHUB_TOKEN`).
+
+**Archive extraction:** ZIP archives are extracted and any inner tarballs (common in GitHub Actions artifacts) are automatically extracted as well.
 
 ##### EEST Fixtures Source
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -335,6 +335,8 @@ type LocalSourceV2 struct {
 // The file can be a local path or a URL (HTTP/HTTPS) to a ZIP or tar.gz archive.
 type ArchiveSourceConfig struct {
 	File        string       `yaml:"file" mapstructure:"file"`
+	OpcodesFile string       `yaml:"opcodes_file,omitempty" mapstructure:"opcodes_file"`
+	Opcodes     string       `yaml:"opcodes,omitempty" mapstructure:"opcodes"`
 	PreRunSteps []string     `yaml:"pre_run_steps,omitempty" mapstructure:"pre_run_steps"`
 	Steps       *StepsConfig `yaml:"steps,omitempty" mapstructure:"steps"`
 }

--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -290,23 +290,43 @@ func (s *ArchiveSource) loadOpcodes(ctx context.Context, prepared *PreparedSourc
 	}
 
 	// Match opcode data to discovered tests by name.
+	// Test names from glob discovery include the .txt extension, but opcode
+	// JSON keys typically omit it, so we try both the full name and without .txt.
 	matched := 0
 
 	for _, test := range prepared.Tests {
-		if counts, ok := opcodeMap[test.Name]; ok {
+		name := test.Name
+		if counts, ok := opcodeMap[name]; ok {
 			test.OpcodeCount = counts
 			matched++
+		} else if trimmed, hasSuffix := strings.CutSuffix(name, ".txt"); hasSuffix {
+			if counts, ok := opcodeMap[trimmed]; ok {
+				test.OpcodeCount = counts
+				matched++
+			}
+		}
+	}
+
+	// Count opcode entries that are relevant (pass the filter) but didn't match a test.
+	filtered := len(opcodeMap)
+	if s.filter != "" {
+		filtered = 0
+
+		for key := range opcodeMap {
+			if strings.Contains(key, s.filter) {
+				filtered++
+			}
 		}
 	}
 
 	s.log.WithFields(logrus.Fields{
 		"file":          s.cfg.Opcodes,
-		"total_entries": len(opcodeMap),
+		"total_entries": filtered,
 		"matched_tests": matched,
 		"total_tests":   len(prepared.Tests),
 	}).Info("Loaded external opcode data")
 
-	if unmatched := len(opcodeMap) - matched; unmatched > 0 {
+	if unmatched := filtered - matched; unmatched > 0 {
 		s.log.WithField("unmatched", unmatched).Warn(
 			"Some opcode entries did not match any discovered test",
 		)

--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,12 +24,13 @@ var ghArtifactURLPattern = regexp.MustCompile(
 // ArchiveSource downloads and extracts an archive file, then discovers tests
 // from the extracted contents using glob patterns.
 type ArchiveSource struct {
-	log         logrus.FieldLogger
-	cfg         *config.ArchiveSourceConfig
-	cacheDir    string
-	filter      string
-	githubToken string
-	basePath    string // temp directory where archive was extracted
+	log            logrus.FieldLogger
+	cfg            *config.ArchiveSourceConfig
+	cacheDir       string
+	filter         string
+	githubToken    string
+	basePath       string // temp directory where archive was extracted
+	opcodeBasePath string // temp directory for separate opcode archive
 }
 
 // Prepare downloads (if URL) and extracts the archive, then discovers tests.
@@ -65,13 +67,32 @@ func (s *ArchiveSource) Prepare(ctx context.Context) (*PreparedSource, error) {
 
 	s.log.WithField("path", s.basePath).Info("Extracted archive")
 
-	return discoverTestsFromConfig(
+	prepared, err := discoverTestsFromConfig(
 		s.basePath, s.cfg.PreRunSteps, s.cfg.Steps, s.filter, s.log,
 	)
+	if err != nil {
+		_ = os.RemoveAll(s.basePath)
+		s.basePath = ""
+
+		return nil, err
+	}
+
+	if err := s.loadOpcodes(ctx, prepared); err != nil {
+		_ = os.RemoveAll(s.basePath)
+		s.basePath = ""
+
+		return nil, fmt.Errorf("loading opcodes: %w", err)
+	}
+
+	return prepared, nil
 }
 
-// Cleanup removes the temporary extraction directory.
+// Cleanup removes the temporary extraction directories.
 func (s *ArchiveSource) Cleanup() error {
+	if s.opcodeBasePath != "" {
+		_ = os.RemoveAll(s.opcodeBasePath)
+	}
+
 	if s.basePath != "" {
 		return os.RemoveAll(s.basePath)
 	}
@@ -232,4 +253,221 @@ func (s *ArchiveSource) extractArchive(archivePath string) error {
 	}
 
 	return nil
+}
+
+// loadOpcodes loads external opcode count data and attaches it to discovered tests.
+func (s *ArchiveSource) loadOpcodes(ctx context.Context, prepared *PreparedSource) error {
+	if s.cfg.Opcodes == "" {
+		return nil
+	}
+
+	searchDir := s.basePath
+
+	// If a separate opcode archive is configured, download and extract it.
+	if s.cfg.OpcodesFile != "" {
+		opcodeDir, err := s.resolveOpcodeArchive(ctx)
+		if err != nil {
+			return fmt.Errorf("resolving opcode archive: %w", err)
+		}
+
+		searchDir = opcodeDir
+	}
+
+	// Find and read the opcodes file.
+	opcodePath, err := findFileInDir(searchDir, s.cfg.Opcodes)
+	if err != nil {
+		return fmt.Errorf("finding opcodes file %q: %w", s.cfg.Opcodes, err)
+	}
+
+	data, err := os.ReadFile(opcodePath)
+	if err != nil {
+		return fmt.Errorf("reading opcodes file %q: %w", opcodePath, err)
+	}
+
+	var opcodeMap map[string]map[string]int
+	if err := json.Unmarshal(data, &opcodeMap); err != nil {
+		return fmt.Errorf("parsing opcodes file: %w", err)
+	}
+
+	// Match opcode data to discovered tests by name.
+	matched := 0
+
+	for _, test := range prepared.Tests {
+		if counts, ok := opcodeMap[test.Name]; ok {
+			test.OpcodeCount = counts
+			matched++
+		}
+	}
+
+	s.log.WithFields(logrus.Fields{
+		"file":          s.cfg.Opcodes,
+		"total_entries": len(opcodeMap),
+		"matched_tests": matched,
+		"total_tests":   len(prepared.Tests),
+	}).Info("Loaded external opcode data")
+
+	if unmatched := len(opcodeMap) - matched; unmatched > 0 {
+		s.log.WithField("unmatched", unmatched).Warn(
+			"Some opcode entries did not match any discovered test",
+		)
+	}
+
+	return nil
+}
+
+// resolveOpcodeArchive downloads and extracts the separate opcode archive,
+// returning the path to the extraction directory.
+func (s *ArchiveSource) resolveOpcodeArchive(ctx context.Context) (string, error) {
+	parentDir := s.cacheDir
+	if parentDir == "" {
+		parentDir = os.TempDir()
+	}
+
+	tmpDir, err := os.MkdirTemp(parentDir, "opcode-archive-*")
+	if err != nil {
+		return "", fmt.Errorf("creating opcode temp directory: %w", err)
+	}
+
+	s.opcodeBasePath = tmpDir
+
+	archivePath, err := s.resolveRemoteFile(ctx, s.cfg.OpcodesFile)
+	if err != nil {
+		return "", fmt.Errorf("resolving opcode file: %w", err)
+	}
+
+	if err := s.extractToDir(archivePath, tmpDir); err != nil {
+		return "", fmt.Errorf("extracting opcode archive: %w", err)
+	}
+
+	s.log.WithField("path", tmpDir).Info("Extracted opcode archive")
+
+	return tmpDir, nil
+}
+
+// resolveRemoteFile resolves a file URL or local path, downloading and caching
+// remote files.
+func (s *ArchiveSource) resolveRemoteFile(ctx context.Context, file string) (string, error) {
+	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
+		hash := sha256.Sum256([]byte(file))
+		name := "archive-" + hex.EncodeToString(hash[:8])
+
+		cacheDir := s.cacheDir
+		if cacheDir == "" {
+			cacheDir = os.TempDir()
+		}
+
+		cachedPath := filepath.Join(cacheDir, name)
+
+		if _, err := os.Stat(cachedPath); err == nil {
+			s.log.WithFields(logrus.Fields{
+				"url":  file,
+				"path": cachedPath,
+			}).Info("Using cached file")
+
+			return cachedPath, nil
+		}
+
+		s.log.WithField("url", file).Info("Downloading file")
+
+		downloadURL, token := s.resolveDownloadURL(file)
+
+		tmpPath := cachedPath + ".tmp"
+
+		if err := os.MkdirAll(filepath.Dir(cachedPath), 0755); err != nil {
+			return "", fmt.Errorf("creating cache directory: %w", err)
+		}
+
+		if err := downloadToFile(ctx, downloadURL, tmpPath, token, s.log); err != nil {
+			_ = os.Remove(tmpPath)
+
+			return "", err
+		}
+
+		if err := os.Rename(tmpPath, cachedPath); err != nil {
+			_ = os.Remove(tmpPath)
+
+			return "", fmt.Errorf("caching file: %w", err)
+		}
+
+		return cachedPath, nil
+	}
+
+	// Local file path.
+	if !filepath.IsAbs(file) {
+		absPath, err := filepath.Abs(file)
+		if err != nil {
+			return "", fmt.Errorf("resolving path %q: %w", file, err)
+		}
+
+		file = absPath
+	}
+
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return "", fmt.Errorf("file %q does not exist", file)
+	}
+
+	return file, nil
+}
+
+// extractToDir detects the archive format and extracts to the given directory.
+func (s *ArchiveSource) extractToDir(archivePath, destDir string) error {
+	format, err := detectArchiveFormat(archivePath)
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case archiveFormatZip:
+		if err := extractZipFile(archivePath, destDir); err != nil {
+			return fmt.Errorf("extracting zip: %w", err)
+		}
+
+		if err := extractInnerTarballs(destDir, s.log); err != nil {
+			return fmt.Errorf("extracting inner tarballs: %w", err)
+		}
+	case archiveFormatTarGz:
+		if err := extractTarGzFile(archivePath, destDir); err != nil {
+			return fmt.Errorf("extracting tar.gz: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported archive format: %s", format)
+	}
+
+	return nil
+}
+
+// findFileInDir searches for a file by name within a directory tree.
+func findFileInDir(dir, filename string) (string, error) {
+	// Try direct path first.
+	direct := filepath.Join(dir, filename)
+	if _, err := os.Stat(direct); err == nil {
+		return direct, nil
+	}
+
+	// Walk the directory to find the file.
+	var found string
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if !info.IsDir() && info.Name() == filename {
+			found = path
+
+			return filepath.SkipAll
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("walking directory: %w", err)
+	}
+
+	if found == "" {
+		return "", fmt.Errorf("file %q not found in %q", filename, dir)
+	}
+
+	return found, nil
 }

--- a/pkg/executor/source.go
+++ b/pkg/executor/source.go
@@ -49,6 +49,7 @@ type TestWithSteps struct {
 	Cleanup     *StepFile         // Optional cleanup step
 	GenesisHash string            // Genesis hash from pre_alloc (empty if single-genesis)
 	EESTInfo    *eest.FixtureInfo // EEST fixture metadata (nil for non-EEST sources)
+	OpcodeCount map[string]int    // External opcode counts (nil if not provided)
 }
 
 // PreparedSource contains the prepared test source with all discovered tests.

--- a/pkg/executor/suite.go
+++ b/pkg/executor/suite.go
@@ -81,6 +81,7 @@ type SuiteTest struct {
 	Test        *SuiteFile     `json:"test,omitempty"`
 	Cleanup     *SuiteFile     `json:"cleanup,omitempty"`
 	EEST        *SuiteTestEEST `json:"eest,omitempty"`
+	OpcodeCount map[string]int `json:"opcode_count,omitempty"`
 }
 
 // ComputeSuiteHash computes a hash of all test file contents.
@@ -183,6 +184,12 @@ func CreateSuiteOutput(
 
 			if test.EESTInfo != nil {
 				suiteTest.EEST = &SuiteTestEEST{Info: test.EESTInfo}
+				suiteTest.OpcodeCount = test.EESTInfo.OpcodeCount
+			}
+
+			// External opcode data takes precedence over EEST-derived opcodes.
+			if test.OpcodeCount != nil {
+				suiteTest.OpcodeCount = test.OpcodeCount
 			}
 
 			// Create test directory.

--- a/pkg/executor/suite.go
+++ b/pkg/executor/suite.go
@@ -241,6 +241,10 @@ func CreateSuiteOutput(
 			var existing SuiteInfo
 			if jsonErr := json.Unmarshal(existingData, &existing); jsonErr == nil {
 				info.PreRunSteps = existing.PreRunSteps
+
+				// Merge opcode data from prepared tests into existing entries.
+				mergeOpcodeData(existing.Tests, prepared)
+
 				info.Tests = existing.Tests
 			}
 		}
@@ -352,4 +356,31 @@ func GetGitCommitSHA(repoPath string) (string, error) {
 	}
 
 	return sha, nil
+}
+
+// mergeOpcodeData updates existing suite tests with opcode data from
+// the current prepared source. This is needed when the suite directory
+// already exists on disk and we re-read its summary.json — the old
+// entries won't have opcode_count if the feature was added after the
+// suite was first created.
+func mergeOpcodeData(existing []SuiteTest, prepared *PreparedSource) {
+	if prepared == nil {
+		return
+	}
+
+	opcodeByName := make(map[string]map[string]int, len(prepared.Tests))
+
+	for _, t := range prepared.Tests {
+		if t.OpcodeCount != nil {
+			opcodeByName[t.Name] = t.OpcodeCount
+		} else if t.EESTInfo != nil && t.EESTInfo.OpcodeCount != nil {
+			opcodeByName[t.Name] = t.EESTInfo.OpcodeCount
+		}
+	}
+
+	for i := range existing {
+		if counts, ok := opcodeByName[existing[i].Name]; ok {
+			existing[i].OpcodeCount = counts
+		}
+	}
 }

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -397,6 +397,7 @@ export interface SuiteTest {
   test?: SuiteFile
   cleanup?: SuiteFile
   eest?: SuiteTestEEST
+  opcode_count?: Record<string, number>
 }
 
 export interface SourceInfo {

--- a/ui/src/components/suite-detail/OpcodeHeatmap.tsx
+++ b/ui/src/components/suite-detail/OpcodeHeatmap.tsx
@@ -4,6 +4,11 @@ import type { SuiteTest } from '@/api/types'
 import { getGroupedOpcodes, getCategoryColor } from '@/utils/opcodeCategories'
 import type { CategorySpan, GroupedResult } from '@/utils/opcodeCategories'
 
+/** Returns the opcode count map from the top-level field or EEST info fallback. */
+function getOpcodeCount(test: SuiteTest): Record<string, number> | undefined {
+  return test.opcode_count ?? test.eest?.info?.opcode_count
+}
+
 export interface ExtraColumn {
   name: string
   getValue: (testIndex: number) => number | undefined
@@ -756,7 +761,7 @@ export function OpcodeHeatmap({ tests, onTestClick, extraColumns = [], searchQue
   const testsWithOpcodes = useMemo(() => {
     return tests
       .map((t, i) => ({ test: t, index: i }))
-      .filter((t) => t.test.eest?.info?.opcode_count && Object.keys(t.test.eest.info.opcode_count).length > 0)
+      .filter((t) => { const oc = getOpcodeCount(t.test); return oc && Object.keys(oc).length > 0 })
   }, [tests])
 
   const filteredTests = useMemo(() => {
@@ -768,7 +773,7 @@ export function OpcodeHeatmap({ tests, onTestClick, extraColumns = [], searchQue
   const allOpcodes = useMemo(() => {
     const set = new Set<string>()
     for (const { test } of testsWithOpcodes) {
-      const counts = test.eest?.info?.opcode_count
+      const counts = getOpcodeCount(test)
       if (counts) {
         for (const op of Object.keys(counts)) {
           set.add(op)
@@ -836,7 +841,7 @@ export function OpcodeHeatmap({ tests, onTestClick, extraColumns = [], searchQue
 
   const getCount = useCallback(
     (test: SuiteTest, col: string): number => {
-      const counts = test.eest?.info?.opcode_count
+      const counts = getOpcodeCount(test)
       if (!counts) return 0
       if (expanded) {
         // If groupStack is on, a column might be a subcategory name

--- a/ui/src/components/suite-detail/TestFilesList.tsx
+++ b/ui/src/components/suite-detail/TestFilesList.tsx
@@ -154,28 +154,28 @@ function SearchIcon({ className }: { className?: string }) {
   return <Search className={className} />
 }
 
-// Component for displaying EEST fixture info
+// Component for displaying EEST fixture info and opcode counts
 export function EESTInfoContent({ test, opcodeSort, onOpcodeSortChange }: { test: SuiteTest; opcodeSort: OpcodeSortMode; onOpcodeSortChange: (sort: OpcodeSortMode) => void }) {
   const info = test.eest?.info
-  if (!info) return null
+  const opcodes = test.opcode_count ?? info?.opcode_count
 
-  const fields = [
+  const fields = info ? [
     { label: 'Description', value: info.description },
     { label: 'Comment', value: info.comment },
     { label: 'Fixture Format', value: info['fixture-format'] },
     { label: 'Filling Tool', value: info['filling-transition-tool'] },
     { label: 'Hash', value: info.hash },
     { label: 'URL', value: info.url },
-  ].filter((f) => f.value)
+  ].filter((f) => f.value) : []
 
-  const hasOpcodes = info.opcode_count && Object.keys(info.opcode_count).length > 0
+  const hasOpcodes = opcodes && Object.keys(opcodes).length > 0
 
   if (fields.length === 0 && !hasOpcodes) return null
 
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center gap-2">
-        <Badge variant="default">EEST Info</Badge>
+        <Badge variant="default">{info ? 'EEST Info' : 'Opcode Info'}</Badge>
       </div>
       <div className="rounded-sm border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
         <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm/6">
@@ -212,7 +212,7 @@ export function EESTInfoContent({ test, opcodeSort, onOpcodeSortChange }: { test
               </button>
             </div>
             <div className="flex flex-wrap gap-1">
-              {Object.entries(info.opcode_count!)
+              {Object.entries(opcodes!)
                 .sort(opcodeSort === 'name'
                   ? ([a], [b]) => a.localeCompare(b)
                   : ([, a], [, b]) => b - a
@@ -247,7 +247,7 @@ function TestStepsContent({ suiteHash, test, opcodeSort, onOpcodeSortChange }: {
     { key: 'cleanup', label: 'Cleanup step', file: test.cleanup },
   ].filter((s) => s.file) as { key: string; label: string; file: SuiteFile }[]
 
-  const hasInfo = !!test.eest?.info
+  const hasInfo = !!test.eest?.info || (test.opcode_count && Object.keys(test.opcode_count).length > 0)
   if (steps.length === 0 && !hasInfo) {
     return <div className="p-4 text-sm/6 text-gray-500">No step files available</div>
   }

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -1275,7 +1275,7 @@ export function SuiteDetailPage() {
                 <TestHeatmap stats={suiteStats!} testFiles={suite.tests} isDark={isDark} isLoading={suiteStatsLoading} suiteHash={suiteHash} suiteName={suite.metadata?.labels?.name} stepFilter={stepFilter} searchQuery={hq} onSearchChange={handleHeatmapSearchChange} showTestName={hn === '1'} onShowTestNameChange={handleHeatmapShowNameChange} showClientStat={hCs === '1'} onShowClientStatChange={handleHeatmapClientStatChange} useRegex={hr === '1'} onUseRegexChange={handleHeatmapRegexChange} fullscreen={hFs === '1'} onFullscreenChange={handleHeatmapFullscreenChange} histogramStat={(hStat as 'avgMgas' | 'minMgas' | 'p99Mgas') || undefined} onHistogramStatChange={handleHeatmapStatChange} threshold={hTh ? Number(hTh) : undefined} onThresholdChange={handleHeatmapThresholdChange} runsPerClient={hRpc ? Number(hRpc) : undefined} onRunsPerClientChange={handleHeatmapRunsPerClientChange} pageSize={hPs ? Number(hPs) : undefined} onPageSizeChange={handleHeatmapPageSizeChange} />
               )
             )}
-            {suite.tests.some((t) => t.eest?.info?.opcode_count && Object.keys(t.eest.info.opcode_count).length > 0) && (
+            {suite.tests.some((t) => { const oc = t.opcode_count ?? t.eest?.info?.opcode_count; return oc && Object.keys(oc).length > 0 }) && (
               <div className="overflow-hidden rounded-sm border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
                 <OpcodeHeatmapSection tests={suite.tests} onTestClick={handleDetailChange} />
               </div>


### PR DESCRIPTION
## Summary
- Adds `opcodes` and `opcodes_file` fields to the archive source config, allowing opcode count data to be provided via an external JSON file when not using EEST fixtures
- Opcode data is written to `opcode_count` at the top level of each test in `summary.json`, and the UI opcode heatmap/test detail views now read from this unified field (with fallback to `eest.info.opcode_count` for backward compatibility)
- Adds archive source documentation to `docs/configuration.md` and `config.example.yaml` which were previously missing

## Config example
```yaml
source:
  archive:
    file: https://github.com/.../artifacts/6222084759
    opcodes: "opcodes_tracing.json"
    # Optional: separate archive for the opcodes file
    opcodes_file: https://github.com/.../artifacts/6222074312
    steps:
      test:
        - "perf-devnet-3/testing/*.txt"
```

## Test plan
- [x] `go build ./pkg/executor/... ./pkg/config/...` compiles
- [x] `go test ./pkg/executor/... ./pkg/config/...` passes
- [x] `golangci-lint run` passes on changed packages
- [x] TypeScript type-checks with `npx tsc --noEmit`
- [x] Manual: run with archive source + opcodes config, verify `summary.json` contains `opcode_count` per test
- [x] Manual: verify UI opcode heatmap renders for non-EEST suite