### PR TITLE
fix(podman): use SeccompProfilePath for unconfined seccomp

### DIFF
--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -193,7 +193,7 @@ func (m *manager) CreateContainer(
 	// Map SecurityOpt entries to specgen fields.
 	for _, opt := range spec.SecurityOpt {
 		if opt == "seccomp=unconfined" || opt == "seccomp:unconfined" {
-			s.SeccompPolicy = "unconfined"
+			s.SeccompProfilePath = "unconfined"
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fixes `invalid seccomp policy "unconfined": valid policies are ["default" "image"]` error when running with Podman
- Podman's `SeccompPolicy` field only accepts `"default"` and `"image"` — to disable seccomp, `SeccompProfilePath` must be set to `"unconfined"` instead

## Test plan
- [x] Run benchmarkoor with Podman and verify containers start without seccomp errors
- [x] Verify Docker path is unaffected (uses `SecurityOpt` directly, not specgen)