### PR TITLE
feat: set seccomp=unconfined as default for all containers

### DIFF
--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -280,6 +280,7 @@ func (r *runner) runContainerLifecycle(
 			Command:     spec.InitCommand(),
 			Mounts:      mounts,
 			NetworkName: r.cfg.ContainerNetwork,
+			SecurityOpt: []string{"seccomp=unconfined"},
 			Labels: map[string]string{
 				"benchmarkoor.instance":   instance.ID,
 				"benchmarkoor.client":     instance.Client,
@@ -666,6 +667,7 @@ func (r *runner) runContainerLifecycle(
 		Mounts:         mounts,
 		NetworkName:    r.cfg.ContainerNetwork,
 		ResourceLimits: containerResourceLimits,
+		SecurityOpt:    []string{"seccomp=unconfined"},
 		Labels: map[string]string{
 			"benchmarkoor.instance":   instance.ID,
 			"benchmarkoor.client":     instance.Client,

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -938,6 +938,7 @@ func (r *runner) runInitForRecreate(
 		Command:     spec.InitCommand(),
 		Mounts:      mounts,
 		NetworkName: r.cfg.ContainerNetwork,
+		SecurityOpt: []string{"seccomp=unconfined"},
 		Labels: map[string]string{
 			"benchmarkoor.instance":   instance.ID,
 			"benchmarkoor.client":     instance.Client,


### PR DESCRIPTION
## Summary
- Adds `seccomp=unconfined` to all container specs (main container, init container, and strategy-recreate init container)
- Prevents Ethereum clients from being blocked by the default Docker/Podman seccomp profile

## Test plan
- [x] Verify containers start with `seccomp=unconfined` on Docker
- [x] Verify containers start with `seccomp=unconfined` on Podman