### PR TITLE
feat(ui): grouped/averaged comparison page

### DIFF
--- a/ui/src/components/compare/GroupBuilder.tsx
+++ b/ui/src/components/compare/GroupBuilder.tsx
@@ -1,6 +1,10 @@
+import { useState } from 'react'
 import clsx from 'clsx'
 import { Plus, Trash2 } from 'lucide-react'
 import { JDenticon } from '@/components/shared/JDenticon'
+import { type IndexEntry, getIndexAggregatedStats } from '@/api/types'
+import { formatTimestamp } from '@/utils/date'
+import { formatDuration } from '@/utils/format'
 import type { GroupDef } from './groupUtils'
 
 // ── Props ────────────────────────────────────────────────────────
@@ -19,6 +23,8 @@ interface GroupBuilderProps {
   aggMode: 'avg' | 'median'
   onAggModeChange: (mode: 'avg' | 'median') => void
   groupRunCounts: number[]
+  /** Matched index entries per group (sorted newest-first, full list before sample-size truncation). */
+  groupMatchedRuns: IndexEntry[][]
 }
 
 // ── Component ────────────────────────────────────────────────────
@@ -37,6 +43,7 @@ export function GroupBuilder({
   aggMode,
   onAggModeChange,
   groupRunCounts,
+  groupMatchedRuns,
 }: GroupBuilderProps) {
   const addGroup = () => {
     const nextClient = availableClients.find((c) => !groups.some((g) => g.client === c)) ?? availableClients[0] ?? ''
@@ -130,6 +137,7 @@ export function GroupBuilder({
               availableMetadataKeys={availableMetadataKeys}
               runCount={groupRunCounts[idx] ?? 0}
               sampleSize={sampleSize}
+              matchedRuns={groupMatchedRuns[idx] ?? []}
               onClientChange={(client) => updateGroup(idx, { client, metadata: {} })}
               onAddMetadata={(key, val) => addMetadata(idx, key, val)}
               onRemoveMetadata={(key) => removeMetadata(idx, key)}
@@ -161,6 +169,7 @@ function GroupCard({
   availableMetadataKeys,
   runCount,
   sampleSize,
+  matchedRuns,
   onClientChange,
   onAddMetadata,
   onRemoveMetadata,
@@ -173,6 +182,7 @@ function GroupCard({
   availableMetadataKeys: Map<string, Set<string>>
   runCount: number
   sampleSize: number
+  matchedRuns: IndexEntry[]
   onClientChange: (client: string) => void
   onAddMetadata: (key: string, value: string) => void
   onRemoveMetadata: (key: string) => void
@@ -290,6 +300,125 @@ function GroupCard({
           })}
         </div>
       )}
+
+      {/* Per-group aggregate stats across the sampled runs */}
+      {matchedRuns.length > 0 && (() => {
+        const sampled = matchedRuns.slice(0, sampleSize)
+        const mgasValues = sampled
+          .map((r) => {
+            const s = getIndexAggregatedStats(r)
+            return s.gasUsedDuration > 0 ? (s.gasUsed * 1000) / s.gasUsedDuration : undefined
+          })
+          .filter((v): v is number => v !== undefined)
+          .sort((a, b) => a - b)
+
+        if (mgasValues.length === 0) return null
+
+        const min = mgasValues[0]
+        const max = mgasValues[mgasValues.length - 1]
+        const mean = mgasValues.reduce((a, b) => a + b, 0) / mgasValues.length
+        const p95 = mgasValues[Math.min(Math.floor(mgasValues.length * 0.95), mgasValues.length - 1)]
+        const p99 = mgasValues[Math.min(Math.floor(mgasValues.length * 0.99), mgasValues.length - 1)]
+
+        return (
+          <div className="flex flex-wrap gap-3 text-xs text-gray-600 dark:text-gray-300">
+            <span>Mean: <strong>{mean.toFixed(2)}</strong></span>
+            <span>Min: {min.toFixed(2)}</span>
+            <span>Max: {max.toFixed(2)}</span>
+            <span>P95: {p95.toFixed(2)}</span>
+            <span>P99: {p99.toFixed(2)}</span>
+            <span className="text-gray-400 dark:text-gray-500">MGas/s</span>
+          </div>
+        )
+      })()}
+
+      {/* Run boxes — shows which runs matched and which are used in the sample */}
+      {matchedRuns.length > 0 && <RunBoxes runs={matchedRuns} sampleSize={sampleSize} />}
+    </div>
+  )
+}
+
+// ── Run boxes with tooltip ───────────────────────────────────────
+
+function RunBoxes({ runs, sampleSize }: { runs: IndexEntry[]; sampleSize: number }) {
+  const [tooltip, setTooltip] = useState<{ run: IndexEntry; x: number; y: number } | null>(null)
+
+  return (
+    <div className="relative flex flex-wrap items-center gap-1">
+      <span className="mr-1 text-xs text-gray-500 dark:text-gray-400">Runs:</span>
+      {runs.map((run, i) => {
+        const inSample = i < sampleSize
+        const passed = run.tests.tests_total > 0 && run.tests.tests_passed === run.tests.tests_total
+        const failed = run.status === 'container_died' || run.status === 'cancelled'
+
+        return (
+          <a
+            key={run.run_id}
+            href={`/runs/${run.run_id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onMouseEnter={(e) => {
+              const rect = e.currentTarget.getBoundingClientRect()
+              setTooltip({ run, x: rect.left + rect.width / 2, y: rect.top })
+            }}
+            onMouseLeave={() => setTooltip(null)}
+            className={clsx(
+              'relative size-4 shrink-0 rounded-xs',
+              !inSample && 'opacity-30',
+              inSample && 'ring-1 ring-inset ring-black/10 dark:ring-white/10',
+            )}
+            style={{
+              backgroundColor: failed
+                ? '#6b7280'
+                : passed
+                  ? '#22c55e'
+                  : '#eab308',
+            }}
+          >
+            {failed && (
+              <svg className="absolute inset-0 size-4 text-red-500" viewBox="0 0 16 16" fill="none">
+                <path d="M3 3l10 10M3 13L13 3" stroke="currentColor" strokeWidth="1.5" />
+              </svg>
+            )}
+          </a>
+        )
+      })}
+
+      {tooltip && (() => {
+        const stats = getIndexAggregatedStats(tooltip.run)
+        const mgas = stats.gasUsedDuration > 0 ? (stats.gasUsed * 1000) / stats.gasUsedDuration : undefined
+        return (
+          <div
+            className="pointer-events-none fixed z-50 rounded-sm bg-white px-3 py-2 text-xs/5 shadow-lg ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-700"
+            style={{ left: tooltip.x, top: tooltip.y - 8, transform: 'translate(-50%, -100%)' }}
+          >
+            <div className="flex flex-col gap-1">
+              <div className="font-medium">{formatTimestamp(tooltip.run.timestamp)}</div>
+              {(tooltip.run.status === 'container_died' || tooltip.run.status === 'cancelled') && (
+                <div className="font-medium text-red-600 dark:text-red-400">
+                  {tooltip.run.status === 'container_died' ? 'Container Died' : 'Cancelled'}
+                </div>
+              )}
+              <div>Duration: {formatDuration(stats.duration)}</div>
+              {mgas !== undefined && <div>MGas/s: {mgas.toFixed(2)}</div>}
+              <div className="flex gap-2">
+                <span className="text-green-600 dark:text-green-400">
+                  {tooltip.run.tests.tests_passed} passed
+                </span>
+                {tooltip.run.tests.tests_total - tooltip.run.tests.tests_passed > 0 && (
+                  <span className="text-red-600 dark:text-red-400">
+                    {tooltip.run.tests.tests_total - tooltip.run.tests.tests_passed} failed
+                  </span>
+                )}
+                <span className="text-gray-500 dark:text-gray-400">
+                  ({tooltip.run.tests.tests_total} total)
+                </span>
+              </div>
+              <div className="text-gray-400 dark:text-gray-500">Click to open run details</div>
+            </div>
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/ui/src/components/compare/GroupBuilder.tsx
+++ b/ui/src/components/compare/GroupBuilder.tsx
@@ -1,0 +1,295 @@
+import clsx from 'clsx'
+import { Plus, Trash2 } from 'lucide-react'
+import { JDenticon } from '@/components/shared/JDenticon'
+import type { GroupDef } from './groupUtils'
+
+// ── Props ────────────────────────────────────────────────────────
+
+interface GroupBuilderProps {
+  availableSuites: string[]
+  selectedSuite: string
+  onSuiteChange: (hash: string) => void
+  suiteName?: string
+  groups: GroupDef[]
+  onGroupsChange: (groups: GroupDef[]) => void
+  availableClients: string[]
+  availableMetadataKeys: Map<string, Set<string>>
+  sampleSize: number
+  onSampleSizeChange: (n: number) => void
+  aggMode: 'avg' | 'median'
+  onAggModeChange: (mode: 'avg' | 'median') => void
+  groupRunCounts: number[]
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export function GroupBuilder({
+  availableSuites,
+  selectedSuite,
+  onSuiteChange,
+  suiteName,
+  groups,
+  onGroupsChange,
+  availableClients,
+  availableMetadataKeys,
+  sampleSize,
+  onSampleSizeChange,
+  aggMode,
+  onAggModeChange,
+  groupRunCounts,
+}: GroupBuilderProps) {
+  const addGroup = () => {
+    const nextClient = availableClients.find((c) => !groups.some((g) => g.client === c)) ?? availableClients[0] ?? ''
+    onGroupsChange([...groups, { client: nextClient, metadata: {} }])
+  }
+
+  const removeGroup = (idx: number) => {
+    onGroupsChange(groups.filter((_, i) => i !== idx))
+  }
+
+  const updateGroup = (idx: number, patch: Partial<GroupDef>) => {
+    onGroupsChange(groups.map((g, i) => (i === idx ? { ...g, ...patch } : g)))
+  }
+
+  const addMetadata = (idx: number, key: string, value: string) => {
+    const group = groups[idx]
+    updateGroup(idx, { metadata: { ...group.metadata, [key]: value } })
+  }
+
+  const removeMetadata = (idx: number, key: string) => {
+    const group = groups[idx]
+    const next = { ...group.metadata }
+    delete next[key]
+    updateGroup(idx, { metadata: next })
+  }
+
+  return (
+    <div className="flex flex-col gap-4 rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
+      {/* Suite picker + controls row */}
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <label className="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Suite:</label>
+          <select
+            value={selectedSuite}
+            onChange={(e) => onSuiteChange(e.target.value)}
+            className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          >
+            <option value="">Select a suite…</option>
+            {availableSuites.map((hash) => (
+              <option key={hash} value={hash}>
+                {hash === selectedSuite && suiteName ? suiteName : hash.slice(0, 12)}
+              </option>
+            ))}
+          </select>
+          {selectedSuite && (
+            <JDenticon value={selectedSuite} size={20} className="shrink-0 rounded-xs" />
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label className="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Sample:</label>
+          <input
+            type="number"
+            min={1}
+            max={20}
+            value={sampleSize}
+            onChange={(e) => onSampleSizeChange(Math.max(1, Math.min(20, parseInt(e.target.value, 10) || 5)))}
+            className="w-14 rounded-xs border border-gray-300 bg-white px-2 py-1 text-center text-sm/6 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          />
+          <span className="text-xs text-gray-500 dark:text-gray-400">latest runs per group</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label className="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Mode:</label>
+          {(['avg', 'median'] as const).map((m) => (
+            <button
+              key={m}
+              onClick={() => onAggModeChange(m)}
+              className={clsx(
+                'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                aggMode === m
+                  ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+              )}
+            >
+              {m === 'avg' ? 'Average' : 'Median'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Group cards */}
+      {selectedSuite && (
+        <div className="flex flex-col gap-3">
+          {groups.map((group, idx) => (
+            <GroupCard
+              key={idx}
+              group={group}
+              index={idx}
+              availableClients={availableClients}
+              availableMetadataKeys={availableMetadataKeys}
+              runCount={groupRunCounts[idx] ?? 0}
+              sampleSize={sampleSize}
+              onClientChange={(client) => updateGroup(idx, { client, metadata: {} })}
+              onAddMetadata={(key, val) => addMetadata(idx, key, val)}
+              onRemoveMetadata={(key) => removeMetadata(idx, key)}
+              onRemove={() => removeGroup(idx)}
+              canRemove={groups.length > 1}
+            />
+          ))}
+          {availableClients.length > 0 && groups.length < 5 && (
+            <button
+              onClick={addGroup}
+              className="flex items-center gap-1.5 self-start rounded-xs border border-dashed border-gray-300 px-3 py-1.5 text-sm/6 text-gray-600 hover:border-gray-400 hover:text-gray-800 dark:border-gray-600 dark:text-gray-400 dark:hover:border-gray-500 dark:hover:text-gray-200"
+            >
+              <Plus className="size-4" />
+              Add group
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Group card ───────────────────────────────────────────────────
+
+function GroupCard({
+  group,
+  index,
+  availableClients,
+  availableMetadataKeys,
+  runCount,
+  sampleSize,
+  onClientChange,
+  onAddMetadata,
+  onRemoveMetadata,
+  onRemove,
+  canRemove,
+}: {
+  group: GroupDef
+  index: number
+  availableClients: string[]
+  availableMetadataKeys: Map<string, Set<string>>
+  runCount: number
+  sampleSize: number
+  onClientChange: (client: string) => void
+  onAddMetadata: (key: string, value: string) => void
+  onRemoveMetadata: (key: string) => void
+  onRemove: () => void
+  canRemove: boolean
+}) {
+  const SLOT_COLORS = ['bg-blue-100 dark:bg-blue-900/30', 'bg-orange-100 dark:bg-orange-900/30', 'bg-purple-100 dark:bg-purple-900/30', 'bg-green-100 dark:bg-green-900/30', 'bg-red-100 dark:bg-red-900/30']
+
+  // Metadata keys not yet used by this group.
+  const unusedKeys = [...availableMetadataKeys.entries()].filter(
+    ([key]) => !(key in group.metadata),
+  )
+
+  return (
+    <div className={clsx('flex flex-col gap-2 rounded-sm border border-gray-200 p-3 dark:border-gray-700', SLOT_COLORS[index % SLOT_COLORS.length])}>
+      <div className="flex items-center gap-3">
+        <span className="text-xs/5 font-bold text-gray-500 dark:text-gray-400">
+          Group {String.fromCharCode(65 + index)}
+        </span>
+
+        <select
+          value={group.client}
+          onChange={(e) => onClientChange(e.target.value)}
+          className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm/6 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+        >
+          <option value="">Select client…</option>
+          {availableClients.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+
+        {group.client && (
+          <img
+            src={`/img/clients/${group.client}.jpg`}
+            alt={group.client}
+            className="size-6 rounded-full object-cover"
+          />
+        )}
+
+        <span className={clsx(
+          'ml-auto rounded-xs px-2 py-0.5 text-xs/5 font-medium',
+          runCount >= sampleSize
+            ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
+            : runCount > 0
+              ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200'
+              : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
+        )}>
+          {runCount} run{runCount !== 1 ? 's' : ''} found
+        </span>
+
+        {canRemove && (
+          <button
+            onClick={onRemove}
+            className="text-gray-400 hover:text-red-600 dark:text-gray-500 dark:hover:text-red-400"
+            title="Remove group"
+          >
+            <Trash2 className="size-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Metadata filter pills */}
+      {group.client && (
+        <div className="flex flex-wrap items-center gap-2">
+          {Object.entries(group.metadata).map(([key, val]) => (
+            <span
+              key={key}
+              className="inline-flex items-center gap-1 rounded-xs bg-white px-2 py-0.5 text-xs/5 font-medium text-gray-700 shadow-xs dark:bg-gray-700 dark:text-gray-200"
+            >
+              {key}={val}
+              <button
+                onClick={() => onRemoveMetadata(key)}
+                className="ml-0.5 text-gray-400 hover:text-red-600 dark:text-gray-500 dark:hover:text-red-400"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+
+          {unusedKeys.length > 0 && (
+            <select
+              value=""
+              onChange={(e) => {
+                const key = e.target.value
+                if (!key) return
+                const values = availableMetadataKeys.get(key)
+                const firstVal = values ? [...values][0] : ''
+                if (firstVal) onAddMetadata(key, firstVal)
+              }}
+              className="rounded-xs border border-dashed border-gray-300 bg-transparent px-2 py-0.5 text-xs/5 text-gray-500 dark:border-gray-600 dark:text-gray-400"
+            >
+              <option value="">+ filter…</option>
+              {unusedKeys.map(([key]) => (
+                <option key={key} value={key}>{key}</option>
+              ))}
+            </select>
+          )}
+
+          {/* Value picker for each metadata key — show next to the pill */}
+          {Object.entries(group.metadata).map(([key]) => {
+            const values = availableMetadataKeys.get(key)
+            if (!values || values.size <= 1) return null
+            return (
+              <select
+                key={`val-${key}`}
+                value={group.metadata[key]}
+                onChange={(e) => onAddMetadata(key, e.target.value)}
+                className="rounded-xs border border-gray-300 bg-white px-1.5 py-0.5 text-xs/5 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+              >
+                {[...values].sort().map((v) => (
+                  <option key={v} value={v}>{v}</option>
+                ))}
+              </select>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -19,6 +19,8 @@ interface TestComparisonTableProps {
   sortDir: SortDirection
   onSortChange: (column: SortColumn, direction: SortDirection) => void
   testNameFilter?: (name: string) => boolean
+  /** When provided, clicking a row calls this with the test name (for opening a detail modal). */
+  onTestClick?: (testName: string) => void
 }
 
 type SortColumn = 'order' | 'name' | 'gasUsed' | 'avgValue' | `run-${number}`
@@ -131,7 +133,7 @@ function SortableHeader({
 
 const PAGE_SIZE = 50
 
-export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun, labelMode, tableBaseline, onTableBaselineChange, sortBy, sortDir, onSortChange, testNameFilter }: TestComparisonTableProps) {
+export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun, labelMode, tableBaseline, onTableBaselineChange, sortBy, sortDir, onSortChange, testNameFilter, onTestClick }: TestComparisonTableProps) {
   const [activeTab, setActiveTab] = useState('mgas')
   const [currentPage, setCurrentPage] = useState(1)
 
@@ -391,7 +393,11 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
               }
 
               return (
-                <tr key={test.name} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                <tr
+                  key={test.name}
+                  className={clsx('hover:bg-gray-50 dark:hover:bg-gray-700/50', onTestClick && 'cursor-pointer')}
+                  onClick={onTestClick ? () => onTestClick(test.name) : undefined}
+                >
                   <td className="whitespace-nowrap px-3 py-2 text-center text-xs/5 text-gray-400 dark:text-gray-500">
                     {test.order || '-'}
                   </td>

--- a/ui/src/components/compare/TestDetailModal.tsx
+++ b/ui/src/components/compare/TestDetailModal.tsx
@@ -1,0 +1,270 @@
+import { useMemo, useState } from 'react'
+import { Check, Copy, X } from 'lucide-react'
+import clsx from 'clsx'
+import type { RunResult } from '@/api/types'
+import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
+import { formatTimestamp } from '@/utils/date'
+import { type GroupDef } from './groupUtils'
+
+interface TestDetailModalProps {
+  testName: string
+  testOrder?: number
+  groups: GroupDef[]
+  /** All individual RunResult objects per group (same order as groups). */
+  groupResults: RunResult[][]
+  /** Timestamps per run per group for labeling. */
+  groupTimestamps: number[][]
+  /** Run IDs per group for linking to run detail pages. */
+  groupRunIds: string[][]
+  stepFilter: StepTypeOption[]
+  sampleSize: number
+  onClose: () => void
+}
+
+/**
+ * TestDetailModal shows per-run MGas/s breakdown for a single test
+ * across all groups. Helps identify outlier runs or variance within
+ * a group that the averaged view hides.
+ */
+export function TestDetailModal({
+  testName,
+  testOrder,
+  groups,
+  groupResults,
+  groupTimestamps,
+  groupRunIds,
+  stepFilter,
+  sampleSize,
+  onClose,
+}: TestDetailModalProps) {
+  const SLOT_COLORS = ['text-blue-700 dark:text-blue-300', 'text-orange-700 dark:text-orange-300', 'text-purple-700 dark:text-purple-300', 'text-green-700 dark:text-green-300', 'text-red-700 dark:text-red-300']
+
+  type SortKey = 'run' | 'mgas' | 'gasUsed' | 'duration'
+  const [sortKey, setSortKey] = useState<SortKey>('run')
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir(key === 'mgas' ? 'desc' : 'asc')
+    }
+  }
+
+  const groupData = useMemo(() => {
+    return groups.map((group, gi) => {
+      const results = groupResults[gi] ?? []
+      const timestamps = groupTimestamps[gi] ?? []
+      const runIds = groupRunIds[gi] ?? []
+
+      const runs = results.slice(0, sampleSize).map((result, ri) => {
+        const entry = result.tests[testName]
+        const stats = entry ? getAggregatedStats(entry, stepFilter) : undefined
+        const mgas = stats && stats.gas_used_time_total > 0
+          ? (stats.gas_used_total * 1000) / stats.gas_used_time_total
+          : undefined
+
+        return {
+          runId: runIds[ri],
+          timestamp: timestamps[ri],
+          mgas,
+          gasUsed: stats?.gas_used_total ?? 0,
+          duration: stats?.time_total ?? 0,
+        }
+      })
+
+      const mgasValues = runs.map((r) => r.mgas).filter((v): v is number => v !== undefined)
+      const mean = mgasValues.length > 0 ? mgasValues.reduce((a, b) => a + b, 0) / mgasValues.length : undefined
+      const min = mgasValues.length > 0 ? Math.min(...mgasValues) : undefined
+      const max = mgasValues.length > 0 ? Math.max(...mgasValues) : undefined
+      const stddev = mgasValues.length >= 2 && mean !== undefined
+        ? Math.sqrt(mgasValues.reduce((sum, v) => sum + (v - mean) ** 2, 0) / (mgasValues.length - 1))
+        : undefined
+
+      const metaStr = Object.entries(group.metadata).map(([k, v]) => `${k}=${v}`).join(', ')
+      const label = metaStr || group.client
+
+      return { label, client: group.client, runs, mean, min, max, stddev, mgasValues }
+    })
+  }, [groups, groupResults, groupTimestamps, groupRunIds, stepFilter, sampleSize, testName])
+
+  // Find global min/max for the dot chart scaling.
+  const allMgas = groupData.flatMap((g) => g.mgasValues)
+  const globalMin = allMgas.length > 0 ? Math.min(...allMgas) : 0
+  const globalMax = allMgas.length > 0 ? Math.max(...allMgas) : 1
+  const range = globalMax - globalMin || 1
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="mx-4 flex max-h-[80vh] w-full max-w-3xl flex-col overflow-hidden rounded-sm bg-white shadow-xl dark:bg-gray-800"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 border-b border-gray-200 px-5 py-4 dark:border-gray-700">
+          <div className="min-w-0">
+            <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+              {testOrder !== undefined ? `Test #${testOrder}` : 'Test Detail'}
+            </h3>
+            <div className="mt-0.5 flex items-start gap-1.5">
+              <p className="break-all font-mono text-xs text-gray-500 dark:text-gray-400">
+                {testName}
+              </p>
+              <CopyButton text={testName} />
+            </div>
+          </div>
+          <button onClick={onClose} className="shrink-0 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300">
+            <X className="size-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <div className="flex flex-col gap-6">
+            {groupData.map((group, gi) => (
+              <div key={gi} className="flex flex-col gap-2">
+                {/* Group header */}
+                <div className="flex items-center gap-2">
+                  <img
+                    src={`/img/clients/${group.client}.jpg`}
+                    alt={group.client}
+                    className="size-5 rounded-full object-cover"
+                  />
+                  <span className={clsx('text-sm/6 font-medium', SLOT_COLORS[gi % SLOT_COLORS.length])}>
+                    {group.label}
+                  </span>
+                  {group.mean !== undefined && (
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      mean: {group.mean.toFixed(2)} MGas/s
+                      {group.stddev !== undefined && <> · σ: {group.stddev.toFixed(2)}</>}
+                    </span>
+                  )}
+                </div>
+
+                {/* Dot chart — each dot is one run's MGas/s for this test */}
+                <div className="relative h-6 rounded-xs bg-gray-100 dark:bg-gray-700">
+                  {group.mgasValues.map((v, i) => {
+                    const pct = ((v - globalMin) / range) * 100
+                    return (
+                      <span
+                        key={i}
+                        className="absolute top-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-current opacity-70"
+                        style={{ left: `${Math.max(2, Math.min(98, pct))}%`, color: SLOT_COLORS[gi % SLOT_COLORS.length].includes('blue') ? '#3b82f6' : SLOT_COLORS[gi % SLOT_COLORS.length].includes('orange') ? '#f97316' : SLOT_COLORS[gi % SLOT_COLORS.length].includes('purple') ? '#a855f7' : SLOT_COLORS[gi % SLOT_COLORS.length].includes('green') ? '#22c55e' : '#ef4444' }}
+                        title={`${v.toFixed(2)} MGas/s`}
+                      />
+                    )
+                  })}
+                  {/* Min/Max labels */}
+                  <span className="absolute left-1 top-full mt-0.5 text-xs text-gray-400">{globalMin.toFixed(1)}</span>
+                  <span className="absolute right-1 top-full mt-0.5 text-xs text-gray-400">{globalMax.toFixed(1)}</span>
+                </div>
+
+                {/* Stats summary */}
+                {group.min !== undefined && (
+                  <div className="mt-4 flex gap-3 border-t border-gray-200 pt-2 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                    <span>Min: {group.min.toFixed(2)}</span>
+                    <span>Max: {group.max?.toFixed(2)}</span>
+                    <span>Range: {((group.max ?? 0) - (group.min ?? 0)).toFixed(2)}</span>
+                    {group.stddev !== undefined && group.mean !== undefined && group.mean > 0 && (
+                      <span title="Coefficient of Variation — standard deviation as a percentage of the mean. Lower = more consistent across runs.">
+                        CV: {((group.stddev / group.mean) * 100).toFixed(1)}%
+                      </span>
+                    )}
+                  </div>
+                )}
+
+                {/* Per-run table */}
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                      <SortableHeader label="Run" sortKey="run" currentKey={sortKey} currentDir={sortDir} onSort={toggleSort} align="left" />
+                      <SortableHeader label="MGas/s" sortKey="mgas" currentKey={sortKey} currentDir={sortDir} onSort={toggleSort} align="right" />
+                      <SortableHeader label="Gas Used" sortKey="gasUsed" currentKey={sortKey} currentDir={sortDir} onSort={toggleSort} align="right" />
+                      <SortableHeader label="Duration" sortKey="duration" currentKey={sortKey} currentDir={sortDir} onSort={toggleSort} align="right" />
+                    </tr>
+                  </thead>
+                  <tbody className="text-gray-700 dark:text-gray-200">
+                    {[...group.runs].sort((a, b) => {
+                      let cmp = 0
+                      switch (sortKey) {
+                        case 'run': cmp = (a.timestamp ?? 0) - (b.timestamp ?? 0); break
+                        case 'mgas': cmp = (a.mgas ?? 0) - (b.mgas ?? 0); break
+                        case 'gasUsed': cmp = a.gasUsed - b.gasUsed; break
+                        case 'duration': cmp = a.duration - b.duration; break
+                      }
+                      return sortDir === 'asc' ? cmp : -cmp
+                    }).map((run, ri) => (
+                      <tr
+                        key={ri}
+                        className="cursor-pointer border-b border-gray-100 last:border-0 hover:bg-gray-50 dark:border-gray-700/50 dark:hover:bg-gray-700/50"
+                        onClick={() => { if (run.runId) window.open(`/runs/${run.runId}?testModal=${encodeURIComponent(testName)}`, '_blank') }}
+                      >
+                        <td className="px-2 py-1">{run.timestamp ? formatTimestamp(run.timestamp) : `Run ${ri + 1}`}</td>
+                        <td className="px-2 py-1 text-right font-mono">
+                          {run.mgas !== undefined ? run.mgas.toFixed(2) : '-'}
+                        </td>
+                        <td className="px-2 py-1 text-right font-mono">
+                          {run.gasUsed > 0 ? `${(run.gasUsed / 1_000_000).toFixed(1)}M` : '-'}
+                        </td>
+                        <td className="px-2 py-1 text-right font-mono">
+                          {run.duration > 0 ? `${(run.duration / 1_000_000_000).toFixed(2)}s` : '-'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SortableHeader({ label, sortKey, currentKey, currentDir, onSort, align }: {
+  label: string
+  sortKey: string
+  currentKey: string
+  currentDir: 'asc' | 'desc'
+  onSort: (key: never) => void
+  align: 'left' | 'right'
+}) {
+  const active = currentKey === sortKey
+  const arrow = active ? (currentDir === 'asc' ? ' ▲' : ' ▼') : ''
+
+  return (
+    <th
+      className={clsx(
+        'cursor-pointer select-none px-2 py-1 font-medium',
+        align === 'right' ? 'text-right' : 'text-left',
+        active && 'text-gray-900 dark:text-gray-100',
+      )}
+      onClick={() => onSort(sortKey as never)}
+    >
+      {label}{arrow}
+    </th>
+  )
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        navigator.clipboard.writeText(text)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1500)
+      }}
+      className="shrink-0 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+      title="Copy test name"
+    >
+      {copied ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
+    </button>
+  )
+}

--- a/ui/src/components/compare/TestDetailModal.tsx
+++ b/ui/src/components/compare/TestDetailModal.tsx
@@ -39,6 +39,15 @@ export function TestDetailModal({
 }: TestDetailModalProps) {
   const SLOT_COLORS = ['text-blue-700 dark:text-blue-300', 'text-orange-700 dark:text-orange-300', 'text-purple-700 dark:text-purple-300', 'text-green-700 dark:text-green-300', 'text-red-700 dark:text-red-300']
 
+  const [expandedGroups, setExpandedGroups] = useState<Set<number>>(new Set())
+  const toggleGroupExpand = (gi: number) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev)
+      if (next.has(gi)) next.delete(gi); else next.add(gi)
+      return next
+    })
+  }
+
   type SortKey = 'run' | 'mgas' | 'gasUsed' | 'duration'
   const [sortKey, setSortKey] = useState<SortKey>('run')
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
@@ -174,8 +183,16 @@ export function TestDetailModal({
                   </div>
                 )}
 
-                {/* Per-run table */}
-                <table className="w-full text-xs">
+                {/* Per-run table (collapsed by default) */}
+                <button
+                  type="button"
+                  onClick={() => toggleGroupExpand(gi)}
+                  className="flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                >
+                  <span className={clsx('transition-transform', expandedGroups.has(gi) && 'rotate-90')}>▶</span>
+                  {expandedGroups.has(gi) ? 'Hide' : 'Show'} individual runs ({group.runs.length})
+                </button>
+                {expandedGroups.has(gi) && <table className="w-full text-xs">
                   <thead>
                     <tr className="border-b border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400">
                       <SortableHeader label="Run" sortKey="run" currentKey={sortKey} currentDir={sortDir} onSort={toggleSort} align="left" />
@@ -213,7 +230,7 @@ export function TestDetailModal({
                       </tr>
                     ))}
                   </tbody>
-                </table>
+                </table>}
 
               </div>
             ))}

--- a/ui/src/components/compare/groupUtils.ts
+++ b/ui/src/components/compare/groupUtils.ts
@@ -1,0 +1,44 @@
+// Group definition type and URL encoding helpers for the group
+// comparison page. Separated from the component file so the React
+// fast-refresh lint rule doesn't complain about mixed exports.
+
+export interface GroupDef {
+  client: string
+  metadata: Record<string, string>
+}
+
+/**
+ * Parse the groups search param. Format:
+ * "client1:key1=val1,key2=val2;client2:"
+ */
+export function parseGroupsParam(param: string | undefined): GroupDef[] {
+  if (!param) return []
+
+  return param
+    .split(';')
+    .filter(Boolean)
+    .map((seg) => {
+      const [client, rest] = seg.split(':', 2)
+      const metadata: Record<string, string> = {}
+      if (rest) {
+        for (const pair of rest.split(',').filter(Boolean)) {
+          const eq = pair.indexOf('=')
+          if (eq > 0) {
+            metadata[pair.slice(0, eq)] = pair.slice(eq + 1)
+          }
+        }
+      }
+      return { client: client || '', metadata }
+    })
+}
+
+export function encodeGroupsParam(groups: GroupDef[]): string {
+  return groups
+    .map((g) => {
+      const meta = Object.entries(g.metadata)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(',')
+      return `${g.client}:${meta}`
+    })
+    .join(';')
+}

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -14,6 +14,7 @@ import { MetricsComparison } from '@/components/compare/MetricsComparison'
 import { MGasComparisonChart } from '@/components/compare/MGasComparisonChart'
 import { PercentageDiffChart } from '@/components/compare/PercentageDiffChart'
 import { TestComparisonTable } from '@/components/compare/TestComparisonTable'
+import { ResourceComparisonCharts } from '@/components/compare/ResourceComparisonCharts'
 import { GroupBuilder } from '@/components/compare/GroupBuilder'
 import { type GroupDef, parseGroupsParam, encodeGroupsParam } from '@/components/compare/groupUtils'
 import { averageResults } from '@/utils/averageResults'
@@ -515,6 +516,16 @@ export function CompareGroupsPage() {
             diffFilter="all"
             onDiffFilterChange={() => {}}
             testNameFilter={testNameFilter}
+            zoomRange={sharedZoom ? chartZoom : undefined}
+            onZoomChange={sharedZoom ? setChartZoom : undefined}
+            chartType={chartType}
+          />
+
+          <ResourceComparisonCharts
+            runs={syntheticRuns}
+            labelMode="instance-id"
+            testNameFilter={testNameFilter}
+            suiteTests={suite?.tests}
             zoomRange={sharedZoom ? chartZoom : undefined}
             onZoomChange={sharedZoom ? setChartZoom : undefined}
             chartType={chartType}

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -9,7 +9,7 @@ import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { type StepTypeOption, ALL_STEP_TYPES, DEFAULT_STEP_FILTER } from '@/pages/RunDetailPage'
-import { type CompareRun } from '@/components/compare/constants'
+import { type CompareRun, type ChartType, CHART_TYPE_OPTIONS } from '@/components/compare/constants'
 import { MetricsComparison } from '@/components/compare/MetricsComparison'
 import { MGasComparisonChart } from '@/components/compare/MGasComparisonChart'
 import { PercentageDiffChart } from '@/components/compare/PercentageDiffChart'
@@ -34,9 +34,12 @@ export function CompareGroupsPage() {
     steps?: string
     baseline?: string
     tableBase?: string
+    chart?: string
     sort?: string
     sortDir?: string
     filter?: string
+    filterRegex?: string
+    gasBuckets?: string
   }
 
   const suiteHash = search.suite ?? ''
@@ -60,9 +63,12 @@ export function CompareGroupsPage() {
           steps: search.steps,
           baseline: search.baseline,
           tableBase: search.tableBase,
+          chart: search.chart,
           sort: search.sort,
           sortDir: search.sortDir,
           filter: search.filter,
+          filterRegex: search.filterRegex,
+          gasBuckets: search.gasBuckets,
           ...patch,
         },
         replace: true,
@@ -239,16 +245,75 @@ export function CompareGroupsPage() {
     : search.tableBase !== undefined && search.tableBase !== 'best'
       ? Math.min(parseInt(search.tableBase, 10) || 0, syntheticRuns.length - 1)
       : 'best'
+  const chartType: ChartType = (search.chart as ChartType) ?? 'line'
   const [sharedZoom, setSharedZoom] = useState(true)
   const [chartZoom, setChartZoom] = useState({ start: 0, end: 100 })
   const tableSortBy = (search.sort ?? 'order') as 'order' | 'name' | 'gasUsed' | 'avgValue' | `run-${number}`
   const tableSortDir = (search.sortDir === 'desc' ? 'desc' : 'asc') as 'asc' | 'desc'
   const testFilter = search.filter ?? ''
+  const testFilterRegex = search.filterRegex === '1'
+
+  // ─── Gas bucket filter ─────────────────────────────────────────
+  const GAS_BUCKET_STEP = 30_000_000
+
+  const selectedGasBuckets = useMemo(() => {
+    if (!search.gasBuckets) return new Set<number>()
+    return new Set(
+      search.gasBuckets.split(',').map((s) => parseInt(s, 10) * 1_000_000).filter((n) => !isNaN(n)),
+    )
+  }, [search.gasBuckets])
+
+  // Compute per-test gas from the first synthetic result for bucketing.
+  const testGasMap = useMemo(() => {
+    const map = new Map<string, number>()
+    const result = syntheticRuns.find((r) => r.result)?.result
+    if (!result) return map
+    for (const [name, entry] of Object.entries(result.tests)) {
+      const step = entry.steps?.test
+      if (step) map.set(name, step.aggregated.gas_used_total)
+    }
+    return map
+  }, [syntheticRuns])
+
+  const availableGasBuckets = useMemo(() => {
+    const buckets = new Set<number>()
+    for (const gas of testGasMap.values()) {
+      buckets.add(Math.round(gas / GAS_BUCKET_STEP) * GAS_BUCKET_STEP)
+    }
+    return [...buckets].sort((a, b) => a - b)
+  }, [testGasMap, GAS_BUCKET_STEP])
+
+  // ─── Combined test name filter ────────────────────────────────
   const testNameFilter = useMemo(() => {
-    if (!testFilter) return undefined
-    const q = testFilter.toLowerCase()
-    return (name: string) => name.toLowerCase().includes(q)
-  }, [testFilter])
+    const textFn = (() => {
+      if (!testFilter) return undefined
+      if (testFilterRegex) {
+        try {
+          const re = new RegExp(testFilter, 'i')
+          return (name: string) => re.test(name)
+        } catch {
+          return undefined
+        }
+      }
+      const q = testFilter.toLowerCase()
+      return (name: string) => name.toLowerCase().includes(q)
+    })()
+
+    const needsGasFilter = selectedGasBuckets.size > 0
+    const gasFn = needsGasFilter
+      ? (name: string) => {
+          const gas = testGasMap.get(name)
+          if (gas === undefined) return false
+          const bucket = Math.round(gas / GAS_BUCKET_STEP) * GAS_BUCKET_STEP
+          return selectedGasBuckets.has(bucket)
+        }
+      : undefined
+
+    if (!textFn && !gasFn) return undefined
+    if (textFn && !gasFn) return textFn
+    if (!textFn && gasFn) return gasFn
+    return (name: string) => textFn!(name) && gasFn!(name)
+  }, [testFilter, testFilterRegex, selectedGasBuckets, testGasMap, GAS_BUCKET_STEP])
 
   const hasResults = syntheticRuns.length >= 2 && syntheticRuns.every((r) => r.result !== null)
 
@@ -319,6 +384,25 @@ export function CompareGroupsPage() {
               ))}
             </div>
             <div className="flex items-center gap-1.5">
+              <span>Chart:</span>
+              <div className="flex gap-1">
+                {CHART_TYPE_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => updateSearch({ chart: opt.value === 'line' ? undefined : opt.value })}
+                    className={clsx(
+                      'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                      chartType === opt.value
+                        ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                        : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                    )}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="flex items-center gap-1.5">
               <span>Shared Zoom:</span>
               <button
                 onClick={() => setSharedZoom(!sharedZoom)}
@@ -332,6 +416,73 @@ export function CompareGroupsPage() {
                 {sharedZoom ? 'On' : 'Off'}
               </button>
             </div>
+            <div className="flex items-center gap-1.5">
+              <span>Filter:</span>
+              <input
+                type="text"
+                placeholder={testFilterRegex ? 'Regex pattern...' : 'Filter tests...'}
+                value={testFilter}
+                onChange={(e) => updateSearch({ filter: e.target.value || undefined })}
+                className={clsx(
+                  'w-36 rounded-xs border bg-white px-2 py-0.5 text-xs/5 placeholder-gray-400 focus:outline-hidden focus:ring-1 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
+                  testFilterRegex && testFilter && (() => { try { new RegExp(testFilter); return false } catch { return true } })()
+                    ? 'border-red-400 focus:border-red-500 focus:ring-red-500 dark:border-red-500'
+                    : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600',
+                )}
+              />
+              <button
+                onClick={() => updateSearch({ filterRegex: testFilterRegex ? undefined : '1' })}
+                title={testFilterRegex ? 'Regex mode (click to switch to text)' : 'Text mode (click to switch to regex)'}
+                className={clsx(
+                  'rounded-xs px-1.5 py-0.5 font-mono text-xs/5 transition-colors',
+                  testFilterRegex
+                    ? 'bg-blue-500 text-white'
+                    : 'border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                )}
+              >
+                .*
+              </button>
+            </div>
+            {availableGasBuckets.length > 1 && (
+              <div className="flex items-center gap-1.5">
+                <span>Gas:</span>
+                <div className="flex flex-wrap gap-1">
+                  <button
+                    onClick={() => updateSearch({ gasBuckets: undefined })}
+                    className={clsx(
+                      'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                      selectedGasBuckets.size === 0
+                        ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                        : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                    )}
+                  >
+                    All
+                  </button>
+                  {availableGasBuckets.map((bucket) => {
+                    const isSelected = selectedGasBuckets.has(bucket)
+                    return (
+                      <button
+                        key={bucket}
+                        onClick={() => {
+                          const next = new Set(selectedGasBuckets)
+                          if (isSelected) next.delete(bucket); else next.add(bucket)
+                          const sorted = [...next].sort((a, b) => a - b)
+                          updateSearch({ gasBuckets: sorted.length > 0 ? sorted.map((v) => String(v / 1_000_000)).join(',') : undefined })
+                        }}
+                        className={clsx(
+                          'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                          isSelected
+                            ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                            : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                        )}
+                      >
+                        {Math.round(bucket / 1_000_000)}M
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
           </div>
 
           <MetricsComparison
@@ -351,7 +502,7 @@ export function CompareGroupsPage() {
             testNameFilter={testNameFilter}
             zoomRange={sharedZoom ? chartZoom : undefined}
             onZoomChange={sharedZoom ? setChartZoom : undefined}
-            chartType="line"
+            chartType={chartType}
           />
 
           <PercentageDiffChart
@@ -366,7 +517,7 @@ export function CompareGroupsPage() {
             testNameFilter={testNameFilter}
             zoomRange={sharedZoom ? chartZoom : undefined}
             onZoomChange={sharedZoom ? setChartZoom : undefined}
-            chartType="line"
+            chartType={chartType}
           />
 
           <TestComparisonTable

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearch, useNavigate } from '@tanstack/react-router'
 import { useQueries } from '@tanstack/react-query'
 import clsx from 'clsx'
@@ -326,6 +326,21 @@ export function CompareGroupsPage() {
 
   const hasResults = syntheticRuns.length >= 2 && syntheticRuns.every((r) => r.result !== null)
 
+  // ─── Sticky bar ────────────────────────────────────────────────
+  const sentinelRef = useRef<HTMLDivElement>(null)
+  const [stickyVisible, setStickyVisible] = useState(false)
+
+  useEffect(() => {
+    const el = sentinelRef.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => setStickyVisible(!entry.isIntersecting),
+      { threshold: 0 },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   // ─── Test detail modal ─────────────────────────────────────────
   const [selectedTest, setSelectedTest] = useState<string | null>(null)
 
@@ -375,7 +390,8 @@ export function CompareGroupsPage() {
         <span className="shrink-0 text-gray-900 dark:text-gray-100">Group Compare</span>
       </div>
 
-      {/* Group Builder */}
+      {/* Group Builder (sentinel for sticky bar) */}
+      <div ref={sentinelRef}>
       <GroupBuilder
         availableSuites={availableSuites}
         selectedSuite={suiteHash}
@@ -392,6 +408,96 @@ export function CompareGroupsPage() {
         groupRunCounts={groupRuns.map((ids) => ids.length)}
         groupMatchedRuns={groupMatchedEntries}
       />
+      </div>
+
+      {/* Sticky bar — appears when the group builder scrolls out of view */}
+      {stickyVisible && hasResults && (
+        <div className="fixed top-0 right-0 left-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/95">
+          <div className="mx-auto flex max-w-7xl flex-col gap-1 px-4 py-2">
+            <div className="flex items-center justify-center gap-4">
+              {groups.map((group, gi) => {
+                const metaStr = Object.entries(group.metadata).map(([k, v]) => `${k}=${v}`).join(', ')
+                return (
+                  <span key={gi} className="inline-flex items-center gap-1.5 rounded-sm bg-gray-100 px-2 py-0.5 text-xs/5 font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+                    <img src={`/img/clients/${group.client}.jpg`} alt={group.client} className="size-3.5 rounded-full object-cover" />
+                    {metaStr || group.client}
+                  </span>
+                )
+              })}
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {aggMode === 'avg' ? 'Average' : 'Median'} of {sampleSize}
+              </span>
+            </div>
+            <div className="flex items-center justify-center gap-4 text-xs/5 text-gray-500 dark:text-gray-400">
+              <div className="flex items-center gap-1.5">
+                <span>Filter:</span>
+                <input
+                  type="text"
+                  placeholder={testFilterRegex ? 'Regex...' : 'Filter...'}
+                  value={testFilter}
+                  onChange={(e) => updateSearch({ filter: e.target.value || undefined })}
+                  className={clsx(
+                    'w-36 rounded-xs border bg-white px-2 py-0.5 text-xs/5 placeholder-gray-400 focus:outline-hidden focus:ring-1 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
+                    'border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600',
+                  )}
+                />
+                <button
+                  onClick={() => updateSearch({ filterRegex: testFilterRegex ? undefined : '1' })}
+                  title={testFilterRegex ? 'Regex mode' : 'Text mode'}
+                  className={clsx(
+                    'rounded-xs px-1 py-0.5 font-mono text-xs/5 transition-colors',
+                    testFilterRegex
+                      ? 'bg-blue-500 text-white'
+                      : 'border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                  )}
+                >
+                  .*
+                </button>
+              </div>
+              {availableGasBuckets.length > 1 && (
+                <div className="flex items-center gap-1.5">
+                  <span>Gas:</span>
+                  <div className="flex flex-wrap gap-1">
+                    <button
+                      onClick={() => updateSearch({ gasBuckets: undefined })}
+                      className={clsx(
+                        'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                        selectedGasBuckets.size === 0
+                          ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                          : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                      )}
+                    >
+                      All
+                    </button>
+                    {availableGasBuckets.map((bucket) => {
+                      const isSelected = selectedGasBuckets.has(bucket)
+                      return (
+                        <button
+                          key={bucket}
+                          onClick={() => {
+                            const next = new Set(selectedGasBuckets)
+                            if (isSelected) next.delete(bucket); else next.add(bucket)
+                            const sorted = [...next].sort((a, b) => a - b)
+                            updateSearch({ gasBuckets: sorted.length > 0 ? sorted.map((v) => String(v / 1_000_000)).join(',') : undefined })
+                          }}
+                          className={clsx(
+                            'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                            isSelected
+                              ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                              : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                          )}
+                        >
+                          {Math.round(bucket / 1_000_000)}M
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {isLoading && allRunIds.length > 0 && (
         <LoadingState message={`Loading results for ${allRunIds.length} runs across ${groups.length} groups...`} />

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -177,7 +177,9 @@ export function CompareGroupsPage() {
       const metaStr = Object.entries(groups[gi].metadata)
         .map(([k, v]) => `${k}=${v}`)
         .join(', ')
-      const label = metaStr ? `${groups[gi].client} (${metaStr})` : groups[gi].client
+      // Client name is omitted since the logo image already identifies
+      // it. Show only the metadata filters, or a generic "default" if none.
+      const label = metaStr || 'default'
 
       const synConfig: RunConfig = {
         ...config,

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -97,11 +97,13 @@ export function CompareGroupsPage() {
 
   // ─── Run selection from the index ──────────────────────────────
   // For each group, find the latest N runs matching the criteria.
-  const groupRuns = useMemo(() => {
+  // All matched entries per group (sorted newest-first, NOT truncated
+  // to sample size). Used for the run-boxes display in the builder.
+  const groupMatchedEntries = useMemo(() => {
     if (!index || !suiteHash || groups.length === 0) return []
 
-    return groups.map((group) => {
-      const matching = index.entries
+    return groups.map((group) =>
+      index.entries
         .filter((e) => {
           if (e.suite_hash !== suiteHash) return false
           if (e.instance.client !== group.client) return false
@@ -110,12 +112,15 @@ export function CompareGroupsPage() {
           }
           return true
         })
-        .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0))
-        .slice(0, sampleSize)
+        .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0)),
+    )
+  }, [index, suiteHash, groups])
 
-      return matching.map((e) => e.run_id)
-    })
-  }, [index, suiteHash, groups, sampleSize])
+  // Run IDs used for data fetching (truncated to sample size).
+  const groupRuns = useMemo(
+    () => groupMatchedEntries.map((entries) => entries.slice(0, sampleSize).map((e) => e.run_id)),
+    [groupMatchedEntries, sampleSize],
+  )
 
   // Flatten all run IDs for batch fetching.
   const allRunIds = useMemo(() => groupRuns.flat(), [groupRuns])
@@ -359,6 +364,7 @@ export function CompareGroupsPage() {
         aggMode={aggMode}
         onAggModeChange={setAggMode}
         groupRunCounts={groupRuns.map((ids) => ids.length)}
+        groupMatchedRuns={groupMatchedEntries}
       />
 
       {isLoading && allRunIds.length > 0 && (

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -1,0 +1,394 @@
+import { useCallback, useMemo, useState } from 'react'
+import { Link, useSearch, useNavigate } from '@tanstack/react-router'
+import { useQueries } from '@tanstack/react-query'
+import clsx from 'clsx'
+import type { RunConfig, RunResult } from '@/api/types'
+import { fetchData } from '@/api/client'
+import { useIndex } from '@/api/hooks/useIndex'
+import { useSuite } from '@/api/hooks/useSuite'
+import { LoadingState } from '@/components/shared/Spinner'
+import { JDenticon } from '@/components/shared/JDenticon'
+import { type StepTypeOption, ALL_STEP_TYPES, DEFAULT_STEP_FILTER } from '@/pages/RunDetailPage'
+import { type CompareRun } from '@/components/compare/constants'
+import { MetricsComparison } from '@/components/compare/MetricsComparison'
+import { MGasComparisonChart } from '@/components/compare/MGasComparisonChart'
+import { PercentageDiffChart } from '@/components/compare/PercentageDiffChart'
+import { TestComparisonTable } from '@/components/compare/TestComparisonTable'
+import { GroupBuilder } from '@/components/compare/GroupBuilder'
+import { type GroupDef, parseGroupsParam, encodeGroupsParam } from '@/components/compare/groupUtils'
+import { averageResults } from '@/utils/averageResults'
+
+function parseStepFilter(param: string | undefined): StepTypeOption[] {
+  if (!param) return DEFAULT_STEP_FILTER
+  const steps = param.split(',').filter((s): s is StepTypeOption => ALL_STEP_TYPES.includes(s as StepTypeOption))
+  return steps.length > 0 ? steps : DEFAULT_STEP_FILTER
+}
+
+export function CompareGroupsPage() {
+  const navigate = useNavigate()
+  const search = useSearch({ from: '/compare/groups' }) as {
+    suite?: string
+    groups?: string
+    sample?: string
+    agg?: string
+    steps?: string
+    baseline?: string
+    tableBase?: string
+    sort?: string
+    sortDir?: string
+    filter?: string
+  }
+
+  const suiteHash = search.suite ?? ''
+  const groups = useMemo(() => parseGroupsParam(search.groups), [search.groups])
+  const sampleSize = Math.max(1, Math.min(20, parseInt(search.sample ?? '5', 10) || 5))
+  const aggMode = (search.agg === 'median' ? 'median' : 'avg') as 'avg' | 'median'
+  const stepFilter = parseStepFilter(search.steps)
+
+  const { data: index } = useIndex()
+  const { data: suite } = useSuite(suiteHash)
+
+  const updateSearch = useCallback(
+    (patch: Record<string, string | undefined>) => {
+      navigate({
+        to: '/compare/groups',
+        search: {
+          suite: search.suite,
+          groups: search.groups,
+          sample: search.sample,
+          agg: search.agg,
+          steps: search.steps,
+          baseline: search.baseline,
+          tableBase: search.tableBase,
+          sort: search.sort,
+          sortDir: search.sortDir,
+          filter: search.filter,
+          ...patch,
+        },
+        replace: true,
+      })
+    },
+    [navigate, search],
+  )
+
+  const setSuiteHash = useCallback(
+    (hash: string) => updateSearch({ suite: hash || undefined, groups: undefined }),
+    [updateSearch],
+  )
+  const setGroups = useCallback(
+    (g: GroupDef[]) => updateSearch({ groups: encodeGroupsParam(g) || undefined }),
+    [updateSearch],
+  )
+  const setSampleSize = useCallback(
+    (n: number) => updateSearch({ sample: n === 5 ? undefined : String(n) }),
+    [updateSearch],
+  )
+  const setAggMode = useCallback(
+    (m: 'avg' | 'median') => updateSearch({ agg: m === 'avg' ? undefined : m }),
+    [updateSearch],
+  )
+
+  // ─── Run selection from the index ──────────────────────────────
+  // For each group, find the latest N runs matching the criteria.
+  const groupRuns = useMemo(() => {
+    if (!index || !suiteHash || groups.length === 0) return []
+
+    return groups.map((group) => {
+      const matching = index.entries
+        .filter((e) => {
+          if (e.suite_hash !== suiteHash) return false
+          if (e.instance.client !== group.client) return false
+          for (const [key, val] of Object.entries(group.metadata)) {
+            if (e.metadata?.[key] !== val) return false
+          }
+          return true
+        })
+        .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0))
+        .slice(0, sampleSize)
+
+      return matching.map((e) => e.run_id)
+    })
+  }, [index, suiteHash, groups, sampleSize])
+
+  // Flatten all run IDs for batch fetching.
+  const allRunIds = useMemo(() => groupRuns.flat(), [groupRuns])
+
+  // ─── Data fetching ─────────────────────────────────────────────
+  const configQueries = useQueries({
+    queries: groups.map((_, i) => {
+      const runId = groupRuns[i]?.[0]
+      return {
+        queryKey: ['run', runId, 'config'],
+        queryFn: async () => {
+          const { data, status } = await fetchData<RunConfig>(`runs/${runId}/config.json`)
+          if (!data) throw new Error(`Failed to fetch config: ${status}`)
+          return data
+        },
+        enabled: !!runId,
+      }
+    }),
+  })
+
+  const resultQueries = useQueries({
+    queries: allRunIds.map((runId) => ({
+      queryKey: ['run', runId, 'result'],
+      queryFn: async () => {
+        const { data } = await fetchData<RunResult>(`runs/${runId}/result.json`)
+        return data ?? null
+      },
+      enabled: !!runId,
+    })),
+  })
+
+  const isLoading = configQueries.some((q) => q.isLoading) || resultQueries.some((q) => q.isLoading)
+
+  // ─── Compute averages and build synthetic CompareRun[] ─────────
+  const { syntheticRuns, varianceMap } = useMemo(() => {
+    if (groups.length === 0 || isLoading) return { syntheticRuns: [] as CompareRun[], varianceMap: new Map() }
+
+    const runs: CompareRun[] = []
+    const varMap = new Map<number, Record<string, { mgasStddev: number; mgasMin: number; mgasMax: number }>>()
+    let resultOffset = 0
+
+    for (let gi = 0; gi < groups.length; gi++) {
+      const runIds = groupRuns[gi] ?? []
+      const config = configQueries[gi]?.data
+
+      // Gather the results for this group.
+      const results: RunResult[] = []
+      for (let ri = 0; ri < runIds.length; ri++) {
+        const r = resultQueries[resultOffset + ri]?.data
+        if (r) results.push(r)
+      }
+      resultOffset += runIds.length
+
+      if (!config || results.length === 0) continue
+
+      const averaged = averageResults(results, stepFilter, aggMode)
+
+      // Build a label from the group criteria.
+      const metaStr = Object.entries(groups[gi].metadata)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(', ')
+      const label = metaStr ? `${groups[gi].client} (${metaStr})` : groups[gi].client
+
+      const synConfig: RunConfig = {
+        ...config,
+        instance: { ...config.instance, id: label },
+      }
+
+      runs.push({
+        runId: `group-${gi}`,
+        config: synConfig,
+        result: averaged.result,
+        index: gi,
+      })
+
+      varMap.set(gi, averaged.variance)
+    }
+
+    return { syntheticRuns: runs, varianceMap: varMap }
+  }, [groups, groupRuns, configQueries, resultQueries, stepFilter, aggMode, isLoading])
+
+  void varianceMap // will be used for variance display in phase 2
+
+  // ─── Available suites + clients for the builder ────────────────
+  const availableSuites = useMemo(() => {
+    if (!index) return []
+    const suites = new Map<string, number>()
+    for (const e of index.entries) {
+      if (e.suite_hash) suites.set(e.suite_hash, (suites.get(e.suite_hash) ?? 0) + 1)
+    }
+    return [...suites.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([hash]) => hash)
+  }, [index])
+
+  const availableClients = useMemo(() => {
+    if (!index || !suiteHash) return []
+    const clients = new Set<string>()
+    for (const e of index.entries) {
+      if (e.suite_hash === suiteHash) clients.add(e.instance.client)
+    }
+    return [...clients].sort()
+  }, [index, suiteHash])
+
+  const availableMetadataKeys = useMemo(() => {
+    if (!index || !suiteHash) return new Map<string, Set<string>>()
+    const keys = new Map<string, Set<string>>()
+    for (const e of index.entries) {
+      if (e.suite_hash !== suiteHash) continue
+      if (!e.metadata) continue
+      for (const [k, v] of Object.entries(e.metadata)) {
+        if (k.startsWith('github.')) continue // skip reserved keys
+        let vals = keys.get(k)
+        if (!vals) {
+          vals = new Set()
+          keys.set(k, vals)
+        }
+        vals.add(v)
+      }
+    }
+    return keys
+  }, [index, suiteHash])
+
+  // ─── Table/chart controls ─────────────────────────────────────
+  const baselineIdx = Math.min(Math.max(parseInt(search.baseline ?? '0', 10) || 0, 0), Math.max(syntheticRuns.length - 1, 0))
+  const tableBaseline: 'best' | 'worst' | number = search.tableBase === 'worst'
+    ? 'worst'
+    : search.tableBase !== undefined && search.tableBase !== 'best'
+      ? Math.min(parseInt(search.tableBase, 10) || 0, syntheticRuns.length - 1)
+      : 'best'
+  const [sharedZoom, setSharedZoom] = useState(true)
+  const [chartZoom, setChartZoom] = useState({ start: 0, end: 100 })
+  const tableSortBy = (search.sort ?? 'order') as 'order' | 'name' | 'gasUsed' | 'avgValue' | `run-${number}`
+  const tableSortDir = (search.sortDir === 'desc' ? 'desc' : 'asc') as 'asc' | 'desc'
+  const testFilter = search.filter ?? ''
+  const testNameFilter = useMemo(() => {
+    if (!testFilter) return undefined
+    const q = testFilter.toLowerCase()
+    return (name: string) => name.toLowerCase().includes(q)
+  }, [testFilter])
+
+  const hasResults = syntheticRuns.length >= 2 && syntheticRuns.every((r) => r.result !== null)
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Breadcrumb */}
+      <div className="flex min-w-0 items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400">
+        <Link to="/runs" className="shrink-0 hover:text-gray-700 dark:hover:text-gray-300">
+          Runs
+        </Link>
+        <span>/</span>
+        {suiteHash && suite && (
+          <>
+            <Link
+              to="/suites/$suiteHash"
+              params={{ suiteHash }}
+              className="flex min-w-0 items-center gap-1.5 hover:text-gray-700 dark:hover:text-gray-300"
+            >
+              <JDenticon value={suiteHash} size={16} className="shrink-0 rounded-xs" />
+              <span className="truncate">{suite?.metadata?.labels?.name ?? suiteHash}</span>
+            </Link>
+            <span>/</span>
+          </>
+        )}
+        <span className="shrink-0 text-gray-900 dark:text-gray-100">Group Compare</span>
+      </div>
+
+      {/* Group Builder */}
+      <GroupBuilder
+        availableSuites={availableSuites}
+        selectedSuite={suiteHash}
+        onSuiteChange={setSuiteHash}
+        suiteName={suite?.metadata?.labels?.name}
+        groups={groups}
+        onGroupsChange={setGroups}
+        availableClients={availableClients}
+        availableMetadataKeys={availableMetadataKeys}
+        sampleSize={sampleSize}
+        onSampleSizeChange={setSampleSize}
+        aggMode={aggMode}
+        onAggModeChange={setAggMode}
+        groupRunCounts={groupRuns.map((ids) => ids.length)}
+      />
+
+      {isLoading && allRunIds.length > 0 && (
+        <LoadingState message={`Loading results for ${allRunIds.length} runs across ${groups.length} groups...`} />
+      )}
+
+      {/* Comparison results */}
+      {hasResults && (
+        <>
+          <div className="flex flex-wrap items-center gap-4 text-xs/5 text-gray-500 dark:text-gray-400">
+            <div className="flex items-center gap-1.5">
+              <span>Aggregation:</span>
+              {(['avg', 'median'] as const).map((m) => (
+                <button
+                  key={m}
+                  onClick={() => setAggMode(m)}
+                  className={clsx(
+                    'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                    aggMode === m
+                      ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                  )}
+                >
+                  {m === 'avg' ? 'Average' : 'Median'}
+                </button>
+              ))}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span>Shared Zoom:</span>
+              <button
+                onClick={() => setSharedZoom(!sharedZoom)}
+                className={clsx(
+                  'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
+                  sharedZoom
+                    ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                )}
+              >
+                {sharedZoom ? 'On' : 'Off'}
+              </button>
+            </div>
+          </div>
+
+          <MetricsComparison
+            runs={syntheticRuns}
+            stepFilter={stepFilter}
+            baselineIdx={baselineIdx}
+            onBaselineChange={(idx) => updateSearch({ baseline: idx > 0 ? String(idx) : undefined })}
+            labelMode="instance-id" // shows the group label we set
+            testNameFilter={testNameFilter}
+          />
+
+          <MGasComparisonChart
+            runs={syntheticRuns}
+            suiteTests={suite?.tests}
+            stepFilter={stepFilter}
+            labelMode="instance-id"
+            testNameFilter={testNameFilter}
+            zoomRange={sharedZoom ? chartZoom : undefined}
+            onZoomChange={sharedZoom ? setChartZoom : undefined}
+            chartType="line"
+          />
+
+          <PercentageDiffChart
+            runs={syntheticRuns}
+            suiteTests={suite?.tests}
+            stepFilter={stepFilter}
+            baselineIdx={baselineIdx}
+            onBaselineChange={(idx) => updateSearch({ baseline: idx > 0 ? String(idx) : undefined })}
+            labelMode="instance-id"
+            diffFilter="all"
+            onDiffFilterChange={() => {}}
+            testNameFilter={testNameFilter}
+            zoomRange={sharedZoom ? chartZoom : undefined}
+            onZoomChange={sharedZoom ? setChartZoom : undefined}
+            chartType="line"
+          />
+
+          <TestComparisonTable
+            runs={syntheticRuns}
+            suiteTests={suite?.tests}
+            stepFilter={stepFilter}
+            labelMode="instance-id"
+            tableBaseline={tableBaseline}
+            onTableBaselineChange={(val) => updateSearch({ tableBase: val === 'best' ? undefined : String(val) })}
+            sortBy={tableSortBy}
+            sortDir={tableSortDir}
+            onSortChange={(col, dir) => updateSearch({ sort: col === 'order' ? undefined : col, sortDir: dir === 'asc' ? undefined : dir })}
+            testNameFilter={testNameFilter}
+          />
+        </>
+      )}
+
+      {!isLoading && groups.length >= 2 && allRunIds.length > 0 && !hasResults && (
+        <div className="rounded-sm bg-yellow-50 p-4 text-sm/6 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300">
+          Not enough result data to compare. Make sure the selected runs have completed with results.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -18,6 +18,7 @@ import { ResourceComparisonCharts } from '@/components/compare/ResourceCompariso
 import { GroupBuilder } from '@/components/compare/GroupBuilder'
 import { type GroupDef, parseGroupsParam, encodeGroupsParam } from '@/components/compare/groupUtils'
 import { averageResults } from '@/utils/averageResults'
+import { TestDetailModal } from '@/components/compare/TestDetailModal'
 
 function parseStepFilter(param: string | undefined): StepTypeOption[] {
   if (!param) return DEFAULT_STEP_FILTER
@@ -325,6 +326,31 @@ export function CompareGroupsPage() {
 
   const hasResults = syntheticRuns.length >= 2 && syntheticRuns.every((r) => r.result !== null)
 
+  // ─── Test detail modal ─────────────────────────────────────────
+  const [selectedTest, setSelectedTest] = useState<string | null>(null)
+
+  // Per-group individual results (not averaged) for the detail modal.
+  const groupResultsForModal = useMemo(() => {
+    if (!selectedTest) return []
+    let offset = 0
+    return groups.map((_, gi) => {
+      const runIds = groupRuns[gi] ?? []
+      const results: RunResult[] = []
+      for (let ri = 0; ri < runIds.length; ri++) {
+        const r = resultQueries[offset + ri]?.data
+        if (r) results.push(r)
+      }
+      offset += runIds.length
+      return results
+    })
+  }, [selectedTest, groups, groupRuns, resultQueries])
+
+  const groupTimestampsForModal = useMemo(() => {
+    return groupMatchedEntries.map((entries) =>
+      entries.slice(0, sampleSize).map((e) => e.timestamp),
+    )
+  }, [groupMatchedEntries, sampleSize])
+
   return (
     <div className="flex flex-col gap-6">
       {/* Breadcrumb */}
@@ -550,6 +576,7 @@ export function CompareGroupsPage() {
             sortDir={tableSortDir}
             onSortChange={(col, dir) => updateSearch({ sort: col === 'order' ? undefined : col, sortDir: dir === 'asc' ? undefined : dir })}
             testNameFilter={testNameFilter}
+            onTestClick={setSelectedTest}
           />
         </>
       )}
@@ -558,6 +585,21 @@ export function CompareGroupsPage() {
         <div className="rounded-sm bg-yellow-50 p-4 text-sm/6 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300">
           Not enough result data to compare. Make sure the selected runs have completed with results.
         </div>
+      )}
+
+      {/* Test detail modal — shows per-run breakdown for a single test */}
+      {selectedTest && (
+        <TestDetailModal
+          testName={selectedTest}
+          testOrder={suite?.tests ? suite.tests.findIndex((t) => t.name === selectedTest) + 1 : undefined}
+          groups={groups}
+          groupResults={groupResultsForModal}
+          groupTimestamps={groupTimestampsForModal}
+          groupRunIds={groupRuns}
+          stepFilter={stepFilter}
+          sampleSize={sampleSize}
+          onClose={() => setSelectedTest(null)}
+        />
       )}
     </div>
   )

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -9,6 +9,7 @@ import { LoginPage } from '@/pages/LoginPage'
 import { AdminPage } from '@/pages/AdminPage'
 import { ApiKeysPage } from '@/pages/ApiKeysPage'
 import { ComparePage } from '@/pages/ComparePage'
+import { CompareGroupsPage } from '@/pages/CompareGroupsPage'
 import { ApiDocsPage } from '@/pages/ApiDocsPage'
 import { QueryBuilderPage } from '@/pages/QueryBuilderPage'
 
@@ -78,6 +79,12 @@ const compareRoute = createRoute({
   component: ComparePage,
 })
 
+const compareGroupsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/compare/groups',
+  component: CompareGroupsPage,
+})
+
 const apiDocsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/api-docs',
@@ -101,6 +108,7 @@ const routeTree = rootRoute.addChildren([
   adminRoute,
   apiKeysRoute,
   compareRoute,
+  compareGroupsRoute,
   apiDocsRoute,
   queryRoute,
 ])

--- a/ui/src/utils/averageResults.ts
+++ b/ui/src/utils/averageResults.ts
@@ -1,0 +1,138 @@
+import type { RunResult, AggregatedStats, TestEntry } from '@/api/types'
+import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
+
+export interface AveragedResult {
+  result: RunResult
+  // Per-test variance on MGas/s for error-bar display.
+  variance: Record<string, { mgasStddev: number; mgasMin: number; mgasMax: number }>
+}
+
+/**
+ * averageResults takes N RunResult objects and produces one synthetic
+ * RunResult where each test's aggregated stats are the average (or
+ * median) across the N runs. Tests that don't appear in all N runs
+ * are still included — their average is taken over however many runs
+ * contained them.
+ */
+export function averageResults(
+  results: RunResult[],
+  stepFilter: StepTypeOption[],
+  mode: 'avg' | 'median',
+): AveragedResult {
+  if (results.length === 0) {
+    return { result: { tests: {} }, variance: {} }
+  }
+
+  if (results.length === 1) {
+    return { result: results[0], variance: {} }
+  }
+
+  // Gather per-test samples.
+  const testSamples = new Map<
+    string,
+    {
+      gasUsedTotal: number[]
+      gasUsedTimeTotal: number[]
+      timeTotal: number[]
+      success: number[]
+      fail: number[]
+      msgCount: number[]
+    }
+  >()
+
+  for (const result of results) {
+    for (const [name, entry] of Object.entries(result.tests)) {
+      const stats = getAggregatedStats(entry, stepFilter)
+      if (!stats) continue
+
+      let samples = testSamples.get(name)
+      if (!samples) {
+        samples = {
+          gasUsedTotal: [],
+          gasUsedTimeTotal: [],
+          timeTotal: [],
+          success: [],
+          fail: [],
+          msgCount: [],
+        }
+        testSamples.set(name, samples)
+      }
+
+      samples.gasUsedTotal.push(stats.gas_used_total)
+      samples.gasUsedTimeTotal.push(stats.gas_used_time_total)
+      samples.timeTotal.push(stats.time_total)
+      samples.success.push(stats.success)
+      samples.fail.push(stats.fail)
+      samples.msgCount.push(stats.msg_count)
+    }
+  }
+
+  // Compute aggregates.
+  const agg = mode === 'avg' ? mean : median
+  const syntheticTests: Record<string, TestEntry> = {}
+  const variance: AveragedResult['variance'] = {}
+
+  for (const [name, samples] of testSamples) {
+    const gasUsedTotal = agg(samples.gasUsedTotal)
+    const gasUsedTimeTotal = agg(samples.gasUsedTimeTotal)
+
+    const aggregated: AggregatedStats = {
+      gas_used_total: gasUsedTotal,
+      gas_used_time_total: gasUsedTimeTotal,
+      time_total: agg(samples.timeTotal),
+      success: Math.round(agg(samples.success)),
+      fail: Math.round(agg(samples.fail)),
+      msg_count: Math.round(agg(samples.msgCount)),
+      method_stats: { times: {}, mgas_s: {} },
+    }
+
+    // Build the TestEntry with the active step populated.
+    // The comparison components read via getAggregatedStats which
+    // iterates the step keys from the filter, so we put the averaged
+    // data under the first step in the filter (usually "test").
+    const stepKey = stepFilter[0] ?? 'test'
+    syntheticTests[name] = {
+      dir: '',
+      steps: {
+        [stepKey]: { aggregated },
+      },
+    }
+
+    // Compute MGas/s variance for error bars.
+    const mgasValues = samples.gasUsedTimeTotal.map((t, i) =>
+      t > 0 ? (samples.gasUsedTotal[i] * 1000) / t : 0,
+    )
+    const mgasAvg = mean(mgasValues)
+    const mgasStddev = stddev(mgasValues, mgasAvg)
+    variance[name] = {
+      mgasStddev,
+      mgasMin: Math.min(...mgasValues),
+      mgasMax: Math.max(...mgasValues),
+    }
+  }
+
+  return {
+    result: { tests: syntheticTests },
+    variance,
+  }
+}
+
+// ── Stats helpers ────────────────────────────────────────────────
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0
+  return values.reduce((a, b) => a + b, 0) / values.length
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+function stddev(values: number[], avg: number): number {
+  if (values.length < 2) return 0
+  const sumSq = values.reduce((sum, v) => sum + (v - avg) ** 2, 0)
+  return Math.sqrt(sumSq / (values.length - 1))
+}

--- a/ui/src/utils/averageResults.ts
+++ b/ui/src/utils/averageResults.ts
@@ -1,4 +1,4 @@
-import type { RunResult, AggregatedStats, TestEntry } from '@/api/types'
+import type { RunResult, AggregatedStats, TestEntry, ResourceTotals } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 
 export interface AveragedResult {
@@ -37,6 +37,13 @@ export function averageResults(
       success: number[]
       fail: number[]
       msgCount: number[]
+      cpuUsec: number[]
+      memoryDeltaBytes: number[]
+      memoryBytes: number[]
+      diskReadBytes: number[]
+      diskWriteBytes: number[]
+      diskReadIops: number[]
+      diskWriteIops: number[]
     }
   >()
 
@@ -54,6 +61,13 @@ export function averageResults(
           success: [],
           fail: [],
           msgCount: [],
+          cpuUsec: [],
+          memoryDeltaBytes: [],
+          memoryBytes: [],
+          diskReadBytes: [],
+          diskWriteBytes: [],
+          diskReadIops: [],
+          diskWriteIops: [],
         }
         testSamples.set(name, samples)
       }
@@ -64,6 +78,23 @@ export function averageResults(
       samples.success.push(stats.success)
       samples.fail.push(stats.fail)
       samples.msgCount.push(stats.msg_count)
+
+      // getAggregatedStats doesn't include resource_totals in its
+      // return value, so read it directly from the step entries.
+      for (const stepKey of stepFilter) {
+        const step = entry.steps?.[stepKey]
+        const r = step?.aggregated?.resource_totals
+        if (r) {
+          samples.cpuUsec.push(r.cpu_usec ?? 0)
+          samples.memoryDeltaBytes.push(r.memory_delta_bytes ?? 0)
+          samples.memoryBytes.push(r.memory_bytes ?? 0)
+          samples.diskReadBytes.push(r.disk_read_bytes ?? 0)
+          samples.diskWriteBytes.push(r.disk_write_bytes ?? 0)
+          samples.diskReadIops.push(r.disk_read_iops ?? 0)
+          samples.diskWriteIops.push(r.disk_write_iops ?? 0)
+          break // one step's resource data per test is enough
+        }
+      }
     }
   }
 
@@ -76,6 +107,20 @@ export function averageResults(
     const gasUsedTotal = agg(samples.gasUsedTotal)
     const gasUsedTimeTotal = agg(samples.gasUsedTimeTotal)
 
+    // Build resource_totals if we have samples for it.
+    let resource_totals: ResourceTotals | undefined
+    if (samples.cpuUsec.length > 0) {
+      resource_totals = {
+        cpu_usec: agg(samples.cpuUsec),
+        memory_delta_bytes: agg(samples.memoryDeltaBytes),
+        memory_bytes: agg(samples.memoryBytes),
+        disk_read_bytes: agg(samples.diskReadBytes),
+        disk_write_bytes: agg(samples.diskWriteBytes),
+        disk_read_iops: agg(samples.diskReadIops),
+        disk_write_iops: agg(samples.diskWriteIops),
+      }
+    }
+
     const aggregated: AggregatedStats = {
       gas_used_total: gasUsedTotal,
       gas_used_time_total: gasUsedTimeTotal,
@@ -84,6 +129,7 @@ export function averageResults(
       fail: Math.round(agg(samples.fail)),
       msg_count: Math.round(agg(samples.msgCount)),
       method_stats: { times: {}, mgas_s: {} },
+      resource_totals,
     }
 
     // Build the TestEntry with the active step populated.


### PR DESCRIPTION
## Summary

New page at `/compare/groups` that compares **averages (or medians) across multiple runs** of the same type, reducing single-run noise. Users define groups by criteria (client + metadata labels), and the system samples the latest N runs per group, computes per-test averages, and renders the comparison using the same chart/table components as the regular compare page.

### Group builder
- Suite picker with jdenticon
- Group cards with client dropdown, metadata filter pills (add/remove key=value pairs), and run-count badge
- Colored run boxes (like suite detail "Recent Runs by Client") showing matched runs — boxes within the sample size are full opacity, beyond are dimmed. Hover shows tooltip with timestamp, duration, MGas/s, pass/fail counts. Click opens run detail in new tab.
- Per-group aggregate stats: Mean (bold), Min, Max, P95, P99 MGas/s
- Sample size control (1–20, default 5)
- Avg / Median toggle

### Comparison views
- All existing comparison components work unchanged with synthetic averaged data:
  - MetricsComparison cards (filter-aware)
  - MGas/s chart
  - Percentage diff chart
  - Resource usage charts (CPU, memory, disk I/O)
  - Test comparison table (with Gas column, sortable)
- Chart type selector (Line/Bar/Dot)
- Shared zoom toggle
- Text filter with regex toggle
- Gas bucket multi-select chips (30M steps)
- Sticky top bar with group badges + filters (appears on scroll)

### Test detail modal
- Click any table row → modal with per-run breakdown for that test
- Per-group: dot chart (one dot per run's MGas/s), Min/Max/Range/CV stats
- Per-run table with sortable columns (timestamp, MGas/s, Gas Used, Duration)
- Rows link to run detail page with `?testModal=` deep link (new tab)
- Tables collapsed by default, expandable per group
- Test name wraps on long names + copy button

### URL state
Fully shareable: `?suite=&groups=geth:bal_mode=full;reth:&sample=5&agg=avg&chart=line&filter=&gasBuckets=30,60`

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] Manual: navigate to `/compare/groups`; select a suite; define 2+ groups; verify charts render with averaged data
- [x] Manual: change sample size / toggle avg↔median; verify values update
- [x] Manual: add metadata filters; verify run count + averages change
- [x] Manual: hover run boxes; verify tooltip with duration/MGas/s; click opens run detail
- [x] Manual: click a table row; verify modal with per-run breakdown; click row in modal opens run detail
- [x] Manual: use text filter + gas bucket chips; verify all components (cards, charts, table) respect the filter
- [x] Manual: scroll down; verify sticky bar appears with group badges + filters
- [x] Manual: share the URL; verify it loads the same comparison on a fresh page