### PR TITLE
feat: live run status reporting from runner to API

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -39,6 +39,18 @@ runner:
   # Can also be set via BENCHMARKOOR_RUNNER_GITHUB_TOKEN environment variable.
   # github_token: ${GITHUB_TOKEN:-}
 
+  # Optional: Stream periodic run-status reports to a benchmarkoor API
+  # instance so the UI can show in-progress runs. The API must have a
+  # matching `api.ingest.token` configured.
+  # live_reporting:
+  #   enabled: true
+  #   endpoint: https://benchmarkoor.example.com
+  #   token: my-shared-secret
+  #   discovery_path: my-host/benchmarks
+  #   interval: 1m
+  #   jitter_fraction: 0.2
+  #   timeout: 10s
+
   benchmark:
     results_dir: ${RESULTS_DIR:-./results}
     # Optional: Set ownership (user:group) for results files. Useful when running as root.
@@ -282,6 +294,14 @@ runner:
 #   #     # Keys become URL prefixes (e.g. /api/v1/files/results/...).
 #   #     discovery_paths:
 #   #       results: /data/benchmarkoor/results
+#   # Optional: Accept live status reports from benchmarkoor runners.
+#   # When configured, runners can POST snapshots to /api/v1/ingest/runs
+#   # using `Authorization: Bearer <token>`. Live reports are stored in a
+#   # separate live_runs table and shown in the UI alongside indexed runs.
+#   # The token here MUST match `runner.live_reporting.token` on each runner.
+#   # ingest:
+#   #   token: ${INGEST_TOKEN:-changeme}
+#   #   stale_threshold: 5m  # remove live runs that haven't reported within this window
 
   client:
     config:

--- a/docs/api.md
+++ b/docs/api.md
@@ -302,6 +302,24 @@ api:
 - You want the UI to always show up-to-date data without manual regeneration
 - You are running the API server as a long-lived service
 
