### PR TITLE
feat: move opcode source to benchmark-level config

### DIFF
--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -242,6 +242,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 				Source:                          &cfg.Runner.Benchmark.Tests.Source,
 				Filter:                          cfg.Runner.Benchmark.Tests.Filter,
 				Metadata:                        suiteMetadata,
+				OpcodeSource:                    cfg.Runner.Benchmark.OpcodeSource,
 				CacheDir:                        cacheDir,
 				ResultsDir:                      cfg.Runner.Benchmark.ResultsDir,
 				ResultsOwner:                    resultsOwner,

--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -242,7 +242,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 				Source:                          &cfg.Runner.Benchmark.Tests.Source,
 				Filter:                          cfg.Runner.Benchmark.Tests.Filter,
 				Metadata:                        suiteMetadata,
-				OpcodeSource:                    cfg.Runner.Benchmark.OpcodeSource,
+				OpcodeSource:                    cfg.Runner.Benchmark.Tests.OpcodeSource,
 				CacheDir:                        cacheDir,
 				ResultsDir:                      cfg.Runner.Benchmark.ResultsDir,
 				ResultsOwner:                    resultsOwner,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -142,12 +142,6 @@ runner:
     #     #       - "perf-devnet-3/setup/*.txt"
     #     #     test:
     #     #       - "perf-devnet-3/testing/*.txt"
-    #     #   # Optional: External opcode metadata file within the archive.
-    #     #   # JSON mapping test names to opcode counts: {"test_name": {"OPCODE": count}}
-    #     #   # opcodes: "opcodes_tracing.json"
-    #     #   # Optional: Separate archive containing the opcodes file.
-    #     #   # If not set, the opcodes file is searched in the main archive.
-    #     #   # opcodes_file: https://github.com/.../artifacts/6222074312
     #
     #     # Option 4: EEST (Ethereum Execution Spec Tests) fixtures from GitHub releases.
     #     # Downloads fixtures directly from ethereum/execution-spec-tests releases.
@@ -190,6 +184,12 @@ runner:
     #     #   local_fixtures_tarball: /home/user/eest-output/fixtures_benchmark.tar.gz
     #     #   local_genesis_tarball: /home/user/eest-output/benchmark_genesis.tar.gz
     #     #   # fixtures_subdir also works with local tarballs
+    #
+    #   # Optional: External opcode metadata for the test suite.
+    #   # A JSON file mapping test names to opcode counts: {"test_name": {"OPCODE": count, ...}}
+    #   # Can be a local path or a URL (including GitHub Actions artifact URLs).
+    #   # opcode_source:
+    #   #   file: opcodes_tracing.json
 
 # Optional: API server for authentication and user management.
 # When configured, the UI can integrate with the API for login, admin, and role-based access.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,13 +316,11 @@ tests:
           - "perf-devnet-3/setup/*.txt"
         test:
           - "perf-devnet-3/testing/*.txt"
-      # Optional: External opcode metadata for the test suite.
-      # When provided, opcode counts are included in the suite summary.json
-      # and displayed in the UI opcode heatmap.
-      opcodes: "opcodes_tracing.json"
-      # Optional: Separate archive containing the opcodes file.
-      # If not set, the opcodes file is searched in the main archive.
-      # opcodes_file: https://github.com/NethermindEth/gas-benchmarks/actions/runs/23847558369/artifacts/6222074312
+    # Optional: External opcode metadata for the test suite.
+    # A JSON file mapping test names to opcode counts.
+    # Can be a local path or URL.
+    opcode_source:
+      file: opcodes_tracing.json
 ```
 
 | Option | Type | Required | Description |
@@ -332,8 +330,21 @@ tests:
 | `steps.setup` | []string | No | Glob patterns for setup phase files |
 | `steps.test` | []string | No | Glob patterns for test phase files |
 | `steps.cleanup` | []string | No | Glob patterns for cleanup phase files |
-| `opcodes` | string | No | Filename within the archive containing opcode count metadata (e.g., `opcodes_tracing.json`). The file must be a JSON object mapping test names to opcode counts: `{"test_name": {"OPCODE": count, ...}}` |
-| `opcodes_file` | string | No | Separate archive URL/path containing the opcodes file. If not set, the opcodes file is searched in the main `file` archive |
+
+##### Opcode Source
+
+Optional external opcode metadata can be configured at the benchmark level, independent of the test source:
+
+```yaml
+runner:
+  benchmark:
+    opcode_source:
+      file: opcodes_tracing.json  # Local path or URL to a JSON file
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `file` | string | Yes | Local path or URL to a JSON file mapping test names to opcode counts: `{"test_name": {"OPCODE": count, ...}}` |
 
 **GitHub Actions artifacts:** Browser URLs like `https://github.com/{owner}/{repo}/actions/runs/{run_id}/artifacts/{artifact_id}` are automatically converted to the GitHub API download endpoint. A GitHub token is required for artifact downloads (set via `runner.github_token` or `BENCHMARKOOR_RUNNER_GITHUB_TOKEN`).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -333,13 +333,14 @@ tests:
 
 ##### Opcode Source
 
