### PR TITLE
fix: add 2s settle delay before graceful container stop

### DIFF
--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -312,6 +312,18 @@ func (m *manager) StopContainer(ctx context.Context, containerID string, timeout
 		opts = new(containers.StopOptions).WithTimeout(t)
 	}
 
+	var timeoutVal uint
+	if timeoutSec != nil {
+		timeoutVal = uint(*timeoutSec)
+	} else {
+		timeoutVal = uint(docker.DefaultStopTimeoutSec)
+	}
+
+	m.log.WithFields(logrus.Fields{
+		"id":      containerID[:12],
+		"timeout": timeoutVal,
+	}).Info("Stopping container with SIGTERM")
+
 	if err := containers.Stop(conn, containerID, opts); err != nil {
 		return fmt.Errorf("stopping container %s: %w", containerID[:12], err)
 	}

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -101,8 +101,16 @@ func (r *runner) runTestsWithContainerStrategy(
 			)
 		}
 
+		// Brief settle time so the client finishes any in-flight
+		// initialisation before we send SIGTERM.
+		log.Info("Waiting 2s for client to settle before stop")
+		time.Sleep(2 * time.Second)
+
 		// Stop the initial container so writes are flushed to disk.
-		log.Info("Stopping container for ZFS snapshot")
+		// Use the default 60s SIGTERM grace period so the client has
+		// time to persist its state cleanly before the ZFS snapshot.
+		log.WithField("timeout", fmt.Sprintf("%ds", docker.DefaultStopTimeoutSec)).
+			Info("Stopping container for ZFS snapshot (graceful)")
 
 		stopStart := time.Now()
 


### PR DESCRIPTION
## Summary
- Adds a 2s settle delay after pre-run steps complete and before sending SIGTERM to the container for ZFS snapshot. This fixes intermittent unclean shutdowns where geth missed the signal when sent immediately after initialization.
- Adds info-level logging of the stop timeout value in podman's `StopContainer` for better observability.
- Enhances the stop log message in `strategy_container.go` to show the timeout value.

## Test plan
- [x] Verified that the 2s delay resolves the flaky graceful shutdown issue
- [x] Confirm geth logs "Persisting dirty state" consistently on stop
- [x] Confirm no "wasn't cleanly shutdown" messages on restart