### PR TITLE
feat: validate remote archive/opcode caches against the origin

### DIFF
--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -107,10 +107,12 @@ func (s *ArchiveSource) GetSourceInfo() (*SuiteSource, error) {
 	return &SuiteSource{Archive: info}, nil
 }
 
-// resolveFile returns the local path to the archive file. For URLs, it checks
-// the cache directory first and only downloads if the file is not already cached.
-// When the config uses `parts`, the parts are downloaded (with caching) and
-// concatenated into a single cached file.
+// resolveFile returns the local path to the archive file. For URLs, it
+// checks the cache directory first and validates any existing cached copy
+// against the origin (via HEAD + ETag/Last-Modified) before reuse. If the
+// remote has changed or has no cache entry yet, a fresh copy is downloaded.
+// When the config uses `parts`, the parts are resolved (each with its own
+// validation) and concatenated into a single cached file.
 func (s *ArchiveSource) resolveFile(ctx context.Context) (string, error) {
 	if len(s.cfg.Parts) > 0 {
 		return s.resolvePartsFile(ctx)
@@ -119,43 +121,14 @@ func (s *ArchiveSource) resolveFile(ctx context.Context) (string, error) {
 	file := s.cfg.File
 
 	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
-		cachedPath := s.cachedArchivePath()
-
-		if _, err := os.Stat(cachedPath); err == nil {
-			s.log.WithFields(logrus.Fields{
-				"url":  file,
-				"path": cachedPath,
-			}).Info("Using cached archive")
-
-			return cachedPath, nil
-		}
-
-		s.log.WithField("url", file).Info("Downloading archive")
-
 		downloadURL, token := s.resolveDownloadURL(file)
 
-		// Download to a temp file first, then rename for atomic cache writes.
-		tmpPath := cachedPath + ".tmp"
-
-		if err := os.MkdirAll(filepath.Dir(cachedPath), 0755); err != nil {
-			return "", fmt.Errorf("creating cache directory: %w", err)
-		}
-
-		if err := downloadToFile(ctx, downloadURL, tmpPath, token, s.log); err != nil {
-			_ = os.Remove(tmpPath)
-
+		res, err := fetchCached(ctx, s.log, file, downloadURL, token, s.cacheDir, "archive")
+		if err != nil {
 			return "", err
 		}
 
-		if err := os.Rename(tmpPath, cachedPath); err != nil {
-			_ = os.Remove(tmpPath)
-
-			return "", fmt.Errorf("caching archive: %w", err)
-		}
-
-		s.log.WithField("path", cachedPath).Info("Archive cached")
-
-		return cachedPath, nil
+		return res.Path, nil
 	}
 
 	// Local file path — resolve relative paths.
@@ -175,27 +148,19 @@ func (s *ArchiveSource) resolveFile(ctx context.Context) (string, error) {
 	return file, nil
 }
 
-// cachedArchivePath returns a stable file path in the cache directory derived
-// from the configured URL, so repeated runs reuse the same downloaded file.
-func (s *ArchiveSource) cachedArchivePath() string {
-	hash := sha256.Sum256([]byte(s.cfg.File))
-	name := "archive-" + hex.EncodeToString(hash[:8])
-
+// resolvePartsFile resolves each configured part (validating HTTP caches
+// against the origin) and concatenates them into a single combined cache
+// file. The combined file is rebuilt whenever any part was (re-)downloaded
+// during resolution, so updating a part on the origin causes the combined
+// archive to be regenerated on the next run.
+func (s *ArchiveSource) resolvePartsFile(ctx context.Context) (string, error) {
 	cacheDir := s.cacheDir
 	if cacheDir == "" {
 		cacheDir = os.TempDir()
 	}
 
-	return filepath.Join(cacheDir, name)
-}
-
-// resolvePartsFile downloads (with caching) all configured parts and
-// concatenates them in order into a single cached file, returning its path.
-// Local paths and URLs can be mixed freely in the parts list.
-func (s *ArchiveSource) resolvePartsFile(ctx context.Context) (string, error) {
-	cacheDir := s.cacheDir
-	if cacheDir == "" {
-		cacheDir = os.TempDir()
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return "", fmt.Errorf("creating cache directory: %w", err)
 	}
 
 	// Combined cache key is derived from the full ordered parts list so any
@@ -203,18 +168,10 @@ func (s *ArchiveSource) resolvePartsFile(ctx context.Context) (string, error) {
 	combined := sha256.Sum256([]byte(strings.Join(s.cfg.Parts, "\n")))
 	combinedPath := filepath.Join(cacheDir, "archive-parts-"+hex.EncodeToString(combined[:8]))
 
-	if _, err := os.Stat(combinedPath); err == nil {
-		s.log.WithField("path", combinedPath).Info("Using cached combined archive")
-
-		return combinedPath, nil
-	}
-
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
-		return "", fmt.Errorf("creating cache directory: %w", err)
-	}
-
-	// Resolve each part to a local file path (downloading URLs as needed).
+	// Resolve each part to a local file path (validating URL caches).
 	partPaths := make([]string, 0, len(s.cfg.Parts))
+
+	anyPartChanged := false
 
 	for i, part := range s.cfg.Parts {
 		s.log.WithFields(logrus.Fields{
@@ -223,12 +180,26 @@ func (s *ArchiveSource) resolvePartsFile(ctx context.Context) (string, error) {
 			"ref":   part,
 		}).Info("Resolving archive part")
 
-		partPath, err := s.resolvePart(ctx, part, cacheDir)
+		partPath, changed, err := s.resolvePart(ctx, part, cacheDir)
 		if err != nil {
 			return "", fmt.Errorf("resolving part %d (%s): %w", i+1, part, err)
 		}
 
+		if changed {
+			anyPartChanged = true
+		}
+
 		partPaths = append(partPaths, partPath)
+	}
+
+	// Reuse the combined file only when it exists AND no underlying part
+	// was refreshed during this call.
+	if !anyPartChanged {
+		if _, err := os.Stat(combinedPath); err == nil {
+			s.log.WithField("path", combinedPath).Info("Using cached combined archive")
+
+			return combinedPath, nil
+		}
 	}
 
 	// Concatenate all parts into a temporary file, then atomically rename.
@@ -251,56 +222,38 @@ func (s *ArchiveSource) resolvePartsFile(ctx context.Context) (string, error) {
 	return combinedPath, nil
 }
 
-// resolvePart resolves a single part reference (URL or local path) to a local
-// file path, downloading and caching remote parts in cacheDir.
-func (s *ArchiveSource) resolvePart(ctx context.Context, part, cacheDir string) (string, error) {
+// resolvePart resolves a single part reference (URL or local path) to a
+// local file path. Remote parts are cache-validated via fetchCached.
+// Returns (path, changed, error), where `changed` is true when the call
+// produced a fresh download; used by resolvePartsFile to know when the
+// concatenated combined file needs to be rebuilt.
+func (s *ArchiveSource) resolvePart(ctx context.Context, part, cacheDir string) (string, bool, error) {
 	if strings.HasPrefix(part, "http://") || strings.HasPrefix(part, "https://") {
-		hash := sha256.Sum256([]byte(part))
-		cachedPath := filepath.Join(cacheDir, "archive-part-"+hex.EncodeToString(hash[:8]))
-
-		if _, err := os.Stat(cachedPath); err == nil {
-			s.log.WithFields(logrus.Fields{
-				"url":  part,
-				"path": cachedPath,
-			}).Info("Using cached archive part")
-
-			return cachedPath, nil
-		}
-
 		downloadURL, token := s.resolveDownloadURL(part)
 
-		tmpPath := cachedPath + ".tmp"
-
-		if err := downloadToFile(ctx, downloadURL, tmpPath, token, s.log); err != nil {
-			_ = os.Remove(tmpPath)
-
-			return "", err
+		res, err := fetchCached(ctx, s.log, part, downloadURL, token, cacheDir, "archive-part")
+		if err != nil {
+			return "", false, err
 		}
 
-		if err := os.Rename(tmpPath, cachedPath); err != nil {
-			_ = os.Remove(tmpPath)
-
-			return "", fmt.Errorf("caching archive part: %w", err)
-		}
-
-		return cachedPath, nil
+		return res.Path, res.Changed, nil
 	}
 
 	// Local file path — resolve relative paths.
 	if !filepath.IsAbs(part) {
 		absPath, err := filepath.Abs(part)
 		if err != nil {
-			return "", fmt.Errorf("resolving path %q: %w", part, err)
+			return "", false, fmt.Errorf("resolving path %q: %w", part, err)
 		}
 
 		part = absPath
 	}
 
 	if _, err := os.Stat(part); os.IsNotExist(err) {
-		return "", fmt.Errorf("archive part %q does not exist", part)
+		return "", false, fmt.Errorf("archive part %q does not exist", part)
 	}
 
-	return part, nil
+	return part, false, nil
 }
 
 // concatFiles concatenates src files (in order) into dst. dst is created (or

--- a/pkg/executor/archive_source_test.go
+++ b/pkg/executor/archive_source_test.go
@@ -7,12 +7,16 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -354,6 +358,131 @@ func splitBytes(b []byte, n int) [][]byte {
 	}
 
 	return chunks
+}
+
+func TestArchiveSource_PartsReconcatenateOnOriginChange(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Build two tar.gz archives, A (one test) and B (two tests). Split
+	// each into two parts. Serve A's parts initially, then flip the ETag
+	// on the second part's server to serve B's second half and verify the
+	// combined file is regenerated on the next Prepare().
+	pathA := filepath.Join(tmpDir, "a.tar.gz")
+	createTestTarGz(t, pathA, map[string]string{
+		"mytest/test/a.txt": "content-a",
+	})
+	pathB := filepath.Join(tmpDir, "b.tar.gz")
+	createTestTarGz(t, pathB, map[string]string{
+		"mytest/test/b1.txt": "content-b1",
+		"mytest/test/b2.txt": "content-b2",
+	})
+
+	bytesA, err := os.ReadFile(pathA)
+	require.NoError(t, err)
+	bytesB, err := os.ReadFile(pathB)
+	require.NoError(t, err)
+
+	chunksA := splitBytes(bytesA, 2)
+	chunksB := splitBytes(bytesB, 2)
+
+	var currentPart2 atomic.Value
+	currentPart2.Store(chunksA[1])
+
+	var etagPart2 atomic.Value
+	etagPart2.Store(`"a"`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var data []byte
+		var etag string
+
+		switch r.URL.Path {
+		case "/part1":
+			data = chunksA[0]
+			etag = `"a"`
+		case "/part2":
+			data = currentPart2.Load().([]byte)
+			etag = etagPart2.Load().(string)
+		default:
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("ETag", etag)
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+		w.WriteHeader(http.StatusOK)
+
+		if r.Method == http.MethodGet {
+			_, _ = w.Write(data)
+		}
+	}))
+	defer srv.Close()
+
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	makeSrc := func() *ArchiveSource {
+		return &ArchiveSource{
+			log:      log.WithField("source", "archive"),
+			cacheDir: tmpDir,
+			cfg: &config.ArchiveSourceConfig{
+				Parts: []string{srv.URL + "/part1", srv.URL + "/part2"},
+				Steps: &config.StepsConfig{
+					Test: []string{"mytest/test/*"},
+				},
+			},
+		}
+	}
+
+	// First run: downloads both parts and writes the combined archive.
+	s1 := makeSrc()
+	result, err := s1.Prepare(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(result.Tests), "first run sees only A's single test")
+	require.NoError(t, s1.Cleanup())
+
+	// Origin publishes a new second half with a different ETag. The
+	// rebuilt combined archive must reflect it.
+	currentPart2.Store(chunksB[1])
+	etagPart2.Store(`"b"`)
+
+	// We also need to replace part1 on the origin since A and B differ
+	// from byte 0 — but here we care about the control flow, so instead
+	// we make A -> A+B2 (first half of A, second half of B). That's
+	// gibberish as a tar.gz; switch both halves to B.
+	// Simpler: also update part1 so the combined is B.
+	// Since we only have one endpoint for /part1, stub it out:
+	//  -> we already serve chunksA[0] unconditionally. Update via a flag.
+	//
+	// For this test the primary assertion is that the re-download of
+	// part2 (ETag change) triggers a rebuild of the combined file, even
+	// if its content is garbled.
+
+	s2 := makeSrc()
+	_, err = s2.Prepare(context.Background())
+	// Extraction will likely fail (chunksA[0] + chunksB[1] is not a valid
+	// tar.gz). We only care that the combined cached file got rebuilt.
+	_ = err
+	require.NoError(t, s2.Cleanup())
+
+	// Verify: the combined cached file now has byte content reflecting
+	// chunksA[0] + chunksB[1], not the original chunksA[0] + chunksA[1].
+	combinedKey := filepath.Join(
+		tmpDir,
+		"archive-parts-"+shortHashCombined(srv.URL+"/part1", srv.URL+"/part2"),
+	)
+	got, err := os.ReadFile(combinedKey) //nolint:gosec // test-only
+	require.NoError(t, err)
+
+	want := append([]byte{}, chunksA[0]...)
+	want = append(want, chunksB[1]...)
+	assert.Equal(t, want, got, "combined file must be rebuilt when any part ETag changes")
+}
+
+// shortHashCombined mirrors how resolvePartsFile computes its combined
+// cache key from the ordered parts list.
+func shortHashCombined(parts ...string) string {
+	h := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	return hex.EncodeToString(h[:8])
 }
 
 func TestArchiveSource_PrepareWithParts(t *testing.T) {

--- a/pkg/executor/cache.go
+++ b/pkg/executor/cache.go
@@ -1,0 +1,285 @@
+package executor
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// cacheMeta stores the HTTP validators of a cached remote file so subsequent
+// runs can decide, via a cheap HEAD request, whether the cache is still
+// current or the origin has published a different artifact.
+type cacheMeta struct {
+	URL           string `json:"url"`
+	ETag          string `json:"etag,omitempty"`
+	LastModified  string `json:"last_modified,omitempty"`
+	ContentLength int64  `json:"content_length,omitempty"`
+}
+
+// fetchResult reports the outcome of a validated fetch.
+type fetchResult struct {
+	Path    string // local path to the validated cache copy
+	Changed bool   // true if the file was (re-)downloaded during this call
+}
+
+// fetchCached resolves a URL to a cached local path, validating any
+// existing cached copy against the origin via a HEAD request before
+// reusing it. If the cached copy is still current (HTTP validators
+// match) it is reused; otherwise it is re-downloaded.
+//
+// When the HEAD request succeeds with no validators (no ETag / no
+// Last-Modified and no Content-Length), the cache is reused with a
+// warning — we have nothing to compare. When the HEAD request fails
+// outright we also fall back to the cache with a warning so a transient
+// network blip doesn't force a multi-hundred-MiB re-download.
+//
+// The cache path layout is:
+//
+//	<cacheDir>/<prefix>-<sha256(url)[:16]>      the file
+//	<cacheDir>/<prefix>-<sha256(url)[:16]>.meta the validators sidecar
+//
+// `rawURL` is the URL written into the sidecar and used for logging.
+// `downloadURL` is what we actually hit (may differ when a GitHub
+// browser URL has been rewritten to an API URL).
+func fetchCached(
+	ctx context.Context,
+	log logrus.FieldLogger,
+	rawURL, downloadURL, bearerToken, cacheDir, prefix string,
+) (*fetchResult, error) {
+	if cacheDir == "" {
+		cacheDir = os.TempDir()
+	}
+
+	cachedPath := cachePath(cacheDir, prefix, rawURL)
+	metaPath := cachedPath + ".meta"
+
+	fileExists := false
+	if _, err := os.Stat(cachedPath); err == nil {
+		fileExists = true
+	}
+
+	// Probe the origin for current validators. Failure is non-fatal when a
+	// cache copy exists — better to serve slightly stale than to fail the
+	// run on a network blip.
+	remoteMeta, headErr := headMeta(ctx, downloadURL, bearerToken)
+
+	if fileExists && headErr == nil {
+		cachedMeta, readErr := readCacheMeta(metaPath)
+		if readErr == nil && metaMatches(cachedMeta, remoteMeta) {
+			log.WithFields(logrus.Fields{
+				"url":  rawURL,
+				"path": cachedPath,
+			}).Info("Using cached file (validators match)")
+
+			return &fetchResult{Path: cachedPath}, nil
+		}
+
+		if readErr == nil && !hasValidators(remoteMeta) {
+			log.WithFields(logrus.Fields{
+				"url":  rawURL,
+				"path": cachedPath,
+			}).Warn("Origin did not return ETag/Last-Modified; using cached file without revalidation")
+
+			return &fetchResult{Path: cachedPath}, nil
+		}
+
+		if readErr != nil {
+			log.WithFields(logrus.Fields{
+				"url":  rawURL,
+				"path": cachedPath,
+			}).Info("Cache sidecar missing; re-downloading to refresh validators")
+		} else {
+			log.WithFields(logrus.Fields{
+				"url":     rawURL,
+				"path":    cachedPath,
+				"changed": describeChange(cachedMeta, remoteMeta),
+			}).Info("Origin changed; re-downloading")
+		}
+	} else if fileExists && headErr != nil {
+		log.WithFields(logrus.Fields{
+			"url":   rawURL,
+			"path":  cachedPath,
+			"error": headErr.Error(),
+		}).Warn("HEAD failed; using cached file without revalidation")
+
+		return &fetchResult{Path: cachedPath}, nil
+	}
+
+	// Either the cache is absent, stale, or unusable. Download a fresh copy.
+	if headErr != nil {
+		// We'll do our best without validators.
+		log.WithFields(logrus.Fields{
+			"url":   rawURL,
+			"error": headErr.Error(),
+		}).Warn("Could not probe origin before download")
+	}
+
+	log.WithField("url", rawURL).Info("Downloading file")
+
+	tmpPath := cachedPath + ".tmp"
+
+	if err := os.MkdirAll(filepath.Dir(cachedPath), 0755); err != nil {
+		return nil, fmt.Errorf("creating cache directory: %w", err)
+	}
+
+	if err := downloadToFile(ctx, downloadURL, tmpPath, bearerToken, log); err != nil {
+		_ = os.Remove(tmpPath)
+
+		return nil, err
+	}
+
+	if err := os.Rename(tmpPath, cachedPath); err != nil {
+		_ = os.Remove(tmpPath)
+
+		return nil, fmt.Errorf("caching file: %w", err)
+	}
+
+	// Persist the validators we just observed (if any). If the HEAD
+	// failed, still write a minimal sidecar with the URL so subsequent
+	// runs treat the cache as present-but-unvalidated.
+	meta := cacheMeta{URL: rawURL}
+	if remoteMeta != nil {
+		meta.ETag = remoteMeta.ETag
+		meta.LastModified = remoteMeta.LastModified
+		meta.ContentLength = remoteMeta.ContentLength
+	}
+
+	if err := writeCacheMeta(metaPath, &meta); err != nil {
+		log.WithError(err).Warn("Failed to write cache sidecar")
+	}
+
+	return &fetchResult{Path: cachedPath, Changed: true}, nil
+}
+
+// cachePath returns the stable on-disk path for a given URL + prefix.
+func cachePath(cacheDir, prefix, key string) string {
+	hash := sha256.Sum256([]byte(key))
+	return filepath.Join(cacheDir, prefix+"-"+hex.EncodeToString(hash[:8]))
+}
+
+// headMeta sends a HEAD request and extracts the validators we care about.
+func headMeta(ctx context.Context, url, bearerToken string) (*cacheMeta, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating HEAD request: %w", err)
+	}
+
+	applyAuth(req, bearerToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HEAD %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HEAD %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	return &cacheMeta{
+		URL:           url,
+		ETag:          strings.TrimSpace(resp.Header.Get("ETag")),
+		LastModified:  strings.TrimSpace(resp.Header.Get("Last-Modified")),
+		ContentLength: resp.ContentLength,
+	}, nil
+}
+
+// metaMatches returns true when the cached validators match the origin
+// response. At least one validator must be present and equal for a match;
+// a bare Content-Length match is not sufficient (it's too common for
+// unrelated rebuilds to produce identical sizes).
+func metaMatches(cached, remote *cacheMeta) bool {
+	if cached == nil || remote == nil {
+		return false
+	}
+
+	if cached.ETag != "" && remote.ETag != "" {
+		return cached.ETag == remote.ETag
+	}
+
+	if cached.LastModified != "" && remote.LastModified != "" {
+		if cached.LastModified == remote.LastModified {
+			// Back up with Content-Length if both sides have it — some CDNs
+			// reuse Last-Modified across content revisions.
+			if cached.ContentLength > 0 && remote.ContentLength > 0 {
+				return cached.ContentLength == remote.ContentLength
+			}
+
+			return true
+		}
+
+		return false
+	}
+
+	return false
+}
+
+// hasValidators reports whether the remote gave us anything we can use to
+// detect content changes beyond Content-Length (which is too weak alone).
+func hasValidators(m *cacheMeta) bool {
+	return m != nil && (m.ETag != "" || m.LastModified != "")
+}
+
+// describeChange produces a compact log field value describing which
+// validator differs between the cached and remote metadata.
+func describeChange(cached, remote *cacheMeta) string {
+	if cached == nil || remote == nil {
+		return "unknown"
+	}
+
+	switch {
+	case cached.ETag != remote.ETag:
+		return fmt.Sprintf("etag %q→%q", cached.ETag, remote.ETag)
+	case cached.LastModified != remote.LastModified:
+		return fmt.Sprintf("last_modified %q→%q", cached.LastModified, remote.LastModified)
+	case cached.ContentLength != remote.ContentLength:
+		return fmt.Sprintf("content_length %d→%d", cached.ContentLength, remote.ContentLength)
+	default:
+		return "no-validators-match"
+	}
+}
+
+// readCacheMeta loads a sidecar JSON file.
+func readCacheMeta(path string) (*cacheMeta, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is under our cache dir
+	if err != nil {
+		return nil, err
+	}
+
+	var m cacheMeta
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing cache sidecar %q: %w", path, err)
+	}
+
+	return &m, nil
+}
+
+// writeCacheMeta atomically writes the sidecar JSON next to the cached file.
+func writeCacheMeta(path string, meta *cacheMeta) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling cache sidecar: %w", err)
+	}
+
+	tmp := path + ".tmp"
+
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("writing cache sidecar: %w", err)
+	}
+
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+
+		return fmt.Errorf("renaming cache sidecar: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/executor/cache_test.go
+++ b/pkg/executor/cache_test.go
@@ -1,0 +1,229 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// etagServer is a tiny test HTTP server that serves `payload` with a
+// configurable ETag. Call SetETag / SetPayload between runs to simulate
+// the origin being updated.
+type etagServer struct {
+	mu         sync.Mutex
+	payload    []byte
+	etag       string
+	getCount   atomic.Int64
+	headCount  atomic.Int64
+	noETag     bool // when true, server omits ETag from responses
+	headStatus int  // 0 = default 200; set to simulate HEAD failures
+}
+
+func newEtagServer(t *testing.T, payload []byte, etag string) (*etagServer, *httptest.Server) {
+	t.Helper()
+
+	es := &etagServer{payload: payload, etag: etag}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		es.mu.Lock()
+		payload := es.payload
+		etag := es.etag
+		noETag := es.noETag
+		headStatus := es.headStatus
+		es.mu.Unlock()
+
+		if r.Method == http.MethodHead {
+			es.headCount.Add(1)
+
+			if headStatus != 0 {
+				w.WriteHeader(headStatus)
+				return
+			}
+
+			if !noETag {
+				w.Header().Set("ETag", etag)
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		es.getCount.Add(1)
+
+		if !noETag {
+			w.Header().Set("ETag", etag)
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+
+	return es, srv
+}
+
+func (es *etagServer) SetETag(etag string) {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	es.etag = etag
+}
+
+func (es *etagServer) SetPayload(payload []byte) {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	es.payload = payload
+}
+
+func (es *etagServer) DisableETag() {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	es.noETag = true
+}
+
+func (es *etagServer) BreakHEAD() {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	es.headStatus = http.StatusInternalServerError
+}
+
+func TestFetchCached_HitWhenValidatorsMatch(t *testing.T) {
+	es, srv := newEtagServer(t, []byte("hello"), `"v1"`)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	// First fetch downloads.
+	r1, err := fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "x")
+	require.NoError(t, err)
+	assert.True(t, r1.Changed)
+
+	// Second fetch sees the same ETag and should NOT re-download.
+	r2, err := fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "x")
+	require.NoError(t, err)
+	assert.False(t, r2.Changed)
+	assert.Equal(t, r1.Path, r2.Path)
+
+	assert.Equal(t, int64(1), es.getCount.Load(), "no re-download on matching ETag")
+	assert.GreaterOrEqual(t, es.headCount.Load(), int64(1), "second fetch does a HEAD")
+}
+
+func TestFetchCached_MissWhenETagChanges(t *testing.T) {
+	es, srv := newEtagServer(t, []byte("hello"), `"v1"`)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	log := logrus.New()
+
+	_, err := fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "x")
+	require.NoError(t, err)
+
+	// Origin publishes a new revision at the same URL.
+	es.SetETag(`"v2"`)
+	es.SetPayload([]byte("updated"))
+
+	r2, err := fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "x")
+	require.NoError(t, err)
+	assert.True(t, r2.Changed, "ETag mismatch must trigger re-download")
+
+	got, err := os.ReadFile(r2.Path) //nolint:gosec // test path
+	require.NoError(t, err)
+	assert.Equal(t, "updated", string(got))
+	assert.Equal(t, int64(2), es.getCount.Load())
+}
+
+func TestFetchCached_LegacySidecarMissingReDownloads(t *testing.T) {
+	_, srv := newEtagServer(t, []byte("hello"), `"v1"`)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	log := logrus.New()
+
+	// Plant a pre-existing cache entry WITHOUT a .meta sidecar — mimics a
+	// cache dir populated by an older benchmarkoor binary.
+	stalePath := cachePath(dir, "x", srv.URL)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.WriteFile(stalePath, []byte("stale"), 0644))
+
+	r, err := fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "x")
+	require.NoError(t, err)
+	assert.True(t, r.Changed)
+
+	got, err := os.ReadFile(r.Path) //nolint:gosec // test path
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(got), "re-downloaded from origin, not stale")
+
+	// Meta sidecar must now exist.
+	_, err = os.Stat(stalePath + ".meta")
+	require.NoError(t, err)
+}
+
+func TestFetchCached_NoValidatorsFallsBackToCache(t *testing.T) {
+	es, srv := newEtagServer(t, []byte("hello"), `"v1"`)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	log := logrus.New()
+
+	// First fetch populates cache (with ETag).
+	_, err := fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "x")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), es.getCount.Load())
+
+	// Origin stops sending ETag/Last-Modified. The next fetch can't
+	// validate, so it should reuse the cache.
+	es.DisableETag()
+
+	_, err = fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "x")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), es.getCount.Load(), "cache reused when origin has no validators")
+}
+
+func TestFetchCached_HeadFailureFallsBackToCache(t *testing.T) {
+	es, srv := newEtagServer(t, []byte("hello"), `"v1"`)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	log := logrus.New()
+
+	_, err := fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "x")
+	require.NoError(t, err)
+
+	es.BreakHEAD()
+
+	_, err = fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "x")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), es.getCount.Load(), "HEAD failure must not trigger a re-download")
+}
+
+func TestFetchCached_CacheMissCoexistsWithOtherPrefixes(t *testing.T) {
+	_, srv := newEtagServer(t, []byte("hello"), `"v1"`)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	log := logrus.New()
+
+	ra, err := fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "archive")
+	require.NoError(t, err)
+
+	rb, err := fetchCached(context.Background(), log, srv.URL, srv.URL, "", dir, "opcode")
+	require.NoError(t, err)
+
+	// Same URL but different prefix must land in distinct cache files so
+	// the two subsystems don't clobber each other.
+	assert.NotEqual(t, ra.Path, rb.Path)
+	assert.Equal(t, filepath.Dir(ra.Path), dir)
+}

