### PR TITLE
feat: live benchmarkoor.log stream over WebSockets

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -50,6 +50,11 @@ runner:
   #   interval: 1m
   #   jitter_fraction: 0.2
   #   timeout: 10s
+  #   # Live log streaming. When enabled, the runner opens a WebSocket to
+  #   # the API for the lifetime of the run. Log bytes only flow while at
+  #   # least one UI client has the log panel open — zero traffic otherwise.
+  #   logs_enabled: true     # default true; set false to disable entirely
+  #   logs_interval: 200ms   # file-tail push cadence while streaming
 
   benchmark:
     results_dir: ${RESULTS_DIR:-./results}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,8 @@ runner:
     interval: 1m
     jitter_fraction: 0.2
     timeout: 10s
+    logs_enabled: true     # default true; set false to disable the log streamer
+    logs_interval: 200ms   # file-tail push cadence while streaming
 ```
 
 | Option | Type | Default | Description |
@@ -150,6 +152,8 @@ runner:
 | `interval` | string | `1m` | Base reporting interval (Go duration). Each tick adds random jitter |
 | `jitter_fraction` | float | `0.2` | Random jitter as a fraction of `interval`. `0` uses the default; negative disables jitter entirely |
 | `timeout` | string | `10s` | Per-request HTTP timeout |
+| `logs_enabled` | bool | `true` | Enable live log streaming. When enabled, the runner opens a WebSocket to the API for the lifetime of the run. Log bytes only flow while at least one UI client has the log panel open — zero traffic otherwise |
+| `logs_interval` | string | `200ms` | How often the runner reads new bytes from `benchmarkoor.log` and pushes them over the WebSocket while streaming is active. Lower values feel smoother; the overhead is negligible since empty ticks don't send a message |
 
 Reports are best-effort: HTTP failures are logged at WARN and dropped. The next tick will retry with the latest snapshot. On `Stop()`, the runner sends one final synchronous report so the terminal status reaches the API.
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
+	github.com/coder/websocket v1.8.14
 	github.com/containers/podman/v5 v5.8.0
 	github.com/docker/docker v28.5.1+incompatible
 	github.com/docker/go-units v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObk
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -40,6 +40,7 @@ type server struct {
 	indexer        indexer.Indexer
 	storageReader  storage.Reader
 	storageDeleter storage.Deleter
+	wsHub          *wsHub
 	httpServer     *http.Server
 	wg             sync.WaitGroup
 	done           chan struct{}
@@ -50,10 +51,13 @@ func NewServer(
 	log logrus.FieldLogger,
 	cfg *config.APIConfig,
 ) Server {
+	componentLog := log.WithField("component", "api")
+
 	return &server{
-		log:  log.WithField("component", "api"),
-		cfg:  cfg,
-		done: make(chan struct{}),
+		log:   componentLog,
+		cfg:   cfg,
+		done:  make(chan struct{}),
+		wsHub: newWsHub(componentLog),
 	}
 }
 
@@ -188,6 +192,10 @@ func (s *server) Start(ctx context.Context) error {
 func (s *server) Stop() error {
 	close(s.done)
 
+	if s.wsHub != nil {
+		s.wsHub.Stop()
+	}
+
 	if s.httpServer != nil {
 		ctx, cancel := context.WithTimeout(
 			context.Background(), shutdownTimeout,
@@ -266,10 +274,18 @@ func (s *server) prepareIndexing(ctx context.Context) error {
 		interval = d
 	}
 
+	// Drop any live log-stream state when the on-disk indexer takes
+	// over a run from the live_runs table.
+	var onLiveRunIndexed func(string)
+	if s.wsHub != nil {
+		onLiveRunIndexed = s.wsHub.DropRun
+	}
+
 	// Create the indexer (not started yet).
 	s.indexer = indexer.NewIndexer(
 		s.log, s.indexStore, s.storageReader, interval,
 		s.cfg.Indexing.Concurrency,
+		onLiveRunIndexed,
 	)
 
 	s.log.Info("Indexing service enabled")

--- a/pkg/api/handlers_ws.go
+++ b/pkg/api/handlers_ws.go
@@ -43,6 +43,12 @@ func (s *server) handleIngestWS(w http.ResponseWriter, r *http.Request) {
 // handleLiveRunLogsWS upgrades an incoming UI connection to a
 // WebSocket. Auth is gated earlier in the router (requireAuth when
 // AnonymousRead is off). run_id comes from the URL path.
+//
+// Origin validation mirrors the HTTP CORS policy: when explicit
+// cors_origins are configured, only those origins can open a WS.
+// When the allowlist is empty or ["*"] (dev mode), any origin is
+// accepted. This is the server-side enforcement that browsers don't
+// provide via CORS on WebSocket handshakes.
 func (s *server) handleLiveRunLogsWS(w http.ResponseWriter, r *http.Request) {
 	runID := chi.URLParam(r, "run_id")
 	if runID == "" {
@@ -51,14 +57,22 @@ func (s *server) handleLiveRunLogsWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		// Reflect-the-origin is handled by the CORS middleware
-		// upstream; nhooyr's origin check would reject cross-origin
-		// connections with 403. We mirror the HTTP policy (dev mode
-		// allows any, explicit origins are allow-listed) by skipping
-		// the library's built-in check and trusting the CORS layer.
-		InsecureSkipVerify: true,
-	})
+	opts := &websocket.AcceptOptions{}
+	origins := s.cfg.Server.CORSOrigins
+
+	if len(origins) == 0 || (len(origins) == 1 && origins[0] == "*") {
+		// Dev / open mode: allow any origin (same as the HTTP CORS
+		// "reflect requesting origin" policy).
+		opts.InsecureSkipVerify = true
+	} else {
+		// Production: enforce the same origin allowlist that HTTP CORS
+		// uses. OriginPatterns uses path.Match; entries containing
+		// "://" are matched against "scheme://host" from the browser's
+		// Origin header, which is exactly the format cors_origins uses.
+		opts.OriginPatterns = origins
+	}
+
+	ws, err := websocket.Accept(w, r, opts)
 	if err != nil {
 		s.log.WithError(err).WithField("run_id", runID).
 			Warn("Failed to accept UI WS")

--- a/pkg/api/handlers_ws.go
+++ b/pkg/api/handlers_ws.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/coder/websocket"
+	"github.com/go-chi/chi/v5"
+)
+
+// handleIngestWS upgrades an incoming runner connection to a
+// WebSocket. Auth has already happened via requireIngestToken on the
+// /ingest subrouter. The run_id is provided as a query param; we
+// don't reject unknown ids here — the wsHub creates run entries
+// lazily and the stalewatcher cleans up idle ones.
+func (s *server) handleIngestWS(w http.ResponseWriter, r *http.Request) {
+	runID := r.URL.Query().Get("run_id")
+	if runID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"run_id query param is required"})
+
+		return
+	}
+
+	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		// We already authenticate via bearer token, so CORS-style
+		// origin checks are not applicable. The runner is not a
+		// browser so the usual origin-header protections don't help.
+		InsecureSkipVerify: true,
+		// permessage-deflate is opt-in on the client side; leaving
+		// CompressionMode defaulted means the server negotiates it
+		// transparently when the client offers it.
+	})
+	if err != nil {
+		s.log.WithError(err).WithField("run_id", runID).
+			Warn("Failed to accept runner WS")
+
+		return
+	}
+
+	// RegisterRunner runs the blocking read loop until the WS closes.
+	s.wsHub.RegisterRunner(r.Context(), runID, ws)
+}
+
+// handleLiveRunLogsWS upgrades an incoming UI connection to a
+// WebSocket. Auth is gated earlier in the router (requireAuth when
+// AnonymousRead is off). run_id comes from the URL path.
+func (s *server) handleLiveRunLogsWS(w http.ResponseWriter, r *http.Request) {
+	runID := chi.URLParam(r, "run_id")
+	if runID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"run_id is required"})
+
+		return
+	}
+
+	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		// Reflect-the-origin is handled by the CORS middleware
+		// upstream; nhooyr's origin check would reject cross-origin
+		// connections with 403. We mirror the HTTP policy (dev mode
+		// allows any, explicit origins are allow-listed) by skipping
+		// the library's built-in check and trusting the CORS layer.
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		s.log.WithError(err).WithField("run_id", runID).
+			Warn("Failed to accept UI WS")
+
+		return
+	}
+
+	s.wsHub.RegisterUI(r.Context(), runID, ws)
+}

--- a/pkg/api/indexer/indexer.go
+++ b/pkg/api/indexer/indexer.go
@@ -34,37 +34,44 @@ type Indexer interface {
 var _ Indexer = (*indexer)(nil)
 
 type indexer struct {
-	log         logrus.FieldLogger
-	store       indexstore.Store
-	reader      storage.Reader
-	interval    time.Duration
-	concurrency int
-	ctx         context.Context // lifecycle context set by Start
-	done        chan struct{}
-	wg          sync.WaitGroup
-	running     atomic.Bool // prevents overlapping indexing passes
-	dbMu        sync.Mutex  // serializes DB writes to avoid SQLite contention
+	log              logrus.FieldLogger
+	store            indexstore.Store
+	reader           storage.Reader
+	interval         time.Duration
+	concurrency      int
+	onLiveRunIndexed func(runID string)
+	ctx              context.Context // lifecycle context set by Start
+	done             chan struct{}
+	wg               sync.WaitGroup
+	running          atomic.Bool // prevents overlapping indexing passes
+	dbMu             sync.Mutex  // serializes DB writes to avoid SQLite contention
 }
 
-// NewIndexer creates a new background indexer.
+// NewIndexer creates a new background indexer. `onLiveRunIndexed`, when
+// non-nil, is invoked with the run_id right after the canonical Run
+// row is upserted (and the matching live_runs row deleted). Used by
+// the API to drop log-stream state for the run since the live panel
+// is about to be superseded by the static run detail view.
 func NewIndexer(
 	log logrus.FieldLogger,
 	store indexstore.Store,
 	reader storage.Reader,
 	interval time.Duration,
 	concurrency int,
+	onLiveRunIndexed func(runID string),
 ) Indexer {
 	if concurrency <= 0 {
 		concurrency = defaultConcurrency
 	}
 
 	return &indexer{
-		log:         log.WithField("component", "indexer"),
-		store:       store,
-		reader:      reader,
-		interval:    interval,
-		concurrency: concurrency,
-		done:        make(chan struct{}),
+		log:              log.WithField("component", "indexer"),
+		store:            store,
+		reader:           reader,
+		interval:         interval,
+		concurrency:      concurrency,
+		onLiveRunIndexed: onLiveRunIndexed,
+		done:             make(chan struct{}),
 	}
 }
 
@@ -480,6 +487,12 @@ func (idx *indexer) indexRun(
 	if err := idx.store.DeleteLiveRun(ctx, dp, runID); err != nil {
 		idx.log.WithError(err).WithField("run_id", runID).
 			Debug("Failed to delete live run entry")
+	}
+
+	// Drop any live log-stream state for this run so lingering UI
+	// WebSockets get a clean run_ended signal and the buffer is freed.
+	if idx.onLiveRunIndexed != nil {
+		idx.onLiveRunIndexed(runID)
 	}
 
 	// Index test stats if result.json is present and suite hash is set.

--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -24,7 +24,7 @@ type Store interface {
 	UpsertLiveRun(ctx context.Context, report *LiveRunReport) error
 	ListLiveRuns(ctx context.Context) ([]LiveRun, error)
 	DeleteLiveRun(ctx context.Context, discoveryPath, runID string) error
-	DeleteStaleLiveRuns(ctx context.Context, olderThan time.Time) (int64, error)
+	DeleteStaleLiveRuns(ctx context.Context, olderThan time.Time) ([]string, error)
 	ListRuns(ctx context.Context, discoveryPath string) ([]Run, error)
 	ListRunIDs(ctx context.Context, discoveryPath string) ([]string, error)
 	ListIncompleteRunIDs(
@@ -350,17 +350,37 @@ func (s *store) DeleteLiveRun(ctx context.Context, dp, runID string) error {
 	return nil
 }
 
-// DeleteStaleLiveRuns removes any live run whose last_reported_at is older
-// than the given threshold. Returns the number of rows deleted.
-func (s *store) DeleteStaleLiveRuns(ctx context.Context, olderThan time.Time) (int64, error) {
-	result := s.db.WithContext(ctx).
+// DeleteStaleLiveRuns removes any live run whose last_reported_at is
+// older than the given threshold. Returns the run_ids that were
+// deleted so callers (e.g. the stale watcher) can clean up associated
+// state like WebSocket hubs.
+func (s *store) DeleteStaleLiveRuns(ctx context.Context, olderThan time.Time) ([]string, error) {
+	// First, collect the run_ids that will be purged.
+	var stale []LiveRun
+	if err := s.db.WithContext(ctx).
+		Select("run_id").
 		Where("last_reported_at < ?", olderThan).
-		Delete(&LiveRun{})
-	if result.Error != nil {
-		return 0, fmt.Errorf("deleting stale live runs: %w", result.Error)
+		Find(&stale).Error; err != nil {
+		return nil, fmt.Errorf("finding stale live runs: %w", err)
 	}
 
-	return result.RowsAffected, nil
+	if len(stale) == 0 {
+		return nil, nil
+	}
+
+	// Delete the rows.
+	if err := s.db.WithContext(ctx).
+		Where("last_reported_at < ?", olderThan).
+		Delete(&LiveRun{}).Error; err != nil {
+		return nil, fmt.Errorf("deleting stale live runs: %w", err)
+	}
+
+	ids := make([]string, len(stale))
+	for i, r := range stale {
+		ids[i] = r.RunID
+	}
+
+	return ids, nil
 }
 
 // ListRuns returns all runs for a given discovery path ordered by timestamp.

--- a/pkg/api/indexstore/indexstore_test.go
+++ b/pkg/api/indexstore/indexstore_test.go
@@ -521,18 +521,19 @@ func TestStore_DeleteStaleLiveRuns(t *testing.T) {
 	}))
 
 	// A threshold in the past leaves freshly-reported rows alone.
-	count, err := s.DeleteStaleLiveRuns(ctx, now.Add(-time.Hour))
+	ids, err := s.DeleteStaleLiveRuns(ctx, now.Add(-time.Hour))
 	require.NoError(t, err)
-	assert.Equal(t, int64(0), count)
+	assert.Empty(t, ids)
 
 	live, err := s.ListLiveRuns(ctx)
 	require.NoError(t, err)
 	assert.Len(t, live, 2)
 
-	// A threshold in the future deletes everything.
-	count, err = s.DeleteStaleLiveRuns(ctx, now.Add(time.Hour))
+	// A threshold in the future deletes everything and returns the ids.
+	ids, err = s.DeleteStaleLiveRuns(ctx, now.Add(time.Hour))
 	require.NoError(t, err)
-	assert.Equal(t, int64(2), count)
+	assert.Len(t, ids, 2)
+	assert.ElementsMatch(t, []string{"fresh-1", "fresh-2"}, ids)
 
 	live, err = s.ListLiveRuns(ctx)
 	require.NoError(t, err)

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -85,6 +85,7 @@ func (s *server) buildRouter() http.Handler {
 				r.Get("/", s.handleIndex)
 				r.Get("/suites/{hash}/stats", s.handleSuiteStats)
 				r.Get("/live_runs", s.handleListLiveRuns)
+				r.Get("/live_runs/{run_id}/logs/ws", s.handleLiveRunLogsWS)
 
 				r.Route("/query", func(r chi.Router) {
 					r.Get("/runs", s.handleQueryRuns)
@@ -116,6 +117,7 @@ func (s *server) buildRouter() http.Handler {
 				}
 
 				r.Post("/runs", s.handleIngestRun)
+				r.Get("/ws", s.handleIngestWS)
 			})
 		}
 

--- a/pkg/api/stalewatcher.go
+++ b/pkg/api/stalewatcher.go
@@ -34,16 +34,26 @@ func (s *server) startStaleLiveRunsWatcher(ctx context.Context) {
 			select {
 			case <-ticker.C:
 				cutoff := time.Now().UTC().Add(-threshold)
-				count, err := s.indexStore.DeleteStaleLiveRuns(ctx, cutoff)
+				purgedIDs, err := s.indexStore.DeleteStaleLiveRuns(ctx, cutoff)
 				if err != nil {
 					s.log.WithError(err).Warn("Failed to purge stale live runs")
 
 					continue
 				}
 
-				if count > 0 {
-					s.log.WithField("deleted", count).
+				if len(purgedIDs) > 0 {
+					s.log.WithField("deleted", len(purgedIDs)).
 						Info("Purged stale live runs")
+
+					// Notify any UI clients still watching a purged
+					// run — their runner died and the DB row is gone,
+					// so the log panel should show "run ended" rather
+					// than hanging on a dead stream.
+					if s.wsHub != nil {
+						for _, id := range purgedIDs {
+							s.wsHub.DropRun(id)
+						}
+					}
 				}
 
 				// Also evict idle log-stream hubs (no runner, no UI,

--- a/pkg/api/stalewatcher.go
+++ b/pkg/api/stalewatcher.go
@@ -45,6 +45,13 @@ func (s *server) startStaleLiveRunsWatcher(ctx context.Context) {
 					s.log.WithField("deleted", count).
 						Info("Purged stale live runs")
 				}
+
+				// Also evict idle log-stream hubs (no runner, no UI,
+				// nothing happening past the same cutoff). Their
+				// buffers sit in API memory until we drop them.
+				if s.wsHub != nil {
+					s.wsHub.EvictIdle(cutoff)
+				}
 			case <-s.done:
 				return
 			}

--- a/pkg/api/wshub.go
+++ b/pkg/api/wshub.go
@@ -1,0 +1,419 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sirupsen/logrus"
+)
+
+// Live log-stream broker between benchmarkoor runners (one persistent
+// WS per run, pushes log bytes when asked) and browser clients (one WS
+// per open log panel, receives the buffered snapshot + live messages).
+//
+// Design:
+//   - Every run has a runHub with an in-memory ring buffer (so late UIs
+//     see recent history), a single runner conn, and zero or more UI
+//     conns.
+//   - Subscriber count flips from 0→1 (first UI connects) cause the
+//     hub to send {type:"stream_on"} to the runner. 1→0 sends
+//     {type:"stream_off"}. No TTL — we rely on the OS detecting the
+//     closed socket.
+//   - Fan-out writes are serialized per connection via the conn's own
+//     mutex + a 5 s deadline; slow / dead subscribers are kicked.
+
+const (
+	maxLogBytesPerRun    = 512 * 1024
+	wsWriteDeadline      = 5 * time.Second
+	wsMaxReadFrame       = 128 * 1024 // 64 KiB chunks + headroom
+	wsServerAcceptClose  = "server shutting down"
+	wsServerRunEndClose  = "run ended"
+	wsServerRunnerChange = "runner replaced"
+)
+
+// wsMessage is the common envelope; not all fields are used in every
+// direction. JSON tags match the schema documented on the endpoints.
+type wsMessage struct {
+	Type      string `json:"type"`
+	Text      string `json:"text,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+type wsHub struct {
+	mu   sync.Mutex
+	runs map[string]*runHub
+	log  logrus.FieldLogger
+}
+
+type runHub struct {
+	mu         sync.Mutex
+	runnerConn *wsConn // nil between connects
+	uis        []*wsConn
+	buf        []byte // ring-style byte slice, capped at maxLogBytesPerRun
+	seq        int64  // total bytes ever received; monotonic across truncations
+	truncated  bool   // sticky once buffer has dropped bytes
+	streaming  bool   // last command sent to runner
+	updated    time.Time
+}
+
+// wsConn wraps a single WebSocket with its own write serialization.
+// nhooyr's Write must not be called concurrently, so every outbound
+// message goes through Write() which takes the mutex + a short
+// deadline.
+type wsConn struct {
+	ws    *websocket.Conn
+	mu    sync.Mutex
+	log   logrus.FieldLogger
+	label string // "runner" / "ui" — for log context
+}
+
+func newWsHub(log logrus.FieldLogger) *wsHub {
+	return &wsHub{
+		runs: make(map[string]*runHub),
+		log:  log.WithField("component", "wshub"),
+	}
+}
+
+// RegisterRunner attaches a newly-connected runner WS to the hub's
+// run. Replaces any existing runner conn (a reconnect supersedes the
+// stale one). Evaluates current subscriber state and pushes an initial
+// stream_on/off command synchronously before returning. Runs the read
+// loop until the WS closes.
+func (h *wsHub) RegisterRunner(ctx context.Context, runID string, ws *websocket.Conn) {
+	conn := &wsConn{ws: ws, log: h.log.WithFields(logrus.Fields{"run_id": runID, "side": "runner"}), label: "runner"}
+
+	rh := h.getOrCreate(runID)
+
+	rh.mu.Lock()
+	var old *wsConn
+	if rh.runnerConn != nil {
+		old = rh.runnerConn
+	}
+	rh.runnerConn = conn
+	rh.updated = time.Now().UTC()
+
+	// Runners default to "not streaming" — only send stream_on if we
+	// already have UIs waiting. stream_off is never sent on connect
+	// because the runner starts in the off state anyway.
+	want := len(rh.uis) > 0
+	rh.streaming = want
+	rh.mu.Unlock()
+
+	if old != nil {
+		_ = old.ws.Close(websocket.StatusNormalClosure, wsServerRunnerChange)
+		conn.log.Info("Replaced stale runner WS connection")
+	} else {
+		conn.log.Info("Runner WS connected")
+	}
+
+	if want {
+		sendCommand(conn, true)
+	}
+
+	h.readRunnerLoop(ctx, runID, conn)
+
+	rh.mu.Lock()
+	if rh.runnerConn == conn {
+		rh.runnerConn = nil
+		rh.streaming = false
+	}
+	rh.mu.Unlock()
+
+	conn.log.Info("Runner WS disconnected")
+}
+
+// RegisterUI attaches a newly-connected UI WS to the hub's run. Sends
+// the current buffer as a snapshot immediately, then fan-out forwards
+// live log messages to this conn. Runs the read loop until the UI
+// closes. The read loop is trivial — we only need it to notice the
+// close; UI clients don't send messages today.
+func (h *wsHub) RegisterUI(ctx context.Context, runID string, ws *websocket.Conn) {
+	conn := &wsConn{ws: ws, log: h.log.WithFields(logrus.Fields{"run_id": runID, "side": "ui"}), label: "ui"}
+
+	rh := h.getOrCreate(runID)
+
+	var (
+		snapshot     []byte
+		wasTruncated bool
+		needStreamOn bool
+		runnerForCmd *wsConn
+	)
+
+	rh.mu.Lock()
+	rh.uis = append(rh.uis, conn)
+	rh.updated = time.Now().UTC()
+	if len(rh.buf) > 0 {
+		snapshot = append(make([]byte, 0, len(rh.buf)), rh.buf...)
+		wasTruncated = rh.truncated
+	}
+	if len(rh.uis) == 1 && rh.runnerConn != nil && !rh.streaming {
+		needStreamOn = true
+		rh.streaming = true
+		runnerForCmd = rh.runnerConn
+	}
+	rh.mu.Unlock()
+
+	conn.log.Info("UI WS connected")
+
+	if err := writeJSONMsg(conn, wsMessage{Type: "snapshot", Text: string(snapshot), Truncated: wasTruncated}); err != nil {
+		conn.log.WithError(err).Debug("Failed to send initial snapshot")
+		_ = ws.Close(websocket.StatusInternalError, "snapshot write failed")
+
+		h.unregisterUI(runID, conn)
+
+		return
+	}
+
+	if needStreamOn {
+		sendCommand(runnerForCmd, true)
+	}
+
+	// Read loop — we just wait for the close; UI clients don't send
+	// messages today. Still honor ping/pong via nhooyr's defaults.
+	for {
+		_, _, err := ws.Read(ctx)
+		if err != nil {
+			break
+		}
+	}
+
+	h.unregisterUI(runID, conn)
+	conn.log.Info("UI WS disconnected")
+}
+
+// DropRun closes all WSes for the run with a run_ended notice and
+// frees the buffer. Called by the indexer right after DeleteLiveRun so
+// the takeover to a canonical Run is clean.
+func (h *wsHub) DropRun(runID string) {
+	h.mu.Lock()
+	rh, ok := h.runs[runID]
+	if ok {
+		delete(h.runs, runID)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	rh.mu.Lock()
+	runner := rh.runnerConn
+	uis := rh.uis
+	rh.runnerConn = nil
+	rh.uis = nil
+	rh.mu.Unlock()
+
+	for _, ui := range uis {
+		_ = writeJSONMsg(ui, wsMessage{Type: "run_ended"})
+		_ = ui.ws.Close(websocket.StatusNormalClosure, wsServerRunEndClose)
+	}
+
+	if runner != nil {
+		_ = runner.ws.Close(websocket.StatusNormalClosure, wsServerRunEndClose)
+	}
+}
+
+// EvictIdle drops runHubs with no runner + no UI that have been idle
+// past `cutoff`. Called from the stalewatcher on its existing tick.
+func (h *wsHub) EvictIdle(cutoff time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for id, rh := range h.runs {
+		rh.mu.Lock()
+		idle := rh.runnerConn == nil && len(rh.uis) == 0 && rh.updated.Before(cutoff)
+		rh.mu.Unlock()
+
+		if idle {
+			delete(h.runs, id)
+		}
+	}
+}
+
+// Stop closes every open WS on server shutdown.
+func (h *wsHub) Stop() {
+	h.mu.Lock()
+	runs := h.runs
+	h.runs = make(map[string]*runHub)
+	h.mu.Unlock()
+
+	for _, rh := range runs {
+		rh.mu.Lock()
+		runner := rh.runnerConn
+		uis := rh.uis
+		rh.runnerConn = nil
+		rh.uis = nil
+		rh.mu.Unlock()
+
+		if runner != nil {
+			_ = runner.ws.Close(websocket.StatusGoingAway, wsServerAcceptClose)
+		}
+		for _, ui := range uis {
+			_ = ui.ws.Close(websocket.StatusGoingAway, wsServerAcceptClose)
+		}
+	}
+}
+
+// getOrCreate returns the runHub for runID, creating it lazily. Used
+// by Register* — we intentionally don't require a live_runs row to
+// exist before accepting WS registrations; callers (handlers) gate
+// that check earlier in the request flow.
+func (h *wsHub) getOrCreate(runID string) *runHub {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if rh, ok := h.runs[runID]; ok {
+		return rh
+	}
+
+	rh := &runHub{updated: time.Now().UTC()}
+	h.runs[runID] = rh
+
+	return rh
+}
+
+// readRunnerLoop handles incoming runner messages (log, bye). Returns
+// when the WS closes or ctx is cancelled.
+func (h *wsHub) readRunnerLoop(ctx context.Context, runID string, conn *wsConn) {
+	conn.ws.SetReadLimit(wsMaxReadFrame)
+
+	for {
+		_, data, err := conn.ws.Read(ctx)
+		if err != nil {
+			return
+		}
+
+		var msg wsMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			conn.log.WithError(err).Debug("Ignoring malformed runner message")
+
+			continue
+		}
+
+		switch msg.Type {
+		case "log":
+			h.appendAndFanOut(runID, []byte(msg.Text))
+		case "bye":
+			return
+		default:
+			conn.log.WithField("type", msg.Type).Debug("Ignoring unknown runner message")
+		}
+	}
+}
+
+// appendAndFanOut writes new bytes into the run's ring buffer and
+// forwards them to every subscribed UI conn. Called on every log
+// message from the runner.
+func (h *wsHub) appendAndFanOut(runID string, data []byte) {
+	if len(data) == 0 {
+		return
+	}
+
+	h.mu.Lock()
+	rh, ok := h.runs[runID]
+	h.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	rh.mu.Lock()
+	// Append + trim to cap (drop oldest bytes but keep seq monotonic).
+	rh.buf = append(rh.buf, data...)
+	if len(rh.buf) > maxLogBytesPerRun {
+		overflow := len(rh.buf) - maxLogBytesPerRun
+		rh.buf = rh.buf[overflow:]
+
+		if !rh.truncated {
+			rh.truncated = true
+		}
+	}
+	rh.seq += int64(len(data))
+	rh.updated = time.Now().UTC()
+
+	uis := make([]*wsConn, len(rh.uis))
+	copy(uis, rh.uis)
+	rh.mu.Unlock()
+
+	msg := wsMessage{Type: "log", Text: string(data)}
+	for _, ui := range uis {
+		if err := writeJSONMsg(ui, msg); err != nil {
+			// Close the conn; the UI's read loop will notice and
+			// unregister itself.
+			_ = ui.ws.Close(websocket.StatusInternalError, "slow ui write")
+		}
+	}
+}
+
+// unregisterUI removes a UI conn from its run. If that drops the
+// subscriber count to 0, send stream_off to the runner.
+func (h *wsHub) unregisterUI(runID string, conn *wsConn) {
+	h.mu.Lock()
+	rh, ok := h.runs[runID]
+	h.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	rh.mu.Lock()
+	for i, ui := range rh.uis {
+		if ui == conn {
+			rh.uis = append(rh.uis[:i], rh.uis[i+1:]...)
+
+			break
+		}
+	}
+
+	var runnerForCmd *wsConn
+
+	if len(rh.uis) == 0 && rh.runnerConn != nil && rh.streaming {
+		rh.streaming = false
+		runnerForCmd = rh.runnerConn
+	}
+
+	rh.updated = time.Now().UTC()
+	rh.mu.Unlock()
+
+	if runnerForCmd != nil {
+		sendCommand(runnerForCmd, false)
+	}
+}
+
+// sendCommand emits stream_on / stream_off to a runner conn. Errors
+// are logged and ignored; the read loop will unregister if the conn
+// is truly dead.
+func sendCommand(conn *wsConn, on bool) {
+	if conn == nil {
+		return
+	}
+
+	msg := wsMessage{Type: "stream_off"}
+	if on {
+		msg.Type = "stream_on"
+	}
+
+	if err := writeJSONMsg(conn, msg); err != nil {
+		conn.log.WithError(err).Debug("Failed to send stream command")
+	}
+}
+
+// writeJSONMsg serializes and sends a message with the write deadline
+// applied. Caller-safe across goroutines via the per-conn mutex.
+func writeJSONMsg(conn *wsConn, msg wsMessage) error {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), wsWriteDeadline)
+	defer cancel()
+
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	return conn.ws.Write(ctx, websocket.MessageText, b)
+}

