### PR TITLE
feat(ui): show live-run ETA inline on runs table and detail page

### DIFF
--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -12,6 +12,7 @@ import { useSuite } from '@/api/hooks/useSuite'
 import { useIndex } from '@/api/hooks/useIndex'
 import { formatTimestamp } from '@/utils/date'
 import { formatNumber } from '@/utils/format'
+import { computeLiveEta, formatEtaShort, formatEtaTooltip, formatHoursMinutes, formatClockHoursMinutes } from '@/components/runs/liveEta'
 import { DEFAULT_INDEX_STEP_FILTER } from '@/api/types'
 
 interface LiveRunDetailViewProps {
@@ -42,6 +43,10 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
   const rollbackStrategy = cfg?.instance.rollback_strategy ?? run.rollback_strategy
   const startTimestamp = cfg?.timestamp ?? run.timestamp
   const labels = cfg?.metadata?.labels ?? run.metadata
+
+  const eta = computeLiveEta(startTimestamp, completed, total)
+  const etaShort = formatEtaShort(eta)
+  const etaTooltip = formatEtaTooltip(eta)
 
   const clientRuns = useMemo(() => {
     if (!index || !run.suite_hash || !clientName) return []
@@ -124,11 +129,20 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
         </div>
         <div className="col-span-3 rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
           <p className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Progress</p>
-          <p className="mt-1 text-2xl/8 font-semibold text-gray-900 dark:text-gray-100">
-            {total > 0 ? `${progress.toFixed(1)}%` : '-'}
+          <p className="mt-1 flex items-baseline gap-3 text-2xl/8 font-semibold text-gray-900 dark:text-gray-100">
+            <span>{total > 0 ? `${progress.toFixed(1)}%` : '-'}</span>
+            {etaShort && (
+              <span
+                className="text-sm/6 font-normal text-gray-500 dark:text-gray-400"
+                title={etaTooltip}
+              >
+                {etaShort}
+              </span>
+            )}
           </p>
-          <p className="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
-            {formatNumber(completed)} of {formatNumber(total)} tests complete
+          <p className="mt-2 text-xs/5 text-gray-500 dark:text-gray-400" title={etaTooltip}>
+            {formatNumber(completed)} of {formatNumber(total)} tests complete · Elapsed {formatHoursMinutes(eta.elapsedSec)}
+            {eta.etaAtMs !== undefined && <> · ETA {formatClockHoursMinutes(new Date(eta.etaAtMs))}</>}
           </p>
           <div className="mt-2 h-1.5 w-full overflow-hidden rounded-sm bg-gray-200 dark:bg-gray-700">
             <div

--- a/ui/src/components/runs/RunsTable.tsx
+++ b/ui/src/components/runs/RunsTable.tsx
@@ -12,6 +12,7 @@ import { Tag } from 'lucide-react'
 import { formatTimestampDate, formatTimestampTime, formatRelativeTime } from '@/utils/date'
 import { formatDuration, formatNumber } from '@/utils/format'
 import { type SortColumn, type SortDirection } from './sortEntries'
+import { computeLiveEta, formatEtaShort, formatEtaTooltip } from './liveEta'
 
 // Calculates MGas/s from gas_used and gas_used_duration
 function calculateMGasPerSec(gasUsed: number, gasUsedDuration: number): number | undefined {
@@ -295,6 +296,7 @@ export function RunsTable({
                           passed={entry.tests.tests_passed}
                           failed={entry.tests.tests_failed}
                           total={entry.tests.tests_total}
+                          startTimestamp={entry.timestamp}
                         />
                       ) : entry.timestamp_end ? (
                         <Duration nanoseconds={(entry.timestamp_end - entry.timestamp) * 1_000_000_000} />
@@ -379,18 +381,26 @@ export function RunsTable({
   )
 }
 
-// LiveProgress renders the test progress for an in-progress run. It shows
-// "N / total" and a thin progress bar scaled by completed-fraction of the
-// total tests.
-function LiveProgress({ passed, failed, total }: { passed: number; failed: number; total: number }) {
+// LiveProgress renders the test progress for an in-progress run. Shows
+// "N / total" plus an ETA line and a thin progress bar. Hover adds
+// full tooltip detail (elapsed, remaining, wall-clock ETA).
+function LiveProgress({ passed, failed, total, startTimestamp }: { passed: number; failed: number; total: number; startTimestamp: number }) {
   const completed = passed + failed
   const pct = total > 0 ? Math.min(100, (completed / total) * 100) : 0
 
+  const eta = computeLiveEta(startTimestamp, completed, total)
+  const etaShort = formatEtaShort(eta)
+
   return (
-    <div className="inline-flex min-w-[5rem] flex-col items-end gap-1">
+    <div className="inline-flex min-w-[5rem] flex-col items-end gap-1" title={formatEtaTooltip(eta)}>
       <span className="text-xs/5 tabular-nums">
         {completed}/{total || '?'}
       </span>
+      {etaShort && (
+        <span className="text-[10px]/3 text-gray-400 tabular-nums dark:text-gray-500">
+          {etaShort}
+        </span>
+      )}
       <div className="h-1 w-full overflow-hidden rounded-sm bg-gray-200 dark:bg-gray-700">
         <div
           className="h-full bg-blue-500 transition-all dark:bg-blue-400"

--- a/ui/src/components/runs/liveEta.ts
+++ b/ui/src/components/runs/liveEta.ts
@@ -1,0 +1,83 @@
+export interface LiveEta {
+  /** Seconds of wall-clock time since the run started. Always present. */
+  elapsedSec: number
+  /**
+   * Seconds estimated before the run completes, if computable. undefined
+   * when we haven't seen any completed tests yet or have no total to
+   * compare against.
+   */
+  remainingSec?: number
+  /** Unix ms timestamp of the predicted completion, if computable. */
+  etaAtMs?: number
+}
+
+/**
+ * computeLiveEta produces a rolling-average estimate of remaining time
+ * from the observed per-test rate. Returns undefined fields when we
+ * can't compute (e.g. before the first test completes).
+ */
+export function computeLiveEta(startTimestampSec: number, completed: number, total: number): LiveEta {
+  const nowMs = Date.now()
+  const nowSec = Math.floor(nowMs / 1000)
+  const elapsedSec = Math.max(0, nowSec - startTimestampSec)
+
+  if (completed <= 0 || total <= 0 || completed >= total) {
+    return { elapsedSec }
+  }
+
+  const remainingSec = Math.round((elapsedSec / completed) * (total - completed))
+  return { elapsedSec, remainingSec, etaAtMs: nowMs + remainingSec * 1000 }
+}
+
+/**
+ * Compact "~5m" label for placing next to progress counts.
+ */
+export function formatEtaShort(eta: LiveEta): string | undefined {
+  if (eta.remainingSec === undefined) return undefined
+  return `~${formatHoursMinutes(eta.remainingSec)} left`
+}
+
+/**
+ * Multi-line tooltip with elapsed, remaining, and completion time.
+ */
+export function formatEtaTooltip(eta: LiveEta): string {
+  const lines = [`Elapsed: ${formatHoursMinutes(eta.elapsedSec)}`]
+
+  if (eta.remainingSec !== undefined) {
+    lines.push(`~${formatHoursMinutes(eta.remainingSec)} remaining`)
+  }
+
+  if (eta.etaAtMs !== undefined) {
+    lines.push(`ETA: ${formatClockHoursMinutes(new Date(eta.etaAtMs))}`)
+  }
+
+  if (eta.remainingSec === undefined && eta.elapsedSec >= 0) {
+    lines.push('ETA: unknown (no tests completed yet)')
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * formatHoursMinutes renders seconds as h/m, rounded to the nearest minute
+ * (with a minimum display of "< 1m" when under 30s).
+ */
+export function formatHoursMinutes(totalSeconds: number): string {
+  if (totalSeconds < 30) return '< 1m'
+
+  const totalMinutes = Math.round(totalSeconds / 60)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+
+  if (hours === 0) return `${minutes}m`
+  if (minutes === 0) return `${hours}h`
+  return `${hours}h ${minutes}m`
+}
+
+/**
+ * formatClockHoursMinutes renders a Date as "HH:MM" in the browser's
+ * current locale without seconds.
+ */
+export function formatClockHoursMinutes(d: Date): string {
+  return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}


### PR DESCRIPTION
## Summary
Live runs now show an inline ETA (not just on hover) so you can see at a glance how much time is left.

- **Runs table** (live row's Duration cell): adds a small `~5m left` line below the `7/150` counts.
- **Live run detail page** (Progress card): adds `~5m left` next to the percentage and `Elapsed 12m · ETA 16:42` on the counts line.
- **Hover tooltip** continues to show the full breakdown (elapsed, remaining, wall-clock ETA).

Durations are rendered in hours + minutes only (no seconds); anything under 30s shows `< 1m`. Wall-clock ETA uses `HH:MM` in the browser's locale.

Shared helpers live in `ui/src/components/runs/liveEta.ts` (`computeLiveEta`, `formatEtaShort`, `formatEtaTooltip`, `formatHoursMinutes`, `formatClockHoursMinutes`) so the table and detail page stay consistent.

## Test plan
- [x] TypeScript + ESLint clean
- [x] Manual: start a long-running benchmark, view the runs table and the live run detail page; confirm ETA updates as tests complete and matches the hover tooltip
- [x] Manual: confirm "< 1m" displays correctly when ≤ 30s remain
- [x] Manual: confirm "ETA: unknown (no tests completed yet)" shows in tooltip before the first test completes