### PR TITLE
fix(ui): show live run detail view immediately without config retries

### DIFF
--- a/ui/src/api/hooks/useRunConfig.ts
+++ b/ui/src/api/hooks/useRunConfig.ts
@@ -2,7 +2,14 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchData } from '../client'
 import type { RunConfig } from '../types'
 
-export function useRunConfig(runId: string) {
+// useRunConfig fetches a run's config.json from the storage backend.
+// Pass enabled=false to skip the fetch entirely (e.g. when the caller
+// already knows the run is live and hasn't been uploaded yet).
+//
+// retry is intentionally low: a 404 on config.json is the deterministic
+// "file not uploaded yet" state, not a transient error, so multiple
+// retries with backoff just delay the fallback live view.
+export function useRunConfig(runId: string, enabled = true) {
   return useQuery({
     queryKey: ['run', runId, 'config'],
     queryFn: async () => {
@@ -12,6 +19,7 @@ export function useRunConfig(runId: string) {
       }
       return data
     },
-    enabled: !!runId,
+    enabled: !!runId && enabled,
+    retry: 1,
   })
 }

--- a/ui/src/api/hooks/useRunResult.ts
+++ b/ui/src/api/hooks/useRunResult.ts
@@ -2,13 +2,16 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchData } from '../client'
 import type { RunResult } from '../types'
 
-export function useRunResult(runId: string) {
+// useRunResult fetches a run's result.json from the storage backend.
+// Pass enabled=false to skip the fetch (e.g. for runs we already know
+// are still live and haven't been uploaded yet).
+export function useRunResult(runId: string, enabled = true) {
   return useQuery({
     queryKey: ['run', runId, 'result'],
     queryFn: async () => {
       const { data } = await fetchData<RunResult>(`runs/${runId}/result.json`)
       return data ?? null
     },
-    enabled: !!runId,
+    enabled: !!runId && enabled,
   })
 }

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -144,12 +144,17 @@ export function RunDetailPage() {
   const stepFilter = parseStepFilter(search.steps)
   const { sortBy = 'order', sortDir = 'asc', q = '', status = 'all', testModal, preRunModal, heatmapGroup, heatmapSort, ohFs = false, blFs = false, dlModal = false, dlFmt } = search
 
-  const { data: config, isLoading: configLoading, error: configError, refetch: refetchConfig } = useRunConfig(runId)
-  const { data: result, isLoading: resultLoading, refetch: refetchResult } = useRunResult(runId)
+  const { data: liveRuns, isLoading: liveRunsLoading } = useLiveRuns()
+  const liveRun = liveRuns?.find((lr) => lr.run_id === runId)
+
+  // Skip fetching config/result on the on-disk backend while we know the
+  // run is live — the files won't exist yet, and blocking the UI on three
+  // retries of a 404'ing fetch delays the live view unnecessarily.
+  const fetchOnDisk = !liveRun
+  const { data: config, isLoading: configLoading, error: configError, refetch: refetchConfig } = useRunConfig(runId, fetchOnDisk)
+  const { data: result, isLoading: resultLoading, refetch: refetchResult } = useRunResult(runId, fetchOnDisk)
   const { data: suite } = useSuite(config?.suite_hash ?? '')
   const { data: index } = useIndex()
-  const { data: liveRuns } = useLiveRuns()
-  const liveRun = liveRuns?.find((lr) => lr.run_id === runId)
   const { data: containerLogHead, isLoading: containerLogLoading } = useQuery({
     queryKey: ['run', runId, 'container-log-head'],
     queryFn: () => fetchHead(`runs/${runId}/container.log`),
@@ -162,7 +167,7 @@ export function RunDetailPage() {
   })
   const { data: blockLogs } = useBlockLogs(runId)
 
-  const isLoading = configLoading || resultLoading
+  const isLoading = liveRunsLoading || configLoading || resultLoading
   const error = configError
 
   const [compareMode, setCompareMode] = useState(false)
@@ -285,16 +290,17 @@ export function RunDetailPage() {
     updateSearch({ dlFmt: format !== 'curl' ? format : undefined })
   }
 
-  if (isLoading) {
-    return <LoadingState message="Loading run details..." />
+  // Short-circuit: if the ingest API is reporting this run as live and
+  // we don't have a completed config.json yet, render the live view
+  // immediately. This avoids waiting for on-disk config.json retries,
+  // which would block the UI for several seconds while react-query
+  // exhausts its retry budget against a 404.
+  if (liveRun && !config) {
+    return <LiveRunDetailView run={liveRun} />
   }
 
-  // If the run is being actively reported by a runner and its files aren't
-  // yet on the storage backend, show the lightweight live view instead of
-  // the error state. Once the run finishes and config.json lands, the next
-  // refetch will drop us back into the normal detail view.
-  if (!config && liveRun) {
-    return <LiveRunDetailView run={liveRun} />
+  if (isLoading) {
+    return <LoadingState message="Loading run details..." />
   }
 
   if (error) {


### PR DESCRIPTION
## Summary
Clicking a live run row previously stalled for ~6s before the live detail view appeared. `useRunConfig` would fetch `config.json` (which doesn't exist yet on the storage backend for live runs), get a 404, and then react-query would retry the default 3 times with exponential backoff before allowing the fallback branch to render `LiveRunDetailView`.

This PR:
- **Short-circuits the render flow**: when `useLiveRuns` returns a match, render `LiveRunDetailView` immediately — before the on-disk config/result fetches have a chance to run their retry budget.
- **Disables `useRunConfig` / `useRunResult` entirely** when we already know the run is live. No point fetching a file we know doesn't exist.
- **Reduces `useRunConfig` retry** from the default 3 → 1 for the fallback case. A 404 on `config.json` is the deterministic "not uploaded yet" state, not a transient error worth retrying with backoff.

End result: live runs open in ~200ms (the latency of `useLiveRuns`) instead of ~6s.

## Test plan
- [x] TypeScript + ESLint clean
- [x] Manual: click a live run row, confirm `LiveRunDetailView` appears immediately
- [x] Manual: click a completed indexed run row, confirm the normal `RunDetailPage` still loads (and still retries once on transient 404)
- [x] Manual: navigate to a `runId` that doesn't exist at all — confirm the error state shows without excessive delay