### PR TITLE
fix: add 60s graceful stop timeout to StopContainer

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -33,7 +33,11 @@ type ContainerManager interface {
 	// Container operations.
 	CreateContainer(ctx context.Context, spec *ContainerSpec) (string, error)
 	StartContainer(ctx context.Context, containerID string) error
-	StopContainer(ctx context.Context, containerID string) error
+	// StopContainer sends SIGTERM and waits up to timeoutSec for a
+	// graceful exit before falling back to SIGKILL. Use a generous
+	// timeout when data integrity matters (e.g. ZFS snapshot after
+	// pre-run steps). Passing nil uses the daemon's default (10 s).
+	StopContainer(ctx context.Context, containerID string, timeoutSec *int) error
 	RemoveContainer(ctx context.Context, containerID string) error
 
 	// Init container support.
@@ -304,13 +308,28 @@ func (m *manager) StartContainer(ctx context.Context, containerID string) error 
 	return nil
 }
 
+// DefaultStopTimeoutSec is the SIGTERM grace period before SIGKILL
+// when no explicit timeout is passed to StopContainer.
+const DefaultStopTimeoutSec = 60
+
 // StopContainer stops a container.
-func (m *manager) StopContainer(ctx context.Context, containerID string) error {
-	if err := m.client.ContainerStop(ctx, containerID, container.StopOptions{}); err != nil {
+func (m *manager) StopContainer(ctx context.Context, containerID string, timeoutSec *int) error {
+	t := timeoutSec
+	if t == nil {
+		d := DefaultStopTimeoutSec
+		t = &d
+	}
+
+	if err := m.client.ContainerStop(ctx, containerID, container.StopOptions{
+		Timeout: t,
+	}); err != nil {
 		return fmt.Errorf("stopping container %s: %w", containerID[:12], err)
 	}
 
-	m.log.WithField("id", containerID[:12]).Debug("Stopped container")
+	m.log.WithFields(logrus.Fields{
+		"id":      containerID[:12],
+		"timeout": *t,
+	}).Debug("Stopped container")
 
 	return nil
 }

--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -299,11 +299,20 @@ func (m *manager) StartContainer(ctx context.Context, containerID string) error 
 }
 
 // StopContainer stops a container.
-func (m *manager) StopContainer(ctx context.Context, containerID string) error {
+func (m *manager) StopContainer(ctx context.Context, containerID string, timeoutSec *int) error {
 	conn, cancel := m.connWithCtx(ctx)
 	defer cancel()
 
-	if err := containers.Stop(conn, containerID, nil); err != nil {
+	var opts *containers.StopOptions
+	if timeoutSec != nil {
+		t := uint(*timeoutSec)
+		opts = new(containers.StopOptions).WithTimeout(t)
+	} else {
+		t := uint(docker.DefaultStopTimeoutSec)
+		opts = new(containers.StopOptions).WithTimeout(t)
+	}
+
+	if err := containers.Stop(conn, containerID, opts); err != nil {
 		return fmt.Errorf("stopping container %s: %w", containerID[:12], err)
 	}
 

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -758,7 +758,7 @@ func (r *runner) runContainerLifecycle(
 		stopStart := time.Now()
 
 		if stopErr := r.containerMgr.StopContainer(
-			stopCtx, containerID,
+			stopCtx, containerID, nil,
 		); stopErr != nil {
 			log.WithError(stopErr).Debug("Failed to stop container")
 		}

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -104,7 +104,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 		stopStart := time.Now()
 
-		if err := r.containerMgr.StopContainer(ctx, containerID); err != nil {
+		if err := r.containerMgr.StopContainer(ctx, containerID, nil); err != nil {
 			return nil, fmt.Errorf("stopping container before checkpoint restart: %w", err)
 		}
 

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -106,7 +106,7 @@ func (r *runner) runTestsWithContainerStrategy(
 
 		stopStart := time.Now()
 
-		if err := r.containerMgr.StopContainer(ctx, containerID); err != nil {
+		if err := r.containerMgr.StopContainer(ctx, containerID, nil); err != nil {
 			return nil, fmt.Errorf("stopping container for ZFS snapshot: %w", err)
 		}
 
@@ -213,7 +213,7 @@ func (r *runner) runTestsWithContainerStrategy(
 			stopStart := time.Now()
 
 			if err := r.containerMgr.StopContainer(
-				stopCtx, currentContainerID,
+				stopCtx, currentContainerID, nil,
 			); err != nil {
 				log.WithError(err).Debug(
 					"Failed to stop container on cancellation",
@@ -498,7 +498,7 @@ func (r *runner) runTestsWithContainerStrategy(
 			stopStart := time.Now()
 
 			if err := r.containerMgr.StopContainer(
-				ctx, currentContainerID,
+				ctx, currentContainerID, nil,
 			); err != nil {
 				testLog.WithError(err).Warn("Failed to stop container")
 			}
@@ -797,7 +797,7 @@ func (r *runner) runTestsWithContainerStrategy(
 			stopStart := time.Now()
 
 			if stopErr := r.containerMgr.StopContainer(
-				stopCtx, currentContainerID,
+				stopCtx, currentContainerID, nil,
 			); stopErr != nil {
 				log.WithError(stopErr).Debug(
 					"Failed to stop container after death/interruption",


### PR DESCRIPTION
## Summary

- Add an explicit \`*int\` timeout parameter to the \`ContainerManager.StopContainer\` interface
- Default timeout (\`DefaultStopTimeoutSec\`) set to **60 seconds** — SIGTERM grace period before SIGKILL
- Both Docker and Podman implementations honor the timeout
- All existing call sites pass \`nil\` (use the 60s default)

## Why

The previous code passed no timeout, relying on daemon defaults (10s for Docker, unspecified for Podman). With the container-recreate strategy + ZFS snapshots, the container is stopped after pre-run steps so the datadir can be snapshotted cleanly. Clients like geth with large MDBX databases need more than 10s to flush to disk on SIGTERM — a dirty shutdown means every test that restores from the snapshot starts from potentially inconsistent state.

The between-tests path already uses \`RemoveContainer\` with \`Force: true\` (SIGKILL, no wait), so test throughput is unaffected by this change.

## Test plan

- [x] \`go vet -tags exclude_graphdriver_btrfs ./...\` clean
- [x] \`go build -tags exclude_graphdriver_btrfs ./...\` clean
- [x] \`go test ./pkg/runner/ ./pkg/docker/\` pass
- [x] Manual: run a container-recreate + ZFS benchmark; confirm the "Container stopped for ZFS snapshot" log line shows a duration consistent with a graceful shutdown (seconds, not sub-second)