-Optional external opcode metadata can be configured at the benchmark level, independent of the test source:
+Optional external opcode metadata can be configured alongside the test source:
 
 ```yaml
 runner:
   benchmark:
-    opcode_source:
-      file: opcodes_tracing.json  # Local path or URL to a JSON file
+    tests:
+      opcode_source:
+        file: opcodes_tracing.json  # Local path or URL to a JSON file
 ```
 
 | Option | Type | Required | Description |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -116,6 +116,7 @@ type BenchmarkConfig struct {
 	GenerateSuiteStatsMethod        string               `yaml:"generate_suite_stats_method,omitempty" mapstructure:"generate_suite_stats_method"`
 	ResultsUpload                   *ResultsUploadConfig `yaml:"results_upload,omitempty" mapstructure:"results_upload"`
 	Tests                           TestsConfig          `yaml:"tests,omitempty" mapstructure:"tests"`
+	OpcodeSource                    *OpcodeSourceConfig  `yaml:"opcode_source,omitempty" mapstructure:"opcode_source"`
 }
 
 // ResultsUploadConfig contains configuration for uploading results.
@@ -335,10 +336,14 @@ type LocalSourceV2 struct {
 // The file can be a local path or a URL (HTTP/HTTPS) to a ZIP or tar.gz archive.
 type ArchiveSourceConfig struct {
 	File        string       `yaml:"file" mapstructure:"file"`
-	OpcodesFile string       `yaml:"opcodes_file,omitempty" mapstructure:"opcodes_file"`
-	Opcodes     string       `yaml:"opcodes,omitempty" mapstructure:"opcodes"`
 	PreRunSteps []string     `yaml:"pre_run_steps,omitempty" mapstructure:"pre_run_steps"`
 	Steps       *StepsConfig `yaml:"steps,omitempty" mapstructure:"steps"`
+}
+
+// OpcodeSourceConfig defines an external opcode metadata file.
+// The file is a JSON map of test name → opcode → count.
+type OpcodeSourceConfig struct {
+	File string `yaml:"file" mapstructure:"file"` // Local path or URL to a JSON file.
 }
 
 // StepsConfig defines glob patterns for each step type.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -116,7 +116,6 @@ type BenchmarkConfig struct {
 	GenerateSuiteStatsMethod        string               `yaml:"generate_suite_stats_method,omitempty" mapstructure:"generate_suite_stats_method"`
 	ResultsUpload                   *ResultsUploadConfig `yaml:"results_upload,omitempty" mapstructure:"results_upload"`
 	Tests                           TestsConfig          `yaml:"tests,omitempty" mapstructure:"tests"`
-	OpcodeSource                    *OpcodeSourceConfig  `yaml:"opcode_source,omitempty" mapstructure:"opcode_source"`
 }
 
 // ResultsUploadConfig contains configuration for uploading results.
@@ -141,9 +140,10 @@ type S3UploadConfig struct {
 
 // TestsConfig contains test execution settings.
 type TestsConfig struct {
-	Filter   string         `yaml:"filter,omitempty" mapstructure:"filter"`
-	Metadata MetadataConfig `yaml:"metadata,omitempty" mapstructure:"metadata"`
-	Source   SourceConfig   `yaml:"source,omitempty" mapstructure:"source"`
+	Filter       string              `yaml:"filter,omitempty" mapstructure:"filter"`
+	Metadata     MetadataConfig      `yaml:"metadata,omitempty" mapstructure:"metadata"`
+	Source       SourceConfig        `yaml:"source,omitempty" mapstructure:"source"`
+	OpcodeSource *OpcodeSourceConfig `yaml:"opcode_source,omitempty" mapstructure:"opcode_source"`
 }
 
 // SourceConfig defines where to find test files.

--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,13 +23,12 @@ var ghArtifactURLPattern = regexp.MustCompile(
 // ArchiveSource downloads and extracts an archive file, then discovers tests
 // from the extracted contents using glob patterns.
 type ArchiveSource struct {
-	log            logrus.FieldLogger
-	cfg            *config.ArchiveSourceConfig
-	cacheDir       string
-	filter         string
-	githubToken    string
-	basePath       string // temp directory where archive was extracted
-	opcodeBasePath string // temp directory for separate opcode archive
+	log         logrus.FieldLogger
+	cfg         *config.ArchiveSourceConfig
+	cacheDir    string
+	filter      string
+	githubToken string
+	basePath    string // temp directory where archive was extracted
 }
 
 // Prepare downloads (if URL) and extracts the archive, then discovers tests.
@@ -77,22 +75,11 @@ func (s *ArchiveSource) Prepare(ctx context.Context) (*PreparedSource, error) {
 		return nil, err
 	}
 
-	if err := s.loadOpcodes(ctx, prepared); err != nil {
-		_ = os.RemoveAll(s.basePath)
-		s.basePath = ""
-
-		return nil, fmt.Errorf("loading opcodes: %w", err)
-	}
-
 	return prepared, nil
 }
 
-// Cleanup removes the temporary extraction directories.
+// Cleanup removes the temporary extraction directory.
 func (s *ArchiveSource) Cleanup() error {
-	if s.opcodeBasePath != "" {
-		_ = os.RemoveAll(s.opcodeBasePath)
-	}
-
 	if s.basePath != "" {
 		return os.RemoveAll(s.basePath)
 	}
@@ -253,241 +240,4 @@ func (s *ArchiveSource) extractArchive(archivePath string) error {
 	}
 
 	return nil
-}
-
-// loadOpcodes loads external opcode count data and attaches it to discovered tests.
-func (s *ArchiveSource) loadOpcodes(ctx context.Context, prepared *PreparedSource) error {
-	if s.cfg.Opcodes == "" {
-		return nil
-	}
-
-	searchDir := s.basePath
-
-	// If a separate opcode archive is configured, download and extract it.
-	if s.cfg.OpcodesFile != "" {
-		opcodeDir, err := s.resolveOpcodeArchive(ctx)
-		if err != nil {
-			return fmt.Errorf("resolving opcode archive: %w", err)
-		}
-
-		searchDir = opcodeDir
-	}
-
-	// Find and read the opcodes file.
-	opcodePath, err := findFileInDir(searchDir, s.cfg.Opcodes)
-	if err != nil {
-		return fmt.Errorf("finding opcodes file %q: %w", s.cfg.Opcodes, err)
-	}
-
-	data, err := os.ReadFile(opcodePath)
-	if err != nil {
-		return fmt.Errorf("reading opcodes file %q: %w", opcodePath, err)
-	}
-
-	var opcodeMap map[string]map[string]int
-	if err := json.Unmarshal(data, &opcodeMap); err != nil {
-		return fmt.Errorf("parsing opcodes file: %w", err)
-	}
-
-	// Match opcode data to discovered tests by name.
-	// Test names from glob discovery include the .txt extension, but opcode
-	// JSON keys typically omit it, so we try both the full name and without .txt.
-	matched := 0
-
-	for _, test := range prepared.Tests {
-		name := test.Name
-		if counts, ok := opcodeMap[name]; ok {
-			test.OpcodeCount = counts
-			matched++
-		} else if trimmed, hasSuffix := strings.CutSuffix(name, ".txt"); hasSuffix {
-			if counts, ok := opcodeMap[trimmed]; ok {
-				test.OpcodeCount = counts
-				matched++
-			}
-		}
-	}
-
-	// Count opcode entries that are relevant (pass the filter) but didn't match a test.
-	filtered := len(opcodeMap)
-	if s.filter != "" {
-		filtered = 0
-
-		for key := range opcodeMap {
-			if strings.Contains(key, s.filter) {
-				filtered++
-			}
-		}
-	}
-
-	s.log.WithFields(logrus.Fields{
-		"file":          s.cfg.Opcodes,
-		"total_entries": filtered,
-		"matched_tests": matched,
-		"total_tests":   len(prepared.Tests),
-	}).Info("Loaded external opcode data")
-
-	if unmatched := filtered - matched; unmatched > 0 {
-		s.log.WithField("unmatched", unmatched).Warn(
-			"Some opcode entries did not match any discovered test",
-		)
-	}
-
-	return nil
-}
-
-// resolveOpcodeArchive downloads and extracts the separate opcode archive,
-// returning the path to the extraction directory.
-func (s *ArchiveSource) resolveOpcodeArchive(ctx context.Context) (string, error) {
-	parentDir := s.cacheDir
-	if parentDir == "" {
-		parentDir = os.TempDir()
-	}
-
-	tmpDir, err := os.MkdirTemp(parentDir, "opcode-archive-*")
-	if err != nil {
-		return "", fmt.Errorf("creating opcode temp directory: %w", err)
-	}
-
-	s.opcodeBasePath = tmpDir
-
-	archivePath, err := s.resolveRemoteFile(ctx, s.cfg.OpcodesFile)
-	if err != nil {
-		return "", fmt.Errorf("resolving opcode file: %w", err)
-	}
-
-	if err := s.extractToDir(archivePath, tmpDir); err != nil {
-		return "", fmt.Errorf("extracting opcode archive: %w", err)
-	}
-
-	s.log.WithField("path", tmpDir).Info("Extracted opcode archive")
-
-	return tmpDir, nil
-}
-
-// resolveRemoteFile resolves a file URL or local path, downloading and caching
-// remote files.
-func (s *ArchiveSource) resolveRemoteFile(ctx context.Context, file string) (string, error) {
-	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
-		hash := sha256.Sum256([]byte(file))
-		name := "archive-" + hex.EncodeToString(hash[:8])
-
-		cacheDir := s.cacheDir
-		if cacheDir == "" {
-			cacheDir = os.TempDir()
-		}
-
-		cachedPath := filepath.Join(cacheDir, name)
-
-		if _, err := os.Stat(cachedPath); err == nil {
-			s.log.WithFields(logrus.Fields{
-				"url":  file,
-				"path": cachedPath,
-			}).Info("Using cached file")
-
-			return cachedPath, nil
-		}
-
-		s.log.WithField("url", file).Info("Downloading file")
-
-		downloadURL, token := s.resolveDownloadURL(file)
-
-		tmpPath := cachedPath + ".tmp"
-
-		if err := os.MkdirAll(filepath.Dir(cachedPath), 0755); err != nil {
-			return "", fmt.Errorf("creating cache directory: %w", err)
-		}
-
-		if err := downloadToFile(ctx, downloadURL, tmpPath, token, s.log); err != nil {
-			_ = os.Remove(tmpPath)
-
-			return "", err
-		}
-
-		if err := os.Rename(tmpPath, cachedPath); err != nil {
-			_ = os.Remove(tmpPath)
-
-			return "", fmt.Errorf("caching file: %w", err)
-		}
-
-		return cachedPath, nil
-	}
-
-	// Local file path.
-	if !filepath.IsAbs(file) {
-		absPath, err := filepath.Abs(file)
-		if err != nil {
-			return "", fmt.Errorf("resolving path %q: %w", file, err)
-		}
-
-		file = absPath
-	}
-
-	if _, err := os.Stat(file); os.IsNotExist(err) {
-		return "", fmt.Errorf("file %q does not exist", file)
-	}
-
-	return file, nil
-}
-
-// extractToDir detects the archive format and extracts to the given directory.
-func (s *ArchiveSource) extractToDir(archivePath, destDir string) error {
-	format, err := detectArchiveFormat(archivePath)
-	if err != nil {
-		return err
-	}
-
-	switch format {
-	case archiveFormatZip:
-		if err := extractZipFile(archivePath, destDir); err != nil {
-			return fmt.Errorf("extracting zip: %w", err)
-		}
-
-		if err := extractInnerTarballs(destDir, s.log); err != nil {
-			return fmt.Errorf("extracting inner tarballs: %w", err)
-		}
-	case archiveFormatTarGz:
-		if err := extractTarGzFile(archivePath, destDir); err != nil {
-			return fmt.Errorf("extracting tar.gz: %w", err)
-		}
-	default:
-		return fmt.Errorf("unsupported archive format: %s", format)
-	}
-
-	return nil
-}
-
-// findFileInDir searches for a file by name within a directory tree.
-func findFileInDir(dir, filename string) (string, error) {
-	// Try direct path first.
-	direct := filepath.Join(dir, filename)
-	if _, err := os.Stat(direct); err == nil {
-		return direct, nil
-	}
-
-	// Walk the directory to find the file.
-	var found string
-
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil
-		}
-
-		if !info.IsDir() && info.Name() == filename {
-			found = path
-
-			return filepath.SkipAll
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return "", fmt.Errorf("walking directory: %w", err)
-	}
-
-	if found == "" {
-		return "", fmt.Errorf("file %q not found in %q", filename, dir)
-	}
-
-	return found, nil
 }

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -90,7 +90,8 @@ type ExecutionResult struct {
 type Config struct {
 	Source                          *config.SourceConfig
 	Filter                          string
-	Metadata                        *config.MetadataConfig // Suite-level metadata labels
+	Metadata                        *config.MetadataConfig     // Suite-level metadata labels
+	OpcodeSource                    *config.OpcodeSourceConfig // Optional external opcode metadata
 	CacheDir                        string
 	ResultsDir                      string
 	ResultsOwner                    *fsutil.OwnerConfig // Optional file ownership for results directory
@@ -141,6 +142,13 @@ func (e *executor) Start(ctx context.Context) error {
 		"pre_run_steps": len(prepared.PreRunSteps),
 		"tests":         len(prepared.Tests),
 	}).Info("Test sources ready")
+
+	// Load external opcode metadata if configured.
+	if e.cfg.OpcodeSource != nil && e.cfg.OpcodeSource.File != "" {
+		if err := e.loadOpcodes(ctx); err != nil {
+			return fmt.Errorf("loading opcodes: %w", err)
+		}
+	}
 
 	// Create suite output if results directory is configured.
 	if e.cfg.ResultsDir != "" {

--- a/pkg/executor/opcode.go
+++ b/pkg/executor/opcode.go
@@ -1,0 +1,155 @@
+package executor
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// loadOpcodes resolves the opcode source file (local path or URL),
+// reads the JSON map, and attaches opcode counts to prepared tests.
+func (e *executor) loadOpcodes(ctx context.Context) error {
+	file := e.cfg.OpcodeSource.File
+
+	resolved, err := resolveFile(ctx, file, e.cfg.CacheDir, e.cfg.GitHubToken, e.log)
+	if err != nil {
+		return fmt.Errorf("resolving opcode file: %w", err)
+	}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return fmt.Errorf("reading opcode file %q: %w", resolved, err)
+	}
+
+	var opcodeMap map[string]map[string]int
+	if err := json.Unmarshal(data, &opcodeMap); err != nil {
+		return fmt.Errorf("parsing opcode file: %w", err)
+	}
+
+	// Match opcode data to discovered tests by name.
+	// Test names from glob discovery include the .txt extension, but opcode
+	// JSON keys typically omit it, so we try both the full name and without .txt.
+	matched := 0
+
+	for _, test := range e.prepared.Tests {
+		name := test.Name
+		if counts, ok := opcodeMap[name]; ok {
+			test.OpcodeCount = counts
+			matched++
+		} else if trimmed, hasSuffix := strings.CutSuffix(name, ".txt"); hasSuffix {
+			if counts, ok := opcodeMap[trimmed]; ok {
+				test.OpcodeCount = counts
+				matched++
+			}
+		}
+	}
+
+	// Count opcode entries that are relevant (pass the filter) but didn't match a test.
+	filtered := len(opcodeMap)
+	if e.cfg.Filter != "" {
+		filtered = 0
+
+		for key := range opcodeMap {
+			if strings.Contains(key, e.cfg.Filter) {
+				filtered++
+			}
+		}
+	}
+
+	e.log.WithFields(logrus.Fields{
+		"file":          file,
+		"total_entries": filtered,
+		"matched_tests": matched,
+		"total_tests":   len(e.prepared.Tests),
+	}).Info("Loaded external opcode data")
+
+	if unmatched := filtered - matched; unmatched > 0 {
+		e.log.WithField("unmatched", unmatched).Warn(
+			"Some opcode entries did not match any discovered test",
+		)
+	}
+
+	return nil
+}
+
+// resolveFile resolves a file reference that can be a local path or HTTP(S)
+// URL. Remote files are downloaded and cached in cacheDir.
+func resolveFile(ctx context.Context, file, cacheDir, githubToken string, log logrus.FieldLogger) (string, error) {
+	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
+		hash := sha256.Sum256([]byte(file))
+		name := "opcode-" + hex.EncodeToString(hash[:8])
+
+		if cacheDir == "" {
+			cacheDir = os.TempDir()
+		}
+
+		cachedPath := filepath.Join(cacheDir, name)
+
+		if _, err := os.Stat(cachedPath); err == nil {
+			log.WithFields(logrus.Fields{
+				"url":  file,
+				"path": cachedPath,
+			}).Info("Using cached opcode file")
+
+			return cachedPath, nil
+		}
+
+		log.WithField("url", file).Info("Downloading opcode file")
+
+		downloadURL := file
+
+		var token string
+
+		if ghArtifactURLPattern.MatchString(file) && githubToken != "" {
+			m := ghArtifactURLPattern.FindStringSubmatch(file)
+			downloadURL = fmt.Sprintf(
+				"https://api.github.com/repos/%s/actions/artifacts/%s/zip",
+				m[1], m[2],
+			)
+			token = githubToken
+		}
+
+		tmpPath := cachedPath + ".tmp"
+
+		if err := os.MkdirAll(filepath.Dir(cachedPath), 0755); err != nil {
+			return "", fmt.Errorf("creating cache directory: %w", err)
+		}
+
+		if err := downloadToFile(ctx, downloadURL, tmpPath, token, log); err != nil {
+			_ = os.Remove(tmpPath)
+
+			return "", err
+		}
+
+		if err := os.Rename(tmpPath, cachedPath); err != nil {
+			_ = os.Remove(tmpPath)
+
+			return "", fmt.Errorf("caching file: %w", err)
+		}
+
+		return cachedPath, nil
+	}
+
+	// Local file path.
+	if !filepath.IsAbs(file) {
+		absPath, err := filepath.Abs(file)
+		if err != nil {
+			return "", fmt.Errorf("resolving path %q: %w", file, err)
+		}
+
+		file = absPath
+	}
+
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return "", fmt.Errorf("file %q does not exist", file)
+	}
+
+	return file, nil
+}


### PR DESCRIPTION
## Summary
- Moves opcode metadata configuration from the archive source (`opcodes_file`/`opcodes`) to a standalone `runner.benchmark.opcode_source.file` field
- Decouples opcode data from the test source — works with any source type (archive, git, local, EEST)
- Supports both local file paths and URLs (including GitHub Actions artifact URLs)
- Opcode loading now happens in the executor after source preparation, not inside the archive source
- **Breaking**: Removes `opcodes_file` and `opcodes` from archive source config

### New config format
```yaml
runner:
  benchmark:
    source:
      archive:
        file: https://example.com/tests.zip
        steps:
          test:
            - "testing/*.txt"
    opcode_source:
      file: opcodes_tracing.json  # local path or URL
```

## Test plan
- [x] All existing tests pass (`go test ./pkg/config/ ./pkg/executor/`)
- [x] `go vet` passes
- [x] Run with `opcode_source.file` pointing to a local JSON file
- [x] Run with `opcode_source.file` pointing to a URL
- [x] Verify opcode heatmap renders in the UI