--- a/pkg/executor/opcode.go
+++ b/pkg/executor/opcode.go
@@ -2,8 +2,6 @@ package executor
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -80,29 +78,11 @@ func (e *executor) loadOpcodes(ctx context.Context) error {
 }
 
 // resolveFile resolves a file reference that can be a local path or HTTP(S)
-// URL. Remote files are downloaded and cached in cacheDir.
+// URL. Remote files are cache-validated (via HEAD + ETag/Last-Modified)
+// before being reused; if the origin has changed, a fresh copy is
+// downloaded.
 func resolveFile(ctx context.Context, file, cacheDir, githubToken string, log logrus.FieldLogger) (string, error) {
 	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
-		hash := sha256.Sum256([]byte(file))
-		name := "opcode-" + hex.EncodeToString(hash[:8])
-
-		if cacheDir == "" {
-			cacheDir = os.TempDir()
-		}
-
-		cachedPath := filepath.Join(cacheDir, name)
-
-		if _, err := os.Stat(cachedPath); err == nil {
-			log.WithFields(logrus.Fields{
-				"url":  file,
-				"path": cachedPath,
-			}).Info("Using cached opcode file")
-
-			return cachedPath, nil
-		}
-
-		log.WithField("url", file).Info("Downloading opcode file")
-
 		downloadURL := file
 
 		var token string
@@ -116,25 +96,12 @@ func resolveFile(ctx context.Context, file, cacheDir, githubToken string, log lo
 			token = githubToken
 		}
 
-		tmpPath := cachedPath + ".tmp"
-
-		if err := os.MkdirAll(filepath.Dir(cachedPath), 0755); err != nil {
-			return "", fmt.Errorf("creating cache directory: %w", err)
-		}
-
-		if err := downloadToFile(ctx, downloadURL, tmpPath, token, log); err != nil {
-			_ = os.Remove(tmpPath)
-
+		res, err := fetchCached(ctx, log, file, downloadURL, token, cacheDir, "opcode")
+		if err != nil {
 			return "", err
 		}
 
-		if err := os.Rename(tmpPath, cachedPath); err != nil {
-			_ = os.Remove(tmpPath)
-
-			return "", fmt.Errorf("caching file: %w", err)
-		}
-
-		return cachedPath, nil
+		return res.Path, nil
 	}
 
 	// Local file path.


### PR DESCRIPTION
## Summary

Before this change, `pkg/executor` cached every HTTP(S) download under a path derived from `sha256(URL)`. Once downloaded, the cached file was reused forever for the same URL with zero revalidation against the origin. If you republished a `.tar.gz` at the same URL (common for GitHub release assets, re-built CI artifacts), every runner kept using the stale copy indefinitely — you had to manually delete the cache dir to force a re-download.

This PR validates cached remote files against the origin on every resolve using standard HTTP validators (`ETag` / `Last-Modified` / `Content-Length`):

- On each resolve, send a HEAD to the origin and compare the response to a sidecar `<cached-file>.meta` JSON stored next to the cached blob.
- **Validators match** → reuse cache (just cost: one HEAD roundtrip).
- **Validators differ** → re-download and refresh the sidecar.
- **No validators returned** or **HEAD fails** → reuse the cache with a warning so transient network errors or dumb servers don't force re-downloads.
- **Legacy cache entry without a sidecar** (populated by an older benchmarkoor) → re-download once to refresh the validators.

Applies to all three HTTP cache sites in `pkg/executor`:

- `archive.file` — single file
- `archive.parts[]` — each part validated independently
- `archive.parts` combined concatenated file — rebuilt when any underlying part was re-downloaded
- `opcode_source.file`

### Cache layout

```
<cacheDir>/archive-<hash>         # the cached file (unchanged)
<cacheDir>/archive-<hash>.meta    # new: {url, etag, last_modified, content_length}
```

## Test plan

- [x] Unit tests (`pkg/executor/cache_test.go`):
  - `TestFetchCached_HitWhenValidatorsMatch`
  - `TestFetchCached_MissWhenETagChanges`
  - `TestFetchCached_LegacySidecarMissingReDownloads`
  - `TestFetchCached_NoValidatorsFallsBackToCache`
  - `TestFetchCached_HeadFailureFallsBackToCache`
  - `TestFetchCached_CacheMissCoexistsWithOtherPrefixes`
- [x] `TestArchiveSource_PartsReconcatenateOnOriginChange` verifies that flipping a part's ETag triggers re-concatenation of the combined archive
- [x] All existing archive_source tests still pass
- [x] `go vet -tags exclude_graphdriver_btrfs ./...` clean
- [x] Manual: republish a `.tar.gz` at a previously-used URL and confirm the next run re-downloads; confirm an unchanged URL continues to use the cache (only adds one HEAD roundtrip)