### PR TITLE
feat(ui): group compare buttons on suite detail page

### DIFF
--- a/ui/src/components/suite-detail/RunsHeatmap.tsx
+++ b/ui/src/components/suite-detail/RunsHeatmap.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import clsx from 'clsx'
-import { AlertTriangle, GitCompareArrows } from 'lucide-react'
+import { AlertTriangle, GitCompareArrows, Layers } from 'lucide-react'
 import { type IndexEntry, type IndexStepType, getIndexAggregatedStats, ALL_INDEX_STEP_TYPES } from '@/api/types'
 import { formatTimestamp } from '@/utils/date'
 import { ClientBadge } from '@/components/shared/ClientBadge'
@@ -100,6 +100,10 @@ interface RunsHeatmapProps {
   onCompareGroup?: (runs: IndexEntry[]) => void
   /** Called with a client name to compare its latest successful run across all groups. */
   onCompareClientAcrossGroups?: (client: string) => void
+  /** Called with the group label + clients to open the averaged group comparison page. */
+  onGroupCompareGroup?: (groupLabel: string, clients: string[]) => void
+  /** Called with a client name to open the averaged group comparison across label groups. */
+  onGroupCompareClientAcrossGroups?: (client: string) => void
   isDark: boolean
   colorNormalization?: ColorNormalization
   onColorNormalizationChange?: (mode: ColorNormalization) => void
@@ -132,6 +136,8 @@ export function RunsHeatmap({
   groupBy,
   onCompareGroup,
   onCompareClientAcrossGroups,
+  onGroupCompareGroup,
+  onGroupCompareClientAcrossGroups,
   isDark,
   colorNormalization = 'suite',
   onColorNormalizationChange,
@@ -474,6 +480,15 @@ export function RunsHeatmap({
                   <GitCompareArrows className="size-3.5" />
                 </button>
               )}
+              {onGroupCompareGroup && (
+                <button
+                  onClick={() => onGroupCompareGroup(section.label, section.clients)}
+                  className="flex shrink-0 cursor-pointer items-center justify-center rounded-xs p-1 shadow-xs ring-1 ring-inset transition-colors bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                  title="Compare averaged groups for clients in this group"
+                >
+                  <Layers className="size-3.5" />
+                </button>
+              )}
               <div className="h-px grow bg-gray-200 dark:bg-gray-700" />
             </div>
           )}
@@ -481,7 +496,7 @@ export function RunsHeatmap({
             {/* Stats header */}
             {sectionIdx === 0 && (
               <div className="flex items-center gap-2 sm:gap-3">
-                <div className={clsx('hidden shrink-0 sm:block', onCompareClientAcrossGroups && groupSections ? 'w-32' : 'w-28')} />
+                <div className={clsx('hidden shrink-0 sm:block', onGroupCompareClientAcrossGroups && groupSections ? 'w-38' : onCompareClientAcrossGroups && groupSections ? 'w-32' : 'w-28')} />
                 <div className="flex-1" />
                 <div className="hidden shrink-0 gap-3 border-l border-transparent pl-3 font-mono text-xs/5 font-medium text-gray-400 md:flex dark:text-gray-500">
                   <span className="w-10 text-center">Min</span>
@@ -503,7 +518,7 @@ export function RunsHeatmap({
               }
               return (
                 <div key={`${section.label}-${client}`} className="flex items-center gap-2 sm:gap-3">
-                  <div className={clsx('flex shrink-0 items-center gap-1', onCompareClientAcrossGroups && groupSections ? 'sm:w-32' : 'sm:w-28')}>
+                  <div className={clsx('flex shrink-0 items-center gap-1', onGroupCompareClientAcrossGroups && groupSections ? 'sm:w-38' : onCompareClientAcrossGroups && groupSections ? 'sm:w-32' : 'sm:w-28')}>
                     <span className="sm:hidden">
                       <ClientBadge client={client} hideLabel />
                     </span>
@@ -514,9 +529,18 @@ export function RunsHeatmap({
                       <button
                         onClick={() => onCompareClientAcrossGroups(client)}
                         className="flex shrink-0 items-center justify-center rounded-xs p-0.5 text-gray-400 transition-colors hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
-                        title={`Compare ${client} across groups`}
+                        title={`Compare latest successful ${client} run across groups`}
                       >
                         <GitCompareArrows className="size-3" />
+                      </button>
+                    )}
+                    {onGroupCompareClientAcrossGroups && groupSections && (
+                      <button
+                        onClick={() => onGroupCompareClientAcrossGroups(client)}
+                        className="flex shrink-0 items-center justify-center rounded-xs p-0.5 text-gray-400 transition-colors hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
+                        title={`Compare ${client} averaged across groups (group comparison)`}
+                      >
+                        <Layers className="size-3" />
                       </button>
                     )}
                   </div>

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState, useEffect, useRef } from 'react'
 import { Link, useParams, useNavigate, useSearch } from '@tanstack/react-router'
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
 import clsx from 'clsx'
-import { ChevronRight, SquareStack, GitCompareArrows, LayoutGrid, Clock, Grid3X3, Trash2, Plus, X } from 'lucide-react'
+import { ChevronRight, SquareStack, GitCompareArrows, Layers, LayoutGrid, Clock, Grid3X3, Trash2, Plus, X } from 'lucide-react'
 import { type IndexEntry, type IndexStepType, ALL_INDEX_STEP_TYPES, DEFAULT_INDEX_STEP_FILTER, type SuiteTest } from '@/api/types'
 import { useSuite } from '@/api/hooks/useSuite'
 import { useSuiteStats } from '@/api/hooks/useSuiteStats'
@@ -508,6 +508,13 @@ export function SuiteDetailPage() {
     const clientSet = new Set(suiteRunsAll.map((e) => e.instance.client))
     return Array.from(clientSet).sort()
   }, [suiteRunsAll])
+
+  // Group compare URL: pre-fills suite + one group per client.
+  const groupCompareUrl = useMemo(() => {
+    if (clients.length < 2) return undefined
+    const groups = clients.map((c) => `${c}:`).join(';')
+    return `/compare/groups?suite=${encodeURIComponent(suiteHash)}&groups=${encodeURIComponent(groups)}`
+  }, [clients, suiteHash])
 
   // Most recent successful run per client, for quick cross-client comparison.
   const recentSuccessfulPerClient = useMemo(() => {
@@ -1024,6 +1031,15 @@ export function SuiteDetailPage() {
                       >
                         <GitCompareArrows className="size-3.5" />
                       </button>
+                      {groupCompareUrl && (
+                        <a
+                          href={groupCompareUrl}
+                          className="flex items-center justify-center rounded-xs p-1 shadow-xs ring-1 ring-inset transition-colors bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                          title="Compare averaged groups (one group per client)"
+                        >
+                          <Layers className="size-3.5" />
+                        </a>
+                      )}
                     </div>
                   </div>
                   {heatmapExpanded && (
@@ -1074,6 +1090,27 @@ export function SuiteDetailPage() {
                             const labels = groupBy === 'instance_id' ? 'instance-id' : `label:${groupBy}`
                             navigate({ to: '/compare', search: { runs: ids.join(','), labels } })
                           }
+                        } : undefined}
+                        onGroupCompareGroup={groupBy ? (groupLabel, groupClients) => {
+                          const labelFilter = groupBy !== 'instance_id' ? `${groupBy}=${groupLabel}` : ''
+                          const groups = groupClients.map((c) => `${c}:${labelFilter}`).join(';')
+                          navigate({ to: '/compare/groups', search: { suite: suiteHash, groups } as Record<string, string> })
+                        } : undefined}
+                        onGroupCompareClientAcrossGroups={groupBy ? (client) => {
+                          // Build one group per label-value for this client.
+                          const labelValues = new Set<string>()
+                          for (const run of suiteRunsAll) {
+                            if (run.instance.client !== client) continue
+                            const val = groupBy === 'instance_id'
+                              ? run.instance.id
+                              : (run.metadata?.[groupBy] ?? '')
+                            if (val) labelValues.add(val)
+                          }
+                          const groups = [...labelValues].sort().map((val) => {
+                            if (groupBy === 'instance_id') return `${client}:`
+                            return `${client}:${groupBy}=${val}`
+                          }).join(';')
+                          navigate({ to: '/compare/groups', search: { suite: suiteHash, groups } as Record<string, string> })
                         } : undefined}
                         isDark={isDark}
                         colorNormalization={heatmapColor}
@@ -1257,6 +1294,15 @@ export function SuiteDetailPage() {
                         >
                           <GitCompareArrows className="size-4" />
                         </button>
+                        {groupCompareUrl && (
+                          <a
+                            href={groupCompareUrl}
+                            className="flex items-center justify-center rounded-xs p-1.5 shadow-xs ring-1 ring-inset transition-colors bg-white text-gray-500 ring-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                            title="Compare averaged groups (one group per client)"
+                          >
+                            <Layers className="size-4" />
+                          </a>
+                        )}
                         {isAdmin && (
                           <button
                             onClick={() => deleteMode ? handleExitDeleteMode() : handleEnterDeleteMode()}


### PR DESCRIPTION
## Summary

Adds Layers icon buttons on the suite detail page that navigate to the group compare page (\`/compare/groups\`) with suite + groups pre-filled:

- **Top-level** (next to existing compare buttons): one group per client in the suite. Only visible when 2+ clients exist.
- **Per-group header** (when grouped by a label): one group per client scoped to that label value (e.g. \`geth:bal_mode=full;reth:bal_mode=full\`).
- **Per-client row** (when grouped by a label): one group per label-value for that client (e.g. \`geth:bal_mode=full;geth:bal_mode=sequential\`) so you can compare the same client across label variants.

Also renames the existing per-client GitCompareArrows tooltip to "Compare latest successful X run across groups" for clarity.

## Test plan

- [x] Manual: open a suite with 2+ clients; verify the Layers button appears next to the existing compare buttons; click it and verify it navigates to \`/compare/groups\` with suite + one group per client pre-filled
- [x] Manual: group by a label; verify Layers buttons appear on group headers and per-client rows; click each and verify the URL has correct label filters
- [x] Manual: hover each button; verify tooltips are clear and distinct