--- a/pkg/api/wshub.go
+++ b/pkg/api/wshub.go
@@ -22,8 +22,10 @@ import (
 //     hub to send {type:"stream_on"} to the runner. 1→0 sends
 //     {type:"stream_off"}. No TTL — we rely on the OS detecting the
 //     closed socket.
-//   - Fan-out writes are serialized per connection via the conn's own
-//     mutex + a 5 s deadline; slow / dead subscribers are kicked.
+//   - Each UI conn has a buffered send channel + a dedicated writer
+//     goroutine. Fan-out is non-blocking: if the channel is full, the
+//     conn is kicked immediately. This prevents a single slow
+//     subscriber from stalling the runner's read loop.
 
 const (
 	maxLogBytesPerRun    = 512 * 1024
@@ -32,6 +34,7 @@ const (
 	wsServerAcceptClose  = "server shutting down"
 	wsServerRunEndClose  = "run ended"
 	wsServerRunnerChange = "runner replaced"
+	uiSendChCapacity     = 64 // buffered messages per UI conn
 )
 
 // wsMessage is the common envelope; not all fields are used in every
@@ -50,8 +53,8 @@ type wsHub struct {
 
 type runHub struct {
 	mu         sync.Mutex
-	runnerConn *wsConn // nil between connects
-	uis        []*wsConn
+	runnerConn *runnerConn // nil between connects
+	uis        []*uiConn
 	buf        []byte // ring-style byte slice, capped at maxLogBytesPerRun
 	seq        int64  // total bytes ever received; monotonic across truncations
 	truncated  bool   // sticky once buffer has dropped bytes
@@ -59,15 +62,23 @@ type runHub struct {
 	updated    time.Time
 }
 
-// wsConn wraps a single WebSocket with its own write serialization.
-// nhooyr's Write must not be called concurrently, so every outbound
-// message goes through Write() which takes the mutex + a short
-// deadline.
-type wsConn struct {
-	ws    *websocket.Conn
-	mu    sync.Mutex
-	log   logrus.FieldLogger
-	label string // "runner" / "ui" — for log context
+// runnerConn wraps the runner-side WS. Commands (stream_on/off) are
+// rare and sent directly under a mutex — no need for a channel.
+type runnerConn struct {
+	ws  *websocket.Conn
+	mu  sync.Mutex
+	log logrus.FieldLogger
+}
+
+// uiConn wraps a UI-side WS with a buffered send channel + a writer
+// goroutine so fan-out never blocks the runner's read loop. If the
+// channel fills (backpressure from a slow client), the conn is kicked.
+type uiConn struct {
+	ws        *websocket.Conn
+	sendCh    chan []byte   // pre-serialized JSON messages
+	done      chan struct{} // closed when writer goroutine exits
+	closeOnce sync.Once
+	log       logrus.FieldLogger
 }
 
 func newWsHub(log logrus.FieldLogger) *wsHub {
@@ -77,27 +88,23 @@ func newWsHub(log logrus.FieldLogger) *wsHub {
 	}
 }
 
+// ── Runner registration ──────────────────────────────────────────
+
 // RegisterRunner attaches a newly-connected runner WS to the hub's
 // run. Replaces any existing runner conn (a reconnect supersedes the
-// stale one). Evaluates current subscriber state and pushes an initial
-// stream_on/off command synchronously before returning. Runs the read
-// loop until the WS closes.
+// stale one). Runs the read loop until the WS closes.
 func (h *wsHub) RegisterRunner(ctx context.Context, runID string, ws *websocket.Conn) {
-	conn := &wsConn{ws: ws, log: h.log.WithFields(logrus.Fields{"run_id": runID, "side": "runner"}), label: "runner"}
+	conn := &runnerConn{ws: ws, log: h.log.WithFields(logrus.Fields{"run_id": runID, "side": "runner"})}
 
 	rh := h.getOrCreate(runID)
 
 	rh.mu.Lock()
-	var old *wsConn
+	var old *runnerConn
 	if rh.runnerConn != nil {
 		old = rh.runnerConn
 	}
 	rh.runnerConn = conn
 	rh.updated = time.Now().UTC()
-
-	// Runners default to "not streaming" — only send stream_on if we
-	// already have UIs waiting. stream_off is never sent on connect
-	// because the runner starts in the off state anyway.
 	want := len(rh.uis) > 0
 	rh.streaming = want
 	rh.mu.Unlock()
@@ -110,7 +117,7 @@ func (h *wsHub) RegisterRunner(ctx context.Context, runID string, ws *websocket.
 	}
 
 	if want {
-		sendCommand(conn, true)
+		sendRunnerCommand(conn, true)
 	}
 
 	h.readRunnerLoop(ctx, runID, conn)
@@ -125,13 +132,14 @@ func (h *wsHub) RegisterRunner(ctx context.Context, runID string, ws *websocket.
 	conn.log.Info("Runner WS disconnected")
 }
 
-// RegisterUI attaches a newly-connected UI WS to the hub's run. Sends
-// the current buffer as a snapshot immediately, then fan-out forwards
-// live log messages to this conn. Runs the read loop until the UI
-// closes. The read loop is trivial — we only need it to notice the
-// close; UI clients don't send messages today.
+// ── UI registration ──────────────────────────────────────────────
+
+// RegisterUI attaches a newly-connected UI WS. Sends the current
+// buffer as a snapshot, starts a writer goroutine for non-blocking
+// fan-out, then blocks on a read loop (just to detect close). On
+// exit, the conn is unregistered and the writer goroutine drained.
 func (h *wsHub) RegisterUI(ctx context.Context, runID string, ws *websocket.Conn) {
-	conn := &wsConn{ws: ws, log: h.log.WithFields(logrus.Fields{"run_id": runID, "side": "ui"}), label: "ui"}
+	conn := newUIConn(ws, h.log.WithFields(logrus.Fields{"run_id": runID, "side": "ui"}))
 
 	rh := h.getOrCreate(runID)
 
@@ -139,7 +147,7 @@ func (h *wsHub) RegisterUI(ctx context.Context, runID string, ws *websocket.Conn
 		snapshot     []byte
 		wasTruncated bool
 		needStreamOn bool
-		runnerForCmd *wsConn
+		runnerForCmd *runnerConn
 	)
 
 	rh.mu.Lock()
@@ -158,21 +166,22 @@ func (h *wsHub) RegisterUI(ctx context.Context, runID string, ws *websocket.Conn
 
 	conn.log.Info("UI WS connected")
 
-	if err := writeJSONMsg(conn, wsMessage{Type: "snapshot", Text: string(snapshot), Truncated: wasTruncated}); err != nil {
-		conn.log.WithError(err).Debug("Failed to send initial snapshot")
-		_ = ws.Close(websocket.StatusInternalError, "snapshot write failed")
-
+	// Send snapshot through the channel (buffered, will not block).
+	snapMsg, _ := json.Marshal(wsMessage{Type: "snapshot", Text: string(snapshot), Truncated: wasTruncated})
+	if !conn.send(snapMsg) {
+		conn.kick()
+		conn.awaitWriter()
 		h.unregisterUI(runID, conn)
 
 		return
 	}
 
 	if needStreamOn {
-		sendCommand(runnerForCmd, true)
+		sendRunnerCommand(runnerForCmd, true)
 	}
 
 	// Read loop — we just wait for the close; UI clients don't send
-	// messages today. Still honor ping/pong via nhooyr's defaults.
+	// messages today. Ping/pong is handled by the library.
 	for {
 		_, _, err := ws.Read(ctx)
 		if err != nil {
@@ -180,13 +189,16 @@ func (h *wsHub) RegisterUI(ctx context.Context, runID string, ws *websocket.Conn
 		}
 	}
 
+	conn.kick()
+	conn.awaitWriter()
 	h.unregisterUI(runID, conn)
 	conn.log.Info("UI WS disconnected")
 }
 
+// ── Lifecycle ────────────────────────────────────────────────────
+
 // DropRun closes all WSes for the run with a run_ended notice and
-// frees the buffer. Called by the indexer right after DeleteLiveRun so
-// the takeover to a canonical Run is clean.
+// frees the buffer. Called by the indexer right after DeleteLiveRun.
 func (h *wsHub) DropRun(runID string) {
 	h.mu.Lock()
 	rh, ok := h.runs[runID]
@@ -206,9 +218,10 @@ func (h *wsHub) DropRun(runID string) {
 	rh.uis = nil
 	rh.mu.Unlock()
 
+	endedMsg, _ := json.Marshal(wsMessage{Type: "run_ended"})
 	for _, ui := range uis {
-		_ = writeJSONMsg(ui, wsMessage{Type: "run_ended"})
-		_ = ui.ws.Close(websocket.StatusNormalClosure, wsServerRunEndClose)
+		ui.send(endedMsg) // buffered; drainAndClose flushes it
+		ui.drainAndClose()
 	}
 
 	if runner != nil {
@@ -252,15 +265,13 @@ func (h *wsHub) Stop() {
 			_ = runner.ws.Close(websocket.StatusGoingAway, wsServerAcceptClose)
 		}
 		for _, ui := range uis {
-			_ = ui.ws.Close(websocket.StatusGoingAway, wsServerAcceptClose)
+			ui.kick()
 		}
 	}
 }
 
-// getOrCreate returns the runHub for runID, creating it lazily. Used
-// by Register* — we intentionally don't require a live_runs row to
-// exist before accepting WS registrations; callers (handlers) gate
-// that check earlier in the request flow.
+// ── Internals ────────────────────────────────────────────────────
+
 func (h *wsHub) getOrCreate(runID string) *runHub {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -277,7 +288,7 @@ func (h *wsHub) getOrCreate(runID string) *runHub {
 
 // readRunnerLoop handles incoming runner messages (log, bye). Returns
 // when the WS closes or ctx is cancelled.
-func (h *wsHub) readRunnerLoop(ctx context.Context, runID string, conn *wsConn) {
+func (h *wsHub) readRunnerLoop(ctx context.Context, runID string, conn *runnerConn) {
 	conn.ws.SetReadLimit(wsMaxReadFrame)
 
 	for {
@@ -305,8 +316,9 @@ func (h *wsHub) readRunnerLoop(ctx context.Context, runID string, conn *wsConn) 
 }
 
 // appendAndFanOut writes new bytes into the run's ring buffer and
-// forwards them to every subscribed UI conn. Called on every log
-// message from the runner.
+// pushes a pre-serialized message to every subscribed UI conn's
+// channel. The push is non-blocking: if a UI's channel is full (slow
+// client), that conn is kicked immediately without affecting others.
 func (h *wsHub) appendAndFanOut(runID string, data []byte) {
 	if len(data) == 0 {
 		return
@@ -334,23 +346,29 @@ func (h *wsHub) appendAndFanOut(runID string, data []byte) {
 	rh.seq += int64(len(data))
 	rh.updated = time.Now().UTC()
 
-	uis := make([]*wsConn, len(rh.uis))
+	uis := make([]*uiConn, len(rh.uis))
 	copy(uis, rh.uis)
 	rh.mu.Unlock()
 
-	msg := wsMessage{Type: "log", Text: string(data)}
+	// Pre-serialize once, push to every UI channel.
+	b, err := json.Marshal(wsMessage{Type: "log", Text: string(data)})
+	if err != nil {
+		return
+	}
+
 	for _, ui := range uis {
-		if err := writeJSONMsg(ui, msg); err != nil {
-			// Close the conn; the UI's read loop will notice and
-			// unregister itself.
-			_ = ui.ws.Close(websocket.StatusInternalError, "slow ui write")
+		if !ui.send(b) {
+			// Channel full → kick this slow subscriber. The read loop
+			// in RegisterUI will notice the close and call unregisterUI.
+			ui.log.Debug("Kicking slow UI subscriber")
+			ui.kick()
 		}
 	}
 }
 
 // unregisterUI removes a UI conn from its run. If that drops the
 // subscriber count to 0, send stream_off to the runner.
-func (h *wsHub) unregisterUI(runID string, conn *wsConn) {
+func (h *wsHub) unregisterUI(runID string, conn *uiConn) {
 	h.mu.Lock()
 	rh, ok := h.runs[runID]
 	h.mu.Unlock()
@@ -368,7 +386,7 @@ func (h *wsHub) unregisterUI(runID string, conn *wsConn) {
 		}
 	}
 
-	var runnerForCmd *wsConn
+	var runnerForCmd *runnerConn
 
 	if len(rh.uis) == 0 && rh.runnerConn != nil && rh.streaming {
 		rh.streaming = false
@@ -379,14 +397,16 @@ func (h *wsHub) unregisterUI(runID string, conn *wsConn) {
 	rh.mu.Unlock()
 
 	if runnerForCmd != nil {
-		sendCommand(runnerForCmd, false)
+		sendRunnerCommand(runnerForCmd, false)
 	}
 }
 
-// sendCommand emits stream_on / stream_off to a runner conn. Errors
-// are logged and ignored; the read loop will unregister if the conn
-// is truly dead.
-func sendCommand(conn *wsConn, on bool) {
+// ── Runner conn helpers ──────────────────────────────────────────
+
+// sendRunnerCommand emits stream_on / stream_off to a runner conn.
+// Errors are logged and ignored; the read loop will notice if the
+// conn is truly dead.
+func sendRunnerCommand(conn *runnerConn, on bool) {
 	if conn == nil {
 		return
 	}
@@ -396,24 +416,93 @@ func sendCommand(conn *wsConn, on bool) {
 		msg.Type = "stream_on"
 	}
 
-	if err := writeJSONMsg(conn, msg); err != nil {
-		conn.log.WithError(err).Debug("Failed to send stream command")
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return
 	}
-}
 
-// writeJSONMsg serializes and sends a message with the write deadline
-// applied. Caller-safe across goroutines via the per-conn mutex.
-func writeJSONMsg(conn *wsConn, msg wsMessage) error {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), wsWriteDeadline)
 	defer cancel()
 
-	b, err := json.Marshal(msg)
-	if err != nil {
-		return err
+	if err := conn.ws.Write(ctx, websocket.MessageText, b); err != nil {
+		conn.log.WithError(err).Debug("Failed to send stream command")
+	}
+}
+
+// ── UI conn helpers ──────────────────────────────────────────────
+
+func newUIConn(ws *websocket.Conn, log logrus.FieldLogger) *uiConn {
+	c := &uiConn{
+		ws:     ws,
+		sendCh: make(chan []byte, uiSendChCapacity),
+		done:   make(chan struct{}),
+		log:    log,
 	}
 
-	return conn.ws.Write(ctx, websocket.MessageText, b)
+	go c.writeLoop()
+
+	return c
+}
+
+// writeLoop drains the send channel and writes to the WS. Exits on
+// channel close or write error.
+func (c *uiConn) writeLoop() {
+	defer close(c.done)
+
+	for msg := range c.sendCh {
+		ctx, cancel := context.WithTimeout(context.Background(), wsWriteDeadline)
+		err := c.ws.Write(ctx, websocket.MessageText, msg)
+		cancel()
+
+		if err != nil {
+			c.log.WithError(err).Debug("UI write failed, exiting writer")
+
+			return
+		}
+	}
+}
+
+// send pushes a pre-serialized message onto the channel. Returns false
+// if the channel is full (backpressure → caller should kick this conn).
+func (c *uiConn) send(msg []byte) bool {
+	select {
+	case c.sendCh <- msg:
+		return true
+	default:
+		return false
+	}
+}
+
+// kick force-closes the WS + channel without waiting for the writer
+// goroutine to drain. Used by appendAndFanOut to kick slow subscribers
+// without blocking the runner's read loop.
+func (c *uiConn) kick() {
+	c.closeOnce.Do(func() {
+		_ = c.ws.Close(websocket.StatusInternalError, "slow client")
+		close(c.sendCh)
+		// Don't wait — the writer goroutine exits on its own after the
+		// WS close makes its current write fail.
+	})
+}
+
+// drainAndClose lets the writer goroutine flush any buffered messages
+// (e.g. a run_ended frame), waits for it to exit, then closes the WS.
+// Used by DropRun where we want the client to see the final message
+// before the connection drops.
+func (c *uiConn) drainAndClose() {
+	c.closeOnce.Do(func() {
+		close(c.sendCh)
+		<-c.done
+		_ = c.ws.Close(websocket.StatusNormalClosure, "closed")
+	})
+}
+
+// awaitWriter blocks until the writer goroutine has exited. Call after
+// kick() in cleanup paths (e.g. RegisterUI return) to prevent
+// goroutine leaks.
+func (c *uiConn) awaitWriter() {
+	<-c.done
 }

--- a/pkg/api/wshub_test.go
+++ b/pkg/api/wshub_test.go
@@ -1,0 +1,294 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wsTestServer spins up an httptest server that upgrades either side
+// via the given handler. Used by the hub tests so we can simulate
+// real runner and UI connections with actual WebSocket frames.
+func wsTestServer(t *testing.T, upgrade func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(upgrade))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// dialWS opens a client WS to the given httptest URL. The caller is
+// responsible for closing the returned conn.
+func dialWS(t *testing.T, baseURL string) *websocket.Conn {
+	t.Helper()
+
+	wsURL := strings.Replace(baseURL, "http://", "ws://", 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(t, err)
+	// Snapshots can approach maxLogBytesPerRun in size; give the
+	// client side a generous read limit.
+	ws.SetReadLimit(2 * int64(maxLogBytesPerRun))
+
+	return ws
+}
+
+// readWSMessage reads one JSON message from the client side, with a
+// short deadline so tests don't hang forever.
+func readWSMessage(t *testing.T, ws *websocket.Conn) wsMessage {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, data, err := ws.Read(ctx)
+	require.NoError(t, err)
+
+	var msg wsMessage
+	require.NoError(t, json.Unmarshal(data, &msg))
+
+	return msg
+}
+
+// drainMessagesUntil reads until a message of the given type is seen
+// (or deadline) and returns that message. Useful when multiple
+// snapshot/log events can interleave.
+func drainMessagesUntil(t *testing.T, ws *websocket.Conn, wantType string, timeout time.Duration) wsMessage {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for {
+		_, data, err := ws.Read(ctx)
+		require.NoError(t, err)
+
+		var msg wsMessage
+		require.NoError(t, json.Unmarshal(data, &msg))
+
+		if msg.Type == wantType {
+			return msg
+		}
+	}
+}
+
+// hubTestSetup wires a wsHub to an httptest server that routes /runner
+// and /ui paths to RegisterRunner / RegisterUI respectively.
+func hubTestSetup(t *testing.T, runID string) (*wsHub, string) {
+	t.Helper()
+
+	log := logrus.New()
+	log.SetLevel(logrus.PanicLevel)
+
+	hub := newWsHub(log)
+	t.Cleanup(hub.Stop)
+
+	srv := wsTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+
+		switch r.URL.Path {
+		case "/runner":
+			hub.RegisterRunner(r.Context(), runID, ws)
+		case "/ui":
+			hub.RegisterUI(r.Context(), runID, ws)
+		}
+	})
+
+	return hub, srv.URL
+}
+
+func TestWsHub_RunnerAloneNoStreamOn(t *testing.T) {
+	_, base := hubTestSetup(t, "r1")
+
+	runner := dialWS(t, base+"/runner")
+	defer func() { _ = runner.Close(websocket.StatusNormalClosure, "") }()
+
+	// No UI subscribers — runner must not receive any stream_on.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, _, err := runner.Read(ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded, "runner should not receive any message")
+}
+
+func TestWsHub_UIConnectSendsStreamOnAndSnapshot(t *testing.T) {
+	_, base := hubTestSetup(t, "r1")
+
+	runner := dialWS(t, base+"/runner")
+	defer func() { _ = runner.Close(websocket.StatusNormalClosure, "") }()
+
+	ui := dialWS(t, base+"/ui")
+	defer func() { _ = ui.Close(websocket.StatusNormalClosure, "") }()
+
+	// UI should receive an initial snapshot (empty text, empty truncated).
+	snap := readWSMessage(t, ui)
+	assert.Equal(t, "snapshot", snap.Type)
+	assert.Equal(t, "", snap.Text)
+	assert.False(t, snap.Truncated)
+
+	// Runner should receive stream_on.
+	cmd := readWSMessage(t, runner)
+	assert.Equal(t, "stream_on", cmd.Type)
+}
+
+func TestWsHub_SecondUIGetsSnapshotNoExtraStreamOn(t *testing.T) {
+	_, base := hubTestSetup(t, "r1")
+
+	runner := dialWS(t, base+"/runner")
+	defer func() { _ = runner.Close(websocket.StatusNormalClosure, "") }()
+
+	ui1 := dialWS(t, base+"/ui")
+	defer func() { _ = ui1.Close(websocket.StatusNormalClosure, "") }()
+
+	// Consume the initial messages so we can assert the second UI
+	// connect doesn't cause another stream_on.
+	_ = readWSMessage(t, ui1) // snapshot
+	streamOn := readWSMessage(t, runner)
+	require.Equal(t, "stream_on", streamOn.Type)
+
+	// Runner sends some log text through, which should fan out to ui1.
+	require.NoError(t, runner.Write(context.Background(), websocket.MessageText, []byte(`{"type":"log","text":"hello "}`)))
+	logMsg := readWSMessage(t, ui1)
+	require.Equal(t, "log", logMsg.Type)
+	require.Equal(t, "hello ", logMsg.Text)
+
+	// Second UI connects. Should get a snapshot with whatever's in the
+	// buffer ("hello ") and the runner should NOT receive a second
+	// stream_on.
+	ui2 := dialWS(t, base+"/ui")
+	defer func() { _ = ui2.Close(websocket.StatusNormalClosure, "") }()
+
+	snap := readWSMessage(t, ui2)
+	assert.Equal(t, "snapshot", snap.Type)
+	assert.Equal(t, "hello ", snap.Text)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, _, err := runner.Read(ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded, "runner should not see another stream_on")
+}
+
+func TestWsHub_LastUIDisconnectSendsStreamOff(t *testing.T) {
+	_, base := hubTestSetup(t, "r1")
+
+	runner := dialWS(t, base+"/runner")
+	defer func() { _ = runner.Close(websocket.StatusNormalClosure, "") }()
+
+	ui := dialWS(t, base+"/ui")
+
+	_ = readWSMessage(t, ui) // snapshot
+	require.Equal(t, "stream_on", readWSMessage(t, runner).Type)
+
+	// UI disconnects; runner should receive stream_off.
+	require.NoError(t, ui.Close(websocket.StatusNormalClosure, "done"))
+
+	cmd := drainMessagesUntil(t, runner, "stream_off", time.Second)
+	assert.Equal(t, "stream_off", cmd.Type)
+}
+
+func TestWsHub_FanOutToMultipleUIs(t *testing.T) {
+	_, base := hubTestSetup(t, "r1")
+
+	runner := dialWS(t, base+"/runner")
+	defer func() { _ = runner.Close(websocket.StatusNormalClosure, "") }()
+
+	ui1 := dialWS(t, base+"/ui")
+	defer func() { _ = ui1.Close(websocket.StatusNormalClosure, "") }()
+	ui2 := dialWS(t, base+"/ui")
+	defer func() { _ = ui2.Close(websocket.StatusNormalClosure, "") }()
+
+	// Consume snapshots + stream_on.
+	_ = readWSMessage(t, ui1)
+	_ = readWSMessage(t, ui2)
+	require.Equal(t, "stream_on", readWSMessage(t, runner).Type)
+
+	// Runner sends a log chunk; both UIs should see it.
+	require.NoError(t, runner.Write(context.Background(), websocket.MessageText, []byte(`{"type":"log","text":"fanout"}`)))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	check := func(ws *websocket.Conn) {
+		defer wg.Done()
+
+		msg := readWSMessage(t, ws)
+		assert.Equal(t, "log", msg.Type)
+		assert.Equal(t, "fanout", msg.Text)
+	}
+
+	go check(ui1)
+	go check(ui2)
+	wg.Wait()
+}
+
+func TestWsHub_DropRunClosesAllAndNotifiesUIs(t *testing.T) {
+	hub, base := hubTestSetup(t, "r1")
+
+	runner := dialWS(t, base+"/runner")
+	ui := dialWS(t, base+"/ui")
+
+	_ = readWSMessage(t, ui)     // snapshot
+	_ = readWSMessage(t, runner) // stream_on
+
+	hub.DropRun("r1")
+
+	msg := readWSMessage(t, ui)
+	assert.Equal(t, "run_ended", msg.Type)
+
+	// Both conns should now close from the server side.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, _, err := ui.Read(ctx)
+	assert.Error(t, err, "UI read should fail after DropRun")
+
+	_, _, err = runner.Read(ctx)
+	assert.Error(t, err, "runner read should fail after DropRun")
+}
+
+func TestWsHub_BufferTruncationFlagsSnapshot(t *testing.T) {
+	hub, base := hubTestSetup(t, "r1")
+
+	runner := dialWS(t, base+"/runner")
+	defer func() { _ = runner.Close(websocket.StatusNormalClosure, "") }()
+
+	// First UI comes and goes so we can populate the buffer without
+	// the test having to drain a zillion log messages.
+	ui := dialWS(t, base+"/ui")
+	_ = readWSMessage(t, ui)     // snapshot
+	_ = readWSMessage(t, runner) // stream_on
+	_ = ui.Close(websocket.StatusNormalClosure, "")
+	_ = drainMessagesUntil(t, runner, "stream_off", time.Second)
+
+	// Push more bytes than the buffer cap straight through the hub.
+	overflow := maxLogBytesPerRun + 1024
+	big := strings.Repeat("x", overflow)
+	hub.appendAndFanOut("r1", []byte(big))
+
+	// New UI should get a truncated snapshot.
+	ui2 := dialWS(t, base+"/ui")
+	defer func() { _ = ui2.Close(websocket.StatusNormalClosure, "") }()
+
+	snap := readWSMessage(t, ui2)
+	assert.Equal(t, "snapshot", snap.Type)
+	assert.True(t, snap.Truncated, "snapshot should flag truncation after overflow")
+	assert.Len(t, snap.Text, maxLogBytesPerRun, "snapshot text should be capped at the buffer size")
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -110,7 +110,7 @@ const (
 	DefaultLiveReportingInterval       = time.Minute
 	DefaultLiveReportingJitterFraction = 0.2
 	DefaultLiveReportingTimeout        = 10 * time.Second
-	DefaultLiveReportingLogsInterval   = 100 * time.Millisecond
+	DefaultLiveReportingLogsInterval   = 200 * time.Millisecond
 )
 
 // GetInterval returns the reporting interval with the default applied.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -110,7 +110,7 @@ const (
 	DefaultLiveReportingInterval       = time.Minute
 	DefaultLiveReportingJitterFraction = 0.2
 	DefaultLiveReportingTimeout        = 10 * time.Second
-	DefaultLiveReportingLogsInterval   = time.Second
+	DefaultLiveReportingLogsInterval   = 100 * time.Millisecond
 )
 
 // GetInterval returns the reporting interval with the default applied.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,6 +97,12 @@ type LiveReportingConfig struct {
 	Interval       string  `yaml:"interval,omitempty" mapstructure:"interval"`               // default 1m
 	JitterFraction float64 `yaml:"jitter_fraction,omitempty" mapstructure:"jitter_fraction"` // default 0.2
 	Timeout        string  `yaml:"timeout,omitempty" mapstructure:"timeout"`                 // default 10s
+	// Logs* control the on-demand benchmarkoor.log streamer. When
+	// LogsEnabled is true, the runner opens a WebSocket to the API for
+	// the lifetime of the run; log bytes only flow while at least one
+	// UI client is actively watching.
+	LogsEnabled  *bool  `yaml:"logs_enabled,omitempty" mapstructure:"logs_enabled"`   // default true
+	LogsInterval string `yaml:"logs_interval,omitempty" mapstructure:"logs_interval"` // default 1s (while streaming)
 }
 
 // Default values for LiveReportingConfig when fields are left empty.
@@ -104,6 +110,7 @@ const (
 	DefaultLiveReportingInterval       = time.Minute
 	DefaultLiveReportingJitterFraction = 0.2
 	DefaultLiveReportingTimeout        = 10 * time.Second
+	DefaultLiveReportingLogsInterval   = time.Second
 )
 
 // GetInterval returns the reporting interval with the default applied.
@@ -144,6 +151,37 @@ func (l *LiveReportingConfig) GetTimeout() time.Duration {
 	d, err := time.ParseDuration(l.Timeout)
 	if err != nil {
 		return DefaultLiveReportingTimeout
+	}
+
+	return d
+}
+
+// GetLogsEnabled reports whether the on-demand log streamer should run.
+// Defaults to true when live reporting is enabled; set LogsEnabled to
+// false explicitly to disable.
+func (l *LiveReportingConfig) GetLogsEnabled() bool {
+	if l == nil {
+		return false
+	}
+
+	if l.LogsEnabled == nil {
+		return true
+	}
+
+	return *l.LogsEnabled
+}
+
+// GetLogsInterval returns the file-tail push cadence with the default
+// applied. Only relevant while a UI client is watching; between ticks
+// the streamer sleeps.
+func (l *LiveReportingConfig) GetLogsInterval() time.Duration {
+	if l == nil || l.LogsInterval == "" {
+		return DefaultLiveReportingLogsInterval
+	}
+
+	d, err := time.ParseDuration(l.LogsInterval)
+	if err != nil {
+		return DefaultLiveReportingLogsInterval
 	}
 
 	return d
@@ -1210,6 +1248,23 @@ func (c *Config) validateLiveReporting() error {
 			return fmt.Errorf(
 				"runner.live_reporting.timeout: invalid duration %q: %w",
 				lr.Timeout, err,
+			)
+		}
+	}
+
+	if lr.LogsInterval != "" {
+		d, err := time.ParseDuration(lr.LogsInterval)
+		if err != nil {
+			return fmt.Errorf(
+				"runner.live_reporting.logs_interval: invalid duration %q: %w",
+				lr.LogsInterval, err,
+			)
+		}
+
+		if d <= 0 {
+			return fmt.Errorf(
+				"runner.live_reporting.logs_interval: must be > 0, got %v",
+				d,
 			)
 		}
 	}

--- a/pkg/livereport/log_streamer.go
+++ b/pkg/livereport/log_streamer.go
@@ -189,7 +189,13 @@ func (s *logStreamer) connectAndServe(ctx context.Context) error {
 	// One write-serializing mutex per connection.
 	writer := &wsWriter{ws: ws, timeout: s.cfg.GetTimeout()}
 
+	// connDone is closed when connectAndServe returns (for any reason),
+	// so the bye-sender goroutine exits with it rather than leaking
+	// across reconnects.
+	connDone := make(chan struct{})
+
 	defer func() {
+		close(connDone)
 		stopTail()
 		_ = ws.Close(websocket.StatusNormalClosure, "runner stopping")
 	}()
@@ -202,6 +208,8 @@ func (s *logStreamer) connectAndServe(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 		case <-s.done:
+		case <-connDone:
+			return // read loop exited; defer already handles cleanup
 		}
 
 		byeCtx, cancel := context.WithTimeout(context.Background(), s.cfg.GetTimeout())

--- a/pkg/livereport/log_streamer.go
+++ b/pkg/livereport/log_streamer.go
@@ -1,0 +1,435 @@
+package livereport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+)
+
+// LogStreamer owns a persistent WebSocket to the API for the lifetime
+// of a run and streams tail-bytes of benchmarkoor.log on demand. The
+// API tells it when to start / stop streaming based on whether any UI
+// client is watching; when nobody is watching, the streamer holds the
+// socket open but sends zero bytes.
+type LogStreamer interface {
+	Start(ctx context.Context)
+	Stop()
+}
+
+// NewLogStreamer creates a streamer. logFilePath is the benchmarkoor.log
+// file for the run; the streamer tails it by byte offset (not
+// line-count) and handles rotation / truncation by resetting its
+// offset when the file shrinks.
+func NewLogStreamer(log logrus.FieldLogger, cfg *config.LiveReportingConfig, runID, logFilePath string) LogStreamer {
+	return &logStreamer{
+		log:         log.WithFields(logrus.Fields{"component": "livereport.log", "run_id": runID}),
+		cfg:         cfg,
+		runID:       runID,
+		logFilePath: logFilePath,
+		done:        make(chan struct{}),
+	}
+}
+
+type logStreamer struct {
+	log         logrus.FieldLogger
+	cfg         *config.LiveReportingConfig
+	runID       string
+	logFilePath string
+
+	done   chan struct{}
+	wg     sync.WaitGroup
+	closed bool
+	mu     sync.Mutex
+}
+
+// Compile-time interface check.
+var _ LogStreamer = (*logStreamer)(nil)
+
+// wsMessage must match the envelope used by pkg/api/wshub.go. Kept in
+// sync by hand — there are only four message types and the surface is
+// intentionally tiny.
+type wsMessage struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+// Start launches the outer goroutine that owns the WS lifecycle with
+// backoff reconnect. Safe to call once. No-op when LogsEnabled is
+// false.
+func (s *logStreamer) Start(ctx context.Context) {
+	if !s.cfg.GetLogsEnabled() {
+		s.log.Debug("Log streamer disabled by config")
+
+		return
+	}
+
+	s.wg.Add(1)
+
+	go s.runConnectLoop(ctx)
+}
+
+// Stop signals the outer goroutine to exit and waits for it. Sends a
+// bye frame on the way out if there's still an open WS. Idempotent.
+func (s *logStreamer) Stop() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+
+		return
+	}
+
+	s.closed = true
+	s.mu.Unlock()
+
+	close(s.done)
+	s.wg.Wait()
+}
+
+// runConnectLoop is the outer lifecycle: dial, run the read/write
+// loop, reconnect with exponential backoff on unexpected close.
+func (s *logStreamer) runConnectLoop(ctx context.Context) {
+	defer s.wg.Done()
+
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.done:
+			return
+		default:
+		}
+
+		if err := s.connectAndServe(ctx); err != nil {
+			// Unexpected disconnect — log at debug and retry.
+			s.log.WithError(err).Debug("Log WS disconnected; will retry")
+		}
+
+		// Bail immediately if we're shutting down.
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.done:
+			return
+		case <-time.After(jitterBackoff(backoff)):
+		}
+
+		if backoff < maxBackoff {
+			backoff = min(backoff*2, maxBackoff)
+		}
+	}
+}
+
+// connectAndServe dials the WS and runs its read loop until the
+// connection closes. Returns the disconnect error (nil on graceful
+// close from our side).
+func (s *logStreamer) connectAndServe(ctx context.Context) error {
+	dialURL, err := s.wsURL()
+	if err != nil {
+		return fmt.Errorf("building ws url: %w", err)
+	}
+
+	// Dial context with a short handshake timeout — the runner must
+	// not block on a dead API forever.
+	dialCtx, cancel := context.WithTimeout(ctx, s.cfg.GetTimeout())
+	defer cancel()
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+s.cfg.Token)
+
+	ws, _, err := websocket.Dial(dialCtx, dialURL, &websocket.DialOptions{
+		HTTPHeader: hdr,
+	})
+	if err != nil {
+		return fmt.Errorf("dialing %s: %w", dialURL, err)
+	}
+
+	// Use a generous read limit to accommodate the 64 KiB-per-message
+	// convention on the server side.
+	ws.SetReadLimit(128 * 1024)
+
+	s.log.Info("Log WS connected")
+
+	// Inner tail state — only live when stream_on is active. Uses a
+	// done-channel (not context.WithCancel) so the static analyzer
+	// doesn't chase a lost-cancel warning across the read-loop exit
+	// paths.
+	var (
+		tailDone   chan struct{}
+		tailWG     sync.WaitGroup
+		tailActive bool
+	)
+
+	stopTail := func() {
+		if !tailActive {
+			return
+		}
+
+		close(tailDone)
+		tailWG.Wait()
+		tailDone = nil
+		tailActive = false
+	}
+
+	// One write-serializing mutex per connection.
+	writer := &wsWriter{ws: ws, timeout: s.cfg.GetTimeout()}
+
+	defer func() {
+		stopTail()
+		_ = ws.Close(websocket.StatusNormalClosure, "runner stopping")
+	}()
+
+	// If the outer loop was cancelled while connected, send a bye
+	// frame and close the WS so the server cleans up immediately and
+	// the read loop unblocks. Use a fresh background context so a
+	// cancelled outer ctx doesn't also stop the write.
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-s.done:
+		}
+
+		byeCtx, cancel := context.WithTimeout(context.Background(), s.cfg.GetTimeout())
+		_ = writer.writeMessage(byeCtx, wsMessage{Type: "bye"})
+		cancel()
+
+		_ = ws.Close(websocket.StatusNormalClosure, "runner stopping")
+	}()
+
+	for {
+		_, data, err := ws.Read(ctx)
+		if err != nil {
+			stopTail()
+
+			return err
+		}
+
+		var msg wsMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			s.log.WithError(err).Debug("Ignoring malformed API message")
+
+			continue
+		}
+
+		switch msg.Type {
+		case "stream_on":
+			if tailActive {
+				continue // already running
+			}
+
+			tailDone = make(chan struct{})
+			tailActive = true
+			done := tailDone
+
+			tailWG.Add(1)
+
+			go func() {
+				defer tailWG.Done()
+				s.runTailLoop(ctx, done, writer)
+			}()
+
+			s.log.Debug("Log tail started")
+		case "stream_off":
+			stopTail()
+			s.log.Debug("Log tail stopped")
+		default:
+			s.log.WithField("type", msg.Type).Debug("Ignoring unknown API message")
+		}
+	}
+}
+
+// runTailLoop periodically reads new bytes from the log file and
+// sends them as wsMessages. Exits when done is closed (stream_off from
+// the outer loop) or ctx is cancelled (outer shutdown).
+func (s *logStreamer) runTailLoop(ctx context.Context, done <-chan struct{}, writer *wsWriter) {
+	interval := s.cfg.GetLogsInterval()
+	if interval <= 0 {
+		interval = config.DefaultLiveReportingLogsInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var offset int64
+
+	readAndShip := func() {
+		newBytes, newOffset, err := readNewBytes(s.logFilePath, offset)
+		if err != nil {
+			s.log.WithError(err).Debug("log file read failed")
+
+			return
+		}
+
+		if len(newBytes) == 0 {
+			offset = newOffset
+
+			return
+		}
+
+		// Split large chunks into <=64 KiB messages so the server's
+		// read limit is never exceeded.
+		const maxMsgBytes = 64 * 1024
+		for len(newBytes) > 0 {
+			n := min(len(newBytes), maxMsgBytes)
+
+			if err := writer.writeMessage(ctx, wsMessage{Type: "log", Text: string(newBytes[:n])}); err != nil {
+				s.log.WithError(err).Debug("Failed to send log chunk")
+
+				return // leave offset unchanged; next connect will retry from here
+			}
+
+			newBytes = newBytes[n:]
+		}
+
+		offset = newOffset
+	}
+
+	// Fire once immediately so the first log chunk doesn't wait a
+	// full tick after stream_on.
+	readAndShip()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Final flush so the last bytes reach the API before we go.
+			readAndShip()
+
+			return
+		case <-done:
+			// stream_off — flush and exit.
+			readAndShip()
+
+			return
+		case <-ticker.C:
+			readAndShip()
+		}
+	}
+}
+
+// wsURL builds the ws(s) URL the runner dials. Converts the configured
+// HTTP(S) endpoint to ws(s) and appends the ingest path with the
+// run_id query param.
+func (s *logStreamer) wsURL() (string, error) {
+	raw := strings.TrimRight(s.cfg.Endpoint, "/") + "/api/v1/ingest/ws"
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	case "ws", "wss":
+		// Already a WS URL; leave it alone.
+	default:
+		return "", fmt.Errorf("unsupported endpoint scheme %q", u.Scheme)
+	}
+
+	q := u.Query()
+	q.Set("run_id", s.runID)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+// wsWriter serializes writes to a WS connection. nhooyr/coder's Write
+// must not be called concurrently; this wrapper enforces that and
+// applies a deadline.
+type wsWriter struct {
+	ws      *websocket.Conn
+	mu      sync.Mutex
+	timeout time.Duration
+}
+
+func (w *wsWriter) writeMessage(ctx context.Context, msg wsMessage) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	writeCtx, cancel := context.WithTimeout(ctx, w.timeout)
+	defer cancel()
+
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	return w.ws.Write(writeCtx, websocket.MessageText, b)
+}
+
+// readNewBytes opens the log file and reads from `offset` to EOF. On
+// truncation / rotation (size < offset), starts from 0. Returns the
+// bytes read and the new offset.
+func readNewBytes(path string, offset int64) ([]byte, int64, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Not yet created — nothing to do.
+			return nil, offset, nil
+		}
+
+		return nil, offset, err
+	}
+
+	size := fi.Size()
+	if size < offset {
+		offset = 0
+	}
+
+	if size == offset {
+		return nil, offset, nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, offset, err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, offset, err
+	}
+
+	// Cap per-tick read so a single surge can't ship unbounded bytes.
+	const maxRead = 64 * 1024
+
+	n := min(size-offset, maxRead)
+
+	buf := make([]byte, n)
+
+	read, err := io.ReadFull(f, buf)
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return nil, offset, err
+	}
+
+	return buf[:read], offset + int64(read), nil
+}
+
+// jitterBackoff returns d with ±25% jitter. Prevents thundering-herd
+// reconnects when the API bounces.
+func jitterBackoff(d time.Duration) time.Duration {
+	jitter := 1 + (rand.Float64()*0.5 - 0.25) // [0.75, 1.25)
+	out := time.Duration(float64(d) * jitter)
+	if out <= 0 {
+		return d
+	}
+
+	return out
+}

--- a/pkg/livereport/log_streamer.go
+++ b/pkg/livereport/log_streamer.go
@@ -275,36 +275,46 @@ func (s *logStreamer) runTailLoop(ctx context.Context, done <-chan struct{}, wri
 
 	var offset int64
 
+	// readAndShip drains all new bytes since the last offset in a
+	// loop, sending ≤64 KiB messages per iteration. This ensures the
+	// live view stays at real-time even during noisy phases (>64 KB
+	// per tick), rather than falling permanently behind with a fixed
+	// per-tick cap.
 	readAndShip := func() {
-		newBytes, newOffset, err := readNewBytes(s.logFilePath, offset)
-		if err != nil {
-			s.log.WithError(err).Debug("log file read failed")
-
-			return
-		}
-
-		if len(newBytes) == 0 {
-			offset = newOffset
-
-			return
-		}
-
-		// Split large chunks into <=64 KiB messages so the server's
-		// read limit is never exceeded.
 		const maxMsgBytes = 64 * 1024
-		for len(newBytes) > 0 {
-			n := min(len(newBytes), maxMsgBytes)
 
-			if err := writer.writeMessage(ctx, wsMessage{Type: "log", Text: string(newBytes[:n])}); err != nil {
-				s.log.WithError(err).Debug("Failed to send log chunk")
+		for {
+			newBytes, newOffset, err := readNewBytes(s.logFilePath, offset)
+			if err != nil {
+				s.log.WithError(err).Debug("log file read failed")
 
-				return // leave offset unchanged; next connect will retry from here
+				return
 			}
 
-			newBytes = newBytes[n:]
-		}
+			if len(newBytes) == 0 {
+				offset = newOffset
 
-		offset = newOffset
+				return
+			}
+
+			// Split into ≤64 KiB messages so the server's read-limit
+			// is never exceeded.
+			for len(newBytes) > 0 {
+				n := min(len(newBytes), maxMsgBytes)
+
+				if err := writer.writeMessage(ctx, wsMessage{Type: "log", Text: string(newBytes[:n])}); err != nil {
+					s.log.WithError(err).Debug("Failed to send log chunk")
+
+					return // leave offset unchanged; next connect will retry
+				}
+
+				newBytes = newBytes[n:]
+			}
+
+			offset = newOffset
+			// Loop back to check if more bytes appeared while we were
+			// shipping the previous batch.
+		}
 	}
 
 	// Fire once immediately so the first log chunk doesn't wait a

--- a/pkg/livereport/log_streamer_test.go
+++ b/pkg/livereport/log_streamer_test.go
@@ -1,0 +1,366 @@
+package livereport
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+)
+
+// testServer spins up an httptest WS server whose handler runs the
+// provided function once per connection. Callers drive the streamer's
+// behavior by writing commands to the server-side conn and asserting
+// on what the streamer sends back.
+type testServer struct {
+	srv        *httptest.Server
+	onConnect  func(ctx context.Context, ws *websocket.Conn)
+	connectCnt atomic.Int64
+}
+
+func newTestServer(t *testing.T, onConnect func(ctx context.Context, ws *websocket.Conn)) *testServer {
+	t.Helper()
+
+	ts := &testServer{onConnect: onConnect}
+	ts.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+
+		ts.connectCnt.Add(1)
+		ts.onConnect(r.Context(), ws)
+	}))
+	t.Cleanup(ts.srv.Close)
+
+	return ts
+}
+
+func (ts *testServer) endpoint() string {
+	// The streamer appends /api/v1/ingest/ws itself; our handler is
+	// catch-all so it doesn't matter what path we use.
+	return ts.srv.URL
+}
+
+// writeJSON sends a wsMessage to the streamer from the test server.
+func writeJSON(t *testing.T, ws *websocket.Conn, msg wsMessage) {
+	t.Helper()
+
+	b, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	require.NoError(t, ws.Write(ctx, websocket.MessageText, b))
+}
+
+// readJSON reads one wsMessage from a client conn with a short deadline.
+func readJSON(t *testing.T, ws *websocket.Conn) (wsMessage, error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, data, err := ws.Read(ctx)
+	if err != nil {
+		return wsMessage{}, err
+	}
+
+	var msg wsMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return wsMessage{}, err
+	}
+
+	return msg, nil
+}
+
+// writeFile is a convenience for overwriting the log tail test file.
+func writeFile(t *testing.T, path, text string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(path, []byte(text), 0o644))
+}
+
+// appendFile appends text atomically.
+func appendFile(t *testing.T, path, text string) {
+	t.Helper()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+
+	_, err = f.WriteString(text)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+}
+
+func streamerCfg(endpoint string) *config.LiveReportingConfig {
+	return &config.LiveReportingConfig{
+		Enabled:       true,
+		Endpoint:      endpoint,
+		Token:         "test-token",
+		DiscoveryPath: "dp",
+		Timeout:       "2s",
+		LogsInterval:  "50ms",
+	}
+}
+
+func silentLogger() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetLevel(logrus.PanicLevel)
+
+	return l
+}
+
+func TestLogStreamer_IdleUntilStreamOn(t *testing.T) {
+	// Collect all messages the streamer sends. No commands are sent
+	// from the server side, so nothing should arrive.
+	var (
+		mu  sync.Mutex
+		got []wsMessage
+	)
+
+	ts := newTestServer(t, func(ctx context.Context, ws *websocket.Conn) {
+		defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+		for {
+			_, data, err := ws.Read(ctx)
+			if err != nil {
+				return
+			}
+
+			var msg wsMessage
+			if err := json.Unmarshal(data, &msg); err == nil {
+				mu.Lock()
+				got = append(got, msg)
+				mu.Unlock()
+			}
+		}
+	})
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "benchmarkoor.log")
+
+	writeFile(t, logPath, "hello there\n")
+
+	s := NewLogStreamer(silentLogger(), streamerCfg(ts.endpoint()), "run-1", logPath)
+	ctx := context.Background()
+	s.Start(ctx)
+
+	// Give the streamer time to connect and for any tail to fire if
+	// it were going to (it shouldn't — no stream_on).
+	time.Sleep(300 * time.Millisecond)
+
+	s.Stop()
+
+	// The server may receive a bye frame on Stop; anything else (like
+	// log messages) would be a bug.
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, m := range got {
+		assert.NotEqual(t, "log", m.Type, "streamer must not send log messages without stream_on")
+	}
+}
+
+func TestLogStreamer_TailsOnStreamOn(t *testing.T) {
+	logCh := make(chan string, 16)
+
+	ts := newTestServer(t, func(ctx context.Context, ws *websocket.Conn) {
+		defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+		// Ask the streamer to start tailing.
+		writeJSON(t, ws, wsMessage{Type: "stream_on"})
+
+		// Drain whatever the streamer sends; deliver log chunks on
+		// logCh so the test can assert on them.
+		for {
+			msg, err := readJSON(t, ws)
+			if err != nil {
+				return
+			}
+
+			if msg.Type == "log" {
+				select {
+				case logCh <- msg.Text:
+				default:
+				}
+			}
+		}
+	})
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "benchmarkoor.log")
+	writeFile(t, logPath, "initial bytes\n")
+
+	s := NewLogStreamer(silentLogger(), streamerCfg(ts.endpoint()), "run-1", logPath)
+
+	ctx := context.Background()
+	s.Start(ctx)
+
+	// First chunk should be the initial file contents.
+	select {
+	case got := <-logCh:
+		assert.Equal(t, "initial bytes\n", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected initial log chunk")
+	}
+
+	// Append more — should show up on the next tick.
+	appendFile(t, logPath, "more stuff\n")
+
+	select {
+	case got := <-logCh:
+		assert.Equal(t, "more stuff\n", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected appended log chunk")
+	}
+
+	s.Stop()
+}
+
+func TestLogStreamer_HandlesTruncation(t *testing.T) {
+	logCh := make(chan string, 16)
+
+	ts := newTestServer(t, func(ctx context.Context, ws *websocket.Conn) {
+		defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+		writeJSON(t, ws, wsMessage{Type: "stream_on"})
+
+		for {
+			msg, err := readJSON(t, ws)
+			if err != nil {
+				return
+			}
+
+			if msg.Type == "log" {
+				select {
+				case logCh <- msg.Text:
+				default:
+				}
+			}
+		}
+	})
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "benchmarkoor.log")
+	writeFile(t, logPath, strings.Repeat("a", 100))
+
+	s := NewLogStreamer(silentLogger(), streamerCfg(ts.endpoint()), "run-1", logPath)
+	ctx := context.Background()
+	s.Start(ctx)
+
+	// Consume the initial chunk.
+	select {
+	case got := <-logCh:
+		assert.Len(t, got, 100)
+	case <-time.After(2 * time.Second):
+		t.Fatal("initial chunk missing")
+	}
+
+	// Truncate by rewriting smaller. Next tick should reset offset to
+	// 0 and ship the new contents from the start.
+	writeFile(t, logPath, "tiny\n")
+
+	select {
+	case got := <-logCh:
+		assert.Equal(t, "tiny\n", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected post-truncation chunk")
+	}
+
+	s.Stop()
+}
+
+func TestLogStreamer_StopSendsBye(t *testing.T) {
+	var (
+		mu  sync.Mutex
+		got []wsMessage
+	)
+
+	done := make(chan struct{})
+
+	ts := newTestServer(t, func(ctx context.Context, ws *websocket.Conn) {
+		defer close(done)
+		defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+		for {
+			msg, err := readJSON(t, ws)
+			if err != nil {
+				return
+			}
+
+			mu.Lock()
+			got = append(got, msg)
+			mu.Unlock()
+		}
+	})
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "benchmarkoor.log")
+	writeFile(t, logPath, "")
+
+	s := NewLogStreamer(silentLogger(), streamerCfg(ts.endpoint()), "run-1", logPath)
+	s.Start(context.Background())
+
+	time.Sleep(150 * time.Millisecond)
+
+	s.Stop()
+
+	// Server should see the connection close (triggering done).
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never saw close")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	found := false
+	for _, m := range got {
+		if m.Type == "bye" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "streamer should send a bye before closing")
+}
+
+func TestLogStreamer_DisabledByConfig(t *testing.T) {
+	disabled := false
+
+	cfg := &config.LiveReportingConfig{
+		Enabled:      true,
+		Endpoint:     "http://127.0.0.1:1", // unreachable; would fail if dialed
+		Token:        "x",
+		Timeout:      "1s",
+		LogsEnabled:  &disabled,
+		LogsInterval: "50ms",
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "benchmarkoor.log")
+	writeFile(t, logPath, "")
+
+	s := NewLogStreamer(silentLogger(), cfg, "run-1", logPath)
+	s.Start(context.Background())
+
+	// Give it a beat to NOT dial anything.
+	time.Sleep(150 * time.Millisecond)
+
+	s.Stop()
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -596,6 +596,16 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 		liveState.mu.Unlock()
 
 		defer reporter.Stop()
+
+		// On-demand log streamer. Holds a persistent WS to the API
+		// but only pushes log bytes while at least one UI client is
+		// subscribed. No-op when logs_enabled is false.
+		logStreamer := livereport.NewLogStreamer(
+			r.logger, lrCfg, compositeRunID, benchmarkoorLogFile.Name(),
+		)
+		logStreamer.Start(ctx)
+
+		defer logStreamer.Stop()
 	}
 
 	// Get client spec.

--- a/ui/src/api/hooks/useLiveRunLogsWS.ts
+++ b/ui/src/api/hooks/useLiveRunLogsWS.ts
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from 'react'
+import { loadRuntimeConfig } from '@/config/runtime'
+
+// useLiveRunLogsWS opens a WebSocket to the API's live-run log stream
+// endpoint for a single run. The API sends:
+//   - `{type:"snapshot", text, truncated?}` once on connect (current buffer)
+//   - `{type:"log", text}` as new chunks arrive
+//   - `{type:"truncated"}` when the ring buffer has evicted older bytes
+//   - `{type:"run_ended"}` when the run is deleted / the runner says bye
+//
+// The hook manages its own reconnect loop (1 s → 30 s backoff) while
+// `enabled` is true. When `enabled` flips to false (panel collapsed)
+// or `runId` changes, the current WS is closed and buffers reset.
+//
+// No React Query — streaming semantics don't fit a full-replace cache.
+
+interface LogsMessage {
+  type: 'snapshot' | 'log' | 'truncated' | 'run_ended'
+  text?: string
+  truncated?: boolean
+}
+
+interface LiveRunLogsState {
+  text: string
+  truncated: boolean
+  ended: boolean
+  connected: boolean
+}
+
+const MAX_BACKOFF_MS = 30_000
+const INITIAL_BACKOFF_MS = 1_000
+
+export function useLiveRunLogsWS(
+  runId: string | undefined,
+  enabled: boolean,
+): LiveRunLogsState {
+  const [state, setState] = useState<LiveRunLogsState>({
+    text: '',
+    truncated: false,
+    ended: false,
+    connected: false,
+  })
+
+  // Ref to the active WebSocket so we can close it on cleanup, and
+  // avoid stale-closure issues with React's effect timing.
+  const wsRef = useRef<WebSocket | null>(null)
+  // Guard against late messages from a WS we're already replacing.
+  const generationRef = useRef(0)
+
+  useEffect(() => {
+    if (!enabled || !runId) {
+      return
+    }
+
+    const myGeneration = ++generationRef.current
+
+    let cancelled = false
+    let backoff = INITIAL_BACKOFF_MS
+    let reconnectTimer: number | undefined
+
+    // Reset state for a fresh connection (new runId or re-enable). One
+    // intentional cascading render — this is a reset signal bounded
+    // per enable/runId change, not steady-state derived data.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState({ text: '', truncated: false, ended: false, connected: false })
+
+    const connect = async () => {
+      if (cancelled || generationRef.current !== myGeneration) return
+
+      const config = await loadRuntimeConfig()
+      if (cancelled || generationRef.current !== myGeneration) return
+
+      const baseUrl = config.api?.baseUrl
+      if (!baseUrl) {
+        // No API configured — nothing to connect to.
+        return
+      }
+
+      const wsUrl =
+        baseUrl.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:') +
+        `/api/v1/index/live_runs/${encodeURIComponent(runId)}/logs/ws`
+
+      const ws = new WebSocket(wsUrl)
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        if (generationRef.current !== myGeneration) {
+          ws.close()
+          return
+        }
+
+        backoff = INITIAL_BACKOFF_MS
+        setState((s) => ({ ...s, connected: true }))
+      }
+
+      ws.onmessage = (event) => {
+        if (generationRef.current !== myGeneration) return
+
+        let msg: LogsMessage
+        try {
+          msg = JSON.parse(event.data as string) as LogsMessage
+        } catch {
+          return
+        }
+
+        setState((s) => {
+          switch (msg.type) {
+            case 'snapshot':
+              return {
+                ...s,
+                text: msg.text ?? '',
+                truncated: !!msg.truncated,
+              }
+            case 'log':
+              return { ...s, text: s.text + (msg.text ?? '') }
+            case 'truncated':
+              return { ...s, truncated: true }
+            case 'run_ended':
+              return { ...s, ended: true }
+            default:
+              return s
+          }
+        })
+      }
+
+      ws.onerror = () => {
+        // Surfaced via onclose; nothing to do here directly.
+      }
+
+      ws.onclose = () => {
+        if (generationRef.current !== myGeneration) return
+
+        setState((s) => ({ ...s, connected: false }))
+        wsRef.current = null
+
+        if (cancelled) return
+
+        // Exponential backoff reconnect while still enabled.
+        reconnectTimer = window.setTimeout(() => {
+          if (!cancelled && generationRef.current === myGeneration) {
+            void connect()
+          }
+        }, backoff)
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
+      }
+    }
+
+    void connect()
+
+    return () => {
+      cancelled = true
+      if (reconnectTimer !== undefined) {
+        window.clearTimeout(reconnectTimer)
+      }
+      if (wsRef.current) {
+        wsRef.current.close()
+        wsRef.current = null
+      }
+    }
+  }, [runId, enabled])
+
+  return state
+}

--- a/ui/src/api/hooks/useLiveRunLogsWS.ts
+++ b/ui/src/api/hooks/useLiveRunLogsWS.ts
@@ -57,6 +57,8 @@ export function useLiveRunLogsWS(
     let cancelled = false
     let backoff = INITIAL_BACKOFF_MS
     let reconnectTimer: number | undefined
+    // Tracks the pending rAF flush so cleanup can cancel it.
+    let activeRafId = 0
 
     // Reset state for a fresh connection (new runId or re-enable). One
     // intentional cascading render — this is a reset signal bounded
@@ -83,6 +85,49 @@ export function useLiveRunLogsWS(
       const ws = new WebSocket(wsUrl)
       wsRef.current = ws
 
+      // ── rAF batching ────────────────────────────────────────────
+      // At 100ms push intervals the runner can send 10+ WS messages
+      // per second. Each message triggering a setState → render →
+      // string-concat cycle creates heavy GC pressure (new 512KB
+      // string every time) and can crash Chromium-based browsers
+      // (V8 SIGILL under load). Instead, we accumulate incoming
+      // chunks in a plain string ref and flush once per animation
+      // frame, so React sees at most ~60 state updates/sec
+      // regardless of WS throughput.
+      let pendingText = ''
+      let pendingSnapshot: { text: string; truncated: boolean } | null = null
+      let pendingTruncated = false
+      let pendingEnded = false
+      const flushPending = () => {
+        activeRafId = 0
+        if (generationRef.current !== myGeneration) return
+
+        setState((s) => {
+          let next = s
+          if (pendingSnapshot) {
+            next = { ...next, text: pendingSnapshot.text, truncated: pendingSnapshot.truncated }
+            pendingSnapshot = null
+          }
+          if (pendingText) {
+            next = { ...next, text: next.text + pendingText }
+            pendingText = ''
+          }
+          if (pendingTruncated) {
+            next = { ...next, truncated: true }
+            pendingTruncated = false
+          }
+          if (pendingEnded) {
+            next = { ...next, ended: true }
+            pendingEnded = false
+          }
+          return next
+        })
+      }
+
+      const scheduleFlush = () => {
+        if (!activeRafId) activeRafId = requestAnimationFrame(flushPending)
+      }
+
       ws.onopen = () => {
         if (generationRef.current !== myGeneration) {
           ws.close()
@@ -103,24 +148,27 @@ export function useLiveRunLogsWS(
           return
         }
 
-        setState((s) => {
-          switch (msg.type) {
-            case 'snapshot':
-              return {
-                ...s,
-                text: msg.text ?? '',
-                truncated: !!msg.truncated,
-              }
-            case 'log':
-              return { ...s, text: s.text + (msg.text ?? '') }
-            case 'truncated':
-              return { ...s, truncated: true }
-            case 'run_ended':
-              return { ...s, ended: true }
-            default:
-              return s
-          }
-        })
+        switch (msg.type) {
+          case 'snapshot':
+            // A snapshot replaces everything — discard any pending
+            // text that was queued before the snapshot arrived.
+            pendingText = ''
+            pendingSnapshot = { text: msg.text ?? '', truncated: !!msg.truncated }
+            break
+          case 'log':
+            pendingText += msg.text ?? ''
+            break
+          case 'truncated':
+            pendingTruncated = true
+            break
+          case 'run_ended':
+            pendingEnded = true
+            break
+          default:
+            return // nothing to flush
+        }
+
+        scheduleFlush()
       }
 
       ws.onerror = () => {
@@ -149,6 +197,7 @@ export function useLiveRunLogsWS(
 
     return () => {
       cancelled = true
+      if (activeRafId) cancelAnimationFrame(activeRafId)
       if (reconnectTimer !== undefined) {
         window.clearTimeout(reconnectTimer)
       }

--- a/ui/src/api/hooks/useLiveRunLogsWS.ts
+++ b/ui/src/api/hooks/useLiveRunLogsWS.ts
@@ -3,16 +3,16 @@ import { loadRuntimeConfig } from '@/config/runtime'
 
 // useLiveRunLogsWS opens a WebSocket to the API's live-run log stream
 // endpoint for a single run. The API sends:
-//   - `{type:"snapshot", text, truncated?}` once on connect (current buffer)
+//   - `{type:"snapshot", text, truncated?}` once on connect (buffer)
 //   - `{type:"log", text}` as new chunks arrive
 //   - `{type:"truncated"}` when the ring buffer has evicted older bytes
-//   - `{type:"run_ended"}` when the run is deleted / the runner says bye
+//   - `{type:"run_ended"}` when the run is deleted / runner says bye
 //
-// The hook manages its own reconnect loop (1 s → 30 s backoff) while
-// `enabled` is true. When `enabled` flips to false (panel collapsed)
-// or `runId` changes, the current WS is closed and buffers reset.
-//
-// No React Query — streaming semantics don't fit a full-replace cache.
+// PERFORMANCE NOTE: the accumulated log text lives in a plain ref (not
+// React state) to avoid V8 GC pressure from React holding old + new
+// copies of a ≥500 KB string during reconciliation. A lightweight
+// `version` counter drives re-renders instead. WS messages are batched
+// via requestAnimationFrame so at most ~60 flushes/sec hit React.
 
 interface LogsMessage {
   type: 'snapshot' | 'log' | 'truncated' | 'run_ended'
@@ -20,8 +20,11 @@ interface LogsMessage {
   truncated?: boolean
 }
 
-interface LiveRunLogsState {
-  text: string
+export interface LiveRunLogsState {
+  /** Ref to the accumulated text buffer. Read .current in render. */
+  textRef: React.RefObject<string>
+  /** Bumped on every flush — lets consumers know text changed. */
+  version: number
   truncated: boolean
   ended: boolean
   connected: boolean
@@ -29,22 +32,25 @@ interface LiveRunLogsState {
 
 const MAX_BACKOFF_MS = 30_000
 const INITIAL_BACKOFF_MS = 1_000
+// Client-side cap so the browser doesn't OOM on a long session. The
+// server caps at 512 KB; we keep a bit more so a reconnect snapshot
+// plus subsequent deltas have headroom before we start trimming.
+const MAX_CLIENT_TEXT_BYTES = 1024 * 1024
 
 export function useLiveRunLogsWS(
   runId: string | undefined,
   enabled: boolean,
 ): LiveRunLogsState {
-  const [state, setState] = useState<LiveRunLogsState>({
-    text: '',
-    truncated: false,
-    ended: false,
-    connected: false,
-  })
+  // Text buffer lives in a ref — React never diffs or holds two
+  // copies of it. A monotonic version counter in state triggers
+  // re-renders when text changes.
+  const textRef = useRef('')
+  const [version, setVersion] = useState(0)
+  const [truncated, setTruncated] = useState(false)
+  const [ended, setEnded] = useState(false)
+  const [connected, setConnected] = useState(false)
 
-  // Ref to the active WebSocket so we can close it on cleanup, and
-  // avoid stale-closure issues with React's effect timing.
   const wsRef = useRef<WebSocket | null>(null)
-  // Guard against late messages from a WS we're already replacing.
   const generationRef = useRef(0)
 
   useEffect(() => {
@@ -57,14 +63,18 @@ export function useLiveRunLogsWS(
     let cancelled = false
     let backoff = INITIAL_BACKOFF_MS
     let reconnectTimer: number | undefined
-    // Tracks the pending rAF flush so cleanup can cancel it.
     let activeRafId = 0
 
-    // Reset state for a fresh connection (new runId or re-enable). One
-    // intentional cascading render — this is a reset signal bounded
-    // per enable/runId change, not steady-state derived data.
+    // Reset for a fresh connection.
+    textRef.current = ''
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setState({ text: '', truncated: false, ended: false, connected: false })
+    setVersion((v) => v + 1)
+     
+    setTruncated(false)
+     
+    setEnded(false)
+     
+    setConnected(false)
 
     const connect = async () => {
       if (cancelled || generationRef.current !== myGeneration) return
@@ -73,10 +83,7 @@ export function useLiveRunLogsWS(
       if (cancelled || generationRef.current !== myGeneration) return
 
       const baseUrl = config.api?.baseUrl
-      if (!baseUrl) {
-        // No API configured — nothing to connect to.
-        return
-      }
+      if (!baseUrl) return
 
       const wsUrl =
         baseUrl.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:') +
@@ -85,43 +92,56 @@ export function useLiveRunLogsWS(
       const ws = new WebSocket(wsUrl)
       wsRef.current = ws
 
-      // ── rAF batching ────────────────────────────────────────────
-      // At 100ms push intervals the runner can send 10+ WS messages
-      // per second. Each message triggering a setState → render →
-      // string-concat cycle creates heavy GC pressure (new 512KB
-      // string every time) and can crash Chromium-based browsers
-      // (V8 SIGILL under load). Instead, we accumulate incoming
-      // chunks in a plain string ref and flush once per animation
-      // frame, so React sees at most ~60 state updates/sec
-      // regardless of WS throughput.
+      // ── rAF batching ────────────────────────────────────────
+      // Accumulate WS messages in plain variables and flush into
+      // the ref + bump the version counter once per animation
+      // frame. This limits React renders to ~60/sec and avoids
+      // creating a new multi-hundred-KB string in React state on
+      // every message.
       let pendingText = ''
       let pendingSnapshot: { text: string; truncated: boolean } | null = null
       let pendingTruncated = false
       let pendingEnded = false
+
       const flushPending = () => {
         activeRafId = 0
         if (generationRef.current !== myGeneration) return
 
-        setState((s) => {
-          let next = s
-          if (pendingSnapshot) {
-            next = { ...next, text: pendingSnapshot.text, truncated: pendingSnapshot.truncated }
-            pendingSnapshot = null
-          }
-          if (pendingText) {
-            next = { ...next, text: next.text + pendingText }
-            pendingText = ''
-          }
-          if (pendingTruncated) {
-            next = { ...next, truncated: true }
-            pendingTruncated = false
-          }
-          if (pendingEnded) {
-            next = { ...next, ended: true }
-            pendingEnded = false
-          }
-          return next
-        })
+        if (pendingSnapshot) {
+          textRef.current = pendingSnapshot.text
+          setTruncated(pendingSnapshot.truncated)
+          pendingSnapshot = null
+        }
+
+        if (pendingText) {
+          textRef.current += pendingText
+          pendingText = ''
+        }
+
+        // Client-side cap — trim from the front if we've grown past
+        // the limit so the browser doesn't OOM on a very long run.
+        if (textRef.current.length > MAX_CLIENT_TEXT_BYTES) {
+          const overflow = textRef.current.length - MAX_CLIENT_TEXT_BYTES
+          // Find the next newline after the trim point so we don't
+          // break a line in the middle.
+          const nextNl = textRef.current.indexOf('\n', overflow)
+          textRef.current = nextNl >= 0
+            ? textRef.current.slice(nextNl + 1)
+            : textRef.current.slice(overflow)
+          setTruncated(true)
+        }
+
+        if (pendingTruncated) {
+          setTruncated(true)
+          pendingTruncated = false
+        }
+
+        if (pendingEnded) {
+          setEnded(true)
+          pendingEnded = false
+        }
+
+        setVersion((v) => v + 1)
       }
 
       const scheduleFlush = () => {
@@ -135,7 +155,7 @@ export function useLiveRunLogsWS(
         }
 
         backoff = INITIAL_BACKOFF_MS
-        setState((s) => ({ ...s, connected: true }))
+        setConnected(true)
       }
 
       ws.onmessage = (event) => {
@@ -150,8 +170,6 @@ export function useLiveRunLogsWS(
 
         switch (msg.type) {
           case 'snapshot':
-            // A snapshot replaces everything — discard any pending
-            // text that was queued before the snapshot arrived.
             pendingText = ''
             pendingSnapshot = { text: msg.text ?? '', truncated: !!msg.truncated }
             break
@@ -165,25 +183,24 @@ export function useLiveRunLogsWS(
             pendingEnded = true
             break
           default:
-            return // nothing to flush
+            return
         }
 
         scheduleFlush()
       }
 
       ws.onerror = () => {
-        // Surfaced via onclose; nothing to do here directly.
+        // Surfaced via onclose.
       }
 
       ws.onclose = () => {
         if (generationRef.current !== myGeneration) return
 
-        setState((s) => ({ ...s, connected: false }))
+        setConnected(false)
         wsRef.current = null
 
         if (cancelled) return
 
-        // Exponential backoff reconnect while still enabled.
         reconnectTimer = window.setTimeout(() => {
           if (!cancelled && generationRef.current === myGeneration) {
             void connect()
@@ -208,5 +225,5 @@ export function useLiveRunLogsWS(
     }
   }, [runId, enabled])
 
-  return state
+  return { textRef, version, truncated, ended, connected }
 }

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -9,6 +9,7 @@ import { MetadataLabels } from '@/components/run-detail/MetadataLabels'
 import { GitHubSection } from '@/components/run-detail/GitHubSection'
 import { ClientRunsStrip } from '@/components/run-detail/ClientRunsStrip'
 import { TestHeatmap, type SortMode, type GroupMode } from '@/components/run-detail/TestHeatmap'
+import { LiveRunLogPanel } from '@/components/run-detail/LiveRunLogPanel'
 import { useSuite } from '@/api/hooks/useSuite'
 import { useIndex } from '@/api/hooks/useIndex'
 import { formatTimestamp } from '@/utils/date'
@@ -276,6 +277,10 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
           metadata={cfg.metadata}
         />
       )}
+
+      {/* Live log stream — collapsed by default; opening the panel is
+          what signals the runner to start pushing log bytes. */}
+      <LiveRunLogPanel runId={run.run_id} />
 
       {/* Live Performance Heatmap — fed by the per-test gas data the
           runner ships in every snapshot. Renders as soon as we have

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -280,7 +280,11 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
 
       {/* Live log stream — collapsed by default; opening the panel is
           what signals the runner to start pushing log bytes. */}
-      <LiveRunLogPanel runId={run.run_id} />
+      <LiveRunLogPanel
+        runId={run.run_id}
+        client={clientName || undefined}
+        instanceId={instanceID || undefined}
+      />
 
       {/* Live Performance Heatmap — fed by the per-test gas data the
           runner ships in every snapshot. Renders as soon as we have

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -294,7 +294,7 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
           <div className="mb-4 flex items-center justify-between">
             <h3 className="flex items-center gap-2 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
               <Flame className="size-4 text-gray-400 dark:text-gray-500" />
-              Performance Heatmap (Live)
+              Performance Heatmap
             </h3>
           </div>
           <TestHeatmap

--- a/ui/src/components/run-detail/LiveRunLogPanel.tsx
+++ b/ui/src/components/run-detail/LiveRunLogPanel.tsx
@@ -1,22 +1,112 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { ChevronDown, ScrollText, AlertTriangle } from 'lucide-react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  ScrollText,
+  AlertTriangle,
+  Maximize2,
+  Pause,
+  Play,
+  Plug,
+  Unplug,
+  X,
+} from 'lucide-react'
 import clsx from 'clsx'
 import { useLiveRunLogsWS } from '@/api/hooks/useLiveRunLogsWS'
+import { AnsiLine } from '@/components/shared/AnsiLine'
 
 interface LiveRunLogPanelProps {
   runId: string
+  // Optional context shown in the fullscreen header so the user knows
+  // which run's logs they're staring at when the rest of the page is
+  // covered. In the inline (non-fullscreen) view the surrounding page
+  // already provides all this context, so we keep that title minimal.
+  client?: string
+  instanceId?: string
 }
 
 /**
  * LiveRunLogPanel streams the runner's benchmarkoor.log over a
- * WebSocket while the user has it expanded. Collapsed = no WS open =
- * no log traffic from the runner. The hook does all the heavy lifting;
- * this component handles layout, sticky-bottom auto-scroll, and the
- * expand/collapse toggle.
+ * WebSocket and renders each line with ANSI coloring. The panel is
+ * always mounted on the live view (so the runner gets told to start
+ * streaming as soon as someone lands on the page), with an optional
+ * fullscreen mode for long debugging sessions.
  */
-export function LiveRunLogPanel({ runId }: LiveRunLogPanelProps) {
-  const [expanded, setExpanded] = useState(false)
-  const { text, truncated, ended, connected } = useLiveRunLogsWS(runId, expanded)
+// AUTO_STOP_MS is how long an open log stream stays connected without
+// an explicit reconnect. The goal is to make sure a tab someone opens
+// and forgets about doesn't keep a WS (and the runner's log tailer)
+// alive forever. Users can reconnect at any time.
+const AUTO_STOP_MS = 5 * 60 * 1000
+
+export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelProps) {
+  const [fullscreen, setFullscreen] = useState(false)
+  // Pause freezes the display but keeps the WS open — the runner
+  // keeps streaming, the API keeps buffering, and Resume catches up.
+  const [paused, setPaused] = useState(false)
+  const [frozenText, setFrozenText] = useState('')
+  // Stop fully disconnects: the UI WS closes, the API's subscriber
+  // count drops to zero, and the runner receives stream_off. Zero
+  // bytes in flight. Reconnect re-opens the WS and picks up the
+  // current API buffer as a fresh snapshot.
+  const [stopped, setStopped] = useState(false)
+  // Absolute wall-clock deadline for the auto-stop timer. Used both
+  // to fire the stop and to drive the countdown label in the header.
+  const [autoStopAt, setAutoStopAt] = useState<number | null>(() => Date.now() + AUTO_STOP_MS)
+  const [now, setNow] = useState(() => Date.now())
+
+  const { text, truncated, ended, connected } = useLiveRunLogsWS(runId, !stopped)
+
+  // Tick once per second while connected, so the countdown label
+  // refreshes. Cheap (one setInterval), and it stops ticking the
+  // moment the stream is stopped.
+  useEffect(() => {
+    if (stopped || autoStopAt === null) return
+
+    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [stopped, autoStopAt])
+
+  // Fire the auto-stop exactly at the deadline.
+  useEffect(() => {
+    if (stopped || autoStopAt === null) return
+
+    const remaining = autoStopAt - Date.now()
+    if (remaining <= 0) {
+      // Deadline already passed (e.g. user returned to a long-idle
+      // tab and the computed deadline is in the past). One bounded
+      // follow-up render.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setStopped(true)
+      return
+    }
+
+    const id = window.setTimeout(() => setStopped(true), remaining)
+    return () => window.clearTimeout(id)
+  }, [stopped, autoStopAt])
+
+  // When paused, render the snapshot we captured; otherwise render
+  // the live buffer. The pending counter shows how many new bytes
+  // have arrived since pause so the user knows they're behind.
+  const displayText = paused ? frozenText : text
+  const pendingBytes = paused ? Math.max(0, text.length - frozenText.length) : 0
+  const pendingLines = useMemo(() => {
+    if (!paused) return 0
+    const delta = text.slice(frozenText.length)
+    if (!delta) return 0
+    // Count newlines in the delta; clamp at 1 so a partial line still
+    // reads as "at least 1 new line".
+    let count = 0
+    for (const c of delta) if (c === '\n') count++
+    return Math.max(count, 1)
+  }, [paused, text, frozenText])
+
+  // Split the rolling buffer into lines once per render so the JSX
+  // below stays declarative. The trailing-empty-string case (from a
+  // final "\n") is trimmed so we don't render a phantom blank row.
+  const lines = useMemo(() => {
+    if (!displayText) return []
+    const parts = displayText.split('\n')
+    if (parts.length > 0 && parts[parts.length - 1] === '') parts.pop()
+    return parts
+  }, [displayText])
 
   // Sticky-bottom auto-scroll: only snap on new data when the user is
   // already at the bottom, so a user scrolling up to read doesn't get
@@ -36,86 +126,262 @@ export function LiveRunLogPanel({ runId }: LiveRunLogPanelProps) {
     if (wasAtBottomRef.current) {
       el.scrollTop = el.scrollHeight
     }
-  }, [text])
+  }, [displayText])
 
-  // When (re)expanding, reset the "was at bottom" flag so the first
-  // snapshot lands at the bottom even if the prior session had scrolled.
+  // Fullscreen UX: ESC to exit; lock body scroll so the page behind
+  // doesn't scroll with the overlay open. Mirrors the pattern used by
+  // the suite-detail heatmaps.
   useEffect(() => {
-    if (expanded) {
-      wasAtBottomRef.current = true
+    if (!fullscreen) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setFullscreen(false)
     }
-  }, [expanded])
+    document.addEventListener('keydown', handleKey)
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = ''
+    }
+  }, [fullscreen])
 
-  return (
-    <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        className={clsx(
-          'flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3 text-left',
-          expanded && 'border-b border-gray-200 dark:border-gray-700',
-          'hover:bg-gray-50 dark:hover:bg-gray-700/50',
-        )}
-      >
-        <h3 className="flex items-center gap-2 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
-          <ScrollText className="size-4 text-gray-400 dark:text-gray-500" />
-          Runner log (live)
-          {expanded && (
-            <span
-              className={clsx(
-                'ml-1 inline-flex items-center gap-1 rounded-xs px-1.5 py-0.5 text-xs font-medium',
-                connected
-                  ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
-                  : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
-              )}
-            >
-              <span
-                className={clsx(
-                  'size-1.5 rounded-full',
-                  connected ? 'bg-green-500' : 'bg-gray-400',
-                )}
-                aria-hidden="true"
-              />
-              {connected ? 'connected' : 'connecting…'}
-            </span>
-          )}
-        </h3>
-        <ChevronDown
-          className={clsx(
-            'size-5 shrink-0 text-gray-500 transition-transform',
-            expanded && 'rotate-180',
-          )}
-        />
-      </button>
+  // When switching modes, the new scroll container needs to start
+  // pinned to the bottom (otherwise the first paint can leave it at 0).
+  useEffect(() => {
+    wasAtBottomRef.current = true
+  }, [fullscreen])
 
-      {expanded && (
-        <div className="flex flex-col">
-          {truncated && (
-            <div className="flex items-center gap-2 border-b border-yellow-200 bg-yellow-50 px-4 py-2 text-xs/5 text-yellow-800 dark:border-yellow-900/50 dark:bg-yellow-900/20 dark:text-yellow-200">
-              <AlertTriangle className="size-3.5 shrink-0" />
-              Older log lines were dropped to stay under the server buffer cap.
-            </div>
-          )}
-          {ended && (
-            <div className="border-b border-gray-200 bg-gray-50 px-4 py-2 text-xs/5 text-gray-600 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400">
-              Run ended. Log stream closed.
-            </div>
-          )}
-          <pre
-            ref={scrollRef}
-            onScroll={handleScroll}
-            className="h-64 max-h-[50vh] overflow-auto whitespace-pre-wrap bg-gray-950 px-4 py-3 font-mono text-xs/5 text-gray-100"
-          >
-            {text.length === 0 ? (
-              <span className="text-gray-500">
-                {connected ? 'Waiting for log output…' : 'Connecting…'}
+  // Three-way status badge: stopped > (connected/connecting) > paused.
+  // Paused is reflected separately via the pendingLines counter so we
+  // don't clutter this badge with it.
+  const statusBadge = (() => {
+    if (stopped) {
+      return {
+        text: 'stopped',
+        dot: 'bg-gray-400',
+        wrap: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+      }
+    }
+    if (connected) {
+      return {
+        text: 'connected',
+        dot: 'bg-green-500',
+        wrap: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
+      }
+    }
+    return {
+      text: 'connecting…',
+      dot: 'bg-gray-400',
+      wrap: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+    }
+  })()
+
+  const connectedBadge = (
+    <span
+      className={clsx(
+        'ml-1 inline-flex items-center gap-1 rounded-xs px-1.5 py-0.5 text-xs font-medium',
+        statusBadge.wrap,
+      )}
+    >
+      <span className={clsx('size-1.5 rounded-full', statusBadge.dot)} aria-hidden="true" />
+      {statusBadge.text}
+    </span>
+  )
+
+  const header = (
+    <div
+      className={clsx(
+        'flex items-center justify-between gap-3 border-b border-gray-200 px-4 py-3',
+        'dark:border-gray-700',
+      )}
+    >
+      <h3 className="flex min-w-0 items-center gap-2 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+        <ScrollText className="size-4 shrink-0 text-gray-400 dark:text-gray-500" />
+        Runner log (live)
+        {/* Fullscreen mode covers the surrounding page context, so we
+            surface the client logo + instance + run id right here. In
+            the inline view those are already visible in the page
+            breadcrumb above, so we keep the title minimal. */}
+        {fullscreen && client && (
+          <>
+            <span className="text-gray-300 dark:text-gray-600">·</span>
+            <img
+              src={`/img/clients/${client}.jpg`}
+              alt={`${client} logo`}
+              className="size-5 shrink-0 rounded-xs object-cover"
+            />
+            {instanceId && (
+              <span className="truncate font-mono text-gray-700 dark:text-gray-200">
+                {instanceId}
               </span>
-            ) : (
-              text
             )}
-          </pre>
+          </>
+        )}
+        {fullscreen && (
+          <>
+            <span className="text-gray-300 dark:text-gray-600">·</span>
+            <span className="truncate font-mono text-xs text-gray-500 dark:text-gray-400">
+              {runId}
+            </span>
+          </>
+        )}
+        {connectedBadge}
+        {/* Countdown for the auto-disconnect. Rendered in the header
+            so the stop is never surprising. Hidden when stopped or
+            when the deadline is unset. */}
+        {!stopped && autoStopAt !== null && (() => {
+          const remainingMs = Math.max(0, autoStopAt - now)
+          const totalSec = Math.ceil(remainingMs / 1000)
+          const mm = Math.floor(totalSec / 60)
+          const ss = totalSec % 60
+          const label = mm > 0 ? `${mm}m ${ss.toString().padStart(2, '0')}s` : `${ss}s`
+          return (
+            <span
+              className="inline-flex items-center rounded-xs bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+              title="The log stream auto-disconnects after 5 minutes. Click reconnect to extend."
+            >
+              auto-stops in {label}
+            </span>
+          )
+        })()}
+        {paused && pendingLines > 0 && (
+          <span
+            className="inline-flex items-center gap-1 rounded-xs bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+            title={`${pendingBytes} new byte(s) buffered since pause`}
+          >
+            +{pendingLines} new
+          </span>
+        )}
+      </h3>
+      <div className="flex shrink-0 items-center gap-2">
+        {/* Pause / Resume — only meaningful while connected to the
+            stream; hidden entirely when stopped. */}
+        {!stopped && (
+          <button
+            type="button"
+            onClick={() => {
+              if (paused) {
+                // Resume: drop the snapshot, fall back to live buffer,
+                // and make sure auto-scroll snaps to the bottom.
+                setPaused(false)
+                setFrozenText('')
+                wasAtBottomRef.current = true
+              } else {
+                // Pause: capture the current buffer so the panel
+                // renders a stable view while new bytes keep arriving.
+                setFrozenText(text)
+                setPaused(true)
+              }
+            }}
+            className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            title={paused ? 'Resume (catch up to latest)' : 'Pause (freeze the current view)'}
+            aria-label={paused ? 'Resume log stream' : 'Pause log stream'}
+          >
+            {paused ? <Play className="size-4" /> : <Pause className="size-4" />}
+          </button>
+        )}
+        {/* Stop / Reconnect — hard toggle that closes the WS entirely.
+            When stopped the pause state is force-cleared (pause is
+            moot without a live feed); reconnect snaps auto-scroll to
+            the bottom so the fresh snapshot renders correctly. */}
+        <button
+          type="button"
+          onClick={() => {
+            if (stopped) {
+              // Reconnect: arm a fresh auto-stop deadline.
+              setStopped(false)
+              setAutoStopAt(Date.now() + AUTO_STOP_MS)
+              wasAtBottomRef.current = true
+            } else {
+              // Explicit stop: cancel any pending auto-stop.
+              setStopped(true)
+              setAutoStopAt(null)
+              setPaused(false)
+              setFrozenText('')
+            }
+          }}
+          className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+          title={
+            stopped
+              ? 'Reconnect to log stream'
+              : autoStopAt
+                ? `Stop log stream (auto-stops at ${new Date(autoStopAt).toLocaleTimeString()})`
+                : 'Stop log stream (disconnect)'
+          }
+          aria-label={stopped ? 'Reconnect log stream' : 'Stop log stream'}
+        >
+          {stopped ? <Plug className="size-4" /> : <Unplug className="size-4" />}
+        </button>
+        <button
+          type="button"
+          onClick={() => setFullscreen((v) => !v)}
+          className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+          title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+          aria-label={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+        >
+          {fullscreen ? <X className="size-4" /> : <Maximize2 className="size-4" />}
+        </button>
+      </div>
+    </div>
+  )
+
+  const banners = (
+    <>
+      {truncated && (
+        <div className="flex items-center gap-2 border-b border-yellow-200 bg-yellow-50 px-4 py-2 text-xs/5 text-yellow-800 dark:border-yellow-900/50 dark:bg-yellow-900/20 dark:text-yellow-200">
+          <AlertTriangle className="size-3.5 shrink-0" />
+          Older log lines were dropped to stay under the server buffer cap.
         </div>
       )}
+      {ended && (
+        <div className="border-b border-gray-200 bg-gray-50 px-4 py-2 text-xs/5 text-gray-600 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400">
+          Run ended. Log stream closed.
+        </div>
+      )}
+    </>
+  )
+
+  const logPre = (
+    <pre
+      ref={scrollRef}
+      onScroll={handleScroll}
+      className={clsx(
+        'overflow-auto whitespace-pre-wrap bg-gray-950 px-4 py-3 font-mono text-xs/5 text-gray-100',
+        fullscreen ? 'min-h-0 flex-1' : 'h-64 max-h-[50vh]',
+      )}
+    >
+      {lines.length === 0 ? (
+        <span className="text-gray-500">
+          {stopped
+            ? 'Stream stopped. Click the reconnect button to resume.'
+            : connected
+              ? 'Waiting for log output…'
+              : 'Connecting…'}
+        </span>
+      ) : (
+        lines.map((line, i) => (
+          <div key={i}>
+            <AnsiLine content={line} />
+          </div>
+        ))
+      )}
+    </pre>
+  )
+
+  if (fullscreen) {
+    return (
+      <div className="fixed inset-0 z-40 flex flex-col bg-white dark:bg-gray-900">
+        {header}
+        {banners}
+        {logPre}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
+      {header}
+      {banners}
+      {logPre}
     </div>
   )
 }

--- a/ui/src/components/run-detail/LiveRunLogPanel.tsx
+++ b/ui/src/components/run-detail/LiveRunLogPanel.tsx
@@ -35,9 +35,23 @@ const LINE_HEIGHT_ESTIMATE = 20
  * virtualization so only visible lines are in the DOM — the total line
  * count can grow unbounded without causing render jank.
  */
+type LogFilter = 'all' | 'runner' | 'client'
+
+// Emoji prefixes used by the runner's logrus formatter to distinguish
+// benchmarkoor's own log lines from lines forwarded from the EL client.
+const RUNNER_PREFIX = '\u{1F535}' // 🔵
+const CLIENT_PREFIX = '\u{1F7E3}' // 🟣
+
+function lineMatchesFilter(line: string, filter: LogFilter): boolean {
+  if (filter === 'all') return true
+  if (filter === 'runner') return line.startsWith(RUNNER_PREFIX)
+  return line.startsWith(CLIENT_PREFIX) // 'client'
+}
+
 export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelProps) {
   const [fullscreen, setFullscreen] = useState(false)
   const [stopped, setStopped] = useState(false)
+  const [logFilter, setLogFilter] = useState<LogFilter>('all')
 
   // ─── Inactivity-based auto-stop ────────────────────────────────
   // Phase 1 (grace): user is active — no countdown shown.
@@ -146,18 +160,50 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     setLineVersion((v) => v + 1)
   }, [version]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ─── Filtered line indices ──────────────────────────────────────
+  // Instead of copying the lines array, we compute a mapping from
+  // virtualizer row index → linesRef index. When filter is 'all'
+  // we skip the indirection entirely for zero overhead.
+  const filteredIndicesRef = useRef<number[]>([])
+  const filteredCountRef = useRef(0)
+
+  // Recompute whenever lines change (lineVersion) or the filter
+  // toggles. We use refs so the virtualizer reads a stable count
+  // without needing React state (avoids an extra render cycle).
+  useEffect(() => {
+    if (logFilter === 'all') {
+      filteredIndicesRef.current = []
+      filteredCountRef.current = linesRef.current.length
+    } else {
+      const indices: number[] = []
+      for (let i = 0; i < linesRef.current.length; i++) {
+        if (lineMatchesFilter(linesRef.current[i], logFilter)) {
+          indices.push(i)
+        }
+      }
+      filteredIndicesRef.current = indices
+      filteredCountRef.current = indices.length
+    }
+  }, [lineVersion, logFilter])
+
+  // Helper: map a virtualizer row to the actual line in linesRef.
+  const lineAt = useCallback(
+    (virtualRow: number): string => {
+      if (logFilter === 'all') {
+        return linesRef.current[virtualRow] ?? ''
+      }
+      const realIdx = filteredIndicesRef.current[virtualRow]
+      return linesRef.current[realIdx] ?? ''
+    },
+    [logFilter],
+  )
+
   // ─── Virtualizer ────────────────────────────────────────────────
   const scrollRef = useRef<HTMLDivElement>(null)
 
-  // Simple scroll model: when the stream is connected, new lines
-  // always auto-scroll to the bottom. If the user scrolls up, we
-  // disconnect the stream entirely so the viewport is completely
-  // stable (no new content, no fighting). The "jump to bottom"
-  // arrow or the reconnect button re-enables the stream.
   const handleWheel = useCallback(
     (e: React.WheelEvent) => {
       if (e.deltaY < 0 && !stopped) {
-        // User scrolling up while connected → disconnect.
         setStopped(true)
         setAutoStopAt(null)
       }
@@ -166,18 +212,15 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
   )
 
   const virtualizer = useVirtualizer({
-    count: linesRef.current.length,
+    count: filteredCountRef.current,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => LINE_HEIGHT_ESTIMATE,
     overscan: 30,
   })
 
-  // While connected, every new line scrolls the last row into view.
-  // Once stopped (by the user scrolling up, or by the disconnect
-  // button, or by the inactivity timer), nothing moves.
   useLayoutEffect(() => {
     if (stopped) return
-    const count = linesRef.current.length
+    const count = filteredCountRef.current
     if (count > 0) {
       virtualizer.scrollToIndex(count - 1, { align: 'end' })
     }
@@ -187,7 +230,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     setStopped(false)
     setAutoStopAt(null)
     lastActivityRef.current = Date.now()
-    const count = linesRef.current.length
+    const count = filteredCountRef.current
     if (count > 0) {
       virtualizer.scrollToIndex(count - 1, { align: 'end' })
     }
@@ -291,6 +334,29 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
         })()}
       </h3>
       <div className="flex shrink-0 items-center gap-2">
+        {/* Log source filter chips */}
+        <div className="flex items-center rounded-xs border border-gray-300 dark:border-gray-600">
+          {([
+            { value: 'all' as LogFilter, label: 'All' },
+            { value: 'runner' as LogFilter, label: '🔵 Runner' },
+            { value: 'client' as LogFilter, label: '🟣 Client' },
+          ]).map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setLogFilter(value)}
+              className={clsx(
+                'px-2 py-1 text-xs/5 font-medium transition-colors',
+                'first:rounded-l-xs last:rounded-r-xs',
+                logFilter === value
+                  ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200'
+                  : 'bg-white text-gray-600 hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
         <button
           type="button"
           onClick={() => {
@@ -381,7 +447,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
                 className="absolute left-0 top-0 w-full whitespace-pre-wrap px-4"
                 style={{ transform: `translateY(${row.start}px)` }}
               >
-                <AnsiLine content={lines[row.index]} />
+                <AnsiLine content={lineAt(row.index)} />
               </div>
             ))}
           </div>

--- a/ui/src/components/run-detail/LiveRunLogPanel.tsx
+++ b/ui/src/components/run-detail/LiveRunLogPanel.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { ChevronDown, ScrollText, AlertTriangle } from 'lucide-react'
+import clsx from 'clsx'
+import { useLiveRunLogsWS } from '@/api/hooks/useLiveRunLogsWS'
+
+interface LiveRunLogPanelProps {
+  runId: string
+}
+
+/**
+ * LiveRunLogPanel streams the runner's benchmarkoor.log over a
+ * WebSocket while the user has it expanded. Collapsed = no WS open =
+ * no log traffic from the runner. The hook does all the heavy lifting;
+ * this component handles layout, sticky-bottom auto-scroll, and the
+ * expand/collapse toggle.
+ */
+export function LiveRunLogPanel({ runId }: LiveRunLogPanelProps) {
+  const [expanded, setExpanded] = useState(false)
+  const { text, truncated, ended, connected } = useLiveRunLogsWS(runId, expanded)
+
+  // Sticky-bottom auto-scroll: only snap on new data when the user is
+  // already at the bottom, so a user scrolling up to read doesn't get
+  // yanked back.
+  const scrollRef = useRef<HTMLPreElement>(null)
+  const wasAtBottomRef = useRef(true)
+
+  const handleScroll = () => {
+    const el = scrollRef.current
+    if (!el) return
+    wasAtBottomRef.current = el.scrollTop + el.clientHeight >= el.scrollHeight - 8
+  }
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    if (wasAtBottomRef.current) {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [text])
+
+  // When (re)expanding, reset the "was at bottom" flag so the first
+  // snapshot lands at the bottom even if the prior session had scrolled.
+  useEffect(() => {
+    if (expanded) {
+      wasAtBottomRef.current = true
+    }
+  }, [expanded])
+
+  return (
+    <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className={clsx(
+          'flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3 text-left',
+          expanded && 'border-b border-gray-200 dark:border-gray-700',
+          'hover:bg-gray-50 dark:hover:bg-gray-700/50',
+        )}
+      >
+        <h3 className="flex items-center gap-2 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+          <ScrollText className="size-4 text-gray-400 dark:text-gray-500" />
+          Runner log (live)
+          {expanded && (
+            <span
+              className={clsx(
+                'ml-1 inline-flex items-center gap-1 rounded-xs px-1.5 py-0.5 text-xs font-medium',
+                connected
+                  ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
+                  : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+              )}
+            >
+              <span
+                className={clsx(
+                  'size-1.5 rounded-full',
+                  connected ? 'bg-green-500' : 'bg-gray-400',
+                )}
+                aria-hidden="true"
+              />
+              {connected ? 'connected' : 'connecting…'}
+            </span>
+          )}
+        </h3>
+        <ChevronDown
+          className={clsx(
+            'size-5 shrink-0 text-gray-500 transition-transform',
+            expanded && 'rotate-180',
+          )}
+        />
+      </button>
+
+      {expanded && (
+        <div className="flex flex-col">
+          {truncated && (
+            <div className="flex items-center gap-2 border-b border-yellow-200 bg-yellow-50 px-4 py-2 text-xs/5 text-yellow-800 dark:border-yellow-900/50 dark:bg-yellow-900/20 dark:text-yellow-200">
+              <AlertTriangle className="size-3.5 shrink-0" />
+              Older log lines were dropped to stay under the server buffer cap.
+            </div>
+          )}
+          {ended && (
+            <div className="border-b border-gray-200 bg-gray-50 px-4 py-2 text-xs/5 text-gray-600 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400">
+              Run ended. Log stream closed.
+            </div>
+          )}
+          <pre
+            ref={scrollRef}
+            onScroll={handleScroll}
+            className="h-64 max-h-[50vh] overflow-auto whitespace-pre-wrap bg-gray-950 px-4 py-3 font-mono text-xs/5 text-gray-100"
+          >
+            {text.length === 0 ? (
+              <span className="text-gray-500">
+                {connected ? 'Waiting for log output…' : 'Connecting…'}
+              </span>
+            ) : (
+              text
+            )}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/run-detail/LiveRunLogPanel.tsx
+++ b/ui/src/components/run-detail/LiveRunLogPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   ArrowDown,
+  Download,
   ScrollText,
   AlertTriangle,
   Maximize2,
@@ -105,6 +106,37 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
 
   const { textRef, version, truncated, ended, connected } = useLiveRunLogsWS(runId, !stopped)
 
+  // ─── Line count + rate ─────────────────────────────────────────
+  // totalLinesRef is monotonically increasing (never decremented by
+  // buffer trimming), so rate-over-time stays meaningful even when
+  // the buffer is at its cap and linesRef.current.length is stable.
+  const totalLinesRef = useRef(0)
+  const rateSamplesRef = useRef<{ t: number; n: number }[]>([])
+  const [lineStats, setLineStats] = useState({ buffered: 0, rate: 0 })
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      const now = Date.now()
+      rateSamplesRef.current.push({ t: now, n: totalLinesRef.current })
+      // Keep only the last 10 seconds of samples.
+      const cutoff = now - 10_000
+      rateSamplesRef.current = rateSamplesRef.current.filter((s) => s.t >= cutoff)
+
+      let rate = 0
+      const samples = rateSamplesRef.current
+      if (samples.length >= 2) {
+        const oldest = samples[0]
+        const newest = samples[samples.length - 1]
+        const dt = (newest.t - oldest.t) / 1000
+        if (dt > 0) rate = Math.round((newest.n - oldest.n) / dt)
+      }
+
+      setLineStats({ buffered: linesRef.current.length, rate })
+    }, 1000)
+
+    return () => window.clearInterval(id)
+  }, [])  
+
   // ─── Incremental line tracking ─────────────────────────────────
   // Instead of re-splitting the entire text on every WS message, we
   // only process the delta. `linesRef` is a stable array mutated in
@@ -130,6 +162,8 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
       const parts = dt.split('\n')
       if (parts.length > 0 && parts[parts.length - 1] === '') parts.pop()
       linesRef.current = parts
+      // Don't add snapshot lines to totalLinesRef — they're
+      // historical buffer content, not new throughput.
       prevEndedWithNewlineRef.current = dt.endsWith('\n')
     } else if (dt.length > prevLen) {
       // Incremental append — only process the new bytes.
@@ -145,6 +179,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
         }
 
         // Remaining segments are complete new lines.
+        totalLinesRef.current += parts.length
         for (const p of parts) linesRef.current.push(p)
 
         // Trim trailing empty (from a final '\n' in the delta).
@@ -283,7 +318,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     >
       <h3 className="flex min-w-0 items-center gap-2 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
         <ScrollText className="size-4 shrink-0 text-gray-400 dark:text-gray-500" />
-        Runner log (live)
+        Logs
         {fullscreen && client && (
           <>
             <span className="text-gray-300 dark:text-gray-600">·</span>
@@ -331,6 +366,13 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
             </span>
           )
         })()}
+        {/* Line count + throughput rate */}
+        {lineStats.buffered > 0 && (
+          <span className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+            {lineStats.buffered.toLocaleString()} lines
+            {lineStats.rate > 0 && <> · ~{lineStats.rate}/s</>}
+          </span>
+        )}
       </h3>
       <div className="flex shrink-0 items-center gap-2">
         {/* Search box */}
@@ -353,7 +395,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
               type="button"
               onClick={() => setLogFilter(value)}
               className={clsx(
-                'px-2 py-1 text-xs/5 font-medium transition-colors',
+                'cursor-pointer px-2 py-1 text-xs/5 font-medium transition-colors',
                 'first:rounded-l-xs last:rounded-r-xs',
                 logFilter === value
                   ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200'
@@ -364,6 +406,24 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
             </button>
           ))}
         </div>
+        {/* Download current buffer as a .log file */}
+        <button
+          type="button"
+          onClick={() => {
+            const blob = new Blob([textRef.current], { type: 'text/plain' })
+            const url = URL.createObjectURL(blob)
+            const a = document.createElement('a')
+            a.href = url
+            a.download = `${runId}.log`
+            a.click()
+            URL.revokeObjectURL(url)
+          }}
+          className="cursor-pointer rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+          title="Download log buffer"
+          aria-label="Download log buffer"
+        >
+          <Download className="size-4" />
+        </button>
         <button
           type="button"
           onClick={() => {
@@ -376,7 +436,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
               setAutoStopAt(null)
             }
           }}
-          className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+          className="cursor-pointer rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
           title={
             stopped
               ? 'Reconnect to log stream'
@@ -391,7 +451,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
         <button
           type="button"
           onClick={() => setFullscreen((v) => !v)}
-          className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+          className="cursor-pointer rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
           title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
           aria-label={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
         >
@@ -467,7 +527,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
         <button
           type="button"
           onClick={jumpToBottom}
-          className="absolute bottom-3 right-5 z-10 rounded-full bg-blue-600 p-1.5 text-white shadow-lg hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+          className="absolute bottom-3 right-5 z-10 cursor-pointer rounded-full bg-blue-600 p-1.5 text-white shadow-lg hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
           title="Jump to latest"
           aria-label="Jump to latest"
         >

--- a/ui/src/components/run-detail/LiveRunLogPanel.tsx
+++ b/ui/src/components/run-detail/LiveRunLogPanel.tsx
@@ -88,7 +88,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     return () => window.clearInterval(id)
   }, [stopped, autoStopAt])
 
-  const { text, truncated, ended, connected } = useLiveRunLogsWS(runId, !stopped)
+  const { textRef, version, truncated, ended, connected } = useLiveRunLogsWS(runId, !stopped)
 
   // ─── Incremental line tracking ─────────────────────────────────
   // Instead of re-splitting the entire text on every WS message, we
@@ -106,7 +106,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
   const [lineVersion, setLineVersion] = useState(0)
 
   useEffect(() => {
-    const dt = text
+    const dt = textRef.current
     const prevLen = prevTextLenRef.current
 
     if (dt.length < prevLen || (prevLen === 0 && dt.length > 0)) {
@@ -144,30 +144,26 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     prevTextLenRef.current = dt.length
      
     setLineVersion((v) => v + 1)
-  }, [text])
+  }, [version]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ─── Virtualizer + auto-follow ──────────────────────────────────
+  // ─── Virtualizer ────────────────────────────────────────────────
   const scrollRef = useRef<HTMLDivElement>(null)
 
-  // "Following" means we auto-scroll to the bottom on every new
-  // line. Default on. Turned off when the user scrolls up (detected
-  // via the wheel event, which only fires on human interaction —
-  // never on our programmatic scrollToIndex calls). The "jump to
-  // bottom" button re-enables it.
-  const [following, setFollowing] = useState(true)
-
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    if (e.deltaY < 0) {
-      // User scrolling up → stop following.
-      setFollowing(false)
-    } else if (e.deltaY > 0) {
-      // User scrolling down — check if they've reached the bottom.
-      const el = scrollRef.current
-      if (el && el.scrollTop + el.clientHeight >= el.scrollHeight - 32) {
-        setFollowing(true)
+  // Simple scroll model: when the stream is connected, new lines
+  // always auto-scroll to the bottom. If the user scrolls up, we
+  // disconnect the stream entirely so the viewport is completely
+  // stable (no new content, no fighting). The "jump to bottom"
+  // arrow or the reconnect button re-enables the stream.
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      if (e.deltaY < 0 && !stopped) {
+        // User scrolling up while connected → disconnect.
+        setStopped(true)
+        setAutoStopAt(null)
       }
-    }
-  }, [])
+    },
+    [stopped],
+  )
 
   const virtualizer = useVirtualizer({
     count: linesRef.current.length,
@@ -176,17 +172,21 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     overscan: 30,
   })
 
-  // When following + new lines arrive, scroll the last row into view.
+  // While connected, every new line scrolls the last row into view.
+  // Once stopped (by the user scrolling up, or by the disconnect
+  // button, or by the inactivity timer), nothing moves.
   useLayoutEffect(() => {
-    if (!following) return
+    if (stopped) return
     const count = linesRef.current.length
     if (count > 0) {
       virtualizer.scrollToIndex(count - 1, { align: 'end' })
     }
-  }, [lineVersion, following]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [lineVersion, stopped]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const jumpToBottom = useCallback(() => {
-    setFollowing(true)
+    setStopped(false)
+    setAutoStopAt(null)
+    lastActivityRef.current = Date.now()
     const count = linesRef.current.length
     if (count > 0) {
       virtualizer.scrollToIndex(count - 1, { align: 'end' })
@@ -207,9 +207,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     }
   }, [fullscreen])
 
-  useEffect(() => {
-    setFollowing(true)
-  }, [fullscreen])
+
 
   // ─── Header ────────────────────────────────────────────────────
   const statusBadge = (() => {
@@ -300,7 +298,6 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
               setStopped(false)
               setAutoStopAt(null)
               lastActivityRef.current = Date.now()
-              setFollowing(true)
             } else {
               setStopped(true)
               setAutoStopAt(null)
@@ -357,7 +354,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
         onWheel={handleWheel}
         className={clsx(
           'overflow-auto bg-gray-950 font-mono text-xs/5 text-gray-100',
-          fullscreen ? 'h-full' : 'h-64 max-h-[50vh]',
+          fullscreen ? 'h-full' : 'h-96 max-h-[60vh]',
         )}
       >
         {lines.length === 0 ? (
@@ -393,7 +390,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
       {/* Floating "jump to bottom" pill — visible when the user has
           scrolled up and auto-follow is off. Clicking re-enables
           following and scrolls to the latest line. */}
-      {!following && lines.length > 0 && (
+      {stopped && lines.length > 0 && (
         <button
           type="button"
           onClick={jumpToBottom}

--- a/ui/src/components/run-detail/LiveRunLogPanel.tsx
+++ b/ui/src/components/run-detail/LiveRunLogPanel.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import {
+  ArrowDown,
   ScrollText,
   AlertTriangle,
   Maximize2,
-  Pause,
-  Play,
   Plug,
   Unplug,
   X,
@@ -15,122 +15,185 @@ import { AnsiLine } from '@/components/shared/AnsiLine'
 
 interface LiveRunLogPanelProps {
   runId: string
-  // Optional context shown in the fullscreen header so the user knows
-  // which run's logs they're staring at when the rest of the page is
-  // covered. In the inline (non-fullscreen) view the surrounding page
-  // already provides all this context, so we keep that title minimal.
   client?: string
   instanceId?: string
 }
 
+// After INACTIVITY_GRACE_MS of no user interaction, a countdown
+// appears. If the user stays idle for another AUTO_STOP_COUNTDOWN_MS,
+// the stream disconnects. Any interaction resets both timers.
+const INACTIVITY_GRACE_MS = 30 * 1000
+const AUTO_STOP_COUNTDOWN_MS = 5 * 60 * 1000
+
+// Estimated line height for the virtualizer. Doesn't need to be exact;
+// the virtualizer measures actual rendered heights dynamically.
+const LINE_HEIGHT_ESTIMATE = 20
+
 /**
  * LiveRunLogPanel streams the runner's benchmarkoor.log over a
- * WebSocket and renders each line with ANSI coloring. The panel is
- * always mounted on the live view (so the runner gets told to start
- * streaming as soon as someone lands on the page), with an optional
- * fullscreen mode for long debugging sessions.
+ * WebSocket and renders each line with ANSI coloring. Uses row
+ * virtualization so only visible lines are in the DOM — the total line
+ * count can grow unbounded without causing render jank.
  */
-// AUTO_STOP_MS is how long an open log stream stays connected without
-// an explicit reconnect. The goal is to make sure a tab someone opens
-// and forgets about doesn't keep a WS (and the runner's log tailer)
-// alive forever. Users can reconnect at any time.
-const AUTO_STOP_MS = 5 * 60 * 1000
-
 export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelProps) {
   const [fullscreen, setFullscreen] = useState(false)
-  // Pause freezes the display but keeps the WS open — the runner
-  // keeps streaming, the API keeps buffering, and Resume catches up.
-  const [paused, setPaused] = useState(false)
-  const [frozenText, setFrozenText] = useState('')
-  // Stop fully disconnects: the UI WS closes, the API's subscriber
-  // count drops to zero, and the runner receives stream_off. Zero
-  // bytes in flight. Reconnect re-opens the WS and picks up the
-  // current API buffer as a fresh snapshot.
   const [stopped, setStopped] = useState(false)
-  // Absolute wall-clock deadline for the auto-stop timer. Used both
-  // to fire the stop and to drive the countdown label in the header.
-  const [autoStopAt, setAutoStopAt] = useState<number | null>(() => Date.now() + AUTO_STOP_MS)
+
+  // ─── Inactivity-based auto-stop ────────────────────────────────
+  // Phase 1 (grace): user is active — no countdown shown.
+  // Phase 2 (countdown): 30 s of inactivity passed — countdown
+  //   badge appears, ticking down from 5 min. If the user interacts
+  //   at any point, we go back to Phase 1.
+  // Phase 3 (stop): countdown reaches 0 → stream disconnects.
+  //
+  // autoStopAt is null during Phase 1 (no countdown), or a
+  // wall-clock timestamp for the disconnect deadline (Phase 2).
+  const [autoStopAt, setAutoStopAt] = useState<number | null>(null)
   const [now, setNow] = useState(() => Date.now())
+  const lastActivityRef = useRef(Date.now())
 
-  const { text, truncated, ended, connected } = useLiveRunLogsWS(runId, !stopped)
-
-  // Tick once per second while connected, so the countdown label
-  // refreshes. Cheap (one setInterval), and it stops ticking the
-  // moment the stream is stopped.
+  // Listen to page-wide interaction events while the stream is open.
   useEffect(() => {
-    if (stopped || autoStopAt === null) return
+    if (stopped) return
 
-    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    const handler = () => { lastActivityRef.current = Date.now() }
+    const events = ['mousemove', 'mousedown', 'keydown', 'scroll', 'touchstart'] as const
+    for (const e of events) window.addEventListener(e, handler, { passive: true })
+    return () => { for (const e of events) window.removeEventListener(e, handler) }
+  }, [stopped])
+
+  // Check inactivity every second; transition between phases.
+  useEffect(() => {
+    if (stopped) return
+
+    const id = window.setInterval(() => {
+      const idleMs = Date.now() - lastActivityRef.current
+      setNow(Date.now())
+
+      if (autoStopAt !== null) {
+        // Phase 2 — check if user became active again.
+        if (idleMs < INACTIVITY_GRACE_MS) {
+          setAutoStopAt(null) // back to Phase 1
+        } else if (Date.now() >= autoStopAt) {
+          setStopped(true) // Phase 3
+        }
+      } else {
+        // Phase 1 — check if we should start the countdown.
+        if (idleMs >= INACTIVITY_GRACE_MS) {
+          setAutoStopAt(Date.now() + AUTO_STOP_COUNTDOWN_MS) // enter Phase 2
+        }
+      }
+    }, 1000)
+
     return () => window.clearInterval(id)
   }, [stopped, autoStopAt])
 
-  // Fire the auto-stop exactly at the deadline.
+  const { text, truncated, ended, connected } = useLiveRunLogsWS(runId, !stopped)
+
+  // ─── Incremental line tracking ─────────────────────────────────
+  // Instead of re-splitting the entire text on every WS message, we
+  // only process the delta. `linesRef` is a stable array mutated in
+  // place; `lineVersion` is bumped to tell the virtualizer the count
+  // changed. This makes each update O(new lines) instead of O(all).
+  const linesRef = useRef<string[]>([])
+  const prevTextLenRef = useRef(0)
+  // Tracks whether the previous chunk ended with '\n'. When true,
+  // the first segment of the next chunk is a NEW line (not a
+  // continuation of the previous one). This was the source of the
+  // multi-entry-on-one-line bug — without this flag, every first
+  // segment got merged with the previous complete line.
+  const prevEndedWithNewlineRef = useRef(true)
+  const [lineVersion, setLineVersion] = useState(0)
+
   useEffect(() => {
-    if (stopped || autoStopAt === null) return
+    const dt = text
+    const prevLen = prevTextLenRef.current
 
-    const remaining = autoStopAt - Date.now()
-    if (remaining <= 0) {
-      // Deadline already passed (e.g. user returned to a long-idle
-      // tab and the computed deadline is in the past). One bounded
-      // follow-up render.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setStopped(true)
-      return
+    if (dt.length < prevLen || (prevLen === 0 && dt.length > 0)) {
+      // Full reset — text was replaced (snapshot on reconnect, or
+      // paused→resumed with different content). Re-split entirely.
+      const parts = dt.split('\n')
+      if (parts.length > 0 && parts[parts.length - 1] === '') parts.pop()
+      linesRef.current = parts
+      prevEndedWithNewlineRef.current = dt.endsWith('\n')
+    } else if (dt.length > prevLen) {
+      // Incremental append — only process the new bytes.
+      const delta = dt.slice(prevLen)
+      const parts = delta.split('\n')
+
+      if (parts.length > 0) {
+        if (linesRef.current.length > 0 && !prevEndedWithNewlineRef.current) {
+          // Previous chunk ended mid-line → first segment is a
+          // continuation of that partial line.
+          linesRef.current[linesRef.current.length - 1] += parts[0]
+          parts.shift()
+        }
+
+        // Remaining segments are complete new lines.
+        for (const p of parts) linesRef.current.push(p)
+
+        // Trim trailing empty (from a final '\n' in the delta).
+        if (linesRef.current.length > 0 && linesRef.current[linesRef.current.length - 1] === '') {
+          linesRef.current.pop()
+        }
+      }
+
+      prevEndedWithNewlineRef.current = delta.endsWith('\n')
     }
 
-    const id = window.setTimeout(() => setStopped(true), remaining)
-    return () => window.clearTimeout(id)
-  }, [stopped, autoStopAt])
+    prevTextLenRef.current = dt.length
+     
+    setLineVersion((v) => v + 1)
+  }, [text])
 
-  // When paused, render the snapshot we captured; otherwise render
-  // the live buffer. The pending counter shows how many new bytes
-  // have arrived since pause so the user knows they're behind.
-  const displayText = paused ? frozenText : text
-  const pendingBytes = paused ? Math.max(0, text.length - frozenText.length) : 0
-  const pendingLines = useMemo(() => {
-    if (!paused) return 0
-    const delta = text.slice(frozenText.length)
-    if (!delta) return 0
-    // Count newlines in the delta; clamp at 1 so a partial line still
-    // reads as "at least 1 new line".
-    let count = 0
-    for (const c of delta) if (c === '\n') count++
-    return Math.max(count, 1)
-  }, [paused, text, frozenText])
+  // ─── Virtualizer + auto-follow ──────────────────────────────────
+  const scrollRef = useRef<HTMLDivElement>(null)
 
-  // Split the rolling buffer into lines once per render so the JSX
-  // below stays declarative. The trailing-empty-string case (from a
-  // final "\n") is trimmed so we don't render a phantom blank row.
-  const lines = useMemo(() => {
-    if (!displayText) return []
-    const parts = displayText.split('\n')
-    if (parts.length > 0 && parts[parts.length - 1] === '') parts.pop()
-    return parts
-  }, [displayText])
+  // "Following" means we auto-scroll to the bottom on every new
+  // line. Default on. Turned off when the user scrolls up (detected
+  // via the wheel event, which only fires on human interaction —
+  // never on our programmatic scrollToIndex calls). The "jump to
+  // bottom" button re-enables it.
+  const [following, setFollowing] = useState(true)
 
-  // Sticky-bottom auto-scroll: only snap on new data when the user is
-  // already at the bottom, so a user scrolling up to read doesn't get
-  // yanked back.
-  const scrollRef = useRef<HTMLPreElement>(null)
-  const wasAtBottomRef = useRef(true)
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    if (e.deltaY < 0) {
+      // User scrolling up → stop following.
+      setFollowing(false)
+    } else if (e.deltaY > 0) {
+      // User scrolling down — check if they've reached the bottom.
+      const el = scrollRef.current
+      if (el && el.scrollTop + el.clientHeight >= el.scrollHeight - 32) {
+        setFollowing(true)
+      }
+    }
+  }, [])
 
-  const handleScroll = () => {
-    const el = scrollRef.current
-    if (!el) return
-    wasAtBottomRef.current = el.scrollTop + el.clientHeight >= el.scrollHeight - 8
-  }
+  const virtualizer = useVirtualizer({
+    count: linesRef.current.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => LINE_HEIGHT_ESTIMATE,
+    overscan: 30,
+  })
 
+  // When following + new lines arrive, scroll the last row into view.
   useLayoutEffect(() => {
-    const el = scrollRef.current
-    if (!el) return
-    if (wasAtBottomRef.current) {
-      el.scrollTop = el.scrollHeight
+    if (!following) return
+    const count = linesRef.current.length
+    if (count > 0) {
+      virtualizer.scrollToIndex(count - 1, { align: 'end' })
     }
-  }, [displayText])
+  }, [lineVersion, following]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Fullscreen UX: ESC to exit; lock body scroll so the page behind
-  // doesn't scroll with the overlay open. Mirrors the pattern used by
-  // the suite-detail heatmaps.
+  const jumpToBottom = useCallback(() => {
+    setFollowing(true)
+    const count = linesRef.current.length
+    if (count > 0) {
+      virtualizer.scrollToIndex(count - 1, { align: 'end' })
+    }
+  }, [virtualizer])
+
+  // ─── Fullscreen ────────────────────────────────────────────────
   useEffect(() => {
     if (!fullscreen) return
     const handleKey = (e: KeyboardEvent) => {
@@ -144,15 +207,11 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     }
   }, [fullscreen])
 
-  // When switching modes, the new scroll container needs to start
-  // pinned to the bottom (otherwise the first paint can leave it at 0).
   useEffect(() => {
-    wasAtBottomRef.current = true
+    setFollowing(true)
   }, [fullscreen])
 
-  // Three-way status badge: stopped > (connected/connecting) > paused.
-  // Paused is reflected separately via the pendingLines counter so we
-  // don't clutter this badge with it.
+  // ─── Header ────────────────────────────────────────────────────
   const statusBadge = (() => {
     if (stopped) {
       return {
@@ -175,18 +234,6 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     }
   })()
 
-  const connectedBadge = (
-    <span
-      className={clsx(
-        'ml-1 inline-flex items-center gap-1 rounded-xs px-1.5 py-0.5 text-xs font-medium',
-        statusBadge.wrap,
-      )}
-    >
-      <span className={clsx('size-1.5 rounded-full', statusBadge.dot)} aria-hidden="true" />
-      {statusBadge.text}
-    </span>
-  )
-
   const header = (
     <div
       className={clsx(
@@ -197,10 +244,6 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
       <h3 className="flex min-w-0 items-center gap-2 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
         <ScrollText className="size-4 shrink-0 text-gray-400 dark:text-gray-500" />
         Runner log (live)
-        {/* Fullscreen mode covers the surrounding page context, so we
-            surface the client logo + instance + run id right here. In
-            the inline view those are already visible in the page
-            breadcrumb above, so we keep the title minimal. */}
         {fullscreen && client && (
           <>
             <span className="text-gray-300 dark:text-gray-600">·</span>
@@ -224,10 +267,15 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
             </span>
           </>
         )}
-        {connectedBadge}
-        {/* Countdown for the auto-disconnect. Rendered in the header
-            so the stop is never surprising. Hidden when stopped or
-            when the deadline is unset. */}
+        <span
+          className={clsx(
+            'ml-1 inline-flex items-center gap-1 rounded-xs px-1.5 py-0.5 text-xs font-medium',
+            statusBadge.wrap,
+          )}
+        >
+          <span className={clsx('size-1.5 rounded-full', statusBadge.dot)} aria-hidden="true" />
+          {statusBadge.text}
+        </span>
         {!stopped && autoStopAt !== null && (() => {
           const remainingMs = Math.max(0, autoStopAt - now)
           const totalSec = Math.ceil(remainingMs / 1000)
@@ -236,67 +284,26 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
           const label = mm > 0 ? `${mm}m ${ss.toString().padStart(2, '0')}s` : `${ss}s`
           return (
             <span
-              className="inline-flex items-center rounded-xs bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300"
-              title="The log stream auto-disconnects after 5 minutes. Click reconnect to extend."
+              className="inline-flex items-center rounded-xs bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+              title="Move your mouse or press a key to cancel the countdown."
             >
-              auto-stops in {label}
+              Stopping in {label} due to inactivity
             </span>
           )
         })()}
-        {paused && pendingLines > 0 && (
-          <span
-            className="inline-flex items-center gap-1 rounded-xs bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
-            title={`${pendingBytes} new byte(s) buffered since pause`}
-          >
-            +{pendingLines} new
-          </span>
-        )}
       </h3>
       <div className="flex shrink-0 items-center gap-2">
-        {/* Pause / Resume — only meaningful while connected to the
-            stream; hidden entirely when stopped. */}
-        {!stopped && (
-          <button
-            type="button"
-            onClick={() => {
-              if (paused) {
-                // Resume: drop the snapshot, fall back to live buffer,
-                // and make sure auto-scroll snaps to the bottom.
-                setPaused(false)
-                setFrozenText('')
-                wasAtBottomRef.current = true
-              } else {
-                // Pause: capture the current buffer so the panel
-                // renders a stable view while new bytes keep arriving.
-                setFrozenText(text)
-                setPaused(true)
-              }
-            }}
-            className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-            title={paused ? 'Resume (catch up to latest)' : 'Pause (freeze the current view)'}
-            aria-label={paused ? 'Resume log stream' : 'Pause log stream'}
-          >
-            {paused ? <Play className="size-4" /> : <Pause className="size-4" />}
-          </button>
-        )}
-        {/* Stop / Reconnect — hard toggle that closes the WS entirely.
-            When stopped the pause state is force-cleared (pause is
-            moot without a live feed); reconnect snaps auto-scroll to
-            the bottom so the fresh snapshot renders correctly. */}
         <button
           type="button"
           onClick={() => {
             if (stopped) {
-              // Reconnect: arm a fresh auto-stop deadline.
               setStopped(false)
-              setAutoStopAt(Date.now() + AUTO_STOP_MS)
-              wasAtBottomRef.current = true
+              setAutoStopAt(null)
+              lastActivityRef.current = Date.now()
+              setFollowing(true)
             } else {
-              // Explicit stop: cancel any pending auto-stop.
               setStopped(true)
               setAutoStopAt(null)
-              setPaused(false)
-              setFrozenText('')
             }
           }}
           className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
@@ -324,6 +331,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     </div>
   )
 
+  // ─── Banners ───────────────────────────────────────────────────
   const banners = (
     <>
       {truncated && (
@@ -340,39 +348,72 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     </>
   )
 
-  const logPre = (
-    <pre
-      ref={scrollRef}
-      onScroll={handleScroll}
-      className={clsx(
-        'overflow-auto whitespace-pre-wrap bg-gray-950 px-4 py-3 font-mono text-xs/5 text-gray-100',
-        fullscreen ? 'min-h-0 flex-1' : 'h-64 max-h-[50vh]',
-      )}
-    >
-      {lines.length === 0 ? (
-        <span className="text-gray-500">
-          {stopped
-            ? 'Stream stopped. Click the reconnect button to resume.'
-            : connected
-              ? 'Waiting for log output…'
-              : 'Connecting…'}
-        </span>
-      ) : (
-        lines.map((line, i) => (
-          <div key={i}>
-            <AnsiLine content={line} />
+  // ─── Virtualized log viewport ──────────────────────────────────
+  const lines = linesRef.current
+  const logViewport = (
+    <div className={clsx('relative', fullscreen ? 'min-h-0 flex-1' : '')}>
+      <div
+        ref={scrollRef}
+        onWheel={handleWheel}
+        className={clsx(
+          'overflow-auto bg-gray-950 font-mono text-xs/5 text-gray-100',
+          fullscreen ? 'h-full' : 'h-64 max-h-[50vh]',
+        )}
+      >
+        {lines.length === 0 ? (
+          <div className="px-4 py-3 text-gray-500">
+            {stopped
+              ? 'Stream stopped. Click the reconnect button to resume.'
+              : connected
+                ? 'Waiting for log output…'
+                : 'Connecting…'}
           </div>
-        ))
+        ) : (
+          <div
+            style={{
+              height: virtualizer.getTotalSize(),
+              width: '100%',
+              position: 'relative',
+            }}
+          >
+            {virtualizer.getVirtualItems().map((row) => (
+              <div
+                key={row.index}
+                data-index={row.index}
+                ref={virtualizer.measureElement}
+                className="absolute left-0 top-0 w-full whitespace-pre-wrap px-4"
+                style={{ transform: `translateY(${row.start}px)` }}
+              >
+                <AnsiLine content={lines[row.index]} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      {/* Floating "jump to bottom" pill — visible when the user has
+          scrolled up and auto-follow is off. Clicking re-enables
+          following and scrolls to the latest line. */}
+      {!following && lines.length > 0 && (
+        <button
+          type="button"
+          onClick={jumpToBottom}
+          className="absolute bottom-3 right-5 z-10 rounded-full bg-blue-600 p-1.5 text-white shadow-lg hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+          title="Jump to latest"
+          aria-label="Jump to latest"
+        >
+          <ArrowDown className="size-4" />
+        </button>
       )}
-    </pre>
+    </div>
   )
 
+  // ─── Layout ────────────────────────────────────────────────────
   if (fullscreen) {
     return (
       <div className="fixed inset-0 z-40 flex flex-col bg-white dark:bg-gray-900">
         {header}
         {banners}
-        {logPre}
+        {logViewport}
       </div>
     )
   }
@@ -381,7 +422,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     <div className="flex flex-col overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
       {header}
       {banners}
-      {logPre}
+      {logViewport}
     </div>
   )
 }

--- a/ui/src/components/run-detail/LiveRunLogPanel.tsx
+++ b/ui/src/components/run-detail/LiveRunLogPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   ArrowDown,
@@ -52,6 +52,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
   const [fullscreen, setFullscreen] = useState(false)
   const [stopped, setStopped] = useState(false)
   const [logFilter, setLogFilter] = useState<LogFilter>('all')
+  const [searchQuery, setSearchQuery] = useState('')
 
   // ─── Inactivity-based auto-stop ────────────────────────────────
   // Phase 1 (grace): user is active — no countdown shown.
@@ -161,41 +162,39 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
   }, [version]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // ─── Filtered line indices ──────────────────────────────────────
-  // Instead of copying the lines array, we compute a mapping from
-  // virtualizer row index → linesRef index. When filter is 'all'
-  // we skip the indirection entirely for zero overhead.
-  const filteredIndicesRef = useRef<number[]>([])
-  const filteredCountRef = useRef(0)
+  // Computed synchronously during render (useMemo, not useEffect) so
+  // the virtualizer sees the correct count on the SAME frame the
+  // filter changes — no one-frame flicker of the unfiltered list.
+  const needsFiltering = logFilter !== 'all' || searchQuery !== ''
+  const searchLower = searchQuery.toLowerCase()
 
-  // Recompute whenever lines change (lineVersion) or the filter
-  // toggles. We use refs so the virtualizer reads a stable count
-  // without needing React state (avoids an extra render cycle).
-  useEffect(() => {
-    if (logFilter === 'all') {
-      filteredIndicesRef.current = []
-      filteredCountRef.current = linesRef.current.length
-    } else {
-      const indices: number[] = []
-      for (let i = 0; i < linesRef.current.length; i++) {
-        if (lineMatchesFilter(linesRef.current[i], logFilter)) {
-          indices.push(i)
-        }
-      }
-      filteredIndicesRef.current = indices
-      filteredCountRef.current = indices.length
+  const { filteredIndices, filteredCount } = useMemo(() => {
+    if (!needsFiltering) {
+      return { filteredIndices: [] as number[], filteredCount: linesRef.current.length }
     }
-  }, [lineVersion, logFilter])
+
+    const indices: number[] = []
+    for (let i = 0; i < linesRef.current.length; i++) {
+      const line = linesRef.current[i]
+      if (!lineMatchesFilter(line, logFilter)) continue
+      if (searchLower && !line.toLowerCase().includes(searchLower)) continue
+      indices.push(i)
+    }
+
+    return { filteredIndices: indices, filteredCount: indices.length }
+    // lineVersion is a proxy for "linesRef.current changed"
+  }, [lineVersion, logFilter, needsFiltering, searchLower]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Helper: map a virtualizer row to the actual line in linesRef.
   const lineAt = useCallback(
     (virtualRow: number): string => {
-      if (logFilter === 'all') {
+      if (!needsFiltering) {
         return linesRef.current[virtualRow] ?? ''
       }
-      const realIdx = filteredIndicesRef.current[virtualRow]
-      return linesRef.current[realIdx] ?? ''
+
+      return linesRef.current[filteredIndices[virtualRow]] ?? ''
     },
-    [logFilter],
+    [needsFiltering, filteredIndices],
   )
 
   // ─── Virtualizer ────────────────────────────────────────────────
@@ -212,7 +211,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
   )
 
   const virtualizer = useVirtualizer({
-    count: filteredCountRef.current,
+    count: filteredCount,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => LINE_HEIGHT_ESTIMATE,
     overscan: 30,
@@ -220,7 +219,7 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
 
   useLayoutEffect(() => {
     if (stopped) return
-    const count = filteredCountRef.current
+    const count = filteredCount
     if (count > 0) {
       virtualizer.scrollToIndex(count - 1, { align: 'end' })
     }
@@ -230,11 +229,11 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
     setStopped(false)
     setAutoStopAt(null)
     lastActivityRef.current = Date.now()
-    const count = filteredCountRef.current
+    const count = filteredCount
     if (count > 0) {
       virtualizer.scrollToIndex(count - 1, { align: 'end' })
     }
-  }, [virtualizer])
+  }, [virtualizer, filteredCount])
 
   // ─── Fullscreen ────────────────────────────────────────────────
   useEffect(() => {
@@ -334,6 +333,14 @@ export function LiveRunLogPanel({ runId, client, instanceId }: LiveRunLogPanelPr
         })()}
       </h3>
       <div className="flex shrink-0 items-center gap-2">
+        {/* Search box */}
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Filter logs…"
+          className="w-36 rounded-xs border border-gray-300 bg-white px-2 py-1 text-xs/5 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
+        />
         {/* Log source filter chips */}
         <div className="flex items-center rounded-xs border border-gray-300 dark:border-gray-600">
           {([

--- a/ui/src/components/shared/AnsiLine.tsx
+++ b/ui/src/components/shared/AnsiLine.tsx
@@ -1,0 +1,63 @@
+import type React from 'react'
+import { parseAnsiCodes, type AnsiStyle } from '@/utils/ansi'
+
+/**
+ * AnsiLine renders a single line of text with embedded ANSI escape
+ * codes (\x1b[...m) interpreted as inline CSS styles. Unknown codes
+ * are ignored silently so the text still shows, just unstyled.
+ * Shared between FileViewerPage and the live log panel.
+ */
+export function AnsiLine({ content }: { content: string }) {
+  if (!content) {
+    return <span>&nbsp;</span>
+  }
+
+  const parts: React.ReactNode[] = []
+  let lastIndex = 0
+  let currentStyle: AnsiStyle = {}
+  let partKey = 0
+
+  // eslint-disable-next-line no-control-regex
+  const regex = /\x1b\[([0-9;]*)m/g
+  let match
+
+  while ((match = regex.exec(content)) !== null) {
+    if (match.index > lastIndex) {
+      const text = content.slice(lastIndex, match.index)
+      if (text) {
+        parts.push(
+          <span key={partKey++} style={currentStyle}>
+            {text}
+          </span>,
+        )
+      }
+    }
+
+    const codesStr = match[1]
+    if (codesStr === '' || codesStr === '0') {
+      currentStyle = {}
+    } else {
+      const codes = codesStr.split(';').map(Number)
+      const newStyle = parseAnsiCodes(codes)
+      currentStyle = { ...currentStyle, ...newStyle }
+      if (codes.includes(0)) {
+        currentStyle = parseAnsiCodes(codes.filter((c) => c !== 0))
+      }
+    }
+
+    lastIndex = regex.lastIndex
+  }
+
+  if (lastIndex < content.length) {
+    const text = content.slice(lastIndex)
+    if (text) {
+      parts.push(
+        <span key={partKey++} style={currentStyle}>
+          {text}
+        </span>,
+      )
+    }
+  }
+
+  return <>{parts.length > 0 ? parts : content}</>
+}

--- a/ui/src/components/shared/AnsiLine.tsx
+++ b/ui/src/components/shared/AnsiLine.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import type React from 'react'
 import { parseAnsiCodes, type AnsiStyle } from '@/utils/ansi'
 
@@ -6,8 +7,12 @@ import { parseAnsiCodes, type AnsiStyle } from '@/utils/ansi'
  * codes (\x1b[...m) interpreted as inline CSS styles. Unknown codes
  * are ignored silently so the text still shows, just unstyled.
  * Shared between FileViewerPage and the live log panel.
+ *
+ * Wrapped in React.memo so virtualized lists that re-render the
+ * container don't re-parse every visible line when only the line
+ * count changed.
  */
-export function AnsiLine({ content }: { content: string }) {
+export const AnsiLine = memo(function AnsiLine({ content }: { content: string }) {
   if (!content) {
     return <span>&nbsp;</span>
   }
@@ -60,4 +65,4 @@ export function AnsiLine({ content }: { content: string }) {
   }
 
   return <>{parts.length > 0 ? parts : content}</>
-}
+})

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -11,6 +11,8 @@ import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { JDenticon } from '@/components/shared/JDenticon'
+import { AnsiLine } from '@/components/shared/AnsiLine'
+import { hasAnsiCodes } from '@/utils/ansi'
 
 const ESTIMATED_LINE_HEIGHT = 20
 const SYNTAX_HIGHLIGHT_LINE_LIMIT = 5_000
@@ -115,16 +117,6 @@ function DownloadButton({ content, filename }: { content: string; filename: stri
   )
 }
 
-// ANSI escape code pattern
-// eslint-disable-next-line no-control-regex
-const ANSI_REGEX = /\x1b\[[0-9;]*m/g
-
-function hasAnsiCodes(content: string): boolean {
-  // Check first 10 lines for ANSI escape codes
-  const first10Lines = content.split('\n').slice(0, 10).join('\n')
-  return ANSI_REGEX.test(first10Lines)
-}
-
 function detectLanguage(content: string): string {
   // Check first few lines to detect content type
   const sample = content.slice(0, 2000)
@@ -141,140 +133,6 @@ function detectLanguage(content: string): string {
 
   // Default to bash for general log output (handles timestamps, log levels, etc.)
   return 'bash'
-}
-
-// ANSI color code to CSS color mapping
-const ANSI_COLORS: Record<number, string> = {
-  30: '#1e1e1e', // black
-  31: '#e06c75', // red
-  32: '#98c379', // green
-  33: '#e5c07b', // yellow
-  34: '#61afef', // blue
-  35: '#c678dd', // magenta
-  36: '#56b6c2', // cyan
-  37: '#abb2bf', // white
-  90: '#5c6370', // bright black (gray)
-  91: '#e06c75', // bright red
-  92: '#98c379', // bright green
-  93: '#e5c07b', // bright yellow
-  94: '#61afef', // bright blue
-  95: '#c678dd', // bright magenta
-  96: '#56b6c2', // bright cyan
-  97: '#ffffff', // bright white
-}
-
-const ANSI_BG_COLORS: Record<number, string> = {
-  40: '#1e1e1e',
-  41: '#e06c75',
-  42: '#98c379',
-  43: '#e5c07b',
-  44: '#61afef',
-  45: '#c678dd',
-  46: '#56b6c2',
-  47: '#abb2bf',
-  100: '#5c6370',
-  101: '#e06c75',
-  102: '#98c379',
-  103: '#e5c07b',
-  104: '#61afef',
-  105: '#c678dd',
-  106: '#56b6c2',
-  107: '#ffffff',
-}
-
-interface AnsiStyle {
-  color?: string
-  backgroundColor?: string
-  fontWeight?: string
-  fontStyle?: string
-  textDecoration?: string
-}
-
-function parseAnsiCodes(codes: number[]): AnsiStyle {
-  const style: AnsiStyle = {}
-
-  for (const code of codes) {
-    if (code === 0) {
-      // Reset
-      return {}
-    } else if (code === 1) {
-      style.fontWeight = 'bold'
-    } else if (code === 3) {
-      style.fontStyle = 'italic'
-    } else if (code === 4) {
-      style.textDecoration = 'underline'
-    } else if (code >= 30 && code <= 37) {
-      style.color = ANSI_COLORS[code]
-    } else if (code >= 40 && code <= 47) {
-      style.backgroundColor = ANSI_BG_COLORS[code]
-    } else if (code >= 90 && code <= 97) {
-      style.color = ANSI_COLORS[code]
-    } else if (code >= 100 && code <= 107) {
-      style.backgroundColor = ANSI_BG_COLORS[code]
-    }
-  }
-
-  return style
-}
-
-function AnsiLine({ content }: { content: string }) {
-  if (!content) {
-    return <span>&nbsp;</span>
-  }
-
-  const parts: React.ReactNode[] = []
-  let lastIndex = 0
-  let currentStyle: AnsiStyle = {}
-  let partKey = 0
-
-  // Reset regex lastIndex
-  // eslint-disable-next-line no-control-regex
-  const regex = /\x1b\[([0-9;]*)m/g
-  let match
-
-  while ((match = regex.exec(content)) !== null) {
-    // Add text before this escape code
-    if (match.index > lastIndex) {
-      const text = content.slice(lastIndex, match.index)
-      if (text) {
-        parts.push(
-          <span key={partKey++} style={currentStyle}>
-            {text}
-          </span>
-        )
-      }
-    }
-
-    // Parse the ANSI codes
-    const codesStr = match[1]
-    if (codesStr === '' || codesStr === '0') {
-      currentStyle = {}
-    } else {
-      const codes = codesStr.split(';').map(Number)
-      const newStyle = parseAnsiCodes(codes)
-      currentStyle = { ...currentStyle, ...newStyle }
-      // Reset if 0 is in the codes
-      if (codes.includes(0)) {
-        currentStyle = parseAnsiCodes(codes.filter((c) => c !== 0))
-      }
-    }
-
-    lastIndex = regex.lastIndex
-  }
-
-  // Add remaining text
-  if (lastIndex < content.length) {
-    const text = content.slice(lastIndex)
-    if (text) {
-      parts.push(
-        <span key={partKey++} style={currentStyle}>
-          {text}
-        </span>
-      )
-    }
-  }
-
-  return <>{parts.length > 0 ? parts : content}</>
 }
 
 function HighlightedLine({ content, language }: { content: string; language: string }) {
@@ -525,7 +383,7 @@ export function FileViewerPage() {
     return digits * 8 + 32
   }, [lines.length])
 
-  // eslint-disable-next-line react-hooks/incompatible-library
+   
   const virtualizer = useVirtualizer({
     count: lines.length,
     getScrollElement: () => scrollContainerRef.current,

--- a/ui/src/utils/ansi.ts
+++ b/ui/src/utils/ansi.ts
@@ -1,0 +1,87 @@
+// ANSI escape-code parsing, shared between the file viewer and the
+// live runner log panel. Keep this file component-free so the React
+// fast-refresh plugin doesn't yell about mixed exports — the rendering
+// component lives in components/shared/AnsiLine.tsx.
+
+// eslint-disable-next-line no-control-regex
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g
+
+export function hasAnsiCodes(content: string): boolean {
+  // Check the first 10 lines so the call stays cheap on huge inputs.
+  const first10Lines = content.split('\n').slice(0, 10).join('\n')
+  return ANSI_REGEX.test(first10Lines)
+}
+
+// Palette is OneDark — reads well on the near-black backgrounds both
+// consumers use.
+export const ANSI_COLORS: Record<number, string> = {
+  30: '#1e1e1e', // black
+  31: '#e06c75', // red
+  32: '#98c379', // green
+  33: '#e5c07b', // yellow
+  34: '#61afef', // blue
+  35: '#c678dd', // magenta
+  36: '#56b6c2', // cyan
+  37: '#abb2bf', // white
+  90: '#5c6370', // bright black (gray)
+  91: '#e06c75',
+  92: '#98c379',
+  93: '#e5c07b',
+  94: '#61afef',
+  95: '#c678dd',
+  96: '#56b6c2',
+  97: '#ffffff',
+}
+
+export const ANSI_BG_COLORS: Record<number, string> = {
+  40: '#1e1e1e',
+  41: '#e06c75',
+  42: '#98c379',
+  43: '#e5c07b',
+  44: '#61afef',
+  45: '#c678dd',
+  46: '#56b6c2',
+  47: '#abb2bf',
+  100: '#5c6370',
+  101: '#e06c75',
+  102: '#98c379',
+  103: '#e5c07b',
+  104: '#61afef',
+  105: '#c678dd',
+  106: '#56b6c2',
+  107: '#ffffff',
+}
+
+export interface AnsiStyle {
+  color?: string
+  backgroundColor?: string
+  fontWeight?: string
+  fontStyle?: string
+  textDecoration?: string
+}
+
+export function parseAnsiCodes(codes: number[]): AnsiStyle {
+  const style: AnsiStyle = {}
+
+  for (const code of codes) {
+    if (code === 0) {
+      return {}
+    } else if (code === 1) {
+      style.fontWeight = 'bold'
+    } else if (code === 3) {
+      style.fontStyle = 'italic'
+    } else if (code === 4) {
+      style.textDecoration = 'underline'
+    } else if (code >= 30 && code <= 37) {
+      style.color = ANSI_COLORS[code]
+    } else if (code >= 40 && code <= 47) {
+      style.backgroundColor = ANSI_BG_COLORS[code]
+    } else if (code >= 90 && code <= 97) {
+      style.color = ANSI_COLORS[code]
+    } else if (code >= 100 && code <= 107) {
+      style.backgroundColor = ANSI_BG_COLORS[code]
+    }
+  }
+
+  return style
+}


### PR DESCRIPTION
## Summary

Streams the runner's `benchmarkoor.log` to the live run detail view in real time via WebSockets. Designed for scale: log bytes flow **only while at least one UI client has the log panel open** — zero traffic when nobody is watching.

### Architecture

- **Runner → API**: one persistent WS per run (`/api/v1/ingest/ws`). API sends `stream_on` / `stream_off` commands based on UI subscriber count.
- **API → UI**: one WS per open log panel (`/api/v1/index/live_runs/{run_id}/logs/ws`). API fans out log chunks from the runner to all subscribed UIs and keeps a 512 KB ring buffer so late joiners see recent history.
- **Runner file tailer**: reads `benchmarkoor.log` by byte offset every 100ms (only while streaming). Handles rotation/truncation, sends `bye` on shutdown, reconnects with backoff.
- Uses `github.com/coder/websocket` (maintained fork of nhooyr) with permessage-deflate compression.

### UI features

- **ANSI coloring**: shared parser (`utils/ansi.ts` + `components/shared/AnsiLine.tsx`) extracted from `FileViewerPage` — renders escape codes with the OneDark palette.
- **Virtualized rendering**: `@tanstack/react-virtual` — only ~30 visible rows in the DOM regardless of total line count. Incremental line tracking via a stable ref array (O(new lines) per update, not O(total)).
- **rAF batching**: WS messages coalesce via `requestAnimationFrame` — max ~60 React renders/sec regardless of WS throughput. Text buffer lives in a ref (not React state) to avoid V8 GC pressure from large string diffs.
- **Scroll model**: connected = auto-scroll to bottom. User scrolls up = stream disconnects (fully stable viewport). Arrow-down button or reconnect button resumes.
- **Fullscreen mode**: covers the viewport; header shows client logo + instance ID + run ID for context. ESC exits.
- **Disconnect / Reconnect**: hard toggle that closes the WS entirely (runner receives `stream_off`). Zero bytes in flight while stopped.
- **Inactivity auto-stop**: after 30s idle, a countdown appears ("Stopping in 4m 32s due to inactivity"). Any interaction cancels it. Prevents forgotten tabs from holding streams open.
- **Source filter**: segmented chips — All | 🔵 Runner | 🟣 Client — based on the emoji prefix each log line starts with.
- **Text search**: case-insensitive substring filter, combines with the source filter.
- **Client-side cap**: text buffer trimmed to 1 MB at line boundaries to prevent OOM on long sessions.

### Config knobs

- `runner.live_reporting.logs_enabled` (default `true`) — disables the WS entirely
- `runner.live_reporting.logs_interval` (default `100ms`) — file-tail push cadence while streaming

## Test plan

- [x] `go vet -tags exclude_graphdriver_btrfs ./...` clean
- [x] `go test ./pkg/{livereport,api/...,runner,config} -count=1` all pass (includes wsHub + log\_streamer tests)
- [x] `golangci-lint run --build-tags=exclude_graphdriver_btrfs --new-from-rev="origin/master"` 0 issues
- [x] `npx tsc --noEmit` and `npx eslint` clean in `ui/`
- [x] Manual: start a live run; confirm log panel streams lines within ~1s, ANSI colors render, auto-scroll sticks
- [x] Manual: scroll up → stream disconnects, viewport is stable; click arrow-down → resumes
- [x] Manual: toggle source filter and search → lines filter without flicker
- [x] Manual: go idle 30s → countdown appears; move mouse → countdown cancels; let it expire → stream stops
- [x] Manual: fullscreen shows client logo + run ID; ESC exits
- [x] Manual: close the panel / navigate away → runner stops pushing (check API access log)