### PR TITLE
fix: create tmp_datadir and tmp_cachedir if they don't exist

### DIFF
--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -46,6 +47,25 @@ func init() {
 		"Add metadata label as key=value (can be repeated)")
 }
 
+// logFileHook writes log entries to a file.
+type logFileHook struct {
+	writer    io.Writer
+	formatter logrus.Formatter
+}
+
+func (h *logFileHook) Levels() []logrus.Level { return logrus.AllLevels }
+
+func (h *logFileHook) Fire(entry *logrus.Entry) error {
+	line, err := h.formatter.Format(entry)
+	if err != nil {
+		return err
+	}
+
+	_, err = h.writer.Write(line)
+
+	return err
+}
+
 func runBenchmark(cmd *cobra.Command, args []string) error {
 	if len(cfgFiles) == 0 {
 		return fmt.Errorf("config file is required (use --config)")
@@ -76,6 +96,27 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("parsing results_owner: %w", err)
 	}
+
+	// Setup top-level benchmarkoor.log in the results directory so that all
+	// logs (config validation, cleanup, image pulls, etc.) are captured, not
+	// just the per-instance logs.
+	if err := fsutil.MkdirAll(cfg.Runner.Benchmark.ResultsDir, 0755, resultsOwner); err != nil {
+		return fmt.Errorf("creating results directory: %w", err)
+	}
+
+	topLevelLogFile, err := fsutil.Create(
+		filepath.Join(cfg.Runner.Benchmark.ResultsDir, "benchmarkoor.log"), resultsOwner,
+	)
+	if err != nil {
+		return fmt.Errorf("creating top-level benchmarkoor log file: %w", err)
+	}
+	defer func() { _ = topLevelLogFile.Close() }()
+
+	topLevelLogHook := &logFileHook{
+		writer:    topLevelLogFile,
+		formatter: log.Formatter,
+	}
+	log.AddHook(topLevelLogHook)
 
 	// Use consistent log format when client logs go to stdout.
 	if cfg.Runner.ClientLogsToStdout {

--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -47,25 +46,6 @@ func init() {
 		"Add metadata label as key=value (can be repeated)")
 }
 
-// logFileHook writes log entries to a file.
-type logFileHook struct {
-	writer    io.Writer
-	formatter logrus.Formatter
-}
-
-func (h *logFileHook) Levels() []logrus.Level { return logrus.AllLevels }
-
-func (h *logFileHook) Fire(entry *logrus.Entry) error {
-	line, err := h.formatter.Format(entry)
-	if err != nil {
-		return err
-	}
-
-	_, err = h.writer.Write(line)
-
-	return err
-}
-
 func runBenchmark(cmd *cobra.Command, args []string) error {
 	if len(cfgFiles) == 0 {
 		return fmt.Errorf("config file is required (use --config)")
@@ -97,26 +77,10 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("parsing results_owner: %w", err)
 	}
 
-	// Setup top-level benchmarkoor.log in the results directory so that all
-	// logs (config validation, cleanup, image pulls, etc.) are captured, not
-	// just the per-instance logs.
-	if err := fsutil.MkdirAll(cfg.Runner.Benchmark.ResultsDir, 0755, resultsOwner); err != nil {
-		return fmt.Errorf("creating results directory: %w", err)
-	}
-
-	topLevelLogFile, err := fsutil.Create(
-		filepath.Join(cfg.Runner.Benchmark.ResultsDir, "benchmarkoor.log"), resultsOwner,
-	)
-	if err != nil {
-		return fmt.Errorf("creating top-level benchmarkoor log file: %w", err)
-	}
-	defer func() { _ = topLevelLogFile.Close() }()
-
-	topLevelLogHook := &logFileHook{
-		writer:    topLevelLogFile,
-		formatter: log.Formatter,
-	}
-	log.AddHook(topLevelLogHook)
+	// Buffer all log entries so they can be replayed into each instance's
+	// benchmarkoor.log file, capturing logs from before RunInstance is called.
+	preRunLogBuffer := runner.NewBufferHook(log.Formatter)
+	log.AddHook(preRunLogBuffer)
 
 	// Use consistent log format when client logs go to stdout.
 	if cfg.Runner.ClientLogsToStdout {
@@ -339,7 +303,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 			FullConfig:         cfg,
 		}
 
-		r := runner.NewRunner(log, runnerCfg, containerMgr, registry, exec, cpufreqMgr, resultsUploader)
+		r := runner.NewRunner(log, runnerCfg, containerMgr, registry, exec, cpufreqMgr, resultsUploader, preRunLogBuffer)
 
 		if err := r.Start(ctx); err != nil {
 			return fmt.Errorf("starting runner: %w", err)

--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -77,9 +77,14 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("parsing results_owner: %w", err)
 	}
 
-	// Buffer all log entries so they can be replayed into each instance's
-	// benchmarkoor.log file, capturing logs from before RunInstance is called.
-	preRunLogBuffer := runner.NewBufferHook(log.Formatter)
+	// Buffer all log entries to a temp file so they can be replayed into each
+	// instance's benchmarkoor.log, capturing logs from before RunInstance.
+	preRunLogBuffer, err := runner.NewBufferHook(log.Formatter, cfg.Runner.Directories.TmpCacheDir)
+	if err != nil {
+		return fmt.Errorf("creating pre-run log buffer: %w", err)
+	}
+	defer preRunLogBuffer.Close()
+
 	log.AddHook(preRunLogBuffer)
 
 	// Use consistent log format when client logs go to stdout.

--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -77,8 +77,15 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("parsing results_owner: %w", err)
 	}
 
+	// Use consistent log format when client logs go to stdout.
+	if cfg.Runner.ClientLogsToStdout {
+		log.SetFormatter(&consistentFormatter{prefix: "🔵"})
+	}
+
 	// Buffer all log entries to a temp file so they can be replayed into each
 	// instance's benchmarkoor.log, capturing logs from before RunInstance.
+	// Created after the formatter is set so the buffered output matches the
+	// per-instance log format.
 	preRunLogBuffer, err := runner.NewBufferHook(log.Formatter, cfg.Runner.Directories.TmpCacheDir)
 	if err != nil {
 		return fmt.Errorf("creating pre-run log buffer: %w", err)
@@ -86,11 +93,6 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 	defer preRunLogBuffer.Close()
 
 	log.AddHook(preRunLogBuffer)
-
-	// Use consistent log format when client logs go to stdout.
-	if cfg.Runner.ClientLogsToStdout {
-		log.SetFormatter(&consistentFormatter{prefix: "🔵"})
-	}
 
 	// Setup context with signal handling.
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -77,6 +77,19 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("parsing results_owner: %w", err)
 	}
 
+	// Ensure configured temporary directories exist.
+	if dir := cfg.Runner.Directories.TmpDataDir; dir != "" {
+		if err := fsutil.MkdirAll(dir, 0755, resultsOwner); err != nil {
+			return fmt.Errorf("creating tmp_datadir %q: %w", dir, err)
+		}
+	}
+
+	if dir := cfg.Runner.Directories.TmpCacheDir; dir != "" {
+		if err := fsutil.MkdirAll(dir, 0755, resultsOwner); err != nil {
+			return fmt.Errorf("creating tmp_cachedir %q: %w", dir, err)
+		}
+	}
+
 	// Use consistent log format when client logs go to stdout.
 	if cfg.Runner.ClientLogsToStdout {
 		log.SetFormatter(&consistentFormatter{prefix: "🔵"})

--- a/pkg/runner/logging.go
+++ b/pkg/runner/logging.go
@@ -68,44 +68,59 @@ func clientLogPrefix(clientName string) func() string {
 	}
 }
 
-// BufferHook buffers formatted log lines so they can be replayed into files
-// created later (e.g. per-instance benchmarkoor.log). Install it on the
-// logger before the runner starts so that pre-instance logs are captured.
+// BufferHook writes formatted log lines to a temporary file so they can be
+// replayed into files created later (e.g. per-instance benchmarkoor.log).
+// Install it on the logger before the runner starts so that pre-instance
+// logs are captured without unbounded memory growth.
 type BufferHook struct {
 	formatter logrus.Formatter
-	lines     [][]byte
+	file      *os.File
 }
 
-// NewBufferHook creates a BufferHook that formats entries with the given
-// formatter.
-func NewBufferHook(formatter logrus.Formatter) *BufferHook {
-	return &BufferHook{formatter: formatter}
+// NewBufferHook creates a BufferHook backed by a temporary file in tmpDir.
+// If tmpDir is empty the system default is used. The caller must call Close
+// when the hook is no longer needed.
+func NewBufferHook(formatter logrus.Formatter, tmpDir string) (*BufferHook, error) {
+	f, err := os.CreateTemp(tmpDir, "benchmarkoor-prelog-*.log")
+	if err != nil {
+		return nil, fmt.Errorf("creating pre-run log buffer: %w", err)
+	}
+
+	return &BufferHook{formatter: formatter, file: f}, nil
 }
 
 // Levels returns all log levels.
 func (h *BufferHook) Levels() []logrus.Level { return logrus.AllLevels }
 
-// Fire formats and buffers a log entry.
+// Fire formats and appends a log entry to the temporary file.
 func (h *BufferHook) Fire(entry *logrus.Entry) error {
 	line, err := h.formatter.Format(entry)
 	if err != nil {
 		return err
 	}
 
-	h.lines = append(h.lines, line)
+	_, err = h.file.Write(line)
+
+	return err
+}
+
+// FlushTo copies all buffered log lines to w.
+func (h *BufferHook) FlushTo(w io.Writer) error {
+	if _, err := h.file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seeking pre-run log buffer: %w", err)
+	}
+
+	if _, err := io.Copy(w, h.file); err != nil {
+		return fmt.Errorf("copying pre-run log buffer: %w", err)
+	}
 
 	return nil
 }
 
-// FlushTo flushes all buffered lines to w.
-func (h *BufferHook) FlushTo(w io.Writer) error {
-	for _, line := range h.lines {
-		if _, err := w.Write(line); err != nil {
-			return err
-		}
-	}
-
-	return nil
+// Close removes the temporary file.
+func (h *BufferHook) Close() {
+	_ = h.file.Close()
+	_ = os.Remove(h.file.Name())
 }
 
 // fileHook writes log entries to a file.

--- a/pkg/runner/logging.go
+++ b/pkg/runner/logging.go
@@ -68,6 +68,46 @@ func clientLogPrefix(clientName string) func() string {
 	}
 }
 
+// BufferHook buffers formatted log lines so they can be replayed into files
+// created later (e.g. per-instance benchmarkoor.log). Install it on the
+// logger before the runner starts so that pre-instance logs are captured.
+type BufferHook struct {
+	formatter logrus.Formatter
+	lines     [][]byte
+}
+
+// NewBufferHook creates a BufferHook that formats entries with the given
+// formatter.
+func NewBufferHook(formatter logrus.Formatter) *BufferHook {
+	return &BufferHook{formatter: formatter}
+}
+
+// Levels returns all log levels.
+func (h *BufferHook) Levels() []logrus.Level { return logrus.AllLevels }
+
+// Fire formats and buffers a log entry.
+func (h *BufferHook) Fire(entry *logrus.Entry) error {
+	line, err := h.formatter.Format(entry)
+	if err != nil {
+		return err
+	}
+
+	h.lines = append(h.lines, line)
+
+	return nil
+}
+
+// FlushTo flushes all buffered lines to w.
+func (h *BufferHook) FlushTo(w io.Writer) error {
+	for _, line := range h.lines {
+		if _, err := w.Write(line); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // fileHook writes log entries to a file.
 type fileHook struct {
 	writer    io.Writer

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -184,35 +184,38 @@ func NewRunner(
 	exec executor.Executor,
 	cpufreqMgr cpufreq.Manager,
 	uploader upload.Uploader,
+	preRunLogBuffer *BufferHook,
 ) Runner {
 	if cfg.ReadyTimeout == 0 {
 		cfg.ReadyTimeout = DefaultReadyTimeout
 	}
 
 	return &runner{
-		logger:       log,
-		log:          log.WithField("component", "runner"),
-		cfg:          cfg,
-		containerMgr: containerMgr,
-		registry:     registry,
-		executor:     exec,
-		cpufreqMgr:   cpufreqMgr,
-		uploader:     uploader,
-		done:         make(chan struct{}),
+		logger:          log,
+		log:             log.WithField("component", "runner"),
+		cfg:             cfg,
+		containerMgr:    containerMgr,
+		registry:        registry,
+		executor:        exec,
+		cpufreqMgr:      cpufreqMgr,
+		uploader:        uploader,
+		preRunLogBuffer: preRunLogBuffer,
+		done:            make(chan struct{}),
 	}
 }
 
 type runner struct {
-	logger       *logrus.Logger     // The actual logger (for hook management)
-	log          logrus.FieldLogger // The field logger (for logging with fields)
-	cfg          *Config
-	containerMgr docker.ContainerManager
-	registry     client.Registry
-	executor     executor.Executor
-	cpufreqMgr   cpufreq.Manager
-	uploader     upload.Uploader
-	done         chan struct{}
-	wg           sync.WaitGroup
+	logger          *logrus.Logger     // The actual logger (for hook management)
+	log             logrus.FieldLogger // The field logger (for logging with fields)
+	cfg             *Config
+	containerMgr    docker.ContainerManager
+	registry        client.Registry
+	executor        executor.Executor
+	cpufreqMgr      cpufreq.Manager
+	uploader        upload.Uploader
+	preRunLogBuffer *BufferHook // Buffered logs from before RunInstance (may be nil).
+	done            chan struct{}
+	wg              sync.WaitGroup
 }
 
 // Ensure interface compliance.
@@ -389,6 +392,14 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 	}
 	r.logger.AddHook(logHook)
 	defer r.removeHook(logHook)
+
+	// Flush any pre-instance logs (config validation, cleanup, image pulls,
+	// etc.) that were buffered before RunInstance was called.
+	if r.preRunLogBuffer != nil {
+		if err := r.preRunLogBuffer.FlushTo(benchmarkoorLogFile); err != nil {
+			return fmt.Errorf("flushing pre-run logs: %w", err)
+		}
+	}
 
 	log := r.log.WithFields(logrus.Fields{
 		"instance": instance.ID,


### PR DESCRIPTION
## Summary
- When `tmp_datadir` or `tmp_cachedir` are configured (via config or env vars like `BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_DATADIR`), create the directories early in the run command if they don't already exist
- Prevents failures later when the runner or executor tries to use them

## Test plan
- [ ] Set `BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_DATADIR` to a non-existent path, run benchmarkoor, verify it creates the directory and proceeds
- [ ] Same for `BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_CACHEDIR`
- [ ] Verify existing directories are not affected