### PR TITLE
feat: support multi-part archive downloads

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -134,6 +134,12 @@ runner:
     #     # GitHub Actions artifact URLs are auto-converted to API download endpoints.
     #     # archive:
     #     #   file: https://github.com/NethermindEth/gas-benchmarks/actions/runs/23847558369/artifacts/6222084759
+    #     #   # Alternative to `file`: a list of parts to download and concatenate.
+    #     #   # Useful when the archive is split across multiple files because of
+    #     #   # per-asset size limits. Mutually exclusive with `file`.
+    #     #   # parts:
+    #     #   #   - https://example.com/tests.tar.gz.00.part
+    #     #   #   - https://example.com/tests.tar.gz.01.part
     #     #   pre_run_steps:
     #     #     - "perf-devnet-3/gas-bump.txt"
     #     #     - "perf-devnet-3/funding.txt"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -325,11 +325,26 @@ tests:
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `file` | string | Yes | Local path or URL to a ZIP or tar.gz archive. GitHub Actions artifact URLs are auto-converted to API endpoints |
+| `file` | string | One of `file`/`parts` | Local path or URL to a ZIP or tar.gz archive. GitHub Actions artifact URLs are auto-converted to API endpoints |
+| `parts` | []string | One of `file`/`parts` | Ordered list of local paths or URLs to concatenate into the final archive. Useful when the archive is split because of per-asset size limits. Mutually exclusive with `file` |
 | `pre_run_steps` | []string | No | Glob patterns for steps executed once before all tests |
 | `steps.setup` | []string | No | Glob patterns for setup phase files |
 | `steps.test` | []string | No | Glob patterns for test phase files |
 | `steps.cleanup` | []string | No | Glob patterns for cleanup phase files |