+## Ingest (live run reporting)
+
+The optional `api.ingest` section enables an authenticated endpoint that benchmarkoor runners use to stream live run-status snapshots to the API. Live entries land in a separate `live_runs` table so they never interfere with the canonical `runs` table populated by the indexer; the UI merges both views.
+
+```yaml
+api:
+  ingest:
+    token: my-shared-secret
+    stale_threshold: 5m
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `token` | string | - | Shared bearer token. Runners must send `Authorization: Bearer <token>`. The ingest endpoint is only registered when this is set |
+| `stale_threshold` | string | `5m` | A live-run row is removed when no new report has arrived within this window (Go duration) |
+
+A background goroutine on the API scans every 30s and deletes live rows whose `last_reported_at` is older than `stale_threshold`. When the on-disk indexer later picks up a real run with the same `(discovery_path, run_id)`, the live row is removed immediately so the UI doesn't show duplicate rows.
+
 ## API Endpoints
 
 All endpoints are under the `/api/v1` prefix.
@@ -354,6 +372,15 @@ Available only when [indexing](#indexing) is enabled.
 | `GET` | `/index/query/test_stats` | Query test stat data with PostgREST-style filtering, sorting, and pagination |
 | `GET` | `/index/query/test_stats_block_logs` | Query per-block log data with PostgREST-style filtering, sorting, and pagination |
 | `GET` | `/index/query/suites` | Query suite data with PostgREST-style filtering, sorting, and pagination |
+| `GET` | `/index/live_runs` | List all live (in-progress) runs reported by runners via the ingest endpoint. Returns an array of `LiveRunResponse` objects |
+
+### Ingest (requires `Authorization: Bearer <api.ingest.token>`)
+
+Available only when [ingest](#ingest-live-run-reporting) is configured.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/ingest/runs` | Upsert a `LiveRunReport` for an in-progress run. Returns 204 on success, 401 on bad token, 400 on missing required fields |
 
 #### Row count
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,6 +123,35 @@ runner:
 | `cpu_sysfs_path` | string | `/sys/devices/system/cpu` | Base path for CPU sysfs files (for containerized environments where `/sys` is read-only and the host path is bind-mounted elsewhere, e.g., `/host_sys_cpu`) |
 | `metadata.labels` | map[string]string | - | Arbitrary key-value labels attached to the run (see [Metadata Labels](#metadata-labels)) |
 | `github_token` | string | - | GitHub token for downloading Actions artifacts via REST API. Not needed if `gh` CLI is installed and authenticated. Requires `actions:read` scope. Can also be set via `BENCHMARKOOR_RUNNER_GITHUB_TOKEN` env var |
+| `live_reporting` | object | - | Stream periodic run-status reports to a benchmarkoor API instance so the UI can display in-progress runs. See [Live Reporting](#live-reporting) |
+
+#### Live Reporting
+
+When `live_reporting` is enabled, every run posts a snapshot of its current state (status, test counts, metadata labels) to the configured benchmarkoor API at a jittered interval. The API stores these in a separate `live_runs` table and the UI merges them into the runs view as ephemeral rows. Once the on-disk indexer picks up the same run from storage, the live entry is removed automatically.
+
+```yaml
+runner:
+  live_reporting:
+    enabled: true
+    endpoint: https://benchmarkoor.example.com
+    token: my-shared-secret
+    discovery_path: my-host/benchmarks  # must match a discovery path on the API side
+    interval: 1m
+    jitter_fraction: 0.2
+    timeout: 10s
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable live reporting |
+| `endpoint` | string | - | Base URL of the benchmarkoor API (no trailing path), e.g. `https://api.example.com` |
+| `token` | string | - | Shared bearer token; must match `api.ingest.token` on the API side |
+| `discovery_path` | string | - | Discovery path the runner's results will be published under. Used as part of the unique key on the API |
+| `interval` | string | `1m` | Base reporting interval (Go duration). Each tick adds random jitter |
+| `jitter_fraction` | float | `0.2` | Random jitter as a fraction of `interval`. `0` uses the default; negative disables jitter entirely |
+| `timeout` | string | `10s` | Per-request HTTP timeout |
+
+Reports are best-effort: HTTP failures are logged at WARN and dropped. The next tick will retry with the latest snapshot. On `Stop()`, the runner sends one final synchronous report so the terminal status reaches the API.
 
 #### Container Runtime
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -178,6 +178,9 @@ func (s *server) Start(ctx context.Context) error {
 		}
 	}
 
+	// Start the stale live-runs watcher (no-op when ingest is unconfigured).
+	s.startStaleLiveRunsWatcher(ctx)
+
 	return nil
 }
 

--- a/pkg/api/handlers_ingest.go
+++ b/pkg/api/handlers_ingest.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/api/indexstore"
+	"github.com/sirupsen/logrus"
+)
+
+// handleIngestRun accepts a periodic status report from a benchmarkoor
+// runner and upserts it into the live_runs table. Always returns 204 on
+// success so the runner can fire-and-forget.
+func (s *server) handleIngestRun(w http.ResponseWriter, r *http.Request) {
+	var report indexstore.LiveRunReport
+	if err := json.NewDecoder(r.Body).Decode(&report); err != nil {
+		writeJSON(w, http.StatusBadRequest,
+			errorResponse{"invalid request body"})
+
+		return
+	}
+
+	if report.DiscoveryPath == "" {
+		writeJSON(w, http.StatusBadRequest,
+			errorResponse{"discovery_path is required"})
+
+		return
+	}
+
+	if report.RunID == "" {
+		writeJSON(w, http.StatusBadRequest,
+			errorResponse{"run_id is required"})
+
+		return
+	}
+
+	if report.Status == "" {
+		writeJSON(w, http.StatusBadRequest,
+			errorResponse{"status is required"})
+
+		return
+	}
+
+	if err := s.indexStore.UpsertLiveRun(r.Context(), &report); err != nil {
+		s.log.WithError(err).
+			WithField("run_id", report.RunID).
+			Warn("Failed to ingest live run report")
+		writeJSON(w, http.StatusInternalServerError,
+			errorResponse{"failed to upsert live run"})
+
+		return
+	}
+
+	fields := logrus.Fields{
+		"run_id":         report.RunID,
+		"discovery_path": report.DiscoveryPath,
+		"status":         report.Status,
+		"client":         report.Client,
+		"instance_id":    report.InstanceID,
+		"tests_total":    report.TestsTotal,
+		"tests_passed":   report.TestsPassed,
+		"tests_failed":   report.TestsFailed,
+		"has_config":     len(report.Config) > 0,
+	}
+
+	if report.SuiteHash != "" {
+		fields["suite_hash"] = report.SuiteHash
+	}
+
+	if report.TerminationReason != "" {
+		fields["termination_reason"] = report.TerminationReason
+	}
+
+	s.log.WithFields(fields).Info("Received live run report")
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleListLiveRuns returns all current live runs for the UI to merge
+// with the indexed runs.
+func (s *server) handleListLiveRuns(w http.ResponseWriter, r *http.Request) {
+	live, err := s.indexStore.ListLiveRuns(r.Context())
+	if err != nil {
+		s.log.WithError(err).Warn("Failed to list live runs")
+		writeJSON(w, http.StatusInternalServerError,
+			errorResponse{"failed to list live runs"})
+
+		return
+	}
+
+	resp := make([]indexstore.LiveRunResponse, 0, len(live))
+	for i := range live {
+		resp = append(resp, toLiveRunResponse(&live[i]))
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// toLiveRunResponse converts a LiveRun model to its JSON DTO.
+func toLiveRunResponse(r *indexstore.LiveRun) indexstore.LiveRunResponse {
+	resp := indexstore.LiveRunResponse{
+		ID:                r.ID,
+		DiscoveryPath:     r.DiscoveryPath,
+		RunID:             r.RunID,
+		Timestamp:         r.Timestamp,
+		TimestampEnd:      r.TimestampEnd,
+		SuiteHash:         r.SuiteHash,
+		Status:            r.Status,
+		TerminationReason: r.TerminationReason,
+		InstanceID:        r.InstanceID,
+		Client:            r.Client,
+		Image:             r.Image,
+		RollbackStrategy:  r.RollbackStrategy,
+		TestsTotal:        r.TestsTotal,
+		TestsPassed:       r.TestsPassed,
+		TestsFailed:       r.TestsFailed,
+		LastReportedAt:    r.LastReportedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	}
+
+	if r.MetadataJSON != "" {
+		var labels map[string]string
+		if err := json.Unmarshal([]byte(r.MetadataJSON), &labels); err == nil {
+			resp.Metadata = labels
+		}
+	}
+
+	if r.ConfigJSON != "" {
+		resp.Config = json.RawMessage(r.ConfigJSON)
+	}
+
+	return resp
+}

--- a/pkg/api/indexer/indexer.go
+++ b/pkg/api/indexer/indexer.go
@@ -474,6 +474,14 @@ func (idx *indexer) indexRun(
 		return fmt.Errorf("upserting run: %w", err)
 	}
 
+	// Once a run has been indexed from disk, drop any live entry for it so
+	// the UI doesn't see both the live and the canonical row at once. We
+	// don't fail the whole run on a delete error.
+	if err := idx.store.DeleteLiveRun(ctx, dp, runID); err != nil {
+		idx.log.WithError(err).WithField("run_id", runID).
+			Debug("Failed to delete live run entry")
+	}
+
 	// Index test stats if result.json is present and suite hash is set.
 	if len(resultData) > 0 && entry.SuiteHash != "" {
 		if err := idx.indexTestStats(

--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -2,6 +2,7 @@ package indexstore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -20,6 +21,10 @@ type Store interface {
 	Stop() error
 
 	UpsertRun(ctx context.Context, run *Run) error
+	UpsertLiveRun(ctx context.Context, report *LiveRunReport) error
+	ListLiveRuns(ctx context.Context) ([]LiveRun, error)
+	DeleteLiveRun(ctx context.Context, discoveryPath, runID string) error
+	DeleteStaleLiveRuns(ctx context.Context, olderThan time.Time) (int64, error)
 	ListRuns(ctx context.Context, discoveryPath string) ([]Run, error)
 	ListRunIDs(ctx context.Context, discoveryPath string) ([]string, error)
 	ListIncompleteRunIDs(
@@ -129,6 +134,7 @@ func (s *store) Start(ctx context.Context) error {
 		&TestStat{},
 		&TestStatsBlockLog{},
 		&Suite{},
+		&LiveRun{},
 	); err != nil {
 		return fmt.Errorf("running index migrations: %w", err)
 	}
@@ -243,6 +249,103 @@ func (s *store) UpsertRun(ctx context.Context, run *Run) error {
 	}
 
 	return nil
+}
+
+// UpsertLiveRun applies a status report from a runner to the live_runs
+// table. The composite key (discovery_path, run_id) identifies the row.
+// Every report refreshes last_reported_at so the stale watcher can detect
+// abandoned runs.
+func (s *store) UpsertLiveRun(ctx context.Context, r *LiveRunReport) error {
+	now := time.Now().UTC()
+
+	// Always-written fields. We use Updates() with a map so an empty map is
+	// not interpreted as "clear all fields".
+	fields := map[string]any{
+		"timestamp":          r.Timestamp,
+		"timestamp_end":      r.TimestampEnd,
+		"suite_hash":         r.SuiteHash,
+		"status":             r.Status,
+		"termination_reason": r.TerminationReason,
+		"instance_id":        r.InstanceID,
+		"client":             r.Client,
+		"image":              r.Image,
+		"rollback_strategy":  r.RollbackStrategy,
+		"tests_total":        r.TestsTotal,
+		"tests_passed":       r.TestsPassed,
+		"tests_failed":       r.TestsFailed,
+		"last_reported_at":   now,
+	}
+
+	if r.Metadata != nil {
+		b, err := json.Marshal(r.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshalling metadata: %w", err)
+		}
+
+		fields["metadata_json"] = string(b)
+	}
+
+	// Only overwrite config_json when the runner actually supplied one.
+	// Empty Config means "no update" — preserve whatever was last stored
+	// so a later zero-config report doesn't wipe an earlier good one.
+	if len(r.Config) > 0 {
+		fields["config_json"] = string(r.Config)
+	}
+
+	seed := &LiveRun{
+		DiscoveryPath:  r.DiscoveryPath,
+		RunID:          r.RunID,
+		LastReportedAt: now,
+	}
+
+	result := s.db.WithContext(ctx).
+		Where("discovery_path = ? AND run_id = ?", r.DiscoveryPath, r.RunID).
+		Assign(fields).
+		FirstOrCreate(seed)
+	if result.Error != nil {
+		return fmt.Errorf("upserting live run: %w", result.Error)
+	}
+
+	return nil
+}
+
+// ListLiveRuns returns all live runs ordered by their start timestamp
+// descending (newest first).
+func (s *store) ListLiveRuns(ctx context.Context) ([]LiveRun, error) {
+	var runs []LiveRun
+	if err := s.readDB.WithContext(ctx).
+		Order("timestamp DESC").
+		Find(&runs).Error; err != nil {
+		return nil, fmt.Errorf("listing live runs: %w", err)
+	}
+
+	return runs, nil
+}
+
+// DeleteLiveRun removes a live run row. Called by the on-disk indexer
+// once it has indexed the canonical Run, so the live entry doesn't show
+// up alongside the indexed one in the UI.
+func (s *store) DeleteLiveRun(ctx context.Context, dp, runID string) error {
+	if err := s.db.WithContext(ctx).
+		Where("discovery_path = ? AND run_id = ?", dp, runID).
+		Delete(&LiveRun{}).Error; err != nil {
+		return fmt.Errorf("deleting live run: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteStaleLiveRuns removes any live run whose last_reported_at is older
+// than the given threshold. Returns the number of rows deleted.
+func (s *store) DeleteStaleLiveRuns(ctx context.Context, olderThan time.Time) (int64, error) {
+	result := s.db.WithContext(ctx).
+		Where("last_reported_at < ?", olderThan).
+		Delete(&LiveRun{})
+	if result.Error != nil {
+		return 0, fmt.Errorf("deleting stale live runs: %w", result.Error)
+	}
+
+	return result.RowsAffected, nil
 }
 
 // ListRuns returns all runs for a given discovery path ordered by timestamp.
@@ -394,7 +497,13 @@ func (s *store) ListRunIDs(
 }
 
 // terminalStatuses are run statuses that will not change.
-var terminalStatuses = []string{"completed", "failed", "cancelled", "container_died", "timeout"}
+var terminalStatuses = []string{
+	RunStatusCompleted,
+	RunStatusFailed,
+	RunStatusCancelled,
+	RunStatusContainerDied,
+	RunStatusTimedOut,
+}
 
 // ListIncompleteRunIDs returns run IDs where the result has not been indexed
 // and the run is still potentially in progress. A run is considered

--- a/pkg/api/indexstore/indexstore_test.go
+++ b/pkg/api/indexstore/indexstore_test.go
@@ -320,3 +320,166 @@ func TestStore_UpsertSuiteUpdatesName(t *testing.T) {
 	assert.NotZero(t, updated.ID, "ID should be populated after upsert")
 	assert.Equal(t, original.ID, updated.ID, "upsert must not create a duplicate")
 }
+
+func TestStore_UpsertLiveRun_ConfigRoundtrip(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	rawCfg := `{"timestamp":1000,"instance":{"client":"geth"},"system":{"hostname":"h"}}`
+
+	require.NoError(t, s.UpsertLiveRun(ctx, &indexstore.LiveRunReport{
+		DiscoveryPath: "dp",
+		RunID:         "run-cfg",
+		Timestamp:     1000,
+		Status:        "running",
+		Config:        []byte(rawCfg),
+	}))
+
+	live, err := s.ListLiveRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	assert.Equal(t, rawCfg, live[0].ConfigJSON, "ConfigJSON must round-trip exactly")
+
+	// Second report without Config must preserve the previously stored value.
+	require.NoError(t, s.UpsertLiveRun(ctx, &indexstore.LiveRunReport{
+		DiscoveryPath: "dp",
+		RunID:         "run-cfg",
+		Status:        "running",
+		TestsPassed:   5,
+	}))
+	live, err = s.ListLiveRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	assert.Equal(t, rawCfg, live[0].ConfigJSON, "config_json must not be wiped by a report without Config")
+}
+
+func TestStore_UpsertLiveRun_InsertAndUpdate(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	report := &indexstore.LiveRunReport{
+		DiscoveryPath: "dp/live",
+		RunID:         "run-1",
+		Timestamp:     1000,
+		Status:        "running",
+		Client:        "geth",
+		Image:         "ethereum/client-go:latest",
+		TestsTotal:    10,
+		TestsPassed:   3,
+		Metadata:      map[string]string{"env": "ci"},
+	}
+	require.NoError(t, s.UpsertLiveRun(ctx, report))
+
+	live, err := s.ListLiveRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	assert.Equal(t, "running", live[0].Status)
+	assert.Equal(t, 3, live[0].TestsPassed)
+	assert.Contains(t, live[0].MetadataJSON, `"env":"ci"`)
+	first := live[0]
+
+	// Update with later report.
+	report.TestsPassed = 7
+	report.TestsFailed = 1
+	require.NoError(t, s.UpsertLiveRun(ctx, report))
+
+	live, err = s.ListLiveRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, live, 1, "second report must not create a duplicate row")
+	assert.Equal(t, first.ID, live[0].ID)
+	assert.Equal(t, 7, live[0].TestsPassed)
+	assert.Equal(t, 1, live[0].TestsFailed)
+}
+
+func TestStore_LiveRun_DoesNotInterfereWithRun(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	// A canonical Run that the on-disk indexer wrote.
+	run := &indexstore.Run{
+		DiscoveryPath: "dp/x",
+		RunID:         "shared-id",
+		Timestamp:     1000,
+		TimestampEnd:  2000,
+		Status:        "completed",
+		Client:        "geth",
+		HasResult:     true,
+		TestsTotal:    10,
+		TestsPassed:   10,
+		StepsJSON:     `{"setup":{"count":10}}`,
+		IndexedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, s.UpsertRun(ctx, run))
+
+	// A live report claiming the same run is still running.
+	require.NoError(t, s.UpsertLiveRun(ctx, &indexstore.LiveRunReport{
+		DiscoveryPath: "dp/x",
+		RunID:         "shared-id",
+		Status:        "running",
+		TestsPassed:   3,
+	}))
+
+	// The Run table entry must be untouched.
+	got, err := s.GetRunByRunID(ctx, "shared-id")
+	require.NoError(t, err)
+	assert.Equal(t, "completed", got.Status)
+	assert.Equal(t, 10, got.TestsPassed)
+	assert.Equal(t, `{"setup":{"count":10}}`, got.StepsJSON)
+}
+
+func TestStore_DeleteLiveRun(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.UpsertLiveRun(ctx, &indexstore.LiveRunReport{
+		DiscoveryPath: "dp/x",
+		RunID:         "doomed",
+		Status:        "running",
+	}))
+
+	live, err := s.ListLiveRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+
+	require.NoError(t, s.DeleteLiveRun(ctx, "dp/x", "doomed"))
+
+	live, err = s.ListLiveRuns(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, live)
+}
+
+func TestStore_DeleteStaleLiveRuns(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+
+	require.NoError(t, s.UpsertLiveRun(ctx, &indexstore.LiveRunReport{
+		DiscoveryPath: "dp/x",
+		RunID:         "fresh-1",
+		Status:        "running",
+	}))
+	require.NoError(t, s.UpsertLiveRun(ctx, &indexstore.LiveRunReport{
+		DiscoveryPath: "dp/x",
+		RunID:         "fresh-2",
+		Status:        "running",
+	}))
+
+	// A threshold in the past leaves freshly-reported rows alone.
+	count, err := s.DeleteStaleLiveRuns(ctx, now.Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+
+	live, err := s.ListLiveRuns(ctx)
+	require.NoError(t, err)
+	assert.Len(t, live, 2)
+
+	// A threshold in the future deletes everything.
+	count, err = s.DeleteStaleLiveRuns(ctx, now.Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	live, err = s.ListLiveRuns(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, live)
+}

--- a/pkg/api/indexstore/live_run.go
+++ b/pkg/api/indexstore/live_run.go
@@ -1,0 +1,91 @@
+package indexstore
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// LiveRun represents an in-progress (or recently-finished but not yet
+// indexed) run that a runner is reporting status for. Live runs live in
+// their own table so they never interfere with the canonical Run table
+// that the on-disk indexer maintains. Once the on-disk indexer picks up
+// the same (discovery_path, run_id) pair, the live row is deleted.
+//
+// Stale live rows (those whose runner stopped reporting) are also deleted
+// after a configurable threshold to keep this table small.
+type LiveRun struct {
+	ID                uint   `gorm:"primaryKey"`
+	DiscoveryPath     string `gorm:"not null;uniqueIndex:idx_live_runs_dp_run"`
+	RunID             string `gorm:"not null;uniqueIndex:idx_live_runs_dp_run"`
+	Timestamp         int64  `gorm:"index"`
+	TimestampEnd      int64
+	SuiteHash         string
+	Status            string
+	TerminationReason string
+
+	InstanceID       string
+	Client           string `gorm:"index"`
+	Image            string
+	RollbackStrategy string
+
+	TestsTotal  int
+	TestsPassed int
+	TestsFailed int
+
+	// Run metadata labels serialized as JSON.
+	MetadataJSON string `gorm:"type:text"`
+
+	// ConfigJSON is the latest full run config.json snapshot reported by
+	// the runner (matches the on-disk config.json schema). Empty until
+	// the runner has built its RunConfig.
+	ConfigJSON string `gorm:"type:text"`
+
+	// LastReportedAt is updated on every report from the runner.
+	LastReportedAt time.Time `gorm:"index"`
+}
+
+// LiveRunReport is the payload a runner sends to POST /api/v1/ingest/runs
+// to update the live status of a run in progress.
+type LiveRunReport struct {
+	DiscoveryPath     string            `json:"discovery_path"`
+	RunID             string            `json:"run_id"`
+	Timestamp         int64             `json:"timestamp"`
+	TimestampEnd      int64             `json:"timestamp_end,omitempty"`
+	SuiteHash         string            `json:"suite_hash,omitempty"`
+	Status            string            `json:"status"`
+	TerminationReason string            `json:"termination_reason,omitempty"`
+	InstanceID        string            `json:"instance_id,omitempty"`
+	Client            string            `json:"client,omitempty"`
+	Image             string            `json:"image,omitempty"`
+	RollbackStrategy  string            `json:"rollback_strategy,omitempty"`
+	TestsTotal        int               `json:"tests_total"`
+	TestsPassed       int               `json:"tests_passed"`
+	TestsFailed       int               `json:"tests_failed"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+	// Config is the full run config.json content at the time of the report.
+	// Passed through verbatim to the UI so it can render the normal run
+	// configuration panels without needing the file to be on disk yet.
+	Config json.RawMessage `json:"config,omitempty"`
+}
+
+// LiveRunResponse is the JSON DTO returned by the live runs endpoint.
+type LiveRunResponse struct {
+	ID                uint              `json:"id"`
+	DiscoveryPath     string            `json:"discovery_path"`
+	RunID             string            `json:"run_id"`
+	Timestamp         int64             `json:"timestamp"`
+	TimestampEnd      int64             `json:"timestamp_end,omitempty"`
+	SuiteHash         string            `json:"suite_hash,omitempty"`
+	Status            string            `json:"status"`
+	TerminationReason string            `json:"termination_reason,omitempty"`
+	InstanceID        string            `json:"instance_id,omitempty"`
+	Client            string            `json:"client,omitempty"`
+	Image             string            `json:"image,omitempty"`
+	RollbackStrategy  string            `json:"rollback_strategy,omitempty"`
+	TestsTotal        int               `json:"tests_total"`
+	TestsPassed       int               `json:"tests_passed"`
+	TestsFailed       int               `json:"tests_failed"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+	Config            json.RawMessage   `json:"config,omitempty"`
+	LastReportedAt    string            `json:"last_reported_at"`
+}

--- a/pkg/api/indexstore/run.go
+++ b/pkg/api/indexstore/run.go
@@ -2,6 +2,17 @@ package indexstore
 
 import "time"
 
+// Run status values. These mirror the runner-side constants but are
+// duplicated here to avoid an import cycle.
+const (
+	RunStatusRunning       = "running"
+	RunStatusCompleted     = "completed"
+	RunStatusFailed        = "failed"
+	RunStatusContainerDied = "container_died"
+	RunStatusCancelled     = "cancelled"
+	RunStatusTimedOut      = "timeout"
+)
+
 // Run represents a single indexed benchmark run in the database.
 type Run struct {
 	ID                uint   `gorm:"primaryKey"`

--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/subtle"
 	"net/http"
 	"strings"
 	"time"
@@ -199,4 +200,38 @@ func userFromContext(ctx context.Context) *store.User {
 	user, _ := ctx.Value(userContextKey).(*store.User)
 
 	return user
+}
+
+// requireIngestToken authenticates a runner using the shared ingest token
+// configured via api.ingest.token. This is a separate auth path from
+// session/API-key auth because runners are not users and the ingest token
+// is a single static shared secret.
+func (s *server) requireIngestToken(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expected := ""
+		if s.cfg.Ingest != nil {
+			expected = s.cfg.Ingest.Token
+		}
+
+		if expected == "" {
+			writeJSON(w, http.StatusServiceUnavailable,
+				errorResponse{"ingest endpoint is not configured"})
+
+			return
+		}
+
+		got := ""
+		if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
+			got = h[7:]
+		}
+
+		if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
+			writeJSON(w, http.StatusUnauthorized,
+				errorResponse{"invalid ingest token"})
+
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -84,6 +84,7 @@ func (s *server) buildRouter() http.Handler {
 
 				r.Get("/", s.handleIndex)
 				r.Get("/suites/{hash}/stats", s.handleSuiteStats)
+				r.Get("/live_runs", s.handleListLiveRuns)
 
 				r.Route("/query", func(r chi.Router) {
 					r.Get("/runs", s.handleQueryRuns)
@@ -93,6 +94,23 @@ func (s *server) buildRouter() http.Handler {
 						s.handleQueryTestStatsBlockLogs)
 					r.Get("/suites", s.handleQuerySuites)
 				})
+			})
+		}
+
+		// Ingest endpoint for runners to post live status reports.
+		// Only registered when an ingest token is configured AND the index
+		// store is available (ingest writes to the live_runs table).
+		if s.indexStore != nil && s.cfg.Ingest != nil && s.cfg.Ingest.Token != "" {
+			r.Route("/ingest", func(r chi.Router) {
+				r.Use(s.requireIngestToken)
+
+				if s.cfg.Server.RateLimit.Enabled {
+					r.Use(s.rateLimitMiddleware(
+						s.cfg.Server.RateLimit.Authenticated,
+					))
+				}
+
+				r.Post("/runs", s.handleIngestRun)
 			})
 		}
 

--- a/pkg/api/stalewatcher.go
+++ b/pkg/api/stalewatcher.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"context"
+	"time"
+)
+
+// staleWatcherInterval is how often the stale watcher scans the live_runs
+// table. The threshold for considering a row stale comes from
+// api.ingest.stale_threshold.
+const staleWatcherInterval = 30 * time.Second
+
+// startStaleLiveRunsWatcher launches a background goroutine that
+// periodically deletes live_runs rows whose runners have stopped reporting.
+// Only started when ingest is configured.
+func (s *server) startStaleLiveRunsWatcher(ctx context.Context) {
+	if s.cfg.Ingest == nil || s.cfg.Ingest.Token == "" || s.indexStore == nil {
+		return
+	}
+
+	threshold := s.cfg.Ingest.GetStaleThreshold()
+
+	s.log.WithField("threshold", threshold).Info("Stale live-runs watcher started")
+
+	s.wg.Add(1)
+
+	go func() {
+		defer s.wg.Done()
+
+		ticker := time.NewTicker(staleWatcherInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				cutoff := time.Now().UTC().Add(-threshold)
+				count, err := s.indexStore.DeleteStaleLiveRuns(ctx, cutoff)
+				if err != nil {
+					s.log.WithError(err).Warn("Failed to purge stale live runs")
+
+					continue
+				}
+
+				if count > 0 {
+					s.log.WithField("deleted", count).
+						Info("Purged stale live runs")
+				}
+			case <-s.done:
+				return
+			}
+		}
+	}()
+}

--- a/pkg/config/api.go
+++ b/pkg/config/api.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // APIConfig contains all API server configuration.
 type APIConfig struct {
 	Server   APIServerConfig    `yaml:"server" mapstructure:"server"`
@@ -7,6 +9,35 @@ type APIConfig struct {
 	Database APIDatabaseConfig  `yaml:"database" mapstructure:"database"`
 	Storage  APIStorageConfig   `yaml:"storage,omitempty" mapstructure:"storage"`
 	Indexing *APIIndexingConfig `yaml:"indexing,omitempty" mapstructure:"indexing"`
+	Ingest   *APIIngestConfig   `yaml:"ingest,omitempty" mapstructure:"ingest"`
+}
+
+// APIIngestConfig configures the live-run ingest endpoint that accepts
+// periodic status reports from benchmarkoor runners. When Token is set,
+// runs can post to POST /api/v1/ingest/runs using that bearer token.
+type APIIngestConfig struct {
+	Token          string `yaml:"token" mapstructure:"token"`
+	StaleThreshold string `yaml:"stale_threshold,omitempty" mapstructure:"stale_threshold"` // default 5m
+}
+
+// DefaultAPIIngestStaleThreshold is the default time after which a live
+// run with no recent reports is purged from the live_runs table.
+const DefaultAPIIngestStaleThreshold = "5m"
+
+// GetStaleThreshold returns the parsed stale threshold or the default.
+func (c *APIIngestConfig) GetStaleThreshold() time.Duration {
+	if c == nil || c.StaleThreshold == "" {
+		d, _ := time.ParseDuration(DefaultAPIIngestStaleThreshold)
+		return d
+	}
+
+	d, err := time.ParseDuration(c.StaleThreshold)
+	if err != nil {
+		d, _ := time.ParseDuration(DefaultAPIIngestStaleThreshold)
+		return d
+	}
+
+	return d
 }
 
 // APIIndexingConfig configures the background indexing service that

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,18 +70,83 @@ type Config struct {
 
 // RunnerConfig contains all run-specific configuration settings.
 type RunnerConfig struct {
-	ContainerRuntime   string            `yaml:"container_runtime,omitempty" mapstructure:"container_runtime"`
-	ClientLogsToStdout bool              `yaml:"client_logs_to_stdout" mapstructure:"client_logs_to_stdout"`
-	ContainerNetwork   string            `yaml:"container_network" mapstructure:"container_network"`
-	CleanupOnStart     bool              `yaml:"cleanup_on_start" mapstructure:"cleanup_on_start"`
-	RunTimeout         string            `yaml:"run_timeout,omitempty" mapstructure:"run_timeout"`
-	Directories        DirectoriesConfig `yaml:"directories,omitempty" mapstructure:"directories"`
-	DropCachesPath     string            `yaml:"drop_caches_path,omitempty" mapstructure:"drop_caches_path"`
-	CPUSysfsPath       string            `yaml:"cpu_sysfs_path,omitempty" mapstructure:"cpu_sysfs_path"`
-	GitHubToken        string            `yaml:"github_token,omitempty" mapstructure:"github_token"`
-	Benchmark          BenchmarkConfig   `yaml:"benchmark" mapstructure:"benchmark"`
-	Client             ClientConfig      `yaml:"client" mapstructure:"client"`
-	Instances          []ClientInstance  `yaml:"instances" mapstructure:"instances"`
+	ContainerRuntime   string               `yaml:"container_runtime,omitempty" mapstructure:"container_runtime"`
+	ClientLogsToStdout bool                 `yaml:"client_logs_to_stdout" mapstructure:"client_logs_to_stdout"`
+	ContainerNetwork   string               `yaml:"container_network" mapstructure:"container_network"`
+	CleanupOnStart     bool                 `yaml:"cleanup_on_start" mapstructure:"cleanup_on_start"`
+	RunTimeout         string               `yaml:"run_timeout,omitempty" mapstructure:"run_timeout"`
+	Directories        DirectoriesConfig    `yaml:"directories,omitempty" mapstructure:"directories"`
+	DropCachesPath     string               `yaml:"drop_caches_path,omitempty" mapstructure:"drop_caches_path"`
+	CPUSysfsPath       string               `yaml:"cpu_sysfs_path,omitempty" mapstructure:"cpu_sysfs_path"`
+	GitHubToken        string               `yaml:"github_token,omitempty" mapstructure:"github_token"`
+	LiveReporting      *LiveReportingConfig `yaml:"live_reporting,omitempty" mapstructure:"live_reporting"`
+	Benchmark          BenchmarkConfig      `yaml:"benchmark" mapstructure:"benchmark"`
+	Client             ClientConfig         `yaml:"client" mapstructure:"client"`
+	Instances          []ClientInstance     `yaml:"instances" mapstructure:"instances"`
+}
+
+// LiveReportingConfig enables periodic run-status reports to a benchmarkoor
+// API instance. When enabled, each run posts a snapshot of its state
+// (status, test counts, etc.) to the API at a jittered interval so the UI
+// can display in-progress runs.
+type LiveReportingConfig struct {
+	Enabled        bool    `yaml:"enabled" mapstructure:"enabled"`
+	Endpoint       string  `yaml:"endpoint" mapstructure:"endpoint"`
+	Token          string  `yaml:"token" mapstructure:"token"`
+	DiscoveryPath  string  `yaml:"discovery_path" mapstructure:"discovery_path"`
+	Interval       string  `yaml:"interval,omitempty" mapstructure:"interval"`               // default 1m
+	JitterFraction float64 `yaml:"jitter_fraction,omitempty" mapstructure:"jitter_fraction"` // default 0.2
+	Timeout        string  `yaml:"timeout,omitempty" mapstructure:"timeout"`                 // default 10s
+}
+
+// Default values for LiveReportingConfig when fields are left empty.
+const (
+	DefaultLiveReportingInterval       = time.Minute
+	DefaultLiveReportingJitterFraction = 0.2
+	DefaultLiveReportingTimeout        = 10 * time.Second
+)
+
+// GetInterval returns the reporting interval with the default applied.
+func (l *LiveReportingConfig) GetInterval() time.Duration {
+	if l == nil || l.Interval == "" {
+		return DefaultLiveReportingInterval
+	}
+
+	d, err := time.ParseDuration(l.Interval)
+	if err != nil {
+		return DefaultLiveReportingInterval
+	}
+
+	return d
+}
+
+// GetJitterFraction returns the jitter fraction with the default applied
+// when the field is unset (zero value). To disable jitter entirely, use a
+// negative value in the config and we'll clamp it to zero.
+func (l *LiveReportingConfig) GetJitterFraction() float64 {
+	if l == nil || l.JitterFraction == 0 {
+		return DefaultLiveReportingJitterFraction
+	}
+
+	if l.JitterFraction < 0 {
+		return 0
+	}
+
+	return l.JitterFraction
+}
+
+// GetTimeout returns the per-request timeout with the default applied.
+func (l *LiveReportingConfig) GetTimeout() time.Duration {
+	if l == nil || l.Timeout == "" {
+		return DefaultLiveReportingTimeout
+	}
+
+	d, err := time.ParseDuration(l.Timeout)
+	if err != nil {
+		return DefaultLiveReportingTimeout
+	}
+
+	return d
 }
 
 // MetadataConfig contains arbitrary metadata labels for a benchmark run.
@@ -1092,9 +1157,61 @@ func (c *Config) Validate(opts ...ValidateOpts) error {
 		return err
 	}
 
+	// Validate live_reporting settings.
+	if err := c.validateLiveReporting(); err != nil {
+		return err
+	}
+
 	// Validate API settings.
 	if err := c.ValidateAPI(); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// validateLiveReporting checks the runner.live_reporting config when enabled.
+func (c *Config) validateLiveReporting() error {
+	lr := c.Runner.LiveReporting
+	if lr == nil || !lr.Enabled {
+		return nil
+	}
+
+	if lr.Endpoint == "" {
+		return fmt.Errorf("runner.live_reporting.endpoint is required when enabled")
+	}
+
+	if lr.Token == "" {
+		return fmt.Errorf("runner.live_reporting.token is required when enabled")
+	}
+
+	if lr.DiscoveryPath == "" {
+		return fmt.Errorf("runner.live_reporting.discovery_path is required when enabled")
+	}
+
+	if lr.Interval != "" {
+		if _, err := time.ParseDuration(lr.Interval); err != nil {
+			return fmt.Errorf(
+				"runner.live_reporting.interval: invalid duration %q: %w",
+				lr.Interval, err,
+			)
+		}
+	}
+
+	if lr.Timeout != "" {
+		if _, err := time.ParseDuration(lr.Timeout); err != nil {
+			return fmt.Errorf(
+				"runner.live_reporting.timeout: invalid duration %q: %w",
+				lr.Timeout, err,
+			)
+		}
+	}
+
+	if lr.JitterFraction >= 1 {
+		return fmt.Errorf(
+			"runner.live_reporting.jitter_fraction: must be < 1, got %v",
+			lr.JitterFraction,
+		)
 	}
 
 	return nil
@@ -2080,6 +2197,33 @@ func (c *Config) ValidateAPI() error {
 	// Validate indexing settings.
 	if err := c.validateAPIIndexing(); err != nil {
 		return err
+	}
+
+	// Validate ingest settings.
+	if err := c.validateAPIIngest(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateAPIIngest validates the ingest configuration.
+func (c *Config) validateAPIIngest() error {
+	if c.API.Ingest == nil {
+		return nil
+	}
+
+	if c.API.Ingest.Token == "" {
+		return fmt.Errorf("api.ingest.token is required when ingest is configured")
+	}
+
+	if c.API.Ingest.StaleThreshold != "" {
+		if _, err := time.ParseDuration(c.API.Ingest.StaleThreshold); err != nil {
+			return fmt.Errorf(
+				"api.ingest.stale_threshold: invalid duration %q: %w",
+				c.API.Ingest.StaleThreshold, err,
+			)
+		}
 	}
 
 	return nil

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"text/template"
 	"time"
 
@@ -48,6 +49,24 @@ type Executor interface {
 
 	// GetSource returns the underlying source, which can be used for genesis resolution.
 	GetSource() Source
+
+	// GetProgress returns a snapshot of the current test execution counts.
+	// Safe to call concurrently from any goroutine while ExecuteTests runs.
+	GetProgress() ProgressSnapshot
+
+	// ResetProgress resets the live progress counters and seeds the total.
+	// Call this exactly once at the start of a logical run, BEFORE any
+	// ExecuteTests invocation. Strategies that invoke ExecuteTests multiple
+	// times per run (e.g. checkpoint-restore, container-recreate) rely on
+	// this so the counters accumulate across calls instead of being reset.
+	ResetProgress(total int)
+}
+
+// ProgressSnapshot is a point-in-time view of the executor's test progress.
+type ProgressSnapshot struct {
+	TestsTotal  int
+	TestsPassed int
+	TestsFailed int
 }
 
 // BlockLogCollector is an interface for capturing JSON payloads from client logs.
@@ -116,6 +135,12 @@ type executor struct {
 	suiteHash   string
 	validator   jsonrpc.Validator
 	statsReader stats.Reader
+
+	// Live progress counters updated during ExecuteTests. Safe to read
+	// concurrently via GetProgress().
+	progressTotal  atomic.Int64
+	progressPassed atomic.Int64
+	progressFailed atomic.Int64
 }
 
 // Ensure interface compliance.
@@ -228,6 +253,24 @@ func (e *executor) GetTests() []*TestWithSteps {
 // GetSource returns the underlying source.
 func (e *executor) GetSource() Source {
 	return e.source
+}
+
+// GetProgress returns a snapshot of the executor's live test counters.
+// Safe to call concurrently from any goroutine while ExecuteTests runs.
+func (e *executor) GetProgress() ProgressSnapshot {
+	return ProgressSnapshot{
+		TestsTotal:  int(e.progressTotal.Load()),
+		TestsPassed: int(e.progressPassed.Load()),
+		TestsFailed: int(e.progressFailed.Load()),
+	}
+}
+
+// ResetProgress resets the live counters and seeds the total. Call exactly
+// once per logical run before any ExecuteTests invocation.
+func (e *executor) ResetProgress(total int) {
+	e.progressTotal.Store(int64(total))
+	e.progressPassed.Store(0)
+	e.progressFailed.Store(0)
 }
 
 // RunPreRunSteps executes the suite's pre-run steps against the given endpoint.
@@ -552,9 +595,11 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 
 		if testPassed {
 			testsPassed++
+			e.progressPassed.Add(1)
 			log.Info("Test completed successfully")
 		} else {
 			testsFailed++
+			e.progressFailed.Add(1)
 			log.Warn("Test completed with failures")
 		}
 	}

--- a/pkg/livereport/reporter.go
+++ b/pkg/livereport/reporter.go
@@ -1,0 +1,186 @@
+// Package livereport implements the runner-side reporter that streams
+// status snapshots to a benchmarkoor API instance during a run.
+package livereport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math/rand/v2"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/api/indexstore"
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+// Snapshotter returns the current state of a run as a LiveRunReport.
+// Called by the reporter on every tick (and on demand via ReportNow).
+// The DiscoveryPath / Token / etc. are filled in by the reporter, so the
+// snapshot only needs to populate the fields that change over time.
+type Snapshotter func() indexstore.LiveRunReport
+
+// Reporter periodically posts run status snapshots to the API.
+type Reporter interface {
+	Start(ctx context.Context)
+	Stop()
+	ReportNow(ctx context.Context)
+}
+
+// New creates a Reporter. The snapshotter is invoked on every tick to
+// produce the report payload. The reporter does not own the snapshotter's
+// lifecycle.
+func New(log logrus.FieldLogger, cfg *config.LiveReportingConfig, snap Snapshotter) Reporter {
+	return &reporter{
+		log:  log.WithField("component", "livereport"),
+		cfg:  cfg,
+		snap: snap,
+		http: &http.Client{Timeout: cfg.GetTimeout()},
+		done: make(chan struct{}),
+	}
+}
+
+type reporter struct {
+	log  logrus.FieldLogger
+	cfg  *config.LiveReportingConfig
+	snap Snapshotter
+	http *http.Client
+
+	done   chan struct{}
+	wg     sync.WaitGroup
+	closed bool
+	mu     sync.Mutex
+}
+
+// Start launches the background reporting loop. Safe to call only once.
+func (r *reporter) Start(ctx context.Context) {
+	r.wg.Add(1)
+
+	go func() {
+		defer r.wg.Done()
+
+		// Send an initial report immediately so the row appears in the API
+		// quickly rather than waiting a full interval.
+		r.report(ctx)
+
+		for {
+			delay := r.nextDelay()
+
+			timer := time.NewTimer(delay)
+
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-r.done:
+				timer.Stop()
+				return
+			case <-timer.C:
+				r.report(ctx)
+			}
+		}
+	}()
+}
+
+// Stop sends one final report synchronously (with a short timeout) and
+// then signals the background loop to exit. Idempotent.
+func (r *reporter) Stop() {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+
+	r.closed = true
+	r.mu.Unlock()
+
+	// Final synchronous report so the terminal status reaches the API.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	r.report(ctx)
+	cancel()
+
+	close(r.done)
+	r.wg.Wait()
+}
+
+// ReportNow triggers an immediate (out-of-band) report. Called by the
+// runner at key transitions like run start and run end.
+func (r *reporter) ReportNow(ctx context.Context) {
+	r.report(ctx)
+}
+
+// report builds a report from the snapshotter and posts it. Errors are
+// logged at WARN and swallowed — the reporter is best-effort.
+func (r *reporter) report(ctx context.Context) {
+	report := r.snap()
+	report.DiscoveryPath = r.cfg.DiscoveryPath
+
+	body, err := json.Marshal(report)
+	if err != nil {
+		r.log.WithError(err).Warn("Failed to marshal live report")
+		return
+	}
+
+	url := strings.TrimRight(r.cfg.Endpoint, "/") + "/api/v1/ingest/runs"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		r.log.WithError(err).Warn("Failed to build live report request")
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+r.cfg.Token)
+
+	resp, err := r.http.Do(req)
+	if err != nil {
+		r.log.WithError(err).WithField("url", url).
+			Warn("Failed to post live report")
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode >= 300 {
+		r.log.WithFields(logrus.Fields{
+			"status": resp.StatusCode,
+			"url":    url,
+		}).Warn("Live report API returned non-success status")
+		return
+	}
+
+	r.log.WithFields(logrus.Fields{
+		"run_id": report.RunID,
+		"status": report.Status,
+	}).Debug("Live report sent")
+}
+
+// nextDelay returns the wait duration before the next report, applying
+// jitter so multiple runners don't all report simultaneously. Result is
+// always in the (0, 2*base) range.
+func (r *reporter) nextDelay() time.Duration {
+	base := r.cfg.GetInterval()
+	frac := r.cfg.GetJitterFraction()
+
+	if frac <= 0 {
+		return base
+	}
+
+	// Multiplier in [1-frac, 1+frac).
+	mul := 1 + (rand.Float64()*2-1)*frac
+	if mul <= 0 {
+		mul = 0.1
+	}
+
+	d := time.Duration(float64(base) * mul)
+	if d <= 0 {
+		return base
+	}
+
+	return d
+}
+
+// ensure Reporter compile-time check
+var _ Reporter = (*reporter)(nil)

--- a/pkg/livereport/reporter_test.go
+++ b/pkg/livereport/reporter_test.go
@@ -1,0 +1,128 @@
+package livereport
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/api/indexstore"
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReporter_PostsOnStartAndStop(t *testing.T) {
+	var (
+		count    atomic.Int64
+		lastBody atomic.Value
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+
+		body, _ := io.ReadAll(r.Body)
+		lastBody.Store(body)
+		count.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	cfg := &config.LiveReportingConfig{
+		Enabled:        true,
+		Endpoint:       srv.URL,
+		Token:          "secret",
+		DiscoveryPath:  "dp/test",
+		Interval:       "1m",
+		JitterFraction: 0,
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.WarnLevel)
+
+	var status atomic.Value
+	status.Store("running")
+
+	snap := func() indexstore.LiveRunReport {
+		return indexstore.LiveRunReport{
+			RunID:  "run-1",
+			Status: status.Load().(string),
+		}
+	}
+
+	r := New(log, cfg, snap)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r.Start(ctx)
+
+	// Wait for the initial report.
+	require.Eventually(t, func() bool { return count.Load() >= 1 }, 2*time.Second, 10*time.Millisecond)
+
+	status.Store("completed")
+	r.Stop()
+
+	// Stop must trigger a final synchronous report carrying the latest status.
+	require.GreaterOrEqual(t, count.Load(), int64(2))
+
+	var got indexstore.LiveRunReport
+	require.NoError(t, json.Unmarshal(lastBody.Load().([]byte), &got))
+	assert.Equal(t, "completed", got.Status)
+	assert.Equal(t, "dp/test", got.DiscoveryPath)
+}
+
+func TestReporter_ContinuesOnHTTPError(t *testing.T) {
+	var count atomic.Int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := &config.LiveReportingConfig{
+		Enabled:       true,
+		Endpoint:      srv.URL,
+		Token:         "x",
+		DiscoveryPath: "dp",
+		Interval:      "1m",
+	}
+
+	r := New(logrus.New(), cfg, func() indexstore.LiveRunReport {
+		return indexstore.LiveRunReport{RunID: "x", Status: "running"}
+	})
+	r.Start(context.Background())
+
+	require.Eventually(t, func() bool { return count.Load() >= 1 }, 2*time.Second, 10*time.Millisecond)
+
+	// Stop should still succeed (and trigger its own final report attempt).
+	r.Stop()
+
+	assert.GreaterOrEqual(t, count.Load(), int64(2))
+}
+
+func TestReporter_NextDelayJitter(t *testing.T) {
+	cfg := &config.LiveReportingConfig{
+		Interval:       "1m",
+		JitterFraction: 0.2,
+	}
+	r := &reporter{cfg: cfg}
+
+	for i := 0; i < 50; i++ {
+		d := r.nextDelay()
+		assert.GreaterOrEqual(t, d, time.Duration(float64(time.Minute)*0.8))
+		assert.LessOrEqual(t, d, time.Duration(float64(time.Minute)*1.2))
+	}
+}
+
+func TestReporter_NextDelayNoJitter(t *testing.T) {
+	// Negative jitter fraction = disabled.
+	cfg := &config.LiveReportingConfig{Interval: "30s", JitterFraction: -1}
+	r := &reporter{cfg: cfg}
+	assert.Equal(t, 30*time.Second, r.nextDelay())
+}

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -649,6 +649,10 @@ func (r *runner) runContainerLifecycle(
 		log.WithError(err).Warn("Failed to write run config")
 	}
 
+	if params.LiveState != nil {
+		params.LiveState.SetConfig(runConfig)
+	}
+
 	// Build container spec.
 	containerName := fmt.Sprintf("benchmarkoor-%s-%s", runID, instance.ID)
 	if params.GenesisGroupHash != "" {
@@ -893,6 +897,10 @@ func (r *runner) runContainerLifecycle(
 			)
 		}
 
+		if params.LiveState != nil {
+			params.LiveState.SetConfig(runConfig)
+		}
+
 		return fmt.Errorf("waiting for RPC: %w", err)
 	}
 
@@ -983,6 +991,10 @@ func (r *runner) runContainerLifecycle(
 		log.WithError(err).Warn(
 			"Failed to update run config with client version",
 		)
+	}
+
+	if params.LiveState != nil {
+		params.LiveState.SetConfig(runConfig)
 	}
 
 	// Execute tests if executor is configured.
@@ -1164,6 +1176,15 @@ func (r *runner) runContainerLifecycle(
 	// Record when the run ended.
 	runConfig.TimestampEnd = time.Now().Unix()
 
+	// Push the terminal status to the live-reporter state so the next
+	// snapshot (including the synchronous one fired by Reporter.Stop()) sees
+	// the final values.
+	if params.LiveState != nil {
+		params.LiveState.SetTerminal(
+			runConfig.Status, runConfig.TerminationReason, runConfig.TimestampEnd,
+		)
+	}
+
 	// Write final config with status.
 	if err := writeRunConfig(
 		runResultsDir, runConfig, r.cfg.ResultsOwner,
@@ -1171,6 +1192,10 @@ func (r *runner) runContainerLifecycle(
 		log.WithError(err).Warn("Failed to write final run config with status")
 	} else {
 		log.WithField("status", runConfig.Status).Info("Run completed")
+	}
+
+	if params.LiveState != nil {
+		params.LiveState.SetConfig(runConfig)
 	}
 
 	// Write block logs if any were captured.

--- a/pkg/runner/livereport_wiring_test.go
+++ b/pkg/runner/livereport_wiring_test.go
@@ -1,0 +1,40 @@
+package runner
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveRunState_ConfigSnapshot verifies the liveRunState SetConfig /
+// SnapshotConfig round-trip, which is the mechanism the live reporter uses
+// to include the full run config in each ingest payload.
+func TestLiveRunState_ConfigSnapshot(t *testing.T) {
+	s := &liveRunState{}
+
+	assert.Nil(t, s.SnapshotConfig(), "no config set yet")
+
+	cfg := &RunConfig{
+		Timestamp: 1234,
+		Status:    "running",
+		System:    &SystemInfo{Hostname: "testhost"},
+		Instance:  &ResolvedInstance{ID: "inst-1", Client: "geth"},
+	}
+	s.SetConfig(cfg)
+
+	got := s.SnapshotConfig()
+	require.NotNil(t, got, "SnapshotConfig should return bytes after SetConfig")
+
+	// Round-trip through JSON so we verify SetConfig actually serialised the
+	// struct with its json tags.
+	var back map[string]any
+	require.NoError(t, json.Unmarshal(got, &back))
+	assert.Equal(t, float64(1234), back["timestamp"])
+	assert.Equal(t, "running", back["status"])
+
+	sysInfo, ok := back["system"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "testhost", sysInfo["hostname"])
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	dockerclient "github.com/docker/docker/client"
+	"github.com/ethpandaops/benchmarkoor/pkg/api/indexstore"
 	"github.com/ethpandaops/benchmarkoor/pkg/blocklog"
 	"github.com/ethpandaops/benchmarkoor/pkg/client"
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
@@ -18,6 +20,7 @@ import (
 	"github.com/ethpandaops/benchmarkoor/pkg/docker"
 	"github.com/ethpandaops/benchmarkoor/pkg/executor"
 	"github.com/ethpandaops/benchmarkoor/pkg/fsutil"
+	"github.com/ethpandaops/benchmarkoor/pkg/livereport"
 	"github.com/ethpandaops/benchmarkoor/pkg/upload"
 	"github.com/sirupsen/logrus"
 )
@@ -95,6 +98,7 @@ type RunConfig struct {
 
 // Run status constants.
 const (
+	RunStatusRunning       = "running"
 	RunStatusCompleted     = "completed"
 	RunStatusFailed        = "failed"
 	RunStatusContainerDied = "container_died"
@@ -355,6 +359,134 @@ type containerRunParams struct {
 	UseDataDir           bool                      // Whether a pre-populated datadir is used.
 	BlockLogCollector    blocklog.Collector        // Optional collector for capturing block logs.
 	AccumulatedTestCount *TestCounts               // Shared across genesis groups for accumulation.
+	LiveState            *liveRunState             // Optional: live status state shared with the reporter goroutine.
+}
+
+// liveRunState is a tiny mutable snapshot of run state shared between the
+// lifecycle code (which writes status transitions) and the live-reporting
+// goroutine (which reads them to build snapshots).
+type liveRunState struct {
+	mu                sync.RWMutex
+	status            string
+	terminationReason string
+	timestampEnd      int64
+	// configJSON is the most recent serialized RunConfig. Lifecycle code
+	// calls SetConfig every time it writes config.json to disk so the
+	// reporter can include the latest content in its next snapshot.
+	configJSON []byte
+	// onChange is optionally set by the reporter; invoked (non-blocking)
+	// whenever SetConfig stores a new config, so the reporter can flush an
+	// out-of-band report immediately instead of waiting for its next tick.
+	onChange func()
+}
+
+func (s *liveRunState) SetStatus(status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = status
+}
+
+func (s *liveRunState) SetTerminal(status, reason string, endTs int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = status
+	s.terminationReason = reason
+	s.timestampEnd = endTs
+}
+
+// SetConfig serializes the given config to JSON and stores it so the next
+// live report snapshot carries the updated content. Errors are silently
+// dropped — the run is more important than the reporter. When an onChange
+// callback is set, it is invoked after the update so the reporter can
+// flush an immediate out-of-band report.
+func (s *liveRunState) SetConfig(cfg any) {
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return
+	}
+
+	s.mu.Lock()
+	s.configJSON = b
+	cb := s.onChange
+	s.mu.Unlock()
+
+	if cb != nil {
+		cb()
+	}
+}
+
+func (s *liveRunState) Snapshot() (status, reason string, endTs int64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.status, s.terminationReason, s.timestampEnd
+}
+
+// SnapshotConfig returns the latest serialized RunConfig. nil if no
+// SetConfig call has happened yet.
+func (s *liveRunState) SnapshotConfig() []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.configJSON
+}
+
+// liveSnapshotter returns a function that builds a LiveRunReport from the
+// current run state plus the executor's live test counters. Used by the
+// reporter goroutine.
+func (r *runner) liveSnapshotter(
+	instance *config.ClientInstance,
+	runID string,
+	runTimestamp int64,
+	state *liveRunState,
+) func() indexstore.LiveRunReport {
+	return func() indexstore.LiveRunReport {
+		status, reason, endTs := state.Snapshot()
+
+		report := indexstore.LiveRunReport{
+			RunID:             runID,
+			Timestamp:         runTimestamp,
+			TimestampEnd:      endTs,
+			Status:            status,
+			TerminationReason: reason,
+			InstanceID:        instance.ID,
+			Client:            instance.Client,
+			Image:             instance.Image,
+		}
+
+		if r.cfg.FullConfig != nil {
+			report.RollbackStrategy = r.cfg.FullConfig.GetRollbackStrategy(instance)
+			report.SuiteHash = ""
+			if r.executor != nil {
+				report.SuiteHash = r.executor.GetSuiteHash()
+			}
+			if labels := r.cfg.FullConfig.GetMetadataLabels(instance); len(labels) > 0 {
+				report.Metadata = labels
+			}
+		}
+
+		if r.executor != nil {
+			progress := r.executor.GetProgress()
+			report.TestsTotal = progress.TestsTotal
+			report.TestsPassed = progress.TestsPassed
+			report.TestsFailed = progress.TestsFailed
+
+			// Before ExecuteTests has started, progress.TestsTotal is 0
+			// because the executor hasn't seeded its live counters yet.
+			// Fall back to the prepared test list so the UI shows the
+			// planned total from the very first report.
+			if report.TestsTotal == 0 {
+				report.TestsTotal = len(r.executor.GetTests())
+			}
+		}
+
+		// Attach the latest config.json snapshot if the lifecycle has
+		// written one; the UI uses it to render the full configuration
+		// panels for in-progress runs.
+		if cfg := state.SnapshotConfig(); len(cfg) > 0 {
+			report.Config = cfg
+		}
+
+		return report
+	}
 }
 
 // RunInstance runs a single client instance through its lifecycle.
@@ -406,6 +538,48 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 		"run_id":   runID,
 	})
 	log.Info("Starting client instance")
+
+	// Reset the executor's live progress counters and seed the total with
+	// the full prepared test count. Strategies that call ExecuteTests once
+	// per test (checkpoint-restore, container-recreate) rely on this being
+	// done exactly once per RunInstance so counters accumulate.
+	if r.executor != nil {
+		r.executor.ResetProgress(len(r.executor.GetTests()))
+	}
+
+	// Set up live status reporting if enabled. The reporter posts periodic
+	// snapshots of the run state to the configured benchmarkoor API. The
+	// liveState struct is shared with the lifecycle code, which writes
+	// status transitions into it.
+	liveState := &liveRunState{status: RunStatusRunning}
+
+	var reporter livereport.Reporter
+
+	if r.cfg.FullConfig != nil &&
+		r.cfg.FullConfig.Runner.LiveReporting != nil &&
+		r.cfg.FullConfig.Runner.LiveReporting.Enabled {
+		lrCfg := r.cfg.FullConfig.Runner.LiveReporting
+
+		// Use the composite run directory name as the run_id so live rows
+		// match the canonical Run rows produced by the on-disk indexer.
+		// The UI links to runs by this id via the /runs/$runId route.
+		compositeRunID := fmt.Sprintf("%d_%s_%s", runTimestamp, runID, instance.ID)
+
+		snap := r.liveSnapshotter(instance, compositeRunID, runTimestamp, liveState)
+		reporter = livereport.New(r.logger, lrCfg, snap)
+		reporter.Start(ctx)
+
+		// Whenever the lifecycle writes a new config, push a report
+		// immediately so the API shows it without waiting for the next
+		// periodic tick.
+		liveState.mu.Lock()
+		liveState.onChange = func() {
+			reporter.ReportNow(ctx)
+		}
+		liveState.mu.Unlock()
+
+		defer reporter.Stop()
+	}
 
 	// Get client spec.
 	spec, err := r.registry.Get(client.ClientType(instance.Client))
@@ -489,6 +663,7 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 						ImageName:            imageName,
 						ImageDigest:          imageDigest,
 						AccumulatedTestCount: accumulatedTestCounts,
+						LiveState:            liveState,
 					}
 
 					if err := r.runContainerLifecycle(
@@ -527,6 +702,7 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 		GenesisSource:   genesisSource,
 		ImageName:       imageName,
 		ImageDigest:     imageDigest,
+		LiveState:       liveState,
 	}
 
 	return r.runContainerLifecycle(

--- a/ui/src/api/hooks/useIndex.ts
+++ b/ui/src/api/hooks/useIndex.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchData, fetchViaS3 } from '../client'
-import type { Index, IndexEntry } from '../types'
+import type { Index, IndexEntry, LiveRun } from '../types'
 import {
   loadRuntimeConfig,
   isS3Mode,
@@ -8,6 +8,10 @@ import {
   isIndexingEnabled,
   registerDiscoveryMapping,
 } from '@/config/runtime'
+
+// How often to refetch the runs/live runs lists. 30s strikes a balance
+// between freshness for in-progress runs and request volume.
+const RUNS_REFETCH_INTERVAL_MS = 30_000
 
 const emptyIndex: Index = { generated: 0, entries: [] }
 
@@ -132,6 +136,7 @@ function mergeIndexResults(results: (Index | null)[]): Index {
 export function useIndex() {
   return useQuery({
     queryKey: ['index'],
+    refetchInterval: RUNS_REFETCH_INTERVAL_MS,
     queryFn: async () => {
       const config = await loadRuntimeConfig()
 
@@ -158,6 +163,33 @@ export function useIndex() {
       }
 
       return data
+    },
+  })
+}
+
+// useLiveRuns returns the list of in-progress runs being reported by
+// runners via the API ingest endpoint. Returns an empty list when the
+// API isn't configured / indexing isn't enabled.
+export function useLiveRuns() {
+  return useQuery({
+    queryKey: ['live-runs'],
+    refetchInterval: RUNS_REFETCH_INTERVAL_MS,
+    queryFn: async (): Promise<LiveRun[]> => {
+      const config = await loadRuntimeConfig()
+      if (!config.api?.baseUrl || !isIndexingEnabled(config)) return []
+
+      const response = await fetch(
+        `${config.api.baseUrl}/api/v1/index/live_runs`,
+        { credentials: 'include' },
+      )
+
+      if (response.status === 404) return []
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch live runs: ${response.status}`)
+      }
+
+      return (await response.json()) as LiveRun[]
     },
   })
 }

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -5,7 +5,32 @@ export interface Index {
 }
 
 // Run status type
-export type RunStatus = 'completed' | 'container_died' | 'cancelled' | 'timeout'
+export type RunStatus = 'running' | 'completed' | 'container_died' | 'cancelled' | 'timeout'
+
+// Live run reported by an active runner via the ingest endpoint. Mirrors
+// indexstore.LiveRunResponse on the API side.
+export interface LiveRun {
+  id: number
+  discovery_path: string
+  run_id: string
+  timestamp: number
+  timestamp_end?: number
+  suite_hash?: string
+  status: RunStatus
+  termination_reason?: string
+  instance_id?: string
+  client?: string
+  image?: string
+  rollback_strategy?: string
+  tests_total: number
+  tests_passed: number
+  tests_failed: number
+  metadata?: Record<string, string>
+  // The full config.json content as reported by the runner. Mirrors the
+  // on-disk config.json schema so the UI can reuse RunConfiguration.
+  config?: RunConfig
+  last_reported_at: string
+}
 
 export interface IndexEntry {
   run_id: string

--- a/ui/src/components/run-detail/GitHubSection.tsx
+++ b/ui/src/components/run-detail/GitHubSection.tsx
@@ -1,0 +1,142 @@
+import { Github, ExternalLink } from 'lucide-react'
+
+interface GitHubSectionProps {
+  labels?: Record<string, string>
+}
+
+/**
+ * Renders the GitHub metadata section (repository, workflow, ref, sha, etc.)
+ * pulled from `github.*` prefixed metadata labels. Used on both the normal
+ * and live run detail pages.
+ */
+export function GitHubSection({ labels }: GitHubSectionProps) {
+  if (!labels) return null
+
+  const gh = Object.entries(labels)
+    .filter(([k]) => k.startsWith('github.'))
+    .reduce<Record<string, string>>((acc, [k, v]) => {
+      acc[k.replace('github.', '')] = v
+      return acc
+    }, {})
+
+  if (Object.keys(gh).length === 0) return null
+
+  const repoUrl = gh.repository ? `https://github.com/${gh.repository}` : undefined
+  const commitUrl = repoUrl && gh.sha ? `${repoUrl}/commit/${gh.sha}` : undefined
+  const runUrl = repoUrl && gh.run_id ? `${repoUrl}/actions/runs/${gh.run_id}` : undefined
+  const jobUrl = runUrl && gh.job_id ? `${runUrl}#step:0:0` : undefined
+
+  return (
+    <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
+      <div className="flex items-center gap-2 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+        <Github className="size-4 text-gray-500 dark:text-gray-400" />
+        <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">GitHub</h3>
+        {runUrl && (
+          <a
+            href={runUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-auto flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            View workflow run <ExternalLink className="size-3" />
+          </a>
+        )}
+      </div>
+      <div className="grid grid-cols-2 gap-x-8 gap-y-2 px-4 py-3 text-sm/6 sm:grid-cols-3 lg:grid-cols-4">
+        {gh.repository && (
+          <Field label="Repository">
+            {repoUrl ? (
+              <a
+                href={repoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                {gh.repository}
+              </a>
+            ) : (
+              <p className="font-medium text-gray-900 dark:text-gray-100">{gh.repository}</p>
+            )}
+          </Field>
+        )}
+        {gh.workflow && (
+          <Field label="Workflow">
+            <p className="font-medium text-gray-900 dark:text-gray-100">{gh.workflow}</p>
+          </Field>
+        )}
+        {gh.ref && (
+          <Field label="Ref">
+            <p className="font-mono text-xs font-medium text-gray-900 dark:text-gray-100">
+              {gh.ref.replace('refs/heads/', '').replace('refs/tags/', '')}
+            </p>
+          </Field>
+        )}
+        {gh.event_name && (
+          <Field label="Event">
+            <p className="font-medium text-gray-900 dark:text-gray-100">{gh.event_name}</p>
+          </Field>
+        )}
+        {gh.sha && (
+          <Field label="Commit">
+            {commitUrl ? (
+              <a
+                href={commitUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                {gh.sha.slice(0, 8)}
+              </a>
+            ) : (
+              <p className="font-mono text-xs font-medium text-gray-900 dark:text-gray-100">
+                {gh.sha.slice(0, 8)}
+              </p>
+            )}
+          </Field>
+        )}
+        {gh.actor && (
+          <Field label="Actor">
+            <a
+              href={`https://github.com/${gh.actor}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              {gh.actor}
+            </a>
+          </Field>
+        )}
+        {gh.job && (
+          <Field label="Job">
+            {jobUrl ? (
+              <a
+                href={jobUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                {gh.job}
+              </a>
+            ) : (
+              <p className="font-medium text-gray-900 dark:text-gray-100">{gh.job}</p>
+            )}
+          </Field>
+        )}
+        {gh.run_number && (
+          <Field label="Run Number">
+            <p className="font-medium text-gray-900 dark:text-gray-100">#{gh.run_number}</p>
+          </Field>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="text-xs text-gray-500 dark:text-gray-400">{label}</p>
+      {children}
+    </div>
+  )
+}

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -1,0 +1,176 @@
+import { useMemo } from 'react'
+import { Link } from '@tanstack/react-router'
+import { Loader } from 'lucide-react'
+import type { LiveRun } from '@/api/types'
+import { ClientStat } from '@/components/shared/ClientStat'
+import { JDenticon } from '@/components/shared/JDenticon'
+import { RunConfiguration } from '@/components/run-detail/RunConfiguration'
+import { MetadataLabels } from '@/components/run-detail/MetadataLabels'
+import { GitHubSection } from '@/components/run-detail/GitHubSection'
+import { ClientRunsStrip } from '@/components/run-detail/ClientRunsStrip'
+import { useSuite } from '@/api/hooks/useSuite'
+import { useIndex } from '@/api/hooks/useIndex'
+import { formatTimestamp } from '@/utils/date'
+import { formatNumber } from '@/utils/format'
+import { DEFAULT_INDEX_STEP_FILTER } from '@/api/types'
+
+interface LiveRunDetailViewProps {
+  run: LiveRun
+}
+
+/**
+ * LiveRunDetailView renders a view mirroring RunDetailPage as closely as
+ * possible, but sourced from the live ingest report's `config` payload
+ * instead of on-disk config.json / result.json. Used when a run is still
+ * in progress and its files haven't landed on the storage backend yet.
+ */
+export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
+  const { data: suite } = useSuite(run.suite_hash ?? '')
+  const { data: index } = useIndex()
+
+  const cfg = run.config
+  const total = run.tests_total || 0
+  const passed = run.tests_passed || 0
+  const failed = run.tests_failed || 0
+  const completed = passed + failed
+  const progress = total > 0 ? Math.min(100, (completed / total) * 100) : 0
+
+  // Prefer values from the reported config.json (richer) and fall back to
+  // the ingest report's scalars when we don't have a config yet.
+  const clientName = cfg?.instance.client ?? run.client ?? ''
+  const instanceID = cfg?.instance.id ?? run.instance_id ?? ''
+  const rollbackStrategy = cfg?.instance.rollback_strategy ?? run.rollback_strategy
+  const startTimestamp = cfg?.timestamp ?? run.timestamp
+  const labels = cfg?.metadata?.labels ?? run.metadata
+
+  const clientRuns = useMemo(() => {
+    if (!index || !run.suite_hash || !clientName) return []
+    return index.entries.filter(
+      (r) => r.suite_hash === run.suite_hash && r.instance.client === clientName,
+    )
+  }, [index, run.suite_hash, clientName])
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Breadcrumb (matches RunDetailPage). */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm/6 text-gray-500 dark:text-gray-400">
+        <div className="flex min-w-0 items-center gap-2">
+          <Link to="/suites" className="shrink-0 hover:text-gray-700 dark:hover:text-gray-300">
+            Suites
+          </Link>
+          <span>/</span>
+          {run.suite_hash && (
+            <>
+              <Link
+                to="/suites/$suiteHash"
+                params={{ suiteHash: run.suite_hash }}
+                className={`flex min-w-0 items-center gap-1.5 hover:text-gray-700 dark:hover:text-gray-300${suite?.metadata?.labels?.name ? '' : ' font-mono'}`}
+              >
+                <JDenticon value={run.suite_hash} size={16} className="shrink-0 rounded-xs" />
+                <span className="truncate">{suite?.metadata?.labels?.name ?? run.suite_hash}</span>
+              </Link>
+              <span>/</span>
+            </>
+          )}
+          <span className="truncate font-mono text-gray-900 dark:text-gray-100">{run.run_id}</span>
+        </div>
+        <span className="sm:ml-auto inline-flex items-center gap-2 rounded-sm bg-blue-100 px-2 py-0.5 text-xs/5 font-medium text-blue-800 dark:bg-blue-900/40 dark:text-blue-200">
+          <Loader className="size-3.5 animate-spin" />
+          Live — last report {formatRelativeAge(run.last_reported_at)}
+        </span>
+      </div>
+
+      {/* Recent runs strip, same as the real detail page. */}
+      {clientRuns.length > 0 && (
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="min-w-0 flex-1">
+            <ClientRunsStrip
+              runs={clientRuns}
+              currentRunId={run.run_id}
+              stepFilter={DEFAULT_INDEX_STEP_FILTER}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Top stat cards. Result-based cards (MGas/s, Calls, Test Duration)
+          don't exist for a live run, so we replace the rest of the row with
+          a single "In progress" card showing the progress bar and counts. */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
+        {clientName && (
+          <ClientStat
+            client={clientName}
+            runId={instanceID}
+            rollbackStrategy={rollbackStrategy}
+          />
+        )}
+        <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
+          <p className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Tests</p>
+          <p className="mt-1 flex items-center gap-2 text-2xl/8 font-semibold">
+            <span className="text-gray-900 dark:text-gray-100">{total}</span>
+            <span className="text-gray-400 dark:text-gray-500">/</span>
+            <span className="text-green-600 dark:text-green-400">{passed}</span>
+            {failed > 0 && (
+              <>
+                <span className="text-gray-400 dark:text-gray-500">/</span>
+                <span className="text-red-600 dark:text-red-400">{failed}</span>
+              </>
+            )}
+          </p>
+          <p className="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">Started at</p>
+          <p className="text-xs/5 text-gray-900 dark:text-gray-100">
+            {formatTimestamp(startTimestamp)}
+          </p>
+        </div>
+        <div className="col-span-3 rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
+          <p className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Progress</p>
+          <p className="mt-1 text-2xl/8 font-semibold text-gray-900 dark:text-gray-100">
+            {total > 0 ? `${progress.toFixed(1)}%` : '-'}
+          </p>
+          <p className="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
+            {formatNumber(completed)} of {formatNumber(total)} tests complete
+          </p>
+          <div className="mt-2 h-1.5 w-full overflow-hidden rounded-sm bg-gray-200 dark:bg-gray-700">
+            <div
+              className="h-full bg-blue-500 transition-all dark:bg-blue-400"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <p className="mt-3 text-xs/5 text-gray-500 dark:text-gray-400">
+            Full per-test results (MGas/s, calls, durations) will appear here once the run completes.
+          </p>
+        </div>
+      </div>
+
+      <MetadataLabels labels={labels} />
+
+      <GitHubSection labels={labels} />
+
+      {/* Configuration panel — shown once the runner has reported its
+          config.json via an ingest snapshot. */}
+      {cfg && (
+        <RunConfiguration
+          instance={cfg.instance}
+          system={cfg.system}
+          startBlock={cfg.start_block}
+          metadata={cfg.metadata}
+        />
+      )}
+    </div>
+  )
+}
+
+function formatRelativeAge(isoTimestamp: string): string {
+  const then = new Date(isoTimestamp).getTime()
+  const now = Date.now()
+  const diffSec = Math.max(0, Math.round((now - then) / 1000))
+
+  if (diffSec < 10) return 'just now'
+  if (diffSec < 60) return `${diffSec}s ago`
+
+  const diffMin = Math.round(diffSec / 60)
+  if (diffMin < 60) return `${diffMin}m ago`
+
+  const diffHr = Math.round(diffMin / 60)
+  return `${diffHr}h ago`
+}

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -137,7 +137,7 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
             />
           </div>
           <p className="mt-3 text-xs/5 text-gray-500 dark:text-gray-400">
-            Full per-test results (MGas/s, calls, durations) will appear here once the run completes.
+            Full per-test results (MGas/s, calls, durations) will appear here once the run completes and gets uploaded.
           </p>
         </div>
       </div>

--- a/ui/src/components/run-detail/MetadataLabels.tsx
+++ b/ui/src/components/run-detail/MetadataLabels.tsx
@@ -1,0 +1,33 @@
+interface MetadataLabelsProps {
+  labels?: Record<string, string>
+}
+
+/**
+ * Renders user-defined metadata labels (everything except `name` and
+ * `github.*` reserved keys) as pill-shaped chips. Used on both the normal
+ * and live run detail pages.
+ */
+export function MetadataLabels({ labels }: MetadataLabelsProps) {
+  if (!labels) return null
+
+  const userLabels = Object.entries(labels).filter(
+    ([k]) => !k.startsWith('github.') && k !== 'name',
+  )
+
+  if (userLabels.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {userLabels.map(([key, value]) => (
+        <span
+          key={key}
+          className="inline-flex items-center gap-1.5 rounded-xs border border-blue-200 bg-blue-50 px-2 py-1 text-xs/5 font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+        >
+          <span className="font-semibold">{key}</span>
+          <span>=</span>
+          <span>{value}</span>
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/ui/src/components/runs/RunFilters.tsx
+++ b/ui/src/components/runs/RunFilters.tsx
@@ -6,7 +6,7 @@ import { LabelFilters } from './LabelFilters'
 import type { LabelFilters as LabelFiltersType } from './labelFilterUtils'
 import type { IndexEntry } from '@/api/types'
 
-export type TestStatusFilter = 'all' | 'passing' | 'failing' | 'timeout' | 'cancelled'
+export type TestStatusFilter = 'all' | 'passing' | 'failing' | 'timeout' | 'cancelled' | 'running'
 
 interface RunFiltersProps {
   clients: string[]
@@ -129,6 +129,7 @@ export function RunFilters({
   const imageOptions = [{ value: '' as const, label: 'All images' }, ...images.map((i) => ({ value: i, label: i }))]
   const statusOptions: { value: TestStatusFilter | ''; label: string }[] = [
     { value: 'all', label: 'All runs' },
+    { value: 'running', label: 'In progress' },
     { value: 'passing', label: 'Passing only' },
     { value: 'failing', label: 'Has failures' },
     { value: 'timeout', label: 'Timed out' },

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -175,7 +175,13 @@ export function RunsTable({
         </thead>
         <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
           {entries.map((entry) => {
-            const hasFailures = entry.status !== 'container_died' && entry.status !== 'cancelled' && entry.status !== 'timeout' && entry.tests.tests_total - entry.tests.tests_passed > 0
+            // For live runs, only count actually-reported failures. For
+            // other statuses we fall back to (total - passed) for rows
+            // whose tests_failed field isn't populated.
+            const failedCount = entry.status === 'running'
+              ? entry.tests.tests_failed
+              : entry.tests.tests_total - entry.tests.tests_passed
+            const hasFailures = entry.status !== 'container_died' && entry.status !== 'cancelled' && entry.status !== 'timeout' && failedCount > 0
             const entryLabels = entry.metadata
               ? Object.entries(entry.metadata).filter(([k]) => !k.startsWith('github.') && k !== 'name')
               : []
@@ -186,6 +192,7 @@ export function RunsTable({
               onClick={selectable ? () => onSelectionChange?.(entry.run_id, !selectedRunIds?.has(entry.run_id)) : undefined}
               className={clsx(
                 'group relative cursor-pointer transition-colors hover:z-20 hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                entry.status === 'running' && 'bg-blue-50/50 dark:bg-blue-900/10',
                 entry.status === 'container_died' && 'bg-red-50/50 dark:bg-red-900/10',
                 entry.status === 'cancelled' && 'bg-yellow-50/50 dark:bg-yellow-900/10',
                 entry.status === 'timeout' && 'bg-orange-50/50 dark:bg-orange-900/10',
@@ -210,11 +217,12 @@ export function RunsTable({
               )}
               <td className={clsx(
                 'whitespace-nowrap px-3 py-2 text-sm/6 text-gray-500 sm:px-4 sm:py-2.5 dark:text-gray-400 border-l-3',
+                entry.status === 'running' && 'border-blue-400 dark:border-blue-500',
                 entry.status === 'container_died' && 'border-red-400 dark:border-red-500',
                 entry.status === 'cancelled' && 'border-yellow-400 dark:border-yellow-500',
                 entry.status === 'timeout' && 'border-orange-400 dark:border-orange-500',
                 hasFailures && 'border-orange-400 dark:border-orange-500',
-                entry.status !== 'container_died' && entry.status !== 'cancelled' && entry.status !== 'timeout' && !hasFailures && 'border-transparent',
+                entry.status !== 'running' && entry.status !== 'container_died' && entry.status !== 'cancelled' && entry.status !== 'timeout' && !hasFailures && 'border-transparent',
               )}>
                 {!selectable && (
                   <Link
@@ -226,7 +234,15 @@ export function RunsTable({
                   />
                 )}
                 <span className="flex flex-col" title={formatRelativeTime(entry.timestamp)}>
-                  <span>{formatTimestampDate(entry.timestamp)}</span>
+                  <span className="flex items-center gap-2">
+                    {formatTimestampDate(entry.timestamp)}
+                    {entry.status === 'running' && (
+                      <span
+                        className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
+                        title="Live — runner is reporting status"
+                      />
+                    )}
+                  </span>
                   <span className="text-xs/4 text-gray-400 dark:text-gray-500">{formatTimestampTime(entry.timestamp)}</span>
                 </span>
               </td>
@@ -274,14 +290,29 @@ export function RunsTable({
                       })()}
                     </td>
                     <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 sm:px-4 sm:py-2.5 dark:text-gray-400">
-                      {entry.timestamp_end
-                        ? <Duration nanoseconds={(entry.timestamp_end - entry.timestamp) * 1_000_000_000} />
-                        : '-'}
+                      {entry.status === 'running' ? (
+                        <LiveProgress
+                          passed={entry.tests.tests_passed}
+                          failed={entry.tests.tests_failed}
+                          total={entry.tests.tests_total}
+                        />
+                      ) : entry.timestamp_end ? (
+                        <Duration nanoseconds={(entry.timestamp_end - entry.timestamp) * 1_000_000_000} />
+                      ) : (
+                        '-'
+                      )}
                     </td>
                     <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-2.5">
-                      {entry.tests.tests_total - entry.tests.tests_passed > 0 && (
-                        <Badge variant="error">{entry.tests.tests_total - entry.tests.tests_passed}</Badge>
-                      )}
+                      {(() => {
+                        // For live runs, show only the tests the runner has
+                        // actually marked as failed. For completed runs, fall
+                        // back to (total - passed) for back-compat with rows
+                        // whose tests_failed field isn't populated.
+                        const failed = entry.status === 'running'
+                          ? entry.tests.tests_failed
+                          : entry.tests.tests_total - entry.tests.tests_passed
+                        return failed > 0 ? <Badge variant="error">{failed}</Badge> : null
+                      })()}
                     </td>
                     <td className="whitespace-nowrap px-1.5 py-2 text-center sm:px-2 sm:py-2.5">
                       <Badge variant="success">{entry.tests.tests_passed}</Badge>
@@ -344,6 +375,28 @@ export function RunsTable({
           )})}
         </tbody>
       </table>
+    </div>
+  )
+}
+
+// LiveProgress renders the test progress for an in-progress run. It shows
+// "N / total" and a thin progress bar scaled by completed-fraction of the
+// total tests.
+function LiveProgress({ passed, failed, total }: { passed: number; failed: number; total: number }) {
+  const completed = passed + failed
+  const pct = total > 0 ? Math.min(100, (completed / total) * 100) : 0
+
+  return (
+    <div className="inline-flex min-w-[5rem] flex-col items-end gap-1">
+      <span className="text-xs/5 tabular-nums">
+        {completed}/{total || '?'}
+      </span>
+      <div className="h-1 w-full overflow-hidden rounded-sm bg-gray-200 dark:bg-gray-700">
+        <div
+          className="h-full bg-blue-500 transition-all dark:bg-blue-400"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
     </div>
   )
 }

--- a/ui/src/components/shared/StatusBadge.tsx
+++ b/ui/src/components/shared/StatusBadge.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { Check, AlertTriangle, X, Clock } from 'lucide-react'
+import { Check, AlertTriangle, X, Clock, Loader } from 'lucide-react'
 import type { RunStatus } from '@/api/types'
 
 interface StatusBadgeProps {
@@ -10,6 +10,11 @@ interface StatusBadgeProps {
 }
 
 const statusConfig: Record<RunStatus, { label: string; className: string; icon: React.ReactNode }> = {
+  running: {
+    label: 'Running',
+    className: 'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-200',
+    icon: <Loader className="size-3.5 animate-spin" />,
+  },
   completed: {
     label: 'Completed',
     className: 'bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-200',
@@ -80,8 +85,8 @@ interface StatusAlertProps {
 }
 
 export function StatusAlert({ status, terminationReason, containerExitCode, containerOOMKilled }: StatusAlertProps) {
-  // Only show alert for non-completed statuses
-  if (!status || status === 'completed') {
+  // Only show alert for failure-like statuses; running/completed are not alerts.
+  if (!status || status === 'completed' || status === 'running') {
     return null
   }
 
@@ -90,21 +95,24 @@ export function StatusAlert({ status, terminationReason, containerExitCode, cont
     return null
   }
 
-  const alertClasses = {
+  const alertClasses: Record<RunStatus, string> = {
+    running: '',
     container_died: 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20',
     cancelled: 'border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-900/20',
     timeout: 'border-orange-200 bg-orange-50 dark:border-orange-800 dark:bg-orange-900/20',
     completed: '',
   }
 
-  const iconClasses = {
+  const iconClasses: Record<RunStatus, string> = {
+    running: '',
     container_died: 'text-red-600 dark:text-red-400',
     cancelled: 'text-yellow-600 dark:text-yellow-400',
     timeout: 'text-orange-600 dark:text-orange-400',
     completed: '',
   }
 
-  const textClasses = {
+  const textClasses: Record<RunStatus, string> = {
+    running: '',
     container_died: 'text-red-800 dark:text-red-200',
     cancelled: 'text-yellow-800 dark:text-yellow-200',
     timeout: 'text-orange-800 dark:text-orange-200',

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -7,6 +7,8 @@ import { useRunConfig } from '@/api/hooks/useRunConfig'
 import { useRunResult } from '@/api/hooks/useRunResult'
 import { useSuite } from '@/api/hooks/useSuite'
 import { RunConfiguration } from '@/components/run-detail/RunConfiguration'
+import { MetadataLabels } from '@/components/run-detail/MetadataLabels'
+import { GitHubSection } from '@/components/run-detail/GitHubSection'
 import { FilesPanel } from '@/components/run-detail/FilesPanel'
 import { ResourceUsageCharts } from '@/components/run-detail/ResourceUsageCharts'
 import { TestsTable, type TestSortColumn, type TestSortDirection, type TestStatusFilter } from '@/components/run-detail/TestsTable'
@@ -22,12 +24,13 @@ import { StatusAlert } from '@/components/shared/StatusBadge'
 import { FilterInput } from '@/components/shared/FilterInput'
 import { formatTimestamp, formatDurationSeconds } from '@/utils/date'
 import { formatNumber, formatBytes } from '@/utils/format'
-import { useIndex } from '@/api/hooks/useIndex'
+import { useIndex, useLiveRuns } from '@/api/hooks/useIndex'
+import { LiveRunDetailView } from '@/components/run-detail/LiveRunDetailView'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES } from '@/api/types'
 import { ClientRunsStrip } from '@/components/run-detail/ClientRunsStrip'
 import { BlockLogsDashboard } from '@/components/run-detail/block-logs-dashboard'
 import { useBlockLogs } from '@/api/hooks/useBlockLogs'
-import { Flame, Download, Github, ExternalLink, SquareStack, GitCompareArrows, Trash2 } from 'lucide-react'
+import { Flame, Download, SquareStack, GitCompareArrows, Trash2 } from 'lucide-react'
 import { MAX_COMPARE_RUNS, MIN_COMPARE_RUNS } from '@/components/compare/constants'
 import { useAuth } from '@/hooks/useAuth'
 import { useDeleteRuns } from '@/api/hooks/useAdmin'
@@ -145,6 +148,8 @@ export function RunDetailPage() {
   const { data: result, isLoading: resultLoading, refetch: refetchResult } = useRunResult(runId)
   const { data: suite } = useSuite(config?.suite_hash ?? '')
   const { data: index } = useIndex()
+  const { data: liveRuns } = useLiveRuns()
+  const liveRun = liveRuns?.find((lr) => lr.run_id === runId)
   const { data: containerLogHead, isLoading: containerLogLoading } = useQuery({
     queryKey: ['run', runId, 'container-log-head'],
     queryFn: () => fetchHead(`runs/${runId}/container.log`),
@@ -282,6 +287,14 @@ export function RunDetailPage() {
 
   if (isLoading) {
     return <LoadingState message="Loading run details..." />
+  }
+
+  // If the run is being actively reported by a runner and its files aren't
+  // yet on the storage backend, show the lightweight live view instead of
+  // the error state. Once the run finishes and config.json lands, the next
+  // refetch will drop us back into the normal detail view.
+  if (!config && liveRun) {
+    return <LiveRunDetailView run={liveRun} />
   }
 
   if (error) {
@@ -612,111 +625,9 @@ export function RunDetailPage() {
         )}
       </div>
 
-      {config.metadata?.labels && (() => {
-        const userLabels = Object.entries(config.metadata.labels)
-          .filter(([k]) => !k.startsWith('github.') && k !== 'name')
-        if (userLabels.length === 0) return null
-        return (
-          <div className="flex flex-wrap items-center gap-2">
-            {userLabels.map(([key, value]) => (
-              <span
-                key={key}
-                className="inline-flex items-center gap-1.5 rounded-xs border border-blue-200 bg-blue-50 px-2 py-1 text-xs/5 font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
-              >
-                <span className="font-semibold">{key}</span>
-                <span>=</span>
-                <span>{value}</span>
-              </span>
-            ))}
-          </div>
-        )
-      })()}
+      <MetadataLabels labels={config.metadata?.labels} />
 
-      {config.metadata?.labels && (() => {
-        const gh = Object.entries(config.metadata.labels)
-          .filter(([k]) => k.startsWith('github.'))
-          .reduce<Record<string, string>>((acc, [k, v]) => { acc[k.replace('github.', '')] = v; return acc }, {})
-        if (Object.keys(gh).length === 0) return null
-        const repoUrl = gh.repository ? `https://github.com/${gh.repository}` : undefined
-        const commitUrl = repoUrl && gh.sha ? `${repoUrl}/commit/${gh.sha}` : undefined
-        const runUrl = repoUrl && gh.run_id ? `${repoUrl}/actions/runs/${gh.run_id}` : undefined
-        const jobUrl = runUrl && gh.job_id ? `${runUrl}#step:0:0` : undefined
-        return (
-          <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
-            <div className="flex items-center gap-2 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
-              <Github className="size-4 text-gray-500 dark:text-gray-400" />
-              <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">GitHub</h3>
-              {runUrl && (
-                <a href={runUrl} target="_blank" rel="noopener noreferrer" className="ml-auto flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
-                  View workflow run <ExternalLink className="size-3" />
-                </a>
-              )}
-            </div>
-            <div className="grid grid-cols-2 gap-x-8 gap-y-2 px-4 py-3 text-sm/6 sm:grid-cols-3 lg:grid-cols-4">
-              {gh.repository && (
-                <div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Repository</p>
-                  {repoUrl ? (
-                    <a href={repoUrl} target="_blank" rel="noopener noreferrer" className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">{gh.repository}</a>
-                  ) : (
-                    <p className="font-medium text-gray-900 dark:text-gray-100">{gh.repository}</p>
-                  )}
-                </div>
-              )}
-              {gh.workflow && (
-                <div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Workflow</p>
-                  <p className="font-medium text-gray-900 dark:text-gray-100">{gh.workflow}</p>
-                </div>
-              )}
-              {gh.ref && (
-                <div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Ref</p>
-                  <p className="font-mono text-xs font-medium text-gray-900 dark:text-gray-100">{gh.ref.replace('refs/heads/', '').replace('refs/tags/', '')}</p>
-                </div>
-              )}
-              {gh.event_name && (
-                <div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Event</p>
-                  <p className="font-medium text-gray-900 dark:text-gray-100">{gh.event_name}</p>
-                </div>
-              )}
-              {gh.sha && (
-                <div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Commit</p>
-                  {commitUrl ? (
-                    <a href={commitUrl} target="_blank" rel="noopener noreferrer" className="font-mono text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">{gh.sha.slice(0, 8)}</a>
-                  ) : (
-                    <p className="font-mono text-xs font-medium text-gray-900 dark:text-gray-100">{gh.sha.slice(0, 8)}</p>
-                  )}
-                </div>
-              )}
-              {gh.actor && (
-                <div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Actor</p>
-                  <a href={`https://github.com/${gh.actor}`} target="_blank" rel="noopener noreferrer" className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">{gh.actor}</a>
-                </div>
-              )}
-              {gh.job && (
-                <div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Job</p>
-                  {jobUrl ? (
-                    <a href={jobUrl} target="_blank" rel="noopener noreferrer" className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">{gh.job}</a>
-                  ) : (
-                    <p className="font-medium text-gray-900 dark:text-gray-100">{gh.job}</p>
-                  )}
-                </div>
-              )}
-              {gh.run_number && (
-                <div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Run Number</p>
-                  <p className="font-medium text-gray-900 dark:text-gray-100">#{gh.run_number}</p>
-                </div>
-              )}
-            </div>
-          </div>
-        )
-      })()}
+      <GitHubSection labels={config.metadata?.labels} />
 
       <RunConfiguration instance={config.instance} system={config.system} startBlock={config.start_block} metadata={config.metadata} />
 

--- a/ui/src/pages/RunsPage.tsx
+++ b/ui/src/pages/RunsPage.tsx
@@ -2,10 +2,10 @@ import { useNavigate, useSearch } from '@tanstack/react-router'
 import { SquareStack, Trash2 } from 'lucide-react'
 import { useMemo, useState, useEffect, useCallback } from 'react'
 import { useQueries } from '@tanstack/react-query'
-import { useIndex } from '@/api/hooks/useIndex'
+import { useIndex, useLiveRuns } from '@/api/hooks/useIndex'
 import { useDeleteRuns } from '@/api/hooks/useAdmin'
 import { fetchData } from '@/api/client'
-import type { SuiteInfo } from '@/api/types'
+import type { SuiteInfo, IndexEntry } from '@/api/types'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES, DEFAULT_INDEX_STEP_FILTER } from '@/api/types'
 import { RunsTable } from '@/components/runs/RunsTable'
 import { sortIndexEntries, type SortColumn, type SortDirection } from '@/components/runs/sortEntries'
@@ -52,6 +52,7 @@ export function RunsPage() {
 
   const stepFilter = parseStepFilter(steps)
   const { data: index, isLoading, error, refetch } = useIndex()
+  const { data: liveRuns } = useLiveRuns()
   const [localPage, setLocalPage] = useState(page)
   const [localPageSize, setLocalPageSize] = useState(pageSize)
 
@@ -156,17 +157,64 @@ export function RunsPage() {
     return allSuites.filter((s) => matchingSuiteHashes.has(s.hash))
   }, [allSuites, matchingSuiteHashes])
 
+  // Merge in-progress live runs as ephemeral IndexEntry rows. A live run is
+  // suppressed when an indexed entry with the same run_id already exists,
+  // so we never show duplicate rows during the brief window when the
+  // on-disk indexer hasn't yet purged the live entry.
+  const mergedEntries = useMemo(() => {
+    if (!index) return [] as typeof index extends undefined ? never : IndexEntry[]
+    if (!liveRuns || liveRuns.length === 0) return index.entries
+
+    const indexedRunIDs = new Set(index.entries.map((e) => e.run_id))
+    const ephemeral: IndexEntry[] = []
+
+    for (const lr of liveRuns) {
+      if (indexedRunIDs.has(lr.run_id)) continue
+
+      ephemeral.push({
+        run_id: lr.run_id,
+        timestamp: lr.timestamp,
+        timestamp_end: lr.timestamp_end,
+        suite_hash: lr.suite_hash,
+        instance: {
+          id: lr.instance_id ?? '',
+          client: lr.client ?? '',
+          image: lr.image ?? '',
+          rollback_strategy: lr.rollback_strategy,
+        },
+        tests: {
+          tests_total: lr.tests_total,
+          tests_passed: lr.tests_passed,
+          tests_failed: lr.tests_failed,
+          steps: {},
+        },
+        status: lr.status,
+        termination_reason: lr.termination_reason,
+        metadata: lr.metadata,
+      })
+    }
+
+    return [...ephemeral, ...index.entries]
+  }, [index, liveRuns])
+
   const filteredEntries = useMemo(() => {
-    if (!index) return []
-    return index.entries.filter((e) => {
+    return mergedEntries.filter((e) => {
       if (client && e.instance.client !== client) return false
       if (image && e.instance.image !== image) return false
       if (suite && e.suite_hash !== suite) return false
       if (strategy && e.instance.rollback_strategy !== strategy) return false
-      if (status === 'passing' && e.tests.tests_total - e.tests.tests_passed > 0) return false
-      if (status === 'failing' && e.tests.tests_total - e.tests.tests_passed === 0) return false
+      // For live runs, failure count means actually-reported failures, not
+      // "tests not yet passed". Apply the same convention here.
+      {
+        const failed = e.status === 'running'
+          ? e.tests.tests_failed
+          : e.tests.tests_total - e.tests.tests_passed
+        if (status === 'passing' && failed > 0) return false
+        if (status === 'failing' && failed === 0) return false
+      }
       if (status === 'timeout' && e.status !== 'timeout') return false
       if (status === 'cancelled' && e.status !== 'cancelled') return false
+      if (status === 'running' && e.status !== 'running') return false
       if (matchingSuiteHashes && (!e.suite_hash || !matchingSuiteHashes.has(e.suite_hash))) return false
       for (const [key, allowedValues] of labelFilters) {
         const actual = e.metadata?.[key]
@@ -174,7 +222,7 @@ export function RunsPage() {
       }
       return true
     })
-  }, [index, client, image, suite, strategy, status, labelFilters, matchingSuiteHashes])
+  }, [mergedEntries, client, image, suite, strategy, status, labelFilters, matchingSuiteHashes])
 
   const sortedEntries = useMemo(() => sortIndexEntries(filteredEntries, sortBy, sortDir, stepFilter), [filteredEntries, sortBy, sortDir, stepFilter])
   const totalPages = Math.ceil(sortedEntries.length / localPageSize)


### PR DESCRIPTION
## Summary

Adds an end-to-end pipeline for streaming in-progress run state from benchmarkoor runners to the API so the UI can display live runs alongside indexed ones.

### Runner side
- New `runner.live_reporting` config (endpoint, token, discovery_path, interval, jitter_fraction, timeout).
- New `pkg/livereport` reporter that POSTs periodic snapshots with jittered intervals, swallows failures, and flushes a final synchronous report on `Stop()`.
- Executor exposes atomic progress counters via `GetProgress`/`ResetProgress` so strategies that call `ExecuteTests` once per test (checkpoint-restore, container-recreate) accumulate correctly.
- Lifecycle pushes each `writeRunConfig` snapshot and the terminal status into a shared `liveRunState`; `SetConfig` triggers an immediate out-of-band report so the API sees the full `config.json` content promptly.
- Composite `timestamp_runID_instanceID` used as `run_id` so live entries key the same way as the on-disk indexer's rows.

### API side
- New `api.ingest` config (token, stale_threshold) and `POST /api/v1/ingest/runs` endpoint guarded by a constant-time bearer-token middleware.
- New `live_runs` table (separate from `runs`) with a full `config_json` column so live rows never interfere with the canonical Run table.
- `GET /api/v1/index/live_runs` returns current live rows.
- Background stalewatcher deletes live rows whose runners have stopped reporting beyond the configured threshold.
- On-disk indexer deletes the matching live row when it upserts a Run so duplicates never reach the UI.

### UI side
- `RunStatus` extended with `'running'`; `useIndex`/`useLiveRuns` now poll on a 30s interval.
- `RunsTable` merges live runs with indexed rows, shows a pulsing dot for in-progress, replaces the Duration cell with a progress bar, and fixes the Failed count to use `tests_failed` (not `total - passed`) for live rows.
- `RunsPage` supports an "In progress" status filter and a suite-labels-based suite filter.
- New `LiveRunDetailView` mirrors the `RunDetailPage` layout (breadcrumb, `ClientRunsStrip`, top stat cards with progress, `MetadataLabels`, `GitHubSection`, `RunConfiguration`) sourced from the live report's config payload.
- Extracted `MetadataLabels` and `GitHubSection` into shared components used by both the normal and live run detail pages.

### Docs
- `docs/configuration.md`: new Live Reporting section on the runner.
- `docs/api.md`: new Ingest section + endpoint table entry.
- `config.example.yaml`: commented `live_reporting` (runner) and `ingest` (api) blocks.

## Example config

Runner:
```yaml
runner:
  live_reporting:
    enabled: true
    endpoint: https://benchmarkoor.example.com
    token: my-shared-secret
    discovery_path: my-host/benchmarks
    interval: 1m
```

API:
```yaml
api:
  ingest:
    token: my-shared-secret
    stale_threshold: 5m
```

## Test plan
- [x] Unit tests: `pkg/api/indexstore` (live run CRUD + config JSON round-trip + stale purge), `pkg/livereport` (initial/final report, jitter, HTTP error resilience), `pkg/runner` (liveRunState config snapshot)
- [x] `go vet` + `go test ./...` pass
- [x] `tsc --noEmit` + `eslint` clean
- [x] Start the API with `ingest.token` configured, start a runner with matching `live_reporting.token`, verify:
  - [x] Live row appears in the runs table with a pulsing dot and progress bar
  - [x] "In progress" status filter shows only live rows
  - [x] Clicking the live row opens the `LiveRunDetailView` with breadcrumb, recent-runs strip, top cards, metadata labels, GitHub section, and RunConfiguration
  - [x] Test counts tick up as tests complete
  - [x] Once the run completes and files upload, the page auto-transitions to the normal RunDetailPage
  - [x] Killing the runner mid-run causes the row to be purged after `stale_threshold`