### PR TITLE
fix(ui): avoid empty-state flicker on suite detail page

### DIFF
--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -286,7 +286,7 @@ export function SuiteDetailPage() {
   const labelFilters = parseLabelFilters(search.labels)
   const { data: suite, isLoading, error, refetch } = useSuite(suiteHash)
   const { data: suiteStats, isLoading: suiteStatsLoading } = useSuiteStats(suiteHash)
-  const { data: index } = useIndex()
+  const { data: index, isLoading: indexLoading } = useIndex()
   const { data: liveRuns } = useLiveRuns()
   const [runsPage, setRunsPage] = useState(1)
   const [runsPageSize, setRunsPageSize] = useState(DEFAULT_PAGE_SIZE)
@@ -903,7 +903,11 @@ export function SuiteDetailPage() {
         </TabList>
         <TabPanels className="mt-4">
           <TabPanel>
-            {suiteRunsAll.length === 0 ? (
+            {indexLoading && suiteRunsAll.length === 0 ? (
+              <div className="flex justify-center py-8">
+                <Spinner size="md" />
+              </div>
+            ) : suiteRunsAll.length === 0 ? (
               <p className="py-8 text-center text-sm/6 text-gray-500 dark:text-gray-400">
                 No runs found for this suite.
               </p>


### PR DESCRIPTION
## Summary
`useIndex()`'s `isLoading` wasn't consumed on the suite detail page, so while the index was still loading, `suiteRunsAll` was empty and the "No runs found for this suite" message briefly flashed before the real runs rendered.

Now:
- While the index is still loading and no runs are available yet → show a spinner.
- Once the index has resolved → either render the runs table, or (if genuinely zero runs for the suite) show the empty-state message.

## Test plan
- [x] TypeScript + ESLint clean
- [x] Manual: hard-reload a suite detail page, confirm no "No runs found" flash — spinner appears instead until the runs load
- [x] Manual: navigate to a suite that has genuinely zero runs, confirm the empty-state message still appears