### PR TITLE
fix(api): update suite metadata on re-index when name changes

### DIFF
--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -678,10 +678,17 @@ func (s *store) DeleteTestStatsBlockLogsForRun(
 }
 
 // UpsertSuite inserts or updates a suite record keyed by suite_hash.
+// Uses a map for Assign so update values are not overwritten when
+// FirstOrCreate populates the struct with the existing DB record.
 func (s *store) UpsertSuite(ctx context.Context, suite *Suite) error {
 	result := s.db.WithContext(ctx).
 		Where("suite_hash = ?", suite.SuiteHash).
-		Assign(suite).
+		Assign(map[string]any{
+			"discovery_path": suite.DiscoveryPath,
+			"name":           suite.Name,
+			"tests_total":    suite.TestsTotal,
+			"indexed_at":     suite.IndexedAt,
+		}).
 		FirstOrCreate(suite)
 	if result.Error != nil {
 		return fmt.Errorf("upserting suite: %w", result.Error)

--- a/pkg/api/indexstore/indexstore_test.go
+++ b/pkg/api/indexstore/indexstore_test.go
@@ -291,3 +291,32 @@ func TestStore_TestStatCRUD(t *testing.T) {
 	assert.Equal(t, runID2, remaining[0].RunID)
 	assert.Equal(t, "TestA", remaining[0].TestName)
 }
+
+func TestStore_UpsertSuiteUpdatesName(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	original := &indexstore.Suite{
+		SuiteHash:     "hash-abc",
+		DiscoveryPath: "dp/test",
+		Name:          "old-name",
+		TestsTotal:    5,
+		IndexedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, s.UpsertSuite(ctx, original))
+
+	// Upsert the same hash with a different name.
+	updated := &indexstore.Suite{
+		SuiteHash:     "hash-abc",
+		DiscoveryPath: "dp/test",
+		Name:          "new-name",
+		TestsTotal:    5,
+		IndexedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, s.UpsertSuite(ctx, updated))
+
+	// The struct should reflect the updated name.
+	assert.Equal(t, "new-name", updated.Name)
+	assert.NotZero(t, updated.ID, "ID should be populated after upsert")
+	assert.Equal(t, original.ID, updated.ID, "upsert must not create a duplicate")
+}


### PR DESCRIPTION
## Summary
- Fixes suite `labels.name` not updating in the database when it changes between runs (while suite hash stays the same)
- Root cause: `UpsertSuite` passed the same struct pointer to both GORM's `Assign()` and `FirstOrCreate()`, making it first-write-wins — when the record was found, `FirstOrCreate` populated the struct with DB values before `Assign` could apply the updates
- Fix: use a map for `Assign()` so update values are independent of the struct pointer

## Test plan
- [x] Added `TestStore_UpsertSuiteUpdatesName` — upserts a suite, then upserts again with a different name, asserts the name is updated
- [x] All existing indexstore tests pass