### PR TITLE
fix(ui): handle null suite.tests on suite detail page

### DIFF
--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -827,7 +827,7 @@ export function SuiteDetailPage() {
             }
           >
             Tests
-            <Badge variant="default">{suite.tests.length}</Badge>
+            <Badge variant="default">{suite.tests?.length ?? 0}</Badge>
           </Tab>
           {hasPreRunSteps && (
             <Tab
@@ -1272,16 +1272,16 @@ export function SuiteDetailPage() {
                   </div>
                 </div>
               ) : (
-                <TestHeatmap stats={suiteStats!} testFiles={suite.tests} isDark={isDark} isLoading={suiteStatsLoading} suiteHash={suiteHash} suiteName={suite.metadata?.labels?.name} stepFilter={stepFilter} searchQuery={hq} onSearchChange={handleHeatmapSearchChange} showTestName={hn === '1'} onShowTestNameChange={handleHeatmapShowNameChange} showClientStat={hCs === '1'} onShowClientStatChange={handleHeatmapClientStatChange} useRegex={hr === '1'} onUseRegexChange={handleHeatmapRegexChange} fullscreen={hFs === '1'} onFullscreenChange={handleHeatmapFullscreenChange} histogramStat={(hStat as 'avgMgas' | 'minMgas' | 'p99Mgas') || undefined} onHistogramStatChange={handleHeatmapStatChange} threshold={hTh ? Number(hTh) : undefined} onThresholdChange={handleHeatmapThresholdChange} runsPerClient={hRpc ? Number(hRpc) : undefined} onRunsPerClientChange={handleHeatmapRunsPerClientChange} pageSize={hPs ? Number(hPs) : undefined} onPageSizeChange={handleHeatmapPageSizeChange} />
+                <TestHeatmap stats={suiteStats!} testFiles={suite.tests ?? []} isDark={isDark} isLoading={suiteStatsLoading} suiteHash={suiteHash} suiteName={suite.metadata?.labels?.name} stepFilter={stepFilter} searchQuery={hq} onSearchChange={handleHeatmapSearchChange} showTestName={hn === '1'} onShowTestNameChange={handleHeatmapShowNameChange} showClientStat={hCs === '1'} onShowClientStatChange={handleHeatmapClientStatChange} useRegex={hr === '1'} onUseRegexChange={handleHeatmapRegexChange} fullscreen={hFs === '1'} onFullscreenChange={handleHeatmapFullscreenChange} histogramStat={(hStat as 'avgMgas' | 'minMgas' | 'p99Mgas') || undefined} onHistogramStatChange={handleHeatmapStatChange} threshold={hTh ? Number(hTh) : undefined} onThresholdChange={handleHeatmapThresholdChange} runsPerClient={hRpc ? Number(hRpc) : undefined} onRunsPerClientChange={handleHeatmapRunsPerClientChange} pageSize={hPs ? Number(hPs) : undefined} onPageSizeChange={handleHeatmapPageSizeChange} />
               )
             )}
-            {suite.tests.some((t) => { const oc = t.opcode_count ?? t.eest?.info?.opcode_count; return oc && Object.keys(oc).length > 0 }) && (
+            {suite.tests?.some((t) => { const oc = t.opcode_count ?? t.eest?.info?.opcode_count; return oc && Object.keys(oc).length > 0 }) && (
               <div className="overflow-hidden rounded-sm border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-                <OpcodeHeatmapSection tests={suite.tests} onTestClick={handleDetailChange} />
+                <OpcodeHeatmapSection tests={suite.tests ?? []} onTestClick={handleDetailChange} />
               </div>
             )}
             <TestFilesList
-              tests={suite.tests}
+              tests={suite.tests ?? []}
               suiteHash={suiteHash}
               type="tests"
               currentPage={filesPage}


### PR DESCRIPTION
## Summary
- Fixes `TypeError: Cannot read properties of null (reading 'length')` on the suite detail page when a suite has 0 tests
- Adds optional chaining (`?.`) and nullish coalescing (`?? []` / `?? 0`) to all `suite.tests` accesses in `SuiteDetailPage.tsx`

## Test plan
- [x] Navigate to a suite with 0 tests and verify the page renders without errors
- [x] Verify suites with tests still display correctly (badge count, heatmap, test list)