### PR TITLE
fix(ui): skip public/results symlink when building

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,10 +1,42 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import { resolve } from 'path'
+import { cpSync, readdirSync } from 'fs'
+import { join, resolve } from 'path'
+
+// Entries under public/ that we deliberately skip when copying into the
+// build output. Avoids Vite following the `public/results -> ../../results`
+// symlink used in local dev, which would pull tens of GB of benchmark
+// output (and sometimes unreadable files) into dist/.
+const publicSkip = new Set(['results'])
+
+// copyPublicFiltered reproduces Vite's default public-dir copy, minus the
+// entries listed in publicSkip. Used together with `build.copyPublicDir:
+// false` to opt out of the built-in recursive copy.
+function copyPublicFiltered(): Plugin {
+  return {
+    name: 'benchmarkoor:copy-public-filtered',
+    apply: 'build',
+    closeBundle() {
+      const src = resolve(__dirname, 'public')
+      const dst = resolve(__dirname, 'dist')
+
+      for (const entry of readdirSync(src, { withFileTypes: true })) {
+        if (publicSkip.has(entry.name)) continue
+
+        cpSync(join(src, entry.name), join(dst, entry.name), {
+          recursive: true,
+          // Copy the target of a symlink, not the link itself, to match
+          // Vite's default behaviour for the other static assets.
+          dereference: true,
+        })
+      }
+    },
+  }
+}
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), copyPublicFiltered()],
   base: '/',
   resolve: {
     alias: {
@@ -14,6 +46,8 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     assetsDir: 'assets',
+    // Disabled so the filtered copy above is the single source of truth.
+    copyPublicDir: false,
   },
   server: {
     watch: {


### PR DESCRIPTION
## Summary
\`ui/public/results\` is a symlink to the top-level \`results/\` dir for local dev. Vite's default public-dir copy follows it and tries to recursively duplicate the entire benchmark output (tens of GB, sometimes unreadable files) into \`dist/\` — which breaks \`make build-ui\` with \`EACCES\`.

This PR disables Vite's built-in public-dir copy (\`build.copyPublicDir: false\`) and replaces it with a small plugin that walks \`public/\` and skips the \`results\` entry. Everything else (\`config.json\`, \`config.docker.json\`, \`favicon.ico\`, \`favicon.png\`, \`img/\`) is copied as before.

## Test plan
- [x] \`npm run build\` completes cleanly (was failing before)
- [x] \`dist/\` contains only the legit static assets — no \`results/\` dir
- [x] Manual: \`make build-ui\` on a clean checkout produces the same output