### PR TITLE
feat: live MGas/s, per-test heatmap, and progress animations

### DIFF
--- a/pkg/api/handlers_ingest.go
+++ b/pkg/api/handlers_ingest.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/ethpandaops/benchmarkoor/pkg/api/indexstore"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/api/indexstore"
 )
 
 // handleIngestRun accepts a periodic status report from a benchmarkoor
@@ -71,6 +72,15 @@ func (s *server) handleIngestRun(w http.ResponseWriter, r *http.Request) {
 		fields["termination_reason"] = report.TerminationReason
 	}
 
+	if report.TotalGasUsedDurationNs > 0 {
+		fields["total_gas_used"] = report.TotalGasUsed
+		fields["total_gas_used_duration_ns"] = report.TotalGasUsedDurationNs
+	}
+
+	if len(report.Tests) > 0 {
+		fields["tests_in_payload"] = len(report.Tests)
+	}
+
 	s.log.WithFields(fields).Info("Received live run report")
 
 	w.WriteHeader(http.StatusNoContent)
@@ -99,22 +109,24 @@ func (s *server) handleListLiveRuns(w http.ResponseWriter, r *http.Request) {
 // toLiveRunResponse converts a LiveRun model to its JSON DTO.
 func toLiveRunResponse(r *indexstore.LiveRun) indexstore.LiveRunResponse {
 	resp := indexstore.LiveRunResponse{
-		ID:                r.ID,
-		DiscoveryPath:     r.DiscoveryPath,
-		RunID:             r.RunID,
-		Timestamp:         r.Timestamp,
-		TimestampEnd:      r.TimestampEnd,
-		SuiteHash:         r.SuiteHash,
-		Status:            r.Status,
-		TerminationReason: r.TerminationReason,
-		InstanceID:        r.InstanceID,
-		Client:            r.Client,
-		Image:             r.Image,
-		RollbackStrategy:  r.RollbackStrategy,
-		TestsTotal:        r.TestsTotal,
-		TestsPassed:       r.TestsPassed,
-		TestsFailed:       r.TestsFailed,
-		LastReportedAt:    r.LastReportedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		ID:                     r.ID,
+		DiscoveryPath:          r.DiscoveryPath,
+		RunID:                  r.RunID,
+		Timestamp:              r.Timestamp,
+		TimestampEnd:           r.TimestampEnd,
+		SuiteHash:              r.SuiteHash,
+		Status:                 r.Status,
+		TerminationReason:      r.TerminationReason,
+		InstanceID:             r.InstanceID,
+		Client:                 r.Client,
+		Image:                  r.Image,
+		RollbackStrategy:       r.RollbackStrategy,
+		TestsTotal:             r.TestsTotal,
+		TestsPassed:            r.TestsPassed,
+		TestsFailed:            r.TestsFailed,
+		TotalGasUsed:           r.TotalGasUsed,
+		TotalGasUsedDurationNs: r.TotalGasUsedDurationNs,
+		LastReportedAt:         r.LastReportedAt.UTC().Format("2006-01-02T15:04:05Z"),
 	}
 
 	if r.MetadataJSON != "" {
@@ -126,6 +138,13 @@ func toLiveRunResponse(r *indexstore.LiveRun) indexstore.LiveRunResponse {
 
 	if r.ConfigJSON != "" {
 		resp.Config = json.RawMessage(r.ConfigJSON)
+	}
+
+	if r.TestsJSON != "" {
+		var tests map[string]indexstore.LiveTestStats
+		if err := json.Unmarshal([]byte(r.TestsJSON), &tests); err == nil {
+			resp.Tests = tests
+		}
 	}
 
 	return resp

--- a/pkg/api/handlers_ingest.go
+++ b/pkg/api/handlers_ingest.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -13,8 +14,20 @@ import (
 // runner and upserts it into the live_runs table. Always returns 204 on
 // success so the runner can fire-and-forget.
 func (s *server) handleIngestRun(w http.ResponseWriter, r *http.Request) {
+	// Read the body fully so we can log its decompressed size — useful
+	// for spotting payload growth (the per-test gas map scales with
+	// suite size). The middleware already inflates Content-Encoding:
+	// gzip bodies, so this size is post-decompression.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest,
+			errorResponse{"failed to read request body"})
+
+		return
+	}
+
 	var report indexstore.LiveRunReport
-	if err := json.NewDecoder(r.Body).Decode(&report); err != nil {
+	if err := json.Unmarshal(body, &report); err != nil {
 		writeJSON(w, http.StatusBadRequest,
 			errorResponse{"invalid request body"})
 
@@ -62,6 +75,11 @@ func (s *server) handleIngestRun(w http.ResponseWriter, r *http.Request) {
 		"tests_passed":   report.TestsPassed,
 		"tests_failed":   report.TestsFailed,
 		"has_config":     len(report.Config) > 0,
+		// payload_bytes is the decoded JSON size; payload_gzip_bytes is
+		// the on-the-wire size (== payload_bytes when the runner did not
+		// gzip). Both are useful for spotting payload growth.
+		"payload_bytes":      len(body),
+		"payload_gzip_bytes": compressedRequestSize(r),
 	}
 
 	if report.SuiteHash != "" {

--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -261,19 +261,21 @@ func (s *store) UpsertLiveRun(ctx context.Context, r *LiveRunReport) error {
 	// Always-written fields. We use Updates() with a map so an empty map is
 	// not interpreted as "clear all fields".
 	fields := map[string]any{
-		"timestamp":          r.Timestamp,
-		"timestamp_end":      r.TimestampEnd,
-		"suite_hash":         r.SuiteHash,
-		"status":             r.Status,
-		"termination_reason": r.TerminationReason,
-		"instance_id":        r.InstanceID,
-		"client":             r.Client,
-		"image":              r.Image,
-		"rollback_strategy":  r.RollbackStrategy,
-		"tests_total":        r.TestsTotal,
-		"tests_passed":       r.TestsPassed,
-		"tests_failed":       r.TestsFailed,
-		"last_reported_at":   now,
+		"timestamp":                  r.Timestamp,
+		"timestamp_end":              r.TimestampEnd,
+		"suite_hash":                 r.SuiteHash,
+		"status":                     r.Status,
+		"termination_reason":         r.TerminationReason,
+		"instance_id":                r.InstanceID,
+		"client":                     r.Client,
+		"image":                      r.Image,
+		"rollback_strategy":          r.RollbackStrategy,
+		"tests_total":                r.TestsTotal,
+		"tests_passed":               r.TestsPassed,
+		"tests_failed":               r.TestsFailed,
+		"total_gas_used":             r.TotalGasUsed,
+		"total_gas_used_duration_ns": r.TotalGasUsedDurationNs,
+		"last_reported_at":           now,
 	}
 
 	if r.Metadata != nil {
@@ -290,6 +292,19 @@ func (s *store) UpsertLiveRun(ctx context.Context, r *LiveRunReport) error {
 	// so a later zero-config report doesn't wipe an earlier good one.
 	if len(r.Config) > 0 {
 		fields["config_json"] = string(r.Config)
+	}
+
+	// Per-test gas map. Always write when the runner sends one (even an
+	// empty map is meaningful — it means "no tests have completed yet"
+	// and the heatmap should clear). Nil means the runner hasn't started
+	// reporting tests, in which case we preserve the previous value.
+	if r.Tests != nil {
+		b, err := json.Marshal(r.Tests)
+		if err != nil {
+			return fmt.Errorf("marshalling tests: %w", err)
+		}
+
+		fields["tests_json"] = string(b)
 	}
 
 	seed := &LiveRun{

--- a/pkg/api/indexstore/indexstore_test.go
+++ b/pkg/api/indexstore/indexstore_test.go
@@ -2,6 +2,7 @@ package indexstore_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -389,6 +390,60 @@ func TestStore_UpsertLiveRun_InsertAndUpdate(t *testing.T) {
 	assert.Equal(t, first.ID, live[0].ID)
 	assert.Equal(t, 7, live[0].TestsPassed)
 	assert.Equal(t, 1, live[0].TestsFailed)
+}
+
+func TestStore_UpsertLiveRun_GasAndTestsRoundTrip(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	// First report carries running gas totals plus a per-test gas map
+	// (one passed, one failed). All of it lives on the live_runs row;
+	// the canonical Run / TestStat tables stay untouched.
+	require.NoError(t, s.UpsertLiveRun(ctx, &indexstore.LiveRunReport{
+		DiscoveryPath:          "dp/live",
+		RunID:                  "run-1",
+		Timestamp:              1000,
+		Status:                 "running",
+		TotalGasUsed:           1_500_000_000,
+		TotalGasUsedDurationNs: 500_000_000,
+		Tests: map[string]indexstore.LiveTestStats{
+			"alpha": {Passed: true, GasUsed: 1_000, GasUsedDurationNs: 500_000},
+			"beta":  {Passed: false},
+		},
+	}))
+
+	live, err := s.ListLiveRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	got := live[0]
+	assert.Equal(t, int64(1_500_000_000), got.TotalGasUsed)
+	assert.Equal(t, int64(500_000_000), got.TotalGasUsedDurationNs)
+	require.NotEmpty(t, got.TestsJSON, "tests_json should round-trip")
+
+	var decoded map[string]indexstore.LiveTestStats
+	require.NoError(t, json.Unmarshal([]byte(got.TestsJSON), &decoded))
+	require.Len(t, decoded, 2)
+	assert.True(t, decoded["alpha"].Passed)
+	assert.Equal(t, int64(1_000), decoded["alpha"].GasUsed)
+	assert.False(t, decoded["beta"].Passed)
+
+	// A nil Tests map means "no update" — the previously-stored map
+	// stays put rather than being wiped to "{}".
+	require.NoError(t, s.UpsertLiveRun(ctx, &indexstore.LiveRunReport{
+		DiscoveryPath:          "dp/live",
+		RunID:                  "run-1",
+		Timestamp:              1000,
+		Status:                 "running",
+		TotalGasUsed:           3_000_000_000,
+		TotalGasUsedDurationNs: 1_000_000_000,
+	}))
+
+	live, err = s.ListLiveRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	got = live[0]
+	assert.Equal(t, int64(3_000_000_000), got.TotalGasUsed, "gas totals should update")
+	assert.NotEmpty(t, got.TestsJSON, "nil Tests should not wipe stored value")
 }
 
 func TestStore_LiveRun_DoesNotInterfereWithRun(t *testing.T) {

--- a/pkg/api/indexstore/live_run.go
+++ b/pkg/api/indexstore/live_run.go
@@ -32,6 +32,12 @@ type LiveRun struct {
 	TestsPassed int
 	TestsFailed int
 
+	// Running totals from the test step of completed tests, used to
+	// compute a live MGas/s estimate. Both stay zero until the first
+	// test completes.
+	TotalGasUsed           int64
+	TotalGasUsedDurationNs int64
+
 	// Run metadata labels serialized as JSON.
 	MetadataJSON string `gorm:"type:text"`
 
@@ -40,12 +46,19 @@ type LiveRun struct {
 	// the runner has built its RunConfig.
 	ConfigJSON string `gorm:"type:text"`
 
+	// TestsJSON is a JSON-encoded map[string]LiveTestStats covering every
+	// completed test (success or failure). Written by every snapshot
+	// report so the live heatmap stays consistent with the rest of the
+	// snapshot. Empty until the first test completes.
+	TestsJSON string `gorm:"type:text"`
+
 	// LastReportedAt is updated on every report from the runner.
 	LastReportedAt time.Time `gorm:"index"`
 }
 
 // LiveRunReport is the payload a runner sends to POST /api/v1/ingest/runs
-// to update the live status of a run in progress.
+// to update the live status of a run in progress. Carries one consistent
+// snapshot of everything observable about the run at this point in time.
 type LiveRunReport struct {
 	DiscoveryPath     string            `json:"discovery_path"`
 	RunID             string            `json:"run_id"`
@@ -62,6 +75,20 @@ type LiveRunReport struct {
 	TestsPassed       int               `json:"tests_passed"`
 	TestsFailed       int               `json:"tests_failed"`
 	Metadata          map[string]string `json:"metadata,omitempty"`
+
+	// Running totals from the test step of completed tests, used to
+	// compute a live MGas/s estimate. Both stay zero until the first
+	// test completes.
+	TotalGasUsed           int64 `json:"total_gas_used,omitempty"`
+	TotalGasUsedDurationNs int64 `json:"total_gas_used_duration_ns,omitempty"`
+
+	// Tests is the per-test gas map covering every completed test
+	// (success or failure). Failed tests carry zero gas data so the live
+	// heatmap can render fail tiles. Sent in every snapshot so the data
+	// is consistent with the aggregate counters above for the same point
+	// in time. The runner gzips the request body when this map is large.
+	Tests map[string]LiveTestStats `json:"tests,omitempty"`
+
 	// Config is the full run config.json content at the time of the report.
 	// Passed through verbatim to the UI so it can render the normal run
 	// configuration panels without needing the file to be on disk yet.
@@ -86,6 +113,27 @@ type LiveRunResponse struct {
 	TestsPassed       int               `json:"tests_passed"`
 	TestsFailed       int               `json:"tests_failed"`
 	Metadata          map[string]string `json:"metadata,omitempty"`
-	Config            json.RawMessage   `json:"config,omitempty"`
-	LastReportedAt    string            `json:"last_reported_at"`
+
+	// Running totals from the test step of completed tests, used to
+	// compute a live MGas/s estimate. Both stay zero until the first
+	// test completes.
+	TotalGasUsed           int64 `json:"total_gas_used,omitempty"`
+	TotalGasUsedDurationNs int64 `json:"total_gas_used_duration_ns,omitempty"`
+
+	// Tests is the per-test gas map decoded from the row's stored
+	// tests_json column. Drives the live Performance Heatmap on the live
+	// run detail view.
+	Tests map[string]LiveTestStats `json:"tests,omitempty"`
+
+	Config         json.RawMessage `json:"config,omitempty"`
+	LastReportedAt string          `json:"last_reported_at"`
+}
+
+// LiveTestStats is the per-test record exposed in the live snapshot.
+// Failed tests carry zero gas data so the heatmap can still render them
+// as fail tiles.
+type LiveTestStats struct {
+	Passed            bool  `json:"passed"`
+	GasUsed           int64 `json:"gas_used,omitempty"`
+	GasUsedDurationNs int64 `json:"gas_used_duration_ns,omitempty"`
 }

--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/subtle"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -15,7 +16,26 @@ import (
 
 type contextKey string
 
-const userContextKey contextKey = "user"
+const (
+	userContextKey                  contextKey = "user"
+	compressedRequestSizeContextKey contextKey = "compressed_request_size"
+)
+
+// countingReader wraps an io.Reader and tracks total bytes read. Used by
+// gzipRequestBody to surface the on-the-wire (gzipped) request size to
+// handlers via context — the decompressed body size is just len(body)
+// at the handler.
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+
+	return n, err
+}
 
 // requestLogger logs incoming HTTP requests with status code, bytes written,
 // and duration. Canceled or slow/errored requests are logged at Warn level.
@@ -249,7 +269,12 @@ func (s *server) gzipRequestBody(next http.Handler) http.Handler {
 			return
 		}
 
-		gz, err := gzip.NewReader(r.Body)
+		// Wrap the raw body in a counter so handlers can log the
+		// on-the-wire size after they finish reading. The counter
+		// accumulates as gzip.NewReader pulls compressed bytes through.
+		cr := &countingReader{r: r.Body}
+
+		gz, err := gzip.NewReader(cr)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest,
 				errorResponse{"invalid gzip request body"})
@@ -267,6 +292,21 @@ func (s *server) gzipRequestBody(next http.Handler) http.Handler {
 		r.Header.Del("Content-Length")
 		r.ContentLength = -1
 
-		next.ServeHTTP(w, r)
+		ctx := context.WithValue(r.Context(), compressedRequestSizeContextKey, cr)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// compressedRequestSize returns the number of compressed (on-the-wire)
+// bytes read by gzipRequestBody for the current request. Returns 0 when
+// the request was not gzipped or the middleware did not run. Must be
+// called after the handler has fully read the body — until then the
+// counter is incomplete.
+func compressedRequestSize(r *http.Request) int64 {
+	cr, ok := r.Context().Value(compressedRequestSizeContextKey).(*countingReader)
+	if !ok {
+		return 0
+	}
+
+	return cr.n
 }

--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"compress/gzip"
 	"context"
 	"crypto/subtle"
 	"net/http"
@@ -231,6 +232,40 @@ func (s *server) requireIngestToken(next http.Handler) http.Handler {
 
 			return
 		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// gzipRequestBody transparently inflates gzipped request bodies so
+// downstream handlers can read them as if they were uncompressed. Used on
+// the ingest subrouter where the runner posts large gzipped payloads
+// (per-test heatmap data). A malformed gzip stream is returned as 400.
+func (s *server) gzipRequestBody(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.EqualFold(r.Header.Get("Content-Encoding"), "gzip") {
+			next.ServeHTTP(w, r)
+
+			return
+		}
+
+		gz, err := gzip.NewReader(r.Body)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest,
+				errorResponse{"invalid gzip request body"})
+
+			return
+		}
+		defer func() { _ = gz.Close() }()
+
+		// Replace the body with the decompressed reader. Strip the header
+		// so handlers can rely on Content-Length being absent rather than
+		// stale. ContentLength is also reset because it referred to the
+		// compressed size.
+		r.Body = gz
+		r.Header.Del("Content-Encoding")
+		r.Header.Del("Content-Length")
+		r.ContentLength = -1
 
 		next.ServeHTTP(w, r)
 	})

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -103,6 +103,11 @@ func (s *server) buildRouter() http.Handler {
 		if s.indexStore != nil && s.cfg.Ingest != nil && s.cfg.Ingest.Token != "" {
 			r.Route("/ingest", func(r chi.Router) {
 				r.Use(s.requireIngestToken)
+				// Inflate gzipped request bodies. The snapshot payload can
+				// grow large (it carries the per-test gas map for the live
+				// heatmap), so the runner gzips it. The middleware is a
+				// no-op when Content-Encoding is absent.
+				r.Use(s.gzipRequestBody)
 
 				if s.cfg.Server.RateLimit.Enabled {
 					r.Use(s.rateLimitMiddleware(

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptrace"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"text/template"
 	"time"
@@ -60,13 +62,30 @@ type Executor interface {
 	// times per run (e.g. checkpoint-restore, container-recreate) rely on
 	// this so the counters accumulate across calls instead of being reset.
 	ResetProgress(total int)
+
+	// GetLiveTests returns a defensive copy of the per-test stats map
+	// recorded by ExecuteTests as each test completes (success or failure).
+	// Entries with Passed=false carry zero gas data. The map is keyed by
+	// test name and includes one entry per completed test.
+	GetLiveTests() map[string]LiveTestStats
 }
 
 // ProgressSnapshot is a point-in-time view of the executor's test progress.
 type ProgressSnapshot struct {
-	TestsTotal  int
-	TestsPassed int
-	TestsFailed int
+	TestsTotal             int
+	TestsPassed            int
+	TestsFailed            int
+	TotalGasUsed           int64 // running sum of test-step gas_used
+	TotalGasUsedDurationNs int64 // running sum of test-step gas_used_duration (ns)
+}
+
+// LiveTestStats is the per-test record exposed via GetLiveTests for the
+// live heatmap. Failed tests are recorded with Passed=false and zero gas
+// so the heatmap can render fail tiles in real time.
+type LiveTestStats struct {
+	Passed            bool
+	GasUsed           int64
+	GasUsedDurationNs int64
 }
 
 // BlockLogCollector is an interface for capturing JSON payloads from client logs.
@@ -138,9 +157,17 @@ type executor struct {
 
 	// Live progress counters updated during ExecuteTests. Safe to read
 	// concurrently via GetProgress().
-	progressTotal  atomic.Int64
-	progressPassed atomic.Int64
-	progressFailed atomic.Int64
+	progressTotal           atomic.Int64
+	progressPassed          atomic.Int64
+	progressFailed          atomic.Int64
+	progressGasUsed         atomic.Int64 // sum of test-step gas_used for completed tests
+	progressGasUsedDuration atomic.Int64 // sum of test-step gas_used_duration (nanoseconds)
+
+	// Per-test live state: full map (one entry per completed test).
+	// Snapshot reports include this so the UI can render a live
+	// Performance Heatmap that grows as tests complete.
+	liveTestsMu sync.RWMutex
+	liveTests   map[string]LiveTestStats
 }
 
 // Ensure interface compliance.
@@ -259,9 +286,11 @@ func (e *executor) GetSource() Source {
 // Safe to call concurrently from any goroutine while ExecuteTests runs.
 func (e *executor) GetProgress() ProgressSnapshot {
 	return ProgressSnapshot{
-		TestsTotal:  int(e.progressTotal.Load()),
-		TestsPassed: int(e.progressPassed.Load()),
-		TestsFailed: int(e.progressFailed.Load()),
+		TestsTotal:             int(e.progressTotal.Load()),
+		TestsPassed:            int(e.progressPassed.Load()),
+		TestsFailed:            int(e.progressFailed.Load()),
+		TotalGasUsed:           e.progressGasUsed.Load(),
+		TotalGasUsedDurationNs: e.progressGasUsedDuration.Load(),
 	}
 }
 
@@ -271,6 +300,45 @@ func (e *executor) ResetProgress(total int) {
 	e.progressTotal.Store(int64(total))
 	e.progressPassed.Store(0)
 	e.progressFailed.Store(0)
+	e.progressGasUsed.Store(0)
+	e.progressGasUsedDuration.Store(0)
+
+	e.liveTestsMu.Lock()
+	e.liveTests = make(map[string]LiveTestStats, total)
+	e.liveTestsMu.Unlock()
+}
+
+// GetLiveTests returns a defensive copy of the per-test stats map. Safe
+// to call concurrently from any goroutine. Returns an empty (non-nil)
+// map when no tests have completed yet.
+func (e *executor) GetLiveTests() map[string]LiveTestStats {
+	e.liveTestsMu.RLock()
+	defer e.liveTestsMu.RUnlock()
+
+	out := make(map[string]LiveTestStats, len(e.liveTests))
+	maps.Copy(out, e.liveTests)
+
+	return out
+}
+
+// recordTestCompletion writes a single completed test into the live map.
+// Called from the test loop once per iteration regardless of pass/fail.
+// Failed tests carry zero gas data so the heatmap can render fail tiles.
+func (e *executor) recordTestCompletion(name string, passed bool, gasUsed, gasUsedDurationNs int64) {
+	stats := LiveTestStats{
+		Passed:            passed,
+		GasUsed:           gasUsed,
+		GasUsedDurationNs: gasUsedDurationNs,
+	}
+
+	e.liveTestsMu.Lock()
+	defer e.liveTestsMu.Unlock()
+
+	if e.liveTests == nil {
+		e.liveTests = make(map[string]LiveTestStats)
+	}
+
+	e.liveTests[name] = stats
 }
 
 // RunPreRunSteps executes the suite's pre-run steps against the given endpoint.
@@ -456,6 +524,15 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 
 		testPassed := true
 
+		// Per-test gas data captured from the test step's aggregated stats
+		// (zero unless the test step ran and produced a result). Hoisted
+		// out of the test-step branch so we can also feed the per-test
+		// live record at the bottom of the loop.
+		var (
+			testGasUsed           int64
+			testGasUsedDurationNs int64
+		)
+
 		// Run setup step if present.
 		if test.Setup != nil {
 			log.Info("Running setup step")
@@ -517,6 +594,15 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 				// Write test results.
 				if err := WriteStepResults(opts.ResultsDir, test.Name, StepTypeTest, testResult, e.cfg.ResultsOwner); err != nil {
 					log.WithError(err).Warn("Failed to write test results")
+				}
+
+				// Capture this test's gas usage. Recorded into the running
+				// totals (drives live MGas/s) and into the per-test map
+				// (drives the live heatmap) at the bottom of the loop.
+				stats := testResult.CalculateStats()
+				if stats.GasUsedTotal > 0 && stats.GasUsedTimeTotal > 0 {
+					testGasUsed = int64(stats.GasUsedTotal) //nolint:gosec // gas values fit comfortably in int64
+					testGasUsedDurationNs = stats.GasUsedTimeTotal
 				}
 			}
 		}
@@ -602,6 +688,17 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 			e.progressFailed.Add(1)
 			log.Warn("Test completed with failures")
 		}
+
+		// Update live aggregate gas counters and the per-test/recent
+		// records together. testGasUsed/testGasUsedDurationNs stay zero
+		// for failed tests or tests with no test step — that's fine, the
+		// heatmap renders such entries as fail / no-data tiles.
+		if testGasUsedDurationNs > 0 {
+			e.progressGasUsed.Add(testGasUsed)
+			e.progressGasUsedDuration.Add(testGasUsedDurationNs)
+		}
+
+		e.recordTestCompletion(test.Name, testPassed, testGasUsed, testGasUsedDurationNs)
 	}
 
 writeResults:

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -107,3 +107,73 @@ func TestBuildJSONRPCPayload(t *testing.T) {
 	assert.Contains(t, payload, `"id":1`)
 	assert.Contains(t, payload, `"0x4d2"`)
 }
+
+func TestExecutor_ProgressGasCounters(t *testing.T) {
+	e := &executor{}
+
+	// ResetProgress seeds the total and zeroes everything else, including
+	// the new gas counters that the test loop accumulates as each test
+	// completes.
+	e.ResetProgress(42)
+
+	got := e.GetProgress()
+	assert.Equal(t, 42, got.TestsTotal)
+	assert.Equal(t, 0, got.TestsPassed)
+	assert.Equal(t, 0, got.TestsFailed)
+	assert.Equal(t, int64(0), got.TotalGasUsed)
+	assert.Equal(t, int64(0), got.TotalGasUsedDurationNs)
+
+	// Simulate the test-loop accumulators firing for two completed tests.
+	e.progressPassed.Add(1)
+	e.progressGasUsed.Add(1_000_000)
+	e.progressGasUsedDuration.Add(500_000_000)
+	e.progressPassed.Add(1)
+	e.progressGasUsed.Add(2_000_000)
+	e.progressGasUsedDuration.Add(1_000_000_000)
+
+	got = e.GetProgress()
+	assert.Equal(t, 2, got.TestsPassed)
+	assert.Equal(t, int64(3_000_000), got.TotalGasUsed)
+	assert.Equal(t, int64(1_500_000_000), got.TotalGasUsedDurationNs)
+
+	// A second ResetProgress (e.g. checkpoint-restore strategy seeding a
+	// new logical run) must zero the new counters too.
+	e.ResetProgress(10)
+	got = e.GetProgress()
+	assert.Equal(t, 10, got.TestsTotal)
+	assert.Equal(t, int64(0), got.TotalGasUsed)
+	assert.Equal(t, int64(0), got.TotalGasUsedDurationNs)
+}
+
+func TestExecutor_LiveTests(t *testing.T) {
+	e := &executor{}
+	e.ResetProgress(0)
+
+	// Empty initially.
+	assert.Empty(t, e.GetLiveTests())
+
+	// Record a successful test.
+	e.recordTestCompletion("alpha", true, 1_000_000, 500_000_000)
+	live := e.GetLiveTests()
+	require.Contains(t, live, "alpha")
+	assert.True(t, live["alpha"].Passed)
+	assert.Equal(t, int64(1_000_000), live["alpha"].GasUsed)
+	assert.Equal(t, int64(500_000_000), live["alpha"].GasUsedDurationNs)
+
+	// Failed tests are recorded with zero gas so the heatmap can render
+	// fail tiles in real time.
+	e.recordTestCompletion("beta", false, 0, 0)
+	live = e.GetLiveTests()
+	assert.Len(t, live, 2)
+	assert.False(t, live["beta"].Passed)
+	assert.Equal(t, int64(0), live["beta"].GasUsed)
+
+	// GetLiveTests returns a defensive copy — mutating it must not leak.
+	live["beta"] = LiveTestStats{Passed: true}
+	assert.False(t, e.GetLiveTests()["beta"].Passed)
+
+	// ResetProgress clears the per-test map alongside the existing
+	// atomic counters.
+	e.ResetProgress(5)
+	assert.Empty(t, e.GetLiveTests())
+}

--- a/pkg/livereport/reporter.go
+++ b/pkg/livereport/reporter.go
@@ -4,6 +4,7 @@ package livereport
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"math/rand/v2"
@@ -124,15 +125,33 @@ func (r *reporter) report(ctx context.Context) {
 		return
 	}
 
+	// Gzip the body. The per-test gas map carried in the snapshot scales
+	// with suite size, so this matters for large suites; the overhead is
+	// negligible for small ones. The API has matching middleware to
+	// inflate the request body transparently.
+	var buf bytes.Buffer
+
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(body); err != nil {
+		r.log.WithError(err).Warn("Failed to gzip live report")
+		return
+	}
+
+	if err := gz.Close(); err != nil {
+		r.log.WithError(err).Warn("Failed to finalize gzipped live report")
+		return
+	}
+
 	url := strings.TrimRight(r.cfg.Endpoint, "/") + "/api/v1/ingest/runs"
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &buf)
 	if err != nil {
 		r.log.WithError(err).Warn("Failed to build live report request")
 		return
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
 	req.Header.Set("Authorization", "Bearer "+r.cfg.Token)
 
 	resp, err := r.http.Do(req)

--- a/pkg/livereport/reporter_test.go
+++ b/pkg/livereport/reporter_test.go
@@ -1,6 +1,7 @@
 package livereport
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -25,8 +26,14 @@ func TestReporter_PostsOnStartAndStop(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		require.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
 
-		body, _ := io.ReadAll(r.Body)
+		gz, err := gzip.NewReader(r.Body)
+		require.NoError(t, err)
+		defer func() { _ = gz.Close() }()
+
+		body, err := io.ReadAll(gz)
+		require.NoError(t, err)
 		lastBody.Store(body)
 		count.Add(1)
 		w.WriteHeader(http.StatusNoContent)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -468,6 +468,8 @@ func (r *runner) liveSnapshotter(
 			report.TestsTotal = progress.TestsTotal
 			report.TestsPassed = progress.TestsPassed
 			report.TestsFailed = progress.TestsFailed
+			report.TotalGasUsed = progress.TotalGasUsed
+			report.TotalGasUsedDurationNs = progress.TotalGasUsedDurationNs
 
 			// Before ExecuteTests has started, progress.TestsTotal is 0
 			// because the executor hasn't seeded its live counters yet.
@@ -475,6 +477,21 @@ func (r *runner) liveSnapshotter(
 			// planned total from the very first report.
 			if report.TestsTotal == 0 {
 				report.TestsTotal = len(r.executor.GetTests())
+			}
+
+			// Per-test gas map. Sent in every snapshot so the live
+			// heatmap stays consistent with the aggregate counters above
+			// for the same point in time. The runner gzips the request
+			// body so this stays cheap on the wire even for big suites.
+			if live := r.executor.GetLiveTests(); len(live) > 0 {
+				report.Tests = make(map[string]indexstore.LiveTestStats, len(live))
+				for name, t := range live {
+					report.Tests[name] = indexstore.LiveTestStats{
+						Passed:            t.Passed,
+						GasUsed:           t.GasUsed,
+						GasUsedDurationNs: t.GasUsedDurationNs,
+					}
+				}
 			}
 		}
 

--- a/ui/src/api/hooks/useIndex.ts
+++ b/ui/src/api/hooks/useIndex.ts
@@ -193,3 +193,4 @@ export function useLiveRuns() {
     },
   })
 }
+

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -26,10 +26,26 @@ export interface LiveRun {
   tests_passed: number
   tests_failed: number
   metadata?: Record<string, string>
+  // Running totals from the test step of completed tests. Both stay zero
+  // until the first test completes, so the UI can guard on
+  // total_gas_used_duration_ns > 0 before computing MGas/s.
+  total_gas_used?: number
+  total_gas_used_duration_ns?: number
+  // Per-test gas map, one entry per completed test (success or failure).
+  // Drives the live Performance Heatmap. Failed tests carry zero gas data.
+  tests?: Record<string, LiveTestStats>
   // The full config.json content as reported by the runner. Mirrors the
   // on-disk config.json schema so the UI can reuse RunConfiguration.
   config?: RunConfig
   last_reported_at: string
+}
+
+// LiveTestStats is the per-test record carried in each LiveRun snapshot
+// for the live heatmap. Failed tests carry zero gas data.
+export interface LiveTestStats {
+  passed: boolean
+  gas_used?: number
+  gas_used_duration_ns?: number
 }
 
 export interface IndexEntry {

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -77,6 +77,20 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
   const showHeatmap =
     Object.keys(heatmapTests).length > 0 || (suite?.tests?.length ?? 0) > 0
 
+  // Heuristic for "the test the runner is currently working on": the
+  // first suite test (in execution order) that hasn't been reported as
+  // completed yet. Only meaningful while the run is still in flight.
+  const inProgressKey = useMemo(() => {
+    if (run.status !== 'running' || !suite?.tests) return undefined
+
+    const completed = run.tests ?? {}
+    for (const t of suite.tests) {
+      if (!completed[t.name]) return t.name
+    }
+
+    return undefined
+  }, [run.status, run.tests, suite])
+
   // Local state for the heatmap controls. Live view doesn't need URL
   // persistence (unlike RunDetailPage), so a plain useState is enough.
   const [heatmapSort, setHeatmapSort] = useState<SortMode>('order')
@@ -283,6 +297,7 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
             sortMode={heatmapSort}
             groupMode={heatmapGroup}
             threshold={heatmapThreshold}
+            inProgressTestKey={inProgressKey}
             onSortModeChange={setHeatmapSort}
             onGroupModeChange={setHeatmapGroup}
             onThresholdChange={setHeatmapThreshold}

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Flame, Loader } from 'lucide-react'
 import type { LiveRun, LiveTestStats, TestEntry, AggregatedStats } from '@/api/types'
@@ -8,7 +8,7 @@ import { RunConfiguration } from '@/components/run-detail/RunConfiguration'
 import { MetadataLabels } from '@/components/run-detail/MetadataLabels'
 import { GitHubSection } from '@/components/run-detail/GitHubSection'
 import { ClientRunsStrip } from '@/components/run-detail/ClientRunsStrip'
-import { TestHeatmap } from '@/components/run-detail/TestHeatmap'
+import { TestHeatmap, type SortMode, type GroupMode } from '@/components/run-detail/TestHeatmap'
 import { useSuite } from '@/api/hooks/useSuite'
 import { useIndex } from '@/api/hooks/useIndex'
 import { formatTimestamp } from '@/utils/date'
@@ -76,6 +76,12 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
   )
   const showHeatmap =
     Object.keys(heatmapTests).length > 0 || (suite?.tests?.length ?? 0) > 0
+
+  // Local state for the heatmap controls. Live view doesn't need URL
+  // persistence (unlike RunDetailPage), so a plain useState is enough.
+  const [heatmapSort, setHeatmapSort] = useState<SortMode>('order')
+  const [heatmapGroup, setHeatmapGroup] = useState<GroupMode>('none')
+  const [heatmapThreshold, setHeatmapThreshold] = useState<number | undefined>(undefined)
 
   return (
     <div className="flex flex-col gap-6">
@@ -225,6 +231,12 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
             runId={run.run_id}
             suiteHash={run.suite_hash}
             stepFilter={DEFAULT_INDEX_STEP_FILTER}
+            sortMode={heatmapSort}
+            groupMode={heatmapGroup}
+            threshold={heatmapThreshold}
+            onSortModeChange={setHeatmapSort}
+            onGroupModeChange={setHeatmapGroup}
+            onThresholdChange={setHeatmapThreshold}
           />
         </div>
       )}

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Flame, Loader } from 'lucide-react'
 import type { LiveRun, LiveTestStats, TestEntry, AggregatedStats } from '@/api/types'
@@ -83,6 +83,35 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
   const [heatmapGroup, setHeatmapGroup] = useState<GroupMode>('none')
   const [heatmapThreshold, setHeatmapThreshold] = useState<number | undefined>(undefined)
 
+  // Smoothly tween the live counters between snapshots so users see
+  // numbers ticking up rather than jumping. Integer counters are
+  // rounded at the render site; the MGas/s float is formatted directly.
+  const animatedPassed = useAnimatedNumber(passed)
+  const animatedFailed = useAnimatedNumber(failed)
+  const animatedCompleted = useAnimatedNumber(completed)
+  const animatedProgress = useAnimatedNumber(progress)
+  const animatedMgas = useAnimatedNumber(mgasPerSec ?? 0)
+
+  // Pulse the "Live" badge whenever a new snapshot arrives (i.e.
+  // last_reported_at advances). Confirms data freshness and the
+  // runner→API link is healthy without an extra widget.
+  const prevReportRef = useRef(run.last_reported_at)
+  const [reportPulse, setReportPulse] = useState(false)
+
+  useEffect(() => {
+    if (prevReportRef.current === run.last_reported_at) return
+
+    prevReportRef.current = run.last_reported_at
+    // One-shot animation signal — setState here is intentional, the
+    // effect runs only when last_reported_at advances and emits one
+    // render to apply the pulse class plus one to clear it.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setReportPulse(true)
+
+    const t = setTimeout(() => setReportPulse(false), 700)
+    return () => clearTimeout(t)
+  }, [run.last_reported_at])
+
   return (
     <div className="flex flex-col gap-6">
       {/* Breadcrumb (matches RunDetailPage). */}
@@ -107,7 +136,10 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
           )}
           <span className="truncate font-mono text-gray-900 dark:text-gray-100">{run.run_id}</span>
         </div>
-        <span className="sm:ml-auto inline-flex items-center gap-2 rounded-sm bg-blue-100 px-2 py-0.5 text-xs/5 font-medium text-blue-800 dark:bg-blue-900/40 dark:text-blue-200">
+        <span
+          className="sm:ml-auto inline-flex items-center gap-2 rounded-sm bg-blue-100 px-2 py-0.5 text-xs/5 font-medium text-blue-800 dark:bg-blue-900/40 dark:text-blue-200"
+          style={reportPulse ? { animation: 'liveBadgePulse 0.7s ease-out' } : undefined}
+        >
           <Loader className="size-3.5 animate-spin" />
           Live — last report {formatRelativeAge(run.last_reported_at)}
         </span>
@@ -143,11 +175,15 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
           <p className="mt-1 flex items-center gap-2 text-2xl/8 font-semibold">
             <span className="text-gray-900 dark:text-gray-100">{total}</span>
             <span className="text-gray-400 dark:text-gray-500">/</span>
-            <span className="text-green-600 dark:text-green-400">{passed}</span>
+            <span className="text-green-600 dark:text-green-400 tabular-nums">
+              {Math.round(animatedPassed)}
+            </span>
             {failed > 0 && (
               <>
                 <span className="text-gray-400 dark:text-gray-500">/</span>
-                <span className="text-red-600 dark:text-red-400">{failed}</span>
+                <span className="text-red-600 dark:text-red-400 tabular-nums">
+                  {Math.round(animatedFailed)}
+                </span>
               </>
             )}
           </p>
@@ -158,8 +194,8 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
         </div>
         <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
           <p className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">MGas/s</p>
-          <p className="mt-1 text-2xl/8 font-semibold text-gray-900 dark:text-gray-100">
-            {mgasPerSec !== undefined ? mgasPerSec.toFixed(2) : '-'}
+          <p className="mt-1 text-2xl/8 font-semibold text-gray-900 dark:text-gray-100 tabular-nums">
+            {mgasPerSec !== undefined ? animatedMgas.toFixed(2) : '-'}
           </p>
           <p className="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
             {mgasPerSec !== undefined
@@ -171,7 +207,9 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
         <div className="col-span-2 rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
           <p className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Progress</p>
           <p className="mt-1 flex items-baseline gap-3 text-2xl/8 font-semibold text-gray-900 dark:text-gray-100">
-            <span>{total > 0 ? `${progress.toFixed(1)}%` : '-'}</span>
+            <span className="tabular-nums">
+              {total > 0 ? `${animatedProgress.toFixed(1)}%` : '-'}
+            </span>
             {etaShort && (
               <span
                 className="text-sm/6 font-normal text-gray-500 dark:text-gray-400"
@@ -182,14 +220,25 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
             )}
           </p>
           <p className="mt-2 text-xs/5 text-gray-500 dark:text-gray-400" title={etaTooltip}>
-            {formatNumber(completed)} of {formatNumber(total)} tests complete · Elapsed {formatHoursMinutes(eta.elapsedSec)}
+            <span className="tabular-nums">{formatNumber(Math.round(animatedCompleted))}</span> of{' '}
+            {formatNumber(total)} tests complete · Elapsed {formatHoursMinutes(eta.elapsedSec)}
             {eta.etaAtMs !== undefined && <> · ETA {formatClockHoursMinutes(new Date(eta.etaAtMs))}</>}
           </p>
           <div className="mt-2 h-1.5 w-full overflow-hidden rounded-sm bg-gray-200 dark:bg-gray-700">
             <div
-              className="h-full bg-blue-500 transition-all dark:bg-blue-400"
-              style={{ width: `${progress}%` }}
-            />
+              className="relative h-full overflow-hidden bg-blue-500 transition-all dark:bg-blue-400"
+              style={{ width: `${animatedProgress}%` }}
+            >
+              {/* Shimmer sweep — only while the run is in flight, so a
+                  completed/canceled run renders a static bar. */}
+              {run.status === 'running' && (
+                <span
+                  aria-hidden="true"
+                  className="absolute inset-0 bg-linear-to-r from-transparent via-white/40 to-transparent"
+                  style={{ animation: 'liveShimmer 1.6s ease-in-out infinite' }}
+                />
+              )}
+            </div>
           </div>
           <p className="mt-3 text-xs/5 text-gray-500 dark:text-gray-400">
             Full per-test results (calls, durations) will appear here once the run completes and gets uploaded.
@@ -277,6 +326,50 @@ function liveTestStatsToAggregated(t: LiveTestStats): AggregatedStats {
     msg_count: 0,
     method_stats: { times: {}, mgas_s: {} },
   }
+}
+
+// useAnimatedNumber tweens between successive `target` values via
+// requestAnimationFrame. Returns the in-flight value; callers round /
+// format as needed. Mid-animation target changes restart from the
+// currently-displayed value so we never visually skip backwards. Used
+// by LiveRunDetailView so the live counters glide instead of jumping.
+const ANIMATE_DURATION_MS = 450
+
+function useAnimatedNumber(target: number): number {
+  const [displayed, setDisplayed] = useState(target)
+  // displayedRef tracks the in-flight tween value so a target change
+  // mid-animation can resume from where we are rather than restarting.
+  // Only written inside the rAF step (and seeded by useState's initial
+  // value), never during render.
+  const displayedRef = useRef(target)
+
+  useEffect(() => {
+    const start = displayedRef.current
+    if (start === target) return
+
+    const delta = target - start
+    const startTime = performance.now()
+    let raf = 0
+
+    const step = (now: number) => {
+      const elapsed = now - startTime
+      const t = Math.min(1, elapsed / ANIMATE_DURATION_MS)
+      // ease-out cubic: fast start, soft landing.
+      const eased = 1 - Math.pow(1 - t, 3)
+      const value = start + delta * eased
+      displayedRef.current = value
+      // One-shot animation tick — the cascade is bounded by `t < 1`.
+       
+      setDisplayed(value)
+
+      if (t < 1) raf = requestAnimationFrame(step)
+    }
+
+    raf = requestAnimationFrame(step)
+    return () => cancelAnimationFrame(raf)
+  }, [target])
+
+  return displayed
 }
 
 function formatRelativeAge(isoTimestamp: string): string {

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -1,13 +1,14 @@
 import { useMemo } from 'react'
 import { Link } from '@tanstack/react-router'
-import { Loader } from 'lucide-react'
-import type { LiveRun } from '@/api/types'
+import { Flame, Loader } from 'lucide-react'
+import type { LiveRun, LiveTestStats, TestEntry, AggregatedStats } from '@/api/types'
 import { ClientStat } from '@/components/shared/ClientStat'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { RunConfiguration } from '@/components/run-detail/RunConfiguration'
 import { MetadataLabels } from '@/components/run-detail/MetadataLabels'
 import { GitHubSection } from '@/components/run-detail/GitHubSection'
 import { ClientRunsStrip } from '@/components/run-detail/ClientRunsStrip'
+import { TestHeatmap } from '@/components/run-detail/TestHeatmap'
 import { useSuite } from '@/api/hooks/useSuite'
 import { useIndex } from '@/api/hooks/useIndex'
 import { formatTimestamp } from '@/utils/date'
@@ -21,9 +22,9 @@ interface LiveRunDetailViewProps {
 
 /**
  * LiveRunDetailView renders a view mirroring RunDetailPage as closely as
- * possible, but sourced from the live ingest report's `config` payload
- * instead of on-disk config.json / result.json. Used when a run is still
- * in progress and its files haven't landed on the storage backend yet.
+ * possible, but sourced from the live ingest snapshot's payload instead
+ * of on-disk config.json / result.json. Used when a run is still in
+ * progress and its files haven't landed on the storage backend yet.
  */
 export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
   const { data: suite } = useSuite(run.suite_hash ?? '')
@@ -48,12 +49,33 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
   const etaShort = formatEtaShort(eta)
   const etaTooltip = formatEtaTooltip(eta)
 
+  // Live MGas/s estimate from completed tests' aggregated `test`-step gas.
+  // Mirrors the formula used in RunDetailPage: gas_used (gwei units) * 1000
+  // divided by gas_used_duration_ns yields gas-per-second in millions.
+  const totalGasUsed = run.total_gas_used ?? 0
+  const totalGasUsedDurationNs = run.total_gas_used_duration_ns ?? 0
+  const mgasPerSec =
+    totalGasUsedDurationNs > 0 ? (totalGasUsed * 1000) / totalGasUsedDurationNs : undefined
+
   const clientRuns = useMemo(() => {
     if (!index || !run.suite_hash || !clientName) return []
     return index.entries.filter(
       (r) => r.suite_hash === run.suite_hash && r.instance.client === clientName,
     )
   }, [index, run.suite_hash, clientName])
+
+  // Per-test gas data for the live Performance Heatmap. Comes from the
+  // same snapshot payload that drives the rest of this view, so heatmap
+  // tiles stay consistent with the aggregate counters above. The
+  // heatmap itself fills in faded tiles for every suite test that hasn't
+  // been processed yet, so we render it as soon as we have *either* the
+  // suite or some completed tests.
+  const heatmapTests = useMemo(
+    () => (run.tests ? liveTestsToHeatmapEntries(run.tests) : {}),
+    [run.tests],
+  )
+  const showHeatmap =
+    Object.keys(heatmapTests).length > 0 || (suite?.tests?.length ?? 0) > 0
 
   return (
     <div className="flex flex-col gap-6">
@@ -98,9 +120,10 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
         </div>
       )}
 
-      {/* Top stat cards. Result-based cards (MGas/s, Calls, Test Duration)
-          don't exist for a live run, so we replace the rest of the row with
-          a single "In progress" card showing the progress bar and counts. */}
+      {/* Top stat cards. Calls / Test Duration cards don't exist for a live
+          run (they require result.json), but MGas/s can be estimated from a
+          running total of completed tests' gas aggregates so we surface it
+          here. The rest of the row is the "In progress" progress bar. */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
         {clientName && (
           <ClientStat
@@ -127,7 +150,19 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
             {formatTimestamp(startTimestamp)}
           </p>
         </div>
-        <div className="col-span-3 rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
+        <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
+          <p className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">MGas/s</p>
+          <p className="mt-1 text-2xl/8 font-semibold text-gray-900 dark:text-gray-100">
+            {mgasPerSec !== undefined ? mgasPerSec.toFixed(2) : '-'}
+          </p>
+          <p className="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
+            {mgasPerSec !== undefined
+              ? `${(totalGasUsed / 1_000_000).toFixed(2)} MGas`
+              : 'Waiting for first completed test'}
+          </p>
+          <p className="text-xs/5 text-gray-500 dark:text-gray-400">Test step, running average</p>
+        </div>
+        <div className="col-span-2 rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
           <p className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Progress</p>
           <p className="mt-1 flex items-baseline gap-3 text-2xl/8 font-semibold text-gray-900 dark:text-gray-100">
             <span>{total > 0 ? `${progress.toFixed(1)}%` : '-'}</span>
@@ -151,7 +186,7 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
             />
           </div>
           <p className="mt-3 text-xs/5 text-gray-500 dark:text-gray-400">
-            Full per-test results (MGas/s, calls, durations) will appear here once the run completes and gets uploaded.
+            Full per-test results (calls, durations) will appear here once the run completes and gets uploaded.
           </p>
         </div>
       </div>
@@ -161,7 +196,9 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
       <GitHubSection labels={labels} />
 
       {/* Configuration panel — shown once the runner has reported its
-          config.json via an ingest snapshot. */}
+          config.json via an ingest snapshot. Rendered before the heatmap
+          so users see what's actually being run before drilling into the
+          per-test results below. */}
       {cfg && (
         <RunConfiguration
           instance={cfg.instance}
@@ -170,8 +207,64 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
           metadata={cfg.metadata}
         />
       )}
+
+      {/* Live Performance Heatmap — fed by the per-test gas data the
+          runner ships in every snapshot. Renders as soon as we have
+          either suite info (un-processed tiles) or completed tests. */}
+      {showHeatmap && (
+        <div className="overflow-hidden rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
+          <div className="mb-4 flex items-center justify-between">
+            <h3 className="flex items-center gap-2 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+              <Flame className="size-4 text-gray-400 dark:text-gray-500" />
+              Performance Heatmap (Live)
+            </h3>
+          </div>
+          <TestHeatmap
+            tests={heatmapTests}
+            suiteTests={suite?.tests}
+            runId={run.run_id}
+            suiteHash={run.suite_hash}
+            stepFilter={DEFAULT_INDEX_STEP_FILTER}
+          />
+        </div>
+      )}
     </div>
   )
+}
+
+// liveTestsToHeatmapEntries adapts the live per-test gas map into the
+// Record<string, TestEntry> shape that the existing TestHeatmap consumes.
+// Only the `test` step's aggregated gas/duration is populated — that's
+// all the heatmap reads when DEFAULT_INDEX_STEP_FILTER is active. Failed
+// tests carry zero gas (rendered as no-data tiles by the heatmap).
+function liveTestsToHeatmapEntries(tests: Record<string, LiveTestStats>): Record<string, TestEntry> {
+  const out: Record<string, TestEntry> = {}
+
+  for (const [name, t] of Object.entries(tests)) {
+    out[name] = {
+      dir: '',
+      steps: {
+        test: { aggregated: liveTestStatsToAggregated(t) },
+      },
+    }
+  }
+
+  return out
+}
+
+function liveTestStatsToAggregated(t: LiveTestStats): AggregatedStats {
+  const gasUsed = t.gas_used ?? 0
+  const gasUsedDurationNs = t.gas_used_duration_ns ?? 0
+
+  return {
+    time_total: gasUsedDurationNs,
+    gas_used_total: gasUsed,
+    gas_used_time_total: gasUsedDurationNs,
+    success: t.passed ? 1 : 0,
+    fail: t.passed ? 0 : 1,
+    msg_count: 0,
+    method_stats: { times: {}, mgas_s: {} },
+  }
 }
 
 function formatRelativeAge(isoTimestamp: string): string {

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQueries } from '@tanstack/react-query'
 import clsx from 'clsx'
 import { Check, Copy, Download } from 'lucide-react'
@@ -262,6 +262,7 @@ function HeatmapCell({
   threshold,
   statusFilter,
   searchQuery,
+  popDelayMs,
   onSelect,
   onMouseEnter,
   onMouseLeave,
@@ -270,6 +271,11 @@ function HeatmapCell({
   threshold: number
   statusFilter: TestStatusFilter
   searchQuery: string
+  // popDelayMs is set when this tile just transitioned from
+  // not-processed to having a result, driving a brief scale + brightness
+  // flash. Undefined means no animation (steady state). The delay is
+  // staggered across newly-completed tiles so they pop one after another.
+  popDelayMs?: number
   onSelect: (testKey: string) => void
   onMouseEnter: (test: TestData, event: React.MouseEvent) => void
   onMouseLeave: () => void
@@ -291,7 +297,15 @@ function HeatmapCell({
   } else {
     baseStyle = { backgroundColor: getColorByThreshold(test.mgasPerSec, threshold) }
   }
-  const style = matchesFilter ? baseStyle : { ...baseStyle, opacity: 0.2 }
+  const style: React.CSSProperties = {
+    ...baseStyle,
+    transition: 'background-color 0.4s ease-out',
+    ...(matchesFilter ? {} : { opacity: 0.2 }),
+    ...(popDelayMs !== undefined && {
+      animation: 'heatmapPop 0.6s ease-out both',
+      animationDelay: `${popDelayMs}ms`,
+    }),
+  }
 
   return (
     <button
@@ -333,6 +347,13 @@ export function TestHeatmap({
   const [opcodeSort, setOpcodeSort] = useState<OpcodeSortMode>('name')
   const [activeStepTab, setActiveStepTab] = useState<'test' | 'setup' | 'cleanup'>('test')
   const { data: blockLogs } = useBlockLogs(runId)
+
+  // Pop-in stagger state for newly-completed tiles. Populated below by
+  // an effect that diffs the latest testData against the previous
+  // completed set; declared up here so it's in scope when we render the
+  // cell list further down.
+  const prevCompletedRef = useRef<Set<string> | null>(null)
+  const [popDelays, setPopDelays] = useState<Map<string, number>>(new Map())
 
   const handleSortModeChange = (mode: SortMode) => {
     onSortModeChange?.(mode)
@@ -428,6 +449,58 @@ export function TestHeatmap({
 
     return { testData: data, minMgas, maxMgas }
   }, [tests, suiteTests, executionOrder, stepFilter])
+
+  // Animate tiles that just transitioned from "not processed" to having
+  // a result by giving each one a staggered pop-in. We diff against the
+  // set of completed keys from the previous render — kept in a ref —
+  // and assign each newly-completed tile a delay so they cascade in
+  // execution order. The first render seeds the ref without animating
+  // anything (avoids flashing every existing tile on initial paint).
+  useEffect(() => {
+    const completed = new Set<string>()
+    const ordered: { key: string; order: number }[] = []
+    for (const t of testData) {
+      if (!t.notProcessed) {
+        completed.add(t.testKey)
+        ordered.push({ key: t.testKey, order: t.order })
+      }
+    }
+
+    if (prevCompletedRef.current === null) {
+      prevCompletedRef.current = completed
+
+      return
+    }
+
+    const newly = ordered
+      .filter(({ key }) => !prevCompletedRef.current!.has(key))
+      .sort((a, b) => a.order - b.order)
+    prevCompletedRef.current = completed
+
+    if (newly.length === 0) return
+
+    // Stagger 60ms per tile, capped so a huge burst still finishes
+    // within ~2s. Tiles past the cap all start at the cap delay.
+    const stepMs = 60
+    const maxStaggerMs = 1800
+    const map = new Map<string, number>()
+    for (let i = 0; i < newly.length; i++) {
+      map.set(newly[i].key, Math.min(i * stepMs, maxStaggerMs))
+    }
+
+    // Intentional cascading render: this is a one-shot animation
+    // signal derived from a diff against the previous render's state,
+    // not steady-state derived data. Each testData change emits exactly
+    // two follow-up renders (set delays, then clear them after the
+    // pop), bounded and small.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPopDelays(map)
+
+    const longest = Math.min((newly.length - 1) * stepMs, maxStaggerMs) + 600 + 100
+    const t = setTimeout(() => setPopDelays(new Map()), longest)
+
+    return () => clearTimeout(t)
+  }, [testData])
 
   const sortedData = useMemo(() => {
     const sorted = [...testData]
@@ -661,6 +734,7 @@ export function TestHeatmap({
                       threshold={threshold}
                       statusFilter={statusFilter}
                       searchQuery={searchQuery}
+                      popDelayMs={popDelays.get(test.testKey)}
                       onSelect={handleSelect}
                       onMouseEnter={handleMouseEnter}
                       onMouseLeave={handleMouseLeave}
@@ -679,6 +753,7 @@ export function TestHeatmap({
                 threshold={threshold}
                 statusFilter={statusFilter}
                 searchQuery={searchQuery}
+                popDelayMs={popDelays.get(test.testKey)}
                 onSelect={handleSelect}
                 onMouseEnter={handleMouseEnter}
                 onMouseLeave={handleMouseLeave}

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -174,12 +174,24 @@ interface TestData {
   gasUsedTimeTotal: number
   hasFail: boolean
   noData: boolean
+  // notProcessed is true when the test is part of the suite but no
+  // result entry exists for it yet (live run still in progress, run
+  // canceled, etc). Distinct from noData (test ran but produced no gas
+  // data) so the cell can show a more faded "didn't run" style.
+  notProcessed: boolean
 }
 
-// Diagonal stripe pattern for tests without data
+// Diagonal stripe pattern for tests that ran but didn't produce gas data
+// (e.g. failed at setup before the test step).
 const NO_DATA_STYLE = {
   backgroundColor: '#374151',
   backgroundImage: 'repeating-linear-gradient(45deg, transparent, transparent 2px, #1f2937 2px, #1f2937 4px)',
+}
+
+// Faded style for tests that exist in the suite but haven't been
+// processed yet (in-progress live runs, canceled runs, etc).
+const NOT_PROCESSED_STYLE = {
+  backgroundColor: 'rgba(156, 163, 175, 0.15)',
 }
 
 function PostTestDumps({ runId, testName, calls }: { runId: string; testName: string; calls: PostTestRPCCallConfig[] }) {
@@ -264,11 +276,21 @@ function HeatmapCell({
 }) {
   const matchesStatusFilter =
     statusFilter === 'all' ||
-    (statusFilter === 'passed' && !test.hasFail) ||
-    (statusFilter === 'failed' && test.hasFail)
+    // Not-processed tiles are neither "passed" nor "failed" — exclude
+    // them from those filters so the user can isolate ran-and-passed /
+    // ran-and-failed tests cleanly.
+    (!test.notProcessed && statusFilter === 'passed' && !test.hasFail) ||
+    (!test.notProcessed && statusFilter === 'failed' && test.hasFail)
   const matchesSearchQuery = !searchQuery || test.testKey.toLowerCase().includes(searchQuery.toLowerCase())
   const matchesFilter = matchesStatusFilter && matchesSearchQuery
-  const baseStyle = test.noData ? NO_DATA_STYLE : { backgroundColor: getColorByThreshold(test.mgasPerSec, threshold) }
+  let baseStyle: React.CSSProperties
+  if (test.notProcessed) {
+    baseStyle = NOT_PROCESSED_STYLE
+  } else if (test.noData) {
+    baseStyle = NO_DATA_STYLE
+  } else {
+    baseStyle = { backgroundColor: getColorByThreshold(test.mgasPerSec, threshold) }
+  }
   const style = matchesFilter ? baseStyle : { ...baseStyle, opacity: 0.2 }
 
   return (
@@ -345,13 +367,42 @@ export function TestHeatmap({
     let minMgas = Infinity
     let maxMgas = -Infinity
 
-    for (const [testName, entry] of Object.entries(tests)) {
+    // Union of suite tests and tests with results, so the heatmap always
+    // shows a tile for every planned test in the suite — even if the run
+    // hasn't reached it yet (live), got canceled before it ran, or only
+    // a subset ran. Tests in `tests` but missing from `suiteTests`
+    // (shouldn't normally happen) are still included so we don't lose data.
+    const allTestNames = new Set<string>(Object.keys(tests))
+    if (suiteTests) {
+      for (const t of suiteTests) allTestNames.add(t.name)
+    }
+
+    for (const testName of allTestNames) {
+      const entry = tests[testName]
+      const order = executionOrder.get(testName) ?? Infinity
+
+      if (!entry) {
+        // Suite test with no result → tile for visual completeness only.
+        data.push({
+          testKey: testName,
+          filename: testName,
+          order,
+          mgasPerSec: 0,
+          gasUsedTotal: 0,
+          gasUsedTimeTotal: 0,
+          hasFail: false,
+          noData: true,
+          notProcessed: true,
+        })
+
+        continue
+      }
+
       // Use stepFilter for MGas/s calculation
       const statsFiltered = getAggregatedStats(entry, stepFilter)
       // Use all steps for hasFail indicator
       const statsAll = getAggregatedStats(entry, ALL_STEP_TYPES)
       const mgasPerSec = statsFiltered ? calculateMGasPerSec(statsFiltered.gas_used_total, statsFiltered.gas_used_time_total) : undefined
-      const order = executionOrder.get(testName) ?? Infinity
       const noData = mgasPerSec === undefined
 
       if (!noData) {
@@ -368,6 +419,7 @@ export function TestHeatmap({
         gasUsedTimeTotal: statsFiltered?.gas_used_time_total ?? 0,
         hasFail: statsAll ? statsAll.fail > 0 : false,
         noData,
+        notProcessed: false,
       })
     }
 
@@ -375,7 +427,7 @@ export function TestHeatmap({
     if (maxMgas === -Infinity) maxMgas = 0
 
     return { testData: data, minMgas, maxMgas }
-  }, [tests, executionOrder, stepFilter])
+  }, [tests, suiteTests, executionOrder, stepFilter])
 
   const sortedData = useMemo(() => {
     const sorted = [...testData]
@@ -577,7 +629,13 @@ export function TestHeatmap({
           </div>
         </div>
         <div className="text-xs/5 text-gray-500 dark:text-gray-400">
-          {testData.length} tests | {minMgas.toFixed(1)} - {maxMgas.toFixed(1)} MGas/s
+          {(() => {
+            const notProcessed = testData.filter((t) => t.notProcessed).length
+            if (notProcessed > 0) {
+              return `${testData.length - notProcessed}/${testData.length} tests processed | ${minMgas.toFixed(1)} - ${maxMgas.toFixed(1)} MGas/s`
+            }
+            return `${testData.length} tests | ${minMgas.toFixed(1)} - ${maxMgas.toFixed(1)} MGas/s`
+          })()}
         </div>
       </div>
 
@@ -691,6 +749,10 @@ export function TestHeatmap({
           No data
         </span>
         <span>
+          <span className="mr-1 inline-block size-3 rounded-xs ring-1 ring-gray-300 dark:ring-gray-700" style={NOT_PROCESSED_STYLE} />
+          Not processed
+        </span>
+        <span>
           <span className="mr-1 inline-block size-3 rounded-xs ring-1 ring-red-500" style={{ backgroundColor: COLORS[2] }} />
           Has failures
         </span>
@@ -711,7 +773,14 @@ export function TestHeatmap({
             {genesisMap.get(tooltip.test.testKey) && (
               <div className="text-gray-500 dark:text-gray-400">Genesis: {genesisMap.get(tooltip.test.testKey)}</div>
             )}
-            <div>MGas/s: {tooltip.test.noData ? 'No data' : tooltip.test.mgasPerSec.toFixed(2)}</div>
+            <div>
+              MGas/s:{' '}
+              {tooltip.test.notProcessed
+                ? 'Not processed yet'
+                : tooltip.test.noData
+                  ? 'No data'
+                  : tooltip.test.mgasPerSec.toFixed(2)}
+            </div>
             {!tooltip.test.noData && (
               <>
                 <div>Gas used: {(tooltip.test.gasUsedTotal / 1_000_000).toFixed(2)} MGas</div>
@@ -720,7 +789,11 @@ export function TestHeatmap({
             )}
             <div className="text-gray-500 dark:text-gray-400">Based on steps: {stepFilter.join(', ')}</div>
             <div className="w-48 break-all text-gray-500 dark:text-gray-400">{tooltip.test.filename}</div>
-            {tooltip.test.noData && <div className="text-gray-500 dark:text-gray-400">No gas usage data available</div>}
+            {tooltip.test.notProcessed ? (
+              <div className="text-gray-500 dark:text-gray-400">Test was not run</div>
+            ) : tooltip.test.noData ? (
+              <div className="text-gray-500 dark:text-gray-400">No gas usage data available</div>
+            ) : null}
             {tooltip.test.hasFail && <div className="text-red-600 dark:text-red-400">Has failures</div>}
             <div className="mt-1 text-gray-400 dark:text-gray-500">Click for details</div>
           </div>

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -110,6 +110,11 @@ interface TestHeatmapProps {
   threshold?: number
   stepFilter?: StepTypeOption[]
   postTestRPCCalls?: PostTestRPCCallConfig[]
+  // inProgressTestKey, when set, marks one tile to pulse blue
+  // continuously — used by the live view to show "the runner is
+  // working on this test right now". Caller (LiveRunDetailView) picks
+  // the lowest-order un-processed tile while status === 'running'.
+  inProgressTestKey?: string
   onSelectedTestChange?: (testName: string | undefined) => void
   onSortModeChange?: (mode: SortMode) => void
   onGroupModeChange?: (mode: GroupMode) => void
@@ -263,6 +268,7 @@ function HeatmapCell({
   statusFilter,
   searchQuery,
   popDelayMs,
+  isInProgress,
   onSelect,
   onMouseEnter,
   onMouseLeave,
@@ -276,6 +282,11 @@ function HeatmapCell({
   // flash. Undefined means no animation (steady state). The delay is
   // staggered across newly-completed tiles so they pop one after another.
   popDelayMs?: number
+  // isInProgress turns on an infinite blue pulse for the tile that
+  // represents the test the runner is most likely currently executing.
+  // Pop animation takes precedence when both are set (a tile transitions
+  // from "in progress" to "completed" on the next snapshot).
+  isInProgress?: boolean
   onSelect: (testKey: string) => void
   onMouseEnter: (test: TestData, event: React.MouseEvent) => void
   onMouseLeave: () => void
@@ -301,10 +312,16 @@ function HeatmapCell({
     ...baseStyle,
     transition: 'background-color 0.4s ease-out',
     ...(matchesFilter ? {} : { opacity: 0.2 }),
-    ...(popDelayMs !== undefined && {
-      animation: 'heatmapPop 0.6s ease-out both',
-      animationDelay: `${popDelayMs}ms`,
-    }),
+  }
+
+  // Animation precedence: a freshly-popping tile takes priority over
+  // the "in progress" pulse, since it represents the in-progress tile
+  // transitioning into a completed one on the latest snapshot.
+  if (popDelayMs !== undefined) {
+    style.animation = 'heatmapPop 0.6s ease-out both'
+    style.animationDelay = `${popDelayMs}ms`
+  } else if (isInProgress) {
+    style.animation = 'liveTilePulse 1.2s ease-in-out infinite'
   }
 
   return (
@@ -335,6 +352,7 @@ export function TestHeatmap({
   threshold: thresholdProp,
   stepFilter = ALL_STEP_TYPES,
   postTestRPCCalls,
+  inProgressTestKey,
   onSelectedTestChange,
   onSortModeChange,
   onGroupModeChange,
@@ -735,6 +753,7 @@ export function TestHeatmap({
                       statusFilter={statusFilter}
                       searchQuery={searchQuery}
                       popDelayMs={popDelays.get(test.testKey)}
+                      isInProgress={test.testKey === inProgressTestKey}
                       onSelect={handleSelect}
                       onMouseEnter={handleMouseEnter}
                       onMouseLeave={handleMouseLeave}
@@ -754,6 +773,7 @@ export function TestHeatmap({
                 statusFilter={statusFilter}
                 searchQuery={searchQuery}
                 popDelayMs={popDelays.get(test.testKey)}
+                isInProgress={test.testKey === inProgressTestKey}
                 onSelect={handleSelect}
                 onMouseEnter={handleMouseEnter}
                 onMouseLeave={handleMouseLeave}

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -795,7 +795,12 @@ export function TestHeatmap({
               <div className="text-gray-500 dark:text-gray-400">No gas usage data available</div>
             ) : null}
             {tooltip.test.hasFail && <div className="text-red-600 dark:text-red-400">Has failures</div>}
-            <div className="mt-1 text-gray-400 dark:text-gray-500">Click for details</div>
+            {/* Only hint at clicking when the parent actually wired a
+                handler — the live view doesn't, since there are no
+                per-test details to open while the run is in progress. */}
+            {onSelectedTestChange && (
+              <div className="mt-1 text-gray-400 dark:text-gray-500">Click for details</div>
+            )}
           </div>
         </div>
       )}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -106,3 +106,17 @@ html {
     box-shadow: 0 0 0 0 transparent;
   }
 }
+
+/* Infinite blue pulse for the heatmap tile representing the test the
+   runner is most likely currently executing — the lowest-order tile
+   that hasn't been processed yet. Signals "something is happening
+   here" between snapshots. */
+@keyframes liveTilePulse {
+  0%,
+  100% {
+    background-color: rgba(59, 130, 246, 0.25);
+  }
+  50% {
+    background-color: rgba(59, 130, 246, 0.85);
+  }
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -60,3 +60,49 @@ html {
   --scalar-background-3: #3f3f46;
   --scalar-border-color: #3f3f46;
 }
+
+/* Pop animation for live heatmap tiles when their color first appears
+   (transition from "not processed" to having a result). Combined scale
+   + brightness flash gives a visceral sense that data just landed. */
+@keyframes heatmapPop {
+  0% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+  35% {
+    transform: scale(1.6);
+    filter: brightness(1.7);
+  }
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+}
+
+/* Sweeping shimmer for the live progress bar — drives the "still in
+   flight" feel; we apply it only while status === 'running'. The
+   element is positioned over the filled portion of the bar via
+   ::after, so the sweep only travels across the colored region. */
+@keyframes liveShimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* Halo flash on the "Live" badge whenever a fresh ingest report
+   arrives. Brief expanding ring that fades to transparent — confirms
+   the runner→API connection is healthy without taking up extra space. */
+@keyframes liveBadgePulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.55);
+  }
+  60% {
+    box-shadow: 0 0 0 6px rgba(59, 130, 246, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}


### PR DESCRIPTION
## Summary

Fills out the empty MGas/s top card on the live run detail view, adds a Performance Heatmap that grows as tests complete, and layers on motion cues so the page reads as actually live.

- **Live MGas/s aggregate**: executor accumulates per-test \`gas_used\` / \`gas_used_duration\` from completed tests and exposes a running total via \`GetProgress\`. Snapshot reporter ships these in every payload, the UI's MGas/s top card binds to it.
- **Live Performance Heatmap**: executor records per-test \`{passed, gas_used, gas_used_duration}\` into a \`liveTests\` map. Snapshot reporter ships the full map in every payload (gzipped — middleware decompresses transparently). UI adapts it into the existing \`<TestHeatmap>\` shape so the live view reuses the same component.
- **Always show every suite tile**: heatmap unions \`tests\` (results) with \`suiteTests\` (planned). Un-processed tiles render in a faded style. Applies to both live and on-disk runs (canceled runs no longer hide the tests that didn't get to execute).
- **Animations to indicate progress**:
  - Newly-completed tiles cascade in execution order with a scale + brightness pop.
  - The lowest-order un-processed tile pulses blue continuously while \`status === 'running'\` (\"this is what the runner is working on right now\").
  - Counters (passed / failed / MGas/s / progress %) tween between snapshot values via rAF.
  - Progress bar gets a sweeping shimmer while running, freezes the instant the run terminates.
  - \"Live — last report\" badge flashes a halo every time a new snapshot arrives.
- **Operational visibility**: ingest handler logs \`payload_bytes\` (decompressed) and \`payload_gzip_bytes\` (on-the-wire) per request so payload growth and compression ratio are observable.

## Test plan

- [x] \`go vet -tags exclude_graphdriver_btrfs ./...\` clean
- [x] \`go test ./pkg/{executor,api/...,runner,livereport,config} -count=1\` all pass
- [x] \`golangci-lint run --build-tags=exclude_graphdriver_btrfs --new-from-rev=\"origin/master\"\` reports 0 issues
- [x] \`npx tsc --noEmit\` and \`npx eslint\` clean in \`ui/\`
- [x] Manual: start a real live run; verify the live detail view shows the suite outline immediately, the next tile pulses blue, completed tiles pop with their colors as snapshots arrive, the MGas/s card fills in, and the live badge flashes on each report
- [x] Manual: cancel a running run; verify the un-run tiles stay faded and the in-progress pulse stops