### PR TITLE
feat: log and surface benchmarkoor version

### DIFF
--- a/cmd/benchmarkoor/main.go
+++ b/cmd/benchmarkoor/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	versionpkg "github.com/ethpandaops/benchmarkoor/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -84,7 +85,9 @@ func (f *consistentFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 var (
-	// Version information set at build time.
+	// Version information set at build time via ldflags.
+	// These are copied into pkg/version at init so other packages
+	// can access them (e.g. the runner logs them to benchmarkoor.log).
 	version = "dev"
 	commit  = "none"
 	date    = "unknown"
@@ -97,6 +100,12 @@ var (
 )
 
 func main() {
+	// Publish build-time version info to the shared package so other
+	// packages (runner, API) can access it.
+	versionpkg.Version = version
+	versionpkg.Commit = commit
+	versionpkg.Date = date
+
 	log = logrus.New()
 	log.SetOutput(os.Stdout)
 	log.SetFormatter(&utcFormatter{

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethpandaops/benchmarkoor/pkg/executor"
 	"github.com/ethpandaops/benchmarkoor/pkg/fsutil"
 	"github.com/ethpandaops/benchmarkoor/pkg/podman"
+	"github.com/ethpandaops/benchmarkoor/pkg/version"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/shirou/gopsutil/v4/mem"
@@ -561,8 +562,9 @@ func (r *runner) runContainerLifecycle(
 
 	// Write run configuration with resolved values.
 	runConfig := &RunConfig{
-		Timestamp: params.RunTimestamp,
-		System:    getSystemInfo(),
+		BenchmarkoorVersion: version.Version,
+		Timestamp:           params.RunTimestamp,
+		System:              getSystemInfo(),
 		Instance: &ResolvedInstance{
 			ID:     instance.ID,
 			Client: instance.Client,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethpandaops/benchmarkoor/pkg/fsutil"
 	"github.com/ethpandaops/benchmarkoor/pkg/livereport"
 	"github.com/ethpandaops/benchmarkoor/pkg/upload"
+	"github.com/ethpandaops/benchmarkoor/pkg/version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -81,6 +82,7 @@ type StartBlock struct {
 
 // RunConfig contains configuration for a single test run.
 type RunConfig struct {
+	BenchmarkoorVersion            string                 `json:"benchmarkoor_version,omitempty"`
 	Timestamp                      int64                  `json:"timestamp"`
 	TimestampEnd                   int64                  `json:"timestamp_end,omitempty"`
 	SuiteHash                      string                 `json:"suite_hash,omitempty"`
@@ -542,6 +544,18 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 	r.logger.AddHook(logHook)
 	defer r.removeHook(logHook)
 
+	// Log version as the very first line in benchmarkoor.log — before
+	// pre-run buffer flush so it's always the first thing you see.
+	r.log.WithFields(logrus.Fields{
+		"version": version.Version,
+		"commit":  version.Commit,
+	}).Info("Starting benchmarkoor run")
+
+	log := r.log.WithFields(logrus.Fields{
+		"instance": instance.ID,
+		"run_id":   runID,
+	})
+
 	// Flush any pre-instance logs (config validation, cleanup, image pulls,
 	// etc.) that were buffered before RunInstance was called.
 	if r.preRunLogBuffer != nil {
@@ -549,12 +563,6 @@ func (r *runner) RunInstance(ctx context.Context, instance *config.ClientInstanc
 			return fmt.Errorf("flushing pre-run logs: %w", err)
 		}
 	}
-
-	log := r.log.WithFields(logrus.Fields{
-		"instance": instance.ID,
-		"run_id":   runID,
-	})
-	log.Info("Starting client instance")
 
 	// Reset the executor's live progress counters and seed the total with
 	// the full prepared test count. Strategies that call ExecuteTests once

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,11 @@
+// Package version holds build-time version information set via ldflags
+// in main. Shared across packages so the runner can log it to
+// benchmarkoor.log alongside the rest of the run output.
+package version
+
+// Set at build time via -ldflags in the main package.
+var (
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -167,6 +167,7 @@ export interface StartBlock {
 
 // config.json per run
 export interface RunConfig {
+  benchmarkoor_version?: string
   timestamp: number
   timestamp_end?: number
   suite_hash?: string

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -275,6 +275,7 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
           system={cfg.system}
           startBlock={cfg.start_block}
           metadata={cfg.metadata}
+          benchmarkoorVersion={cfg.benchmarkoor_version}
         />
       )}
 

--- a/ui/src/components/run-detail/RunConfiguration.tsx
+++ b/ui/src/components/run-detail/RunConfiguration.tsx
@@ -11,6 +11,7 @@ interface RunConfigurationProps {
   metadata?: {
     labels?: Record<string, string>
   }
+  benchmarkoorVersion?: string
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -45,7 +46,7 @@ function InfoItem({ label, value }: { label: string; value: string | number }) {
   )
 }
 
-export function RunConfiguration({ instance, system, startBlock, metadata }: RunConfigurationProps) {
+export function RunConfiguration({ instance, system, startBlock, metadata, benchmarkoorVersion }: RunConfigurationProps) {
   const [expanded, setExpanded] = useState(false)
 
   const shortImage = instance.image.includes('/') ? instance.image.split('/').pop()! : instance.image
@@ -61,7 +62,7 @@ export function RunConfiguration({ instance, system, startBlock, metadata }: Run
           Configuration
         </h3>
         <div className="flex min-w-0 items-center gap-3">
-          <span className="flex min-w-0 items-center gap-1.5 truncate text-xs/5">
+          <span className="flex min-w-0 flex-wrap items-center gap-1.5 text-xs/5">
             <span className="text-gray-400 dark:text-gray-500">Image:</span>
             <span className="text-gray-600 dark:text-gray-300">{shortImage}</span>
             {instance.client_version && (
@@ -118,6 +119,18 @@ export function RunConfiguration({ instance, system, startBlock, metadata }: Run
                       {instance.client_version}
                     </span>
                     <CopyButton text={instance.client_version} />
+                  </dd>
+                </div>
+              )}
+
+              {benchmarkoorVersion && (
+                <div>
+                  <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Benchmarkoor Version</dt>
+                  <dd className="mt-1 flex items-center gap-2">
+                    <span className="font-mono text-sm/6 text-gray-900 dark:text-gray-100">
+                      {benchmarkoorVersion}
+                    </span>
+                    <CopyButton text={benchmarkoorVersion} />
                   </dd>
                 </div>
               )}

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -635,7 +635,7 @@ export function RunDetailPage() {
 
       <GitHubSection labels={config.metadata?.labels} />
 
-      <RunConfiguration instance={config.instance} system={config.system} startBlock={config.start_block} metadata={config.metadata} />
+      <RunConfiguration instance={config.instance} system={config.system} startBlock={config.start_block} metadata={config.metadata} benchmarkoorVersion={config.benchmarkoor_version} />
 
       <FilesPanel
         runId={runId}


### PR DESCRIPTION
## Summary

Adds version visibility across the stack:

- **Shared version package** (`pkg/version`): exported `Version`, `Commit`, `Date` vars set from ldflags in main, accessible by any package.
- **First line in benchmarkoor.log**: version+commit logged immediately after the log file hook is attached (before pre-run buffer flush) so it's always the first thing visible.
- **config.json output**: new `benchmarkoor_version` field as the first key in the output config.json.
- **UI**: renders "Benchmarkoor Version" in the Configuration section's expanded view (after Client Version) with a copy button. Shown on both the run detail page and the live view.

## Test plan

- [x] `go build -tags exclude_graphdriver_btrfs ./...` clean
- [x] `npx tsc --noEmit` clean
- [x] Manual: run a benchmark; check benchmarkoor.log starts with "Starting benchmarkoor run version=dev commit=none"
- [x] Manual: check the output config.json has `"benchmarkoor_version": "dev"` as the first field
- [x] Manual: open a run detail page in the UI; expand Configuration; verify "Benchmarkoor Version" appears after "Client Version"