+
+**Multi-part archives:** when an archive is too large for a single asset upload, `parts` accepts an ordered list of URLs or local paths. All parts are downloaded (with caching) and concatenated into a single file before extraction:
+
+```yaml
+tests:
+  source:
+    archive:
+      parts:
+        - https://github.com/org/repo/releases/download/v1.0.0/tests.tar.gz.00.part
+        - https://github.com/org/repo/releases/download/v1.0.0/tests.tar.gz.01.part
+      steps:
+        test:
+          - "testing/*.txt"
+```
 
 ##### Opcode Source
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -334,8 +334,13 @@ type LocalSourceV2 struct {
 
 // ArchiveSourceConfig defines an archive file source for tests.
 // The file can be a local path or a URL (HTTP/HTTPS) to a ZIP or tar.gz archive.
+// Alternatively, `parts` can be a list of paths/URLs that are concatenated in
+// order into the final archive (useful when the archive is split across
+// multiple files because of per-asset size limits). `file` and `parts` are
+// mutually exclusive.
 type ArchiveSourceConfig struct {
-	File        string       `yaml:"file" mapstructure:"file"`
+	File        string       `yaml:"file,omitempty" mapstructure:"file"`
+	Parts       []string     `yaml:"parts,omitempty" mapstructure:"parts"`
 	PreRunSteps []string     `yaml:"pre_run_steps,omitempty" mapstructure:"pre_run_steps"`
 	Steps       *StepsConfig `yaml:"steps,omitempty" mapstructure:"steps"`
 }
@@ -1145,8 +1150,15 @@ func (s *SourceConfig) Validate() error {
 	}
 
 	if s.Archive != nil {
-		if s.Archive.File == "" {
-			return fmt.Errorf("archive.file is required")
+		hasFile := s.Archive.File != ""
+		hasParts := len(s.Archive.Parts) > 0
+
+		if !hasFile && !hasParts {
+			return fmt.Errorf("archive.file or archive.parts is required")
+		}
+
+		if hasFile && hasParts {
+			return fmt.Errorf("archive.file and archive.parts are mutually exclusive")
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -628,12 +628,35 @@ func TestSourceConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "archive missing file",
+			name: "archive missing file and parts",
 			source: SourceConfig{
 				Archive: &ArchiveSourceConfig{},
 			},
 			wantErr:   true,
-			errSubstr: "archive.file is required",
+			errSubstr: "archive.file or archive.parts is required",
+		},
+		{
+			name: "valid archive source with parts",
+			source: SourceConfig{
+				Archive: &ArchiveSourceConfig{
+					Parts: []string{
+						"https://example.com/fixtures.tar.gz.00.part",
+						"https://example.com/fixtures.tar.gz.01.part",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "archive file and parts are mutually exclusive",
+			source: SourceConfig{
+				Archive: &ArchiveSourceConfig{
+					File:  "https://example.com/fixtures.tar.gz",
+					Parts: []string{"https://example.com/fixtures.tar.gz.00.part"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "mutually exclusive",
 		},
 		{
 			name: "multiple sources not allowed - archive and git",

--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -91,6 +92,7 @@ func (s *ArchiveSource) Cleanup() error {
 func (s *ArchiveSource) GetSourceInfo() (*SuiteSource, error) {
 	info := &ArchiveSourceInfo{
 		File:        s.cfg.File,
+		Parts:       s.cfg.Parts,
 		PreRunSteps: s.cfg.PreRunSteps,
 	}
 
@@ -107,7 +109,13 @@ func (s *ArchiveSource) GetSourceInfo() (*SuiteSource, error) {
 
 // resolveFile returns the local path to the archive file. For URLs, it checks
 // the cache directory first and only downloads if the file is not already cached.
+// When the config uses `parts`, the parts are downloaded (with caching) and
+// concatenated into a single cached file.
 func (s *ArchiveSource) resolveFile(ctx context.Context) (string, error) {
+	if len(s.cfg.Parts) > 0 {
+		return s.resolvePartsFile(ctx)
+	}
+
 	file := s.cfg.File
 
 	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
@@ -179,6 +187,149 @@ func (s *ArchiveSource) cachedArchivePath() string {
 	}
 
 	return filepath.Join(cacheDir, name)
+}
+
+// resolvePartsFile downloads (with caching) all configured parts and
+// concatenates them in order into a single cached file, returning its path.
+// Local paths and URLs can be mixed freely in the parts list.
+func (s *ArchiveSource) resolvePartsFile(ctx context.Context) (string, error) {
+	cacheDir := s.cacheDir
+	if cacheDir == "" {
+		cacheDir = os.TempDir()
+	}
+
+	// Combined cache key is derived from the full ordered parts list so any
+	// change to the list produces a fresh combined file.
+	combined := sha256.Sum256([]byte(strings.Join(s.cfg.Parts, "\n")))
+	combinedPath := filepath.Join(cacheDir, "archive-parts-"+hex.EncodeToString(combined[:8]))
+
+	if _, err := os.Stat(combinedPath); err == nil {
+		s.log.WithField("path", combinedPath).Info("Using cached combined archive")
+
+		return combinedPath, nil
+	}
+
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return "", fmt.Errorf("creating cache directory: %w", err)
+	}
+
+	// Resolve each part to a local file path (downloading URLs as needed).
+	partPaths := make([]string, 0, len(s.cfg.Parts))
+
+	for i, part := range s.cfg.Parts {
+		s.log.WithFields(logrus.Fields{
+			"part":  i + 1,
+			"total": len(s.cfg.Parts),
+			"ref":   part,
+		}).Info("Resolving archive part")
+
+		partPath, err := s.resolvePart(ctx, part, cacheDir)
+		if err != nil {
+			return "", fmt.Errorf("resolving part %d (%s): %w", i+1, part, err)
+		}
+
+		partPaths = append(partPaths, partPath)
+	}
+
+	// Concatenate all parts into a temporary file, then atomically rename.
+	tmpPath := combinedPath + ".tmp"
+
+	if err := concatFiles(tmpPath, partPaths); err != nil {
+		_ = os.Remove(tmpPath)
+
+		return "", fmt.Errorf("concatenating parts: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, combinedPath); err != nil {
+		_ = os.Remove(tmpPath)
+
+		return "", fmt.Errorf("caching combined archive: %w", err)
+	}
+
+	s.log.WithField("path", combinedPath).Info("Combined archive parts")
+
+	return combinedPath, nil
+}
+
+// resolvePart resolves a single part reference (URL or local path) to a local
+// file path, downloading and caching remote parts in cacheDir.
+func (s *ArchiveSource) resolvePart(ctx context.Context, part, cacheDir string) (string, error) {
+	if strings.HasPrefix(part, "http://") || strings.HasPrefix(part, "https://") {
+		hash := sha256.Sum256([]byte(part))
+		cachedPath := filepath.Join(cacheDir, "archive-part-"+hex.EncodeToString(hash[:8]))
+
+		if _, err := os.Stat(cachedPath); err == nil {
+			s.log.WithFields(logrus.Fields{
+				"url":  part,
+				"path": cachedPath,
+			}).Info("Using cached archive part")
+
+			return cachedPath, nil
+		}
+
+		downloadURL, token := s.resolveDownloadURL(part)
+
+		tmpPath := cachedPath + ".tmp"
+
+		if err := downloadToFile(ctx, downloadURL, tmpPath, token, s.log); err != nil {
+			_ = os.Remove(tmpPath)
+
+			return "", err
+		}
+
+		if err := os.Rename(tmpPath, cachedPath); err != nil {
+			_ = os.Remove(tmpPath)
+
+			return "", fmt.Errorf("caching archive part: %w", err)
+		}
+
+		return cachedPath, nil
+	}
+
+	// Local file path — resolve relative paths.
+	if !filepath.IsAbs(part) {
+		absPath, err := filepath.Abs(part)
+		if err != nil {
+			return "", fmt.Errorf("resolving path %q: %w", part, err)
+		}
+
+		part = absPath
+	}
+
+	if _, err := os.Stat(part); os.IsNotExist(err) {
+		return "", fmt.Errorf("archive part %q does not exist", part)
+	}
+
+	return part, nil
+}
+
+// concatFiles concatenates src files (in order) into dst. dst is created (or
+// truncated) and written through a streamed copy so memory usage stays flat.
+func concatFiles(dst string, srcs []string) error {
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", dst, err)
+	}
+	defer out.Close() //nolint:errcheck
+
+	for _, src := range srcs {
+		in, err := os.Open(src) //nolint:gosec // trusted paths under our cache
+		if err != nil {
+			return fmt.Errorf("opening %s: %w", src, err)
+		}
+
+		if _, err := io.Copy(out, in); err != nil {
+			_ = in.Close()
+
+			return fmt.Errorf("copying %s: %w", src, err)
+		}
+
+		if err := in.Close(); err != nil {
+			return fmt.Errorf("closing %s: %w", src, err)
+		}
+	}
+
+	return out.Close()
 }
 
 // resolveDownloadURL converts browser URLs to API URLs where needed and returns

--- a/pkg/executor/archive_source_test.go
+++ b/pkg/executor/archive_source_test.go
@@ -341,6 +341,159 @@ func TestArchiveSource_CachesDownload(t *testing.T) {
 	require.NoError(t, s2.Cleanup())
 }
 
+// splitBytes splits b into n roughly-equal chunks. Used to simulate a tar.gz
+// archive that has been split across multiple .part files.
+func splitBytes(b []byte, n int) [][]byte {
+	chunks := make([][]byte, n)
+	chunkSize := (len(b) + n - 1) / n
+
+	for i := range n {
+		start := i * chunkSize
+		end := min(start+chunkSize, len(b))
+		chunks[i] = b[start:end]
+	}
+
+	return chunks
+}
+
+func TestArchiveSource_PrepareWithParts(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Build a real tar.gz in memory, then split it into two parts.
+	fullPath := filepath.Join(tmpDir, "full.tar.gz")
+	createTestTarGz(t, fullPath, map[string]string{
+		"mytest/test/abc.txt": "test-content",
+		"mytest/test/def.txt": "another-content",
+	})
+
+	fullBytes, err := os.ReadFile(fullPath)
+	require.NoError(t, err)
+	chunks := splitBytes(fullBytes, 2)
+
+	var part1Count, part2Count int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var data []byte
+
+		switch r.URL.Path {
+		case "/part1":
+			data = chunks[0]
+			if r.Method == http.MethodGet {
+				part1Count++
+			}
+		case "/part2":
+			data = chunks[1]
+			if r.Method == http.MethodGet {
+				part2Count++
+			}
+		default:
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+		w.WriteHeader(http.StatusOK)
+
+		if r.Method == http.MethodGet {
+			_, _ = w.Write(data)
+		}
+	}))
+	defer srv.Close()
+
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	makeSrc := func() *ArchiveSource {
+		return &ArchiveSource{
+			log:      log.WithField("source", "archive"),
+			cacheDir: tmpDir,
+			cfg: &config.ArchiveSourceConfig{
+				Parts: []string{srv.URL + "/part1", srv.URL + "/part2"},
+				Steps: &config.StepsConfig{
+					Test: []string{"mytest/test/*"},
+				},
+			},
+		}
+	}
+
+	// First run: downloads both parts and concatenates them.
+	s1 := makeSrc()
+	result, err := s1.Prepare(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(result.Tests))
+	assert.Equal(t, 1, part1Count)
+	assert.Equal(t, 1, part2Count)
+	require.NoError(t, s1.Cleanup())
+
+	// Second run: uses cached combined file, no new downloads.
+	s2 := makeSrc()
+	result, err = s2.Prepare(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(result.Tests))
+	assert.Equal(t, 1, part1Count, "expected no additional part1 download")
+	assert.Equal(t, 1, part2Count, "expected no additional part2 download")
+	require.NoError(t, s2.Cleanup())
+}
+
+func TestArchiveSource_PrepareWithLocalParts(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fullPath := filepath.Join(tmpDir, "full.tar.gz")
+	createTestTarGz(t, fullPath, map[string]string{
+		"mytest/test/abc.txt": "test-content",
+	})
+
+	fullBytes, err := os.ReadFile(fullPath)
+	require.NoError(t, err)
+	chunks := splitBytes(fullBytes, 3)
+
+	partPaths := make([]string, 3)
+	for i, chunk := range chunks {
+		partPaths[i] = filepath.Join(tmpDir, "chunk-"+strconv.Itoa(i)+".part")
+		require.NoError(t, os.WriteFile(partPaths[i], chunk, 0644))
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	source := &ArchiveSource{
+		log:      log.WithField("source", "archive"),
+		cacheDir: tmpDir,
+		cfg: &config.ArchiveSourceConfig{
+			Parts: partPaths,
+			Steps: &config.StepsConfig{
+				Test: []string{"mytest/test/*"},
+			},
+		},
+	}
+
+	result, err := source.Prepare(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(result.Tests))
+	require.NoError(t, source.Cleanup())
+}
+
+func TestArchiveSource_GetSourceInfo_Parts(t *testing.T) {
+	parts := []string{
+		"https://example.com/tests.tar.gz.00.part",
+		"https://example.com/tests.tar.gz.01.part",
+	}
+	source := &ArchiveSource{
+		cfg: &config.ArchiveSourceConfig{
+			Parts: parts,
+			Steps: &config.StepsConfig{
+				Test: []string{"test/*"},
+			},
+		},
+	}
+
+	info, err := source.GetSourceInfo()
+	require.NoError(t, err)
+	require.NotNil(t, info.Archive)
+	assert.Empty(t, info.Archive.File)
+	assert.Equal(t, parts, info.Archive.Parts)
+}
+
 func TestDownloadToFile_Parallel(t *testing.T) {
 	// Create a test payload large enough to trigger parallel downloads.
 	payload := make([]byte, minParallelSize+1024)

--- a/pkg/executor/suite.go
+++ b/pkg/executor/suite.go
@@ -51,7 +51,8 @@ type LocalSourceInfo struct {
 
 // ArchiveSourceInfo contains archive file source information.
 type ArchiveSourceInfo struct {
-	File        string            `json:"file"`
+	File        string            `json:"file,omitempty"`
+	Parts       []string          `json:"parts,omitempty"`
 	PreRunSteps []string          `json:"pre_run_steps,omitempty"`
 	Steps       *SourceStepsGlobs `json:"steps,omitempty"`
 }

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -422,7 +422,8 @@ export interface SourceInfo {
     }
   }
   archive?: {
-    file: string
+    file?: string
+    parts?: string[]
     pre_run_steps?: string[]
     steps?: {
       setup?: string[]

--- a/ui/src/components/shared/SourceBadge.tsx
+++ b/ui/src/components/shared/SourceBadge.tsx
@@ -67,15 +67,19 @@ export function SourceBadge({ source, label }: SourceBadgeProps) {
   }
 
   if (source.archive) {
-    const isUrl = source.archive.file.startsWith('http://') || source.archive.file.startsWith('https://')
+    const file = source.archive.file ?? ''
+    const parts = source.archive.parts ?? []
+    const primary = file || parts[0] || ''
+    const title = file ? file : parts.length > 0 ? `${parts.length} parts` : ''
+    const isUrl = primary.startsWith('http://') || primary.startsWith('https://')
 
-    if (isUrl) {
+    if (isUrl && file) {
       return (
         <a
-          href={source.archive.file}
+          href={file}
           target="_blank"
           rel="noopener noreferrer"
-          title={source.archive.file}
+          title={title}
           className="inline-flex items-center gap-1.5 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
         >
           <ArchiveIcon className="size-4" />
@@ -86,7 +90,7 @@ export function SourceBadge({ source, label }: SourceBadgeProps) {
 
     return (
       <span
-        title={source.archive.file}
+        title={title}
         className="inline-flex items-center gap-1.5 text-gray-600 dark:text-gray-400"
       >
         <ArchiveIcon className="size-4" />

--- a/ui/src/components/suite-detail/SuiteSource.tsx
+++ b/ui/src/components/suite-detail/SuiteSource.tsx
@@ -187,31 +187,60 @@ export function SuiteSource({ title, source }: SuiteSourceProps) {
   }
 
   if (source.archive) {
-    const isUrl = source.archive.file.startsWith('http://') || source.archive.file.startsWith('https://')
-    const ghRunMatch = source.archive.file.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/actions\/runs\/(\d+)\/artifacts\/\d+$/)
+    const archive = source.archive
+    const file = archive.file ?? ''
+    const parts = archive.parts ?? []
+    const isUrl = (s: string) => s.startsWith('http://') || s.startsWith('https://')
+    const ghRunRegex = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/actions\/runs\/(\d+)\/artifacts\/\d+$/
+    const ghRunMatch = file ? file.match(ghRunRegex) : null
     const ghRunUrl = ghRunMatch ? `https://github.com/${ghRunMatch[1]}/actions/runs/${ghRunMatch[2]}` : null
 
     return (
       <Card title={<span className="flex items-center gap-2">{title}<SourceTypeBadge source={source} /></span>} collapsible>
         <div className="flex flex-col gap-4">
           <dl className="grid grid-cols-1 gap-4">
-            <div>
-              <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Archive File</dt>
-              <dd className="mt-1 break-all font-mono text-sm/6 text-gray-900 dark:text-gray-100">
-                {isUrl ? (
-                  <a
-                    href={source.archive.file}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 hover:underline dark:text-blue-400"
-                  >
-                    {source.archive.file}
-                  </a>
-                ) : (
-                  source.archive.file
-                )}
-              </dd>
-            </div>
+            {file && (
+              <div>
+                <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Archive File</dt>
+                <dd className="mt-1 break-all font-mono text-sm/6 text-gray-900 dark:text-gray-100">
+                  {isUrl(file) ? (
+                    <a
+                      href={file}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      {file}
+                    </a>
+                  ) : (
+                    file
+                  )}
+                </dd>
+              </div>
+            )}
+            {parts.length > 0 && (
+              <div>
+                <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Archive Parts ({parts.length})</dt>
+                <dd className="mt-1 flex flex-col gap-1 font-mono text-sm/6 text-gray-900 dark:text-gray-100">
+                  {parts.map((p, i) => (
+                    <span key={i} className="break-all">
+                      {isUrl(p) ? (
+                        <a
+                          href={p}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 hover:underline dark:text-blue-400"
+                        >
+                          {p}
+                        </a>
+                      ) : (
+                        p
+                      )}
+                    </span>
+                  ))}
+                </dd>
+              </div>
+            )}
             {ghRunUrl && (
               <div>
                 <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">GitHub Actions Run</dt>
@@ -228,7 +257,7 @@ export function SuiteSource({ title, source }: SuiteSourceProps) {
               </div>
             )}
           </dl>
-          <StepsInfo steps={source.archive.steps} preRunSteps={source.archive.pre_run_steps} />
+          <StepsInfo steps={archive.steps} preRunSteps={archive.pre_run_steps} />
           {ghRunUrl && (
             <a
               href={ghRunUrl}


### PR DESCRIPTION
## Summary
- Adds a `parts` field to the archive source config as a mutually-exclusive alternative to `file`
- Each part (URL or local path) is downloaded and cached independently, then all parts are concatenated into a single cached archive before extraction
- Useful when the archive exceeds per-asset upload size limits (e.g. GitHub Releases)
- Per-part and combined files both use sha256-derived cache keys so re-runs skip redundant downloads

### Example config
```yaml
runner:
  benchmark:
    tests:
      source:
        archive:
          parts:
            - https://github.com/org/repo/releases/download/v1.0.0/tests.tar.gz.00.part
            - https://github.com/org/repo/releases/download/v1.0.0/tests.tar.gz.01.part
          steps:
            test:
              - "testing/*.txt"
```

## Test plan
- [x] New unit tests for parts download + caching (`TestArchiveSource_PrepareWithParts`)
- [x] New unit tests for local-path parts (`TestArchiveSource_PrepareWithLocalParts`)
- [x] New unit tests for source info (`TestArchiveSource_GetSourceInfo_Parts`)
- [x] Validation tests for mutual exclusivity
- [x] All existing archive tests still pass
- [x] Run with a real parts-based archive URL and verify extraction + test discovery