### PR TITLE
feat(ui): gas-bucket filter on comparison page

### DIFF
--- a/ui/src/components/compare/MetricsComparison.tsx
+++ b/ui/src/components/compare/MetricsComparison.tsx
@@ -12,6 +12,7 @@ interface MetricsComparisonProps {
   baselineIdx: number
   onBaselineChange: (idx: number) => void
   labelMode: LabelMode
+  testNameFilter?: (name: string) => boolean
 }
 
 interface ComputedMetrics {
@@ -26,14 +27,22 @@ interface ComputedMetrics {
   totalRuntime: number | undefined
 }
 
-function computeMetrics(config: RunConfig, result: RunResult | null, stepFilter: StepTypeOption[]): ComputedMetrics {
-  const aggregatedStats = result
-    ? Object.values(result.tests).map((t) => getAggregatedStats(t, stepFilter)).filter((s): s is AggregatedStats => s !== undefined)
+function computeMetrics(config: RunConfig, result: RunResult | null, stepFilter: StepTypeOption[], testNameFilter?: (name: string) => boolean): ComputedMetrics {
+  const filteredTests = result
+    ? Object.entries(result.tests).filter(([name]) => !testNameFilter || testNameFilter(name))
     : []
 
-  const testCount = config.test_counts?.total ?? (result ? Object.keys(result.tests).length : 0)
-  const passedTests = config.test_counts?.passed ?? aggregatedStats.filter((s) => s.fail === 0).length
-  const failedTests = config.test_counts ? (config.test_counts.total - config.test_counts.passed) : aggregatedStats.filter((s) => s.fail > 0).length
+  const aggregatedStats = filteredTests
+    .map(([, t]) => getAggregatedStats(t, stepFilter))
+    .filter((s): s is AggregatedStats => s !== undefined)
+
+  const testCount = testNameFilter
+    ? filteredTests.length
+    : (config.test_counts?.total ?? (result ? Object.keys(result.tests).length : 0))
+  const passedTests = testNameFilter
+    ? aggregatedStats.filter((s) => s.fail === 0).length
+    : (config.test_counts?.passed ?? aggregatedStats.filter((s) => s.fail === 0).length)
+  const failedTests = testCount - passedTests
   const totalDuration = aggregatedStats.reduce((sum, s) => sum + s.time_total, 0)
   const totalGasUsed = aggregatedStats.reduce((sum, s) => sum + s.gas_used_total, 0)
   const totalGasUsedTime = aggregatedStats.reduce((sum, s) => sum + s.gas_used_time_total, 0)
@@ -149,8 +158,8 @@ function MetricCard({
   )
 }
 
-export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineChange, labelMode }: MetricsComparisonProps) {
-  const metrics = runs.map((r) => computeMetrics(r.config, r.result, stepFilter))
+export function MetricsComparison({ runs, stepFilter, baselineIdx, onBaselineChange, labelMode, testNameFilter }: MetricsComparisonProps) {
+  const metrics = runs.map((r) => computeMetrics(r.config, r.result, stepFilter, testNameFilter))
   const clients = runs.map((r) => r.config.instance.client)
   const runLabels = runs.map((r) => formatRunLabel(RUN_SLOTS[r.index], r, labelMode))
   const base = metrics[baselineIdx]

--- a/ui/src/components/compare/StickyRunBar.tsx
+++ b/ui/src/components/compare/StickyRunBar.tsx
@@ -13,9 +13,14 @@ interface StickyRunBarProps {
   testFilterRegex: boolean
   onTestFilterChange: (query: string) => void
   onTestFilterRegexChange: (enabled: boolean) => void
+  /** Gas-bucket filter state for the second row */
+  availableGasBuckets: number[]
+  selectedGasBuckets: Set<number>
+  onToggleGasBucket: (bucket: number) => void
+  onClearGasBuckets: () => void
 }
 
-export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, testFilter, testFilterRegex, onTestFilterChange, onTestFilterRegexChange }: StickyRunBarProps) {
+export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, testFilter, testFilterRegex, onTestFilterChange, onTestFilterRegexChange, availableGasBuckets, selectedGasBuckets, onToggleGasBucket, onClearGasBuckets }: StickyRunBarProps) {
   const [visible, setVisible] = useState(false)
   const observerRef = useRef<IntersectionObserver | null>(null)
 
@@ -36,7 +41,8 @@ export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, 
 
   return (
     <div className="fixed top-0 right-0 left-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/95">
-      <div className="mx-auto flex max-w-7xl items-center justify-center gap-4 px-4 py-2">
+      <div className="mx-auto flex max-w-7xl flex-col gap-1 px-4 py-2">
+      <div className="flex items-center justify-center gap-4">
         {runs.map((run) => {
           const slot = RUN_SLOTS[run.index]
           return (
@@ -64,7 +70,10 @@ export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, 
             ))}
           </div>
         </div>
-        <div className="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
+      </div>
+      {/* Filter + gas bucket row */}
+      <div className="flex items-center justify-center gap-4 text-xs/5 text-gray-500 dark:text-gray-400">
+        <div className="flex items-center gap-1.5">
           <span>Filter:</span>
           <FilterInput
             placeholder={testFilterRegex ? 'Regex...' : 'Filter...'}
@@ -90,6 +99,37 @@ export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, 
             .*
           </button>
         </div>
+        {availableGasBuckets.length > 1 && (
+          <div className="flex items-center gap-1.5">
+            <span>Gas:</span>
+            <div className="flex flex-wrap gap-1">
+              <button
+                onClick={onClearGasBuckets}
+                className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+                  selectedGasBuckets.size === 0
+                    ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                }`}
+              >
+                All
+              </button>
+              {availableGasBuckets.map((bucket) => (
+                <button
+                  key={bucket}
+                  onClick={() => onToggleGasBucket(bucket)}
+                  className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+                    selectedGasBuckets.has(bucket)
+                      ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                  }`}
+                >
+                  {Math.round(bucket / 1_000_000)}M
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
       </div>
     </div>
   )

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -21,13 +21,14 @@ interface TestComparisonTableProps {
   testNameFilter?: (name: string) => boolean
 }
 
-type SortColumn = 'order' | 'name' | 'avgValue' | `run-${number}`
+type SortColumn = 'order' | 'name' | 'gasUsed' | 'avgValue' | `run-${number}`
 type SortDirection = 'asc' | 'desc'
 type TableBaseline = 'best' | 'worst' | number
 
 interface ComparedTest {
   name: string
   order: number
+  gasUsed: number | undefined
   values: (number | undefined)[]
   avgValue: number | undefined
 }
@@ -198,7 +199,22 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
       const defined = values.filter((v): v is number => v !== undefined)
       const avgValue = defined.length > 0 ? defined.reduce((a, b) => a + b, 0) / defined.length : undefined
 
-      tests.push({ name, order, values, avgValue })
+      // Gas used from the first run that has this test (tests are the
+      // same across compared runs in normal usage). Used for the Gas
+      // column in the table.
+      let gasUsed: number | undefined
+      for (const run of runs) {
+        const entry = run.result?.tests[name]
+        if (entry) {
+          const stats = getAggregatedStats(entry, stepFilter)
+          if (stats) {
+            gasUsed = stats.gas_used_total
+            break
+          }
+        }
+      }
+
+      tests.push({ name, order, gasUsed, values, avgValue })
     }
     return tests
   }, [runs, suiteOrder, stepFilter, activeTab, blockLogsPerRun])
@@ -233,6 +249,9 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
             break
           case 'name':
             cmp = a.name.localeCompare(b.name)
+            break
+          case 'gasUsed':
+            cmp = (a.gasUsed ?? 0) - (b.gasUsed ?? 0)
             break
           case 'avgValue':
             cmp = (a.avgValue ?? 0) - (b.avgValue ?? 0)
@@ -329,6 +348,7 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
             <tr>
               <SortableHeader label="#" column="order" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="w-12 px-3 py-3" />
               <SortableHeader label="Test Name" column="name" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} />
+              <SortableHeader label="Gas" column="gasUsed" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-4 py-3 text-right" />
               <SortableHeader label="Avg" column="avgValue" currentSort={sortBy} currentDirection={sortDir} onSort={handleSort} className="px-4 py-3 text-right" />
               {runs.map((run, i) => {
                 const slot = RUN_SLOTS[run.index]
@@ -377,6 +397,9 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
                   </td>
                   <td className="max-w-sm truncate px-4 py-2 text-sm/6 text-gray-900 dark:text-gray-100" title={test.name}>
                     {test.name}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-2 text-right text-xs/5 text-gray-500 dark:text-gray-400">
+                    {test.gasUsed !== undefined ? `${Math.round(test.gasUsed / 1_000_000)}M` : '-'}
                   </td>
                   <td className="whitespace-nowrap px-4 py-2 text-right text-sm/6 text-gray-400 dark:text-gray-500">
                     {test.avgValue !== undefined ? activeMetric.format(test.avgValue) : '-'}

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -44,6 +44,7 @@ export function ComparePage() {
     diffFilter?: string
     filter?: string
     filterRegex?: string
+    gasBuckets?: string
   }
 
   // Backward-compat redirect: ?a=X&b=Y → ?runs=X,Y
@@ -129,27 +130,83 @@ export function ComparePage() {
   const [chartZoom, setChartZoom] = useState({ start: 0, end: 100 })
   const [chartType, setChartType] = useState<ChartType>('line')
 
-  const testNameFilter = useMemo(() => {
-    if (!testFilter) return undefined
-    if (testFilterRegex) {
-      try {
-        const re = new RegExp(testFilter, 'i')
-        return (name: string) => re.test(name)
-      } catch {
-        return undefined
+  // ─── Gas bucket filter ─────────────────────────────────────────
+  // Parse the currently-selected gas buckets from the URL. Empty set
+  // means "show all" (no filtering). Values are in millions (e.g.
+  // "30,60" means the 30M and 60M buckets).
+  const GAS_BUCKET_STEP = 30_000_000 // 30M gas per bucket
+
+  const selectedGasBuckets = useMemo(() => {
+    if (!search.gasBuckets) return new Set<number>()
+    return new Set(
+      search.gasBuckets.split(',').map((s) => parseInt(s, 10) * 1_000_000).filter((n) => !isNaN(n)),
+    )
+  }, [search.gasBuckets])
+
+  // Compute per-test gas used from the first run that has results.
+  // Used both for the available-buckets list and for the filter.
+  const testGasMap = useMemo(() => {
+    const map = new Map<string, number>()
+    // Use the first result that's loaded — tests are typically the
+    // same across compared runs (same suite).
+    const result = resultQueries.find((q) => q.data)?.data
+    if (!result) return map
+    for (const [name, entry] of Object.entries(result.tests)) {
+      const step = entry.steps?.test
+      if (step) {
+        map.set(name, step.aggregated.gas_used_total)
       }
     }
-    const q = testFilter.toLowerCase()
-    return (name: string) => name.toLowerCase().includes(q)
-  }, [testFilter, testFilterRegex])
+    return map
+  }, [resultQueries])
+
+  // Available gas buckets sorted ascending. Shown as chips.
+  const availableGasBuckets = useMemo(() => {
+    const buckets = new Set<number>()
+    for (const gas of testGasMap.values()) {
+      buckets.add(Math.round(gas / GAS_BUCKET_STEP) * GAS_BUCKET_STEP)
+    }
+    return [...buckets].sort((a, b) => a - b)
+  }, [testGasMap, GAS_BUCKET_STEP])
+
+  const testNameFilter = useMemo(() => {
+    // Combine text/regex filter with gas-bucket filter.
+    const textFn = (() => {
+      if (!testFilter) return undefined
+      if (testFilterRegex) {
+        try {
+          const re = new RegExp(testFilter, 'i')
+          return (name: string) => re.test(name)
+        } catch {
+          return undefined
+        }
+      }
+      const q = testFilter.toLowerCase()
+      return (name: string) => name.toLowerCase().includes(q)
+    })()
+
+    const gasFn = selectedGasBuckets.size > 0
+      ? (name: string) => {
+          const gas = testGasMap.get(name)
+          if (gas === undefined) return false
+          const bucket = Math.round(gas / GAS_BUCKET_STEP) * GAS_BUCKET_STEP
+          return selectedGasBuckets.has(bucket)
+        }
+      : undefined
+
+    if (!textFn && !gasFn) return undefined
+    if (textFn && !gasFn) return textFn
+    if (!textFn && gasFn) return gasFn
+    return (name: string) => textFn!(name) && gasFn!(name)
+  }, [testFilter, testFilterRegex, selectedGasBuckets, testGasMap, GAS_BUCKET_STEP])
 
   const updateSearch = useCallback((patch: Record<string, string | undefined>) => {
     navigate({
       to: '/compare',
-      search: { runs: search.runs, steps: search.steps, baseline: search.baseline, labels: search.labels, tableBase: search.tableBase, sort: search.sort, sortDir: search.sortDir, diffFilter: search.diffFilter, filter: search.filter, filterRegex: search.filterRegex, ...patch },
+      search: { runs: search.runs, steps: search.steps, baseline: search.baseline, labels: search.labels, tableBase: search.tableBase, sort: search.sort, sortDir: search.sortDir, diffFilter: search.diffFilter, filter: search.filter, filterRegex: search.filterRegex, gasBuckets: search.gasBuckets, ...patch },
       replace: true,
     })
-  }, [navigate, search.runs, search.steps, search.baseline, search.labels, search.tableBase, search.sort, search.sortDir, search.diffFilter, search.filter, search.filterRegex])
+  }, [navigate, search.runs, search.steps, search.baseline, search.labels, search.tableBase, search.sort, search.sortDir, search.diffFilter, search.filter, search.filterRegex, search.gasBuckets])
 
   const setBaselineIdx = useCallback((idx: number) => {
     updateSearch({ baseline: idx > 0 ? String(idx) : undefined })
@@ -172,6 +229,31 @@ export function ComparePage() {
   const setTestFilterRegex = useCallback((enabled: boolean) => {
     updateSearch({ filterRegex: enabled ? '1' : undefined })
   }, [updateSearch])
+
+  const setGasBuckets = useCallback(
+    (buckets: Set<number>) => {
+      if (buckets.size === 0) {
+        updateSearch({ gasBuckets: undefined })
+      } else {
+        const sorted = [...buckets].sort((a, b) => a - b)
+        updateSearch({ gasBuckets: sorted.map((v) => String(v / 1_000_000)).join(',') })
+      }
+    },
+    [updateSearch],
+  )
+
+  const toggleGasBucket = useCallback(
+    (bucket: number) => {
+      const next = new Set(selectedGasBuckets)
+      if (next.has(bucket)) {
+        next.delete(bucket)
+      } else {
+        next.add(bucket)
+      }
+      setGasBuckets(next)
+    },
+    [selectedGasBuckets, setGasBuckets],
+  )
 
   // Handle backward-compat redirect in progress
   if (search.a && search.b && !search.runs) {
@@ -316,6 +398,36 @@ export function ComparePage() {
             .*
           </button>
         </div>
+        {availableGasBuckets.length > 1 && (
+          <div className="flex items-center gap-1.5">
+            <span>Gas:</span>
+            <div className="flex flex-wrap gap-1">
+              <button
+                onClick={() => setGasBuckets(new Set())}
+                className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+                  selectedGasBuckets.size === 0
+                    ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                }`}
+              >
+                All
+              </button>
+              {availableGasBuckets.map((bucket) => (
+                <button
+                  key={bucket}
+                  onClick={() => toggleGasBucket(bucket)}
+                  className={`rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors ${
+                    selectedGasBuckets.has(bucket)
+                      ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                  }`}
+                >
+                  {Math.round(bucket / 1_000_000)}M
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       {suiteMismatch && (
@@ -336,7 +448,7 @@ export function ComparePage() {
         }} />
       </div>
 
-      <MetricsComparison runs={runs} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} />
+      <MetricsComparison runs={runs} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} testNameFilter={testNameFilter} />
 
       {allResults && (
         <MGasComparisonChart runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} labelMode={labelMode} testNameFilter={testNameFilter} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} chartType={chartType} />

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -121,7 +121,7 @@ export function ComparePage() {
       ? Math.min(parseInt(search.tableBase, 10) || 0, runIds.length - 1)
       : 'best'
 
-  const tableSortBy = (search.sort ?? 'order') as 'order' | 'name' | 'avgValue' | `run-${number}`
+  const tableSortBy = (search.sort ?? 'order') as 'order' | 'name' | 'gasUsed' | 'avgValue' | `run-${number}`
   const tableSortDir = (search.sortDir === 'desc' ? 'desc' : 'asc') as 'asc' | 'desc'
   const diffFilter = (search.diffFilter === 'faster' || search.diffFilter === 'slower' ? search.diffFilter : 'all') as 'all' | 'faster' | 'slower'
   const testFilter = search.filter ?? ''
@@ -298,7 +298,7 @@ export function ComparePage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <StickyRunBar runs={runs} sentinelRef={headerRef} labelMode={labelMode} onLabelModeChange={setLabelMode} testFilter={testFilter} testFilterRegex={testFilterRegex} onTestFilterChange={setTestFilter} onTestFilterRegexChange={setTestFilterRegex} />
+      <StickyRunBar runs={runs} sentinelRef={headerRef} labelMode={labelMode} onLabelModeChange={setLabelMode} testFilter={testFilter} testFilterRegex={testFilterRegex} onTestFilterChange={setTestFilter} onTestFilterRegexChange={setTestFilterRegex} availableGasBuckets={availableGasBuckets} selectedGasBuckets={selectedGasBuckets} onToggleGasBucket={toggleGasBucket} onClearGasBuckets={() => setGasBuckets(new Set())} />
 
       {/* Breadcrumb */}
       <div className="flex min-w-0 items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary

Adds gas-used bucket filtering to the comparison page, matching the "Group by Gas used" feature on the run detail heatmap.

- **Multi-select gas-bucket chips** in the main controls row (30M steps: All | 0M | 30M | 60M | 90M | ...). Selection persisted in URL via \`?gasBuckets=30,60\`.
- **Sticky scroll bar**: text filter + gas chips together on the second row so they stay accessible while scrolling through charts.
- **Filter-aware metric cards**: Tests, MGas/s, Total Gas, Duration, etc. now aggregate only from tests matching the active filters (both text/regex and gas buckets).
- **Gas column in the comparison table**: sortable column after the test name showing per-test \`gas_used_total\` in \`XM\` format.
- Composes with the existing text/regex filter — both must match for a test to appear.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean
- [x] Manual: open comparison page with 2+ runs; confirm gas chips appear; toggle buckets and verify charts + table + metric cards all update
- [x] Manual: combine a text filter with a gas-bucket selection; confirm both constraints apply
- [x] Manual: scroll down; confirm sticky bar shows both filter + gas chips on the second row
- [x] Manual: sort the table by the Gas column; confirm ordering is correct