### PR TITLE
feat(ui): group comparison page improvements — CV chart, test modal selection, single group

### DIFF
--- a/ui/src/components/compare/CVComparisonChart.tsx
+++ b/ui/src/components/compare/CVComparisonChart.tsx
@@ -4,6 +4,7 @@ import { Activity } from 'lucide-react'
 import type { RunResult, SuiteTest } from '@/api/types'
 import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 import type { ZoomRange } from './MGasComparisonChart'
+import { useChartAreaClick } from './useChartAreaClick'
 
 interface CVComparisonChartProps {
   runs: CompareRun[]
@@ -15,6 +16,7 @@ interface CVComparisonChartProps {
   chartType?: ChartType
   /** Per-run variance keyed by CompareRun.index. */
   varianceByRunIndex: Map<number, Record<string, { mgasStddev: number; mgasMean: number }>>
+  onTestClick?: (testName: string) => void
 }
 
 function useDarkMode() {
@@ -65,7 +67,7 @@ function buildCVData(
   return entries.map((e, i) => ({ testIndex: i + 1, testOrder: e.order, testName: e.name, cv: e.cv }))
 }
 
-export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line', varianceByRunIndex }: CVComparisonChartProps) {
+export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line', varianceByRunIndex, onTestClick }: CVComparisonChartProps) {
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -96,6 +98,8 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
     () => runs.map((r) => r.result ? buildCVData(r.result, suiteTests, varianceByRunIndex.get(r.index), testNameFilter) : []),
     [runs, suiteTests, varianceByRunIndex, testNameFilter],
   )
+
+  const { highlightedTestRef, handleMouseDown, handleClick, cursor } = useChartAreaClick(onTestClick)
 
   const option = useMemo(() => {
     const textColor = isDark ? '#ffffff' : '#374151'
@@ -134,6 +138,7 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
           if (!params.length) return ''
           const testOrder = params[0].value[3]
           const testName = params[0].value[2]
+          highlightedTestRef.current = testName
           let content = `<strong>Test #${testOrder}</strong>`
           if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
           content += '<br/>'
@@ -230,6 +235,7 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
           name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
           data,
           itemStyle: { color: slot.color },
+          cursor: onTestClick ? 'pointer' : 'default',
           ...(markLine ? { markLine } : {}),
         }
         if (chartType === 'bar') {
@@ -249,7 +255,7 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
         }
       }),
     }
-  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, threshold])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, threshold, onTestClick, highlightedTestRef])
 
   if (pointsPerRun.every((p) => p.length === 0)) return null
 
@@ -290,12 +296,14 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
           })}
         </div>
       </div>
-      <ReactECharts
-        option={option}
-        style={{ height: '300px', width: '100%' }}
-        opts={{ renderer: 'svg' }}
-        onEvents={onEvents}
-      />
+      <div onMouseDown={handleMouseDown} onClick={handleClick} style={{ cursor }}>
+        <ReactECharts
+          option={option}
+          style={{ height: '300px', width: '100%' }}
+          opts={{ renderer: 'svg' }}
+          onEvents={onEvents}
+        />
+      </div>
       <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700">
         <table className="w-full text-xs/5">
           <thead>

--- a/ui/src/components/compare/CVComparisonChart.tsx
+++ b/ui/src/components/compare/CVComparisonChart.tsx
@@ -302,6 +302,7 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
           style={{ height: '300px', width: '100%' }}
           opts={{ renderer: 'svg' }}
           onEvents={onEvents}
+          notMerge
         />
       </div>
       <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700">

--- a/ui/src/components/compare/CVComparisonChart.tsx
+++ b/ui/src/components/compare/CVComparisonChart.tsx
@@ -70,6 +70,7 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
   const prevZoomRef = useRef(zoomRange)
+  const [threshold, setThreshold] = useState(20)
 
   const handleZoom = useCallback((params: { start?: number; end?: number; batch?: Array<{ start: number; end: number }> }) => {
     let start: number | undefined
@@ -206,10 +207,30 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
         const slot = RUN_SLOTS[i]
         const points = pointsPerRun[i]
         const data = points.map((d) => [d.testIndex, d.cv, d.testName, d.testOrder])
+        const markLine = i === 0
+          ? {
+              silent: true,
+              symbol: 'none' as const,
+              lineStyle: {
+                color: isDark ? '#ef4444' : '#dc2626',
+                type: 'dashed' as const,
+                width: 1.5,
+              },
+              label: {
+                show: true,
+                position: 'insideEndTop' as const,
+                formatter: `${threshold}%`,
+                color: isDark ? '#fca5a5' : '#b91c1c',
+                fontSize: 10,
+              },
+              data: [{ yAxis: threshold }],
+            }
+          : undefined
         const base = {
           name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
           data,
           itemStyle: { color: slot.color },
+          ...(markLine ? { markLine } : {}),
         }
         if (chartType === 'bar') {
           return { ...base, type: 'bar' as const, barMaxWidth: 6 }
@@ -228,13 +249,13 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
         }
       }),
     }
-  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, threshold])
 
   if (pointsPerRun.every((p) => p.length === 0)) return null
 
   return (
     <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
-      <div className="mb-2 flex items-center justify-between">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Activity className="size-4 text-gray-400 dark:text-gray-500" />
           <h3
@@ -244,7 +265,20 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
             Coefficient of Variation per Test (MGas/s)
           </h3>
         </div>
-        <div className="flex items-center gap-2 text-xs/5">
+        <div className="flex flex-wrap items-center gap-3 text-xs/5">
+          <label className="flex items-center gap-1.5 text-gray-500 dark:text-gray-400">
+            <span>Threshold:</span>
+            <input
+              type="range"
+              min={0}
+              max={50}
+              step={1}
+              value={threshold}
+              onChange={(e) => setThreshold(Number(e.target.value))}
+              className="w-24 accent-red-600 dark:accent-red-500"
+            />
+            <span className="w-8 font-mono tabular-nums text-gray-700 dark:text-gray-300">{threshold}%</span>
+          </label>
           {runs.map((run) => {
             const slot = RUN_SLOTS[run.index]
             return (

--- a/ui/src/components/compare/CVComparisonChart.tsx
+++ b/ui/src/components/compare/CVComparisonChart.tsx
@@ -1,0 +1,267 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import ReactECharts from 'echarts-for-react'
+import { Activity } from 'lucide-react'
+import type { RunResult, SuiteTest } from '@/api/types'
+import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
+import type { ZoomRange } from './MGasComparisonChart'
+
+interface CVComparisonChartProps {
+  runs: CompareRun[]
+  suiteTests?: SuiteTest[]
+  labelMode: LabelMode
+  testNameFilter?: (name: string) => boolean
+  zoomRange?: ZoomRange
+  onZoomChange?: (range: ZoomRange) => void
+  chartType?: ChartType
+  /** Per-run variance keyed by CompareRun.index. */
+  varianceByRunIndex: Map<number, Record<string, { mgasStddev: number; mgasMean: number }>>
+}
+
+function useDarkMode() {
+  const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'))
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains('dark'))
+    })
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  return isDark
+}
+
+interface CVDataPoint {
+  testIndex: number
+  testOrder: number
+  testName: string
+  cv: number
+}
+
+function buildCVData(
+  result: RunResult,
+  suiteTests: SuiteTest[] | undefined,
+  variance: Record<string, { mgasStddev: number; mgasMean: number }> | undefined,
+  nameFilter?: (name: string) => boolean,
+): CVDataPoint[] {
+  if (!variance) return []
+
+  const suiteOrder = new Map<string, number>()
+  if (suiteTests) {
+    suiteTests.forEach((t, i) => suiteOrder.set(t.name, i + 1))
+  }
+
+  const entries: { name: string; order: number; cv: number }[] = []
+  for (const [name, entry] of Object.entries(result.tests)) {
+    if (nameFilter && !nameFilter(name)) continue
+    const v = variance[name]
+    if (!v || v.mgasMean <= 0) continue
+    const cv = (v.mgasStddev / v.mgasMean) * 100
+    const order = suiteOrder.get(name) ?? (parseInt(entry.dir, 10) || 0)
+    entries.push({ name, order, cv })
+  }
+
+  entries.sort((a, b) => a.order - b.order)
+  return entries.map((e, i) => ({ testIndex: i + 1, testOrder: e.order, testName: e.name, cv: e.cv }))
+}
+
+export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line', varianceByRunIndex }: CVComparisonChartProps) {
+  const isDark = useDarkMode()
+  const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
+  const zoomRange = externalZoom ?? internalZoom
+  const prevZoomRef = useRef(zoomRange)
+
+  const handleZoom = useCallback((params: { start?: number; end?: number; batch?: Array<{ start: number; end: number }> }) => {
+    let start: number | undefined
+    let end: number | undefined
+    if (params.batch && params.batch.length > 0) {
+      start = params.batch[0].start
+      end = params.batch[0].end
+    } else {
+      start = params.start
+      end = params.end
+    }
+    if (start !== undefined && end !== undefined && (prevZoomRef.current.start !== start || prevZoomRef.current.end !== end)) {
+      const newRange = { start, end }
+      prevZoomRef.current = newRange
+      setInternalZoom(newRange)
+      onZoomChange?.(newRange)
+    }
+  }, [onZoomChange])
+
+  const onEvents = useMemo(() => ({ datazoom: handleZoom }), [handleZoom])
+
+  const pointsPerRun = useMemo(
+    () => runs.map((r) => r.result ? buildCVData(r.result, suiteTests, varianceByRunIndex.get(r.index), testNameFilter) : []),
+    [runs, suiteTests, varianceByRunIndex, testNameFilter],
+  )
+
+  const option = useMemo(() => {
+    const textColor = isDark ? '#ffffff' : '#374151'
+    const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
+    const splitLineColor = isDark ? '#374151' : '#e5e7eb'
+    const maxLen = Math.max(...pointsPerRun.map((p) => p.length))
+    const indexToOrder = new Map<number, number>()
+    for (const points of pointsPerRun) {
+      for (const d of points) {
+        indexToOrder.set(d.testIndex, d.testOrder)
+      }
+    }
+    const clientBySeriesName = new Map(runs.map((r, i) => [`Run ${formatRunLabel(RUN_SLOTS[i], r, labelMode)}`, r.config.instance.client]))
+
+    return {
+      backgroundColor: 'transparent',
+      animation: maxLen <= 100,
+      textStyle: { color: textColor },
+      grid: {
+        left: '3%',
+        right: '4%',
+        bottom: '50',
+        top: '15%',
+        containLabel: true,
+      },
+      tooltip: {
+        trigger: 'axis' as const,
+        appendToBody: true,
+        backgroundColor: isDark ? '#1f2937' : '#ffffff',
+        borderColor: isDark ? '#374151' : '#e5e7eb',
+        textStyle: { color: textColor },
+        extraCssText: 'max-width: 300px; white-space: normal;',
+        formatter: (
+          params: Array<{ seriesName: string; color: string; value: [number, number, string, number] }>,
+        ) => {
+          if (!params.length) return ''
+          const testOrder = params[0].value[3]
+          const testName = params[0].value[2]
+          let content = `<strong>Test #${testOrder}</strong>`
+          if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
+          content += '<br/>'
+          params.forEach((p) => {
+            const value = p.value[1]
+            const client = clientBySeriesName.get(p.seriesName)
+            const clientImg = client ? `<img src="/img/clients/${client}.jpg" style="display:inline-block;width:14px;height:14px;border-radius:50%;object-fit:cover;vertical-align:middle;margin-right:4px;" />` : ''
+            content += `${clientImg}<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${p.color};margin-right:6px;vertical-align:middle;"></span>${p.seriesName}: ${value.toFixed(2)}%<br/>`
+          })
+          return content
+        },
+      },
+      xAxis: {
+        type: 'value' as const,
+        min: 1,
+        max: maxLen,
+        minInterval: 1,
+        axisLabel: {
+          color: textColor,
+          fontSize: 11,
+          formatter: (value: number) => `#${indexToOrder.get(value) ?? value}`,
+        },
+        axisLine: { show: true, lineStyle: { color: axisLineColor } },
+        axisTick: { show: true, lineStyle: { color: axisLineColor } },
+        splitLine: { show: false },
+      },
+      yAxis: {
+        type: 'value' as const,
+        axisLabel: {
+          color: textColor,
+          fontSize: 11,
+          formatter: (value: number) => `${value.toFixed(1)}%`,
+        },
+        axisLine: { show: true, lineStyle: { color: axisLineColor } },
+        axisTick: { show: true, lineStyle: { color: axisLineColor } },
+        splitLine: { lineStyle: { color: splitLineColor } },
+        name: 'CV (%)',
+        nameTextStyle: { color: textColor, fontSize: 11 },
+      },
+      legend: {
+        bottom: 25,
+        textStyle: { color: textColor, fontSize: 11 },
+        itemWidth: 12,
+        itemHeight: 8,
+      },
+      dataZoom: [
+        {
+          type: 'slider' as const,
+          xAxisIndex: 0,
+          start: zoomRange.start,
+          end: zoomRange.end,
+          height: 20,
+          bottom: 5,
+          borderColor: axisLineColor,
+          fillerColor: isDark ? 'rgba(139, 92, 246, 0.3)' : 'rgba(139, 92, 246, 0.1)',
+          backgroundColor: isDark ? '#374151' : '#f3f4f6',
+          textStyle: { color: textColor },
+          labelFormatter: (value: number) => `#${indexToOrder.get(Math.round(value)) ?? Math.round(value)}`,
+        },
+        {
+          type: 'inside' as const,
+          xAxisIndex: 0,
+          start: zoomRange.start,
+          end: zoomRange.end,
+          zoomOnMouseWheel: true,
+          moveOnMouseMove: true,
+          moveOnMouseWheel: false,
+        },
+      ],
+      series: runs.map((_run, i) => {
+        const slot = RUN_SLOTS[i]
+        const points = pointsPerRun[i]
+        const data = points.map((d) => [d.testIndex, d.cv, d.testName, d.testOrder])
+        const base = {
+          name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
+          data,
+          itemStyle: { color: slot.color },
+        }
+        if (chartType === 'bar') {
+          return { ...base, type: 'bar' as const, barMaxWidth: 6 }
+        }
+        if (chartType === 'dot') {
+          return { ...base, type: 'scatter' as const, symbolSize: 4 }
+        }
+        return {
+          ...base,
+          type: 'line' as const,
+          smooth: maxLen <= 100,
+          showSymbol: maxLen <= 100,
+          symbolSize: 4,
+          lineStyle: { width: 2 },
+          areaStyle: { opacity: 0.08, color: slot.color },
+        }
+      }),
+    }
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType])
+
+  if (pointsPerRun.every((p) => p.length === 0)) return null
+
+  return (
+    <div className="rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Activity className="size-4 text-gray-400 dark:text-gray-500" />
+          <h3
+            className="text-sm/6 font-medium text-gray-900 dark:text-gray-100"
+            title="Coefficient of Variation — standard deviation of MGas/s as a percentage of the mean, across the sampled runs in each group. Lower = more consistent."
+          >
+            Coefficient of Variation per Test (MGas/s)
+          </h3>
+        </div>
+        <div className="flex items-center gap-2 text-xs/5">
+          {runs.map((run) => {
+            const slot = RUN_SLOTS[run.index]
+            return (
+              <span key={slot.label} className={`inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 font-medium ${slot.badgeBgClass} ${slot.badgeTextClass}`}>
+                <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
+                {formatRunLabel(slot, run, labelMode)}
+              </span>
+            )
+          })}
+        </div>
+      </div>
+      <ReactECharts
+        option={option}
+        style={{ height: '300px', width: '100%' }}
+        opts={{ renderer: 'svg' }}
+        onEvents={onEvents}
+      />
+    </div>
+  )
+}

--- a/ui/src/components/compare/CVComparisonChart.tsx
+++ b/ui/src/components/compare/CVComparisonChart.tsx
@@ -296,6 +296,64 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
         opts={{ renderer: 'svg' }}
         onEvents={onEvents}
       />
+      <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700">
+        <table className="w-full text-xs/5">
+          <thead>
+            <tr className="text-gray-500 dark:text-gray-400">
+              <th className="pb-1 text-left font-medium">Run</th>
+              <th className="pb-1 text-right font-medium" title={`Tests with CV ≤ ${threshold}%`}>Below</th>
+              <th className="pb-1 text-right font-medium">Avg</th>
+              <th className="pb-1 text-right font-medium">P95</th>
+              <th className="pb-1 pr-3 text-right font-medium">Max</th>
+              <th className="border-l border-gray-200 pb-1 pl-3 text-right font-medium dark:border-gray-600" title={`Tests with CV > ${threshold}%`}>Above</th>
+              <th className="pb-1 text-right font-medium">Avg</th>
+              <th className="pb-1 text-right font-medium">P95</th>
+              <th className="pb-1 pr-3 text-right font-medium">Max</th>
+              <th className="border-l border-gray-200 pb-1 pl-3 text-right font-medium dark:border-gray-600">Total</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-700/50">
+            {runs.map((run, i) => {
+              const slot = RUN_SLOTS[run.index]
+              const points = pointsPerRun[i]
+              const below: number[] = []
+              const above: number[] = []
+              for (const p of points) {
+                if (p.cv > threshold) above.push(p.cv)
+                else below.push(p.cv)
+              }
+              const total = below.length + above.length
+              const avg = (arr: number[]) => arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : 0
+              const percentile = (arr: number[], p: number) => {
+                if (arr.length === 0) return 0
+                const sorted = [...arr].sort((a, b) => a - b)
+                const idx = Math.ceil((p / 100) * sorted.length) - 1
+                return sorted[Math.max(0, idx)]
+              }
+              const max = (arr: number[]) => arr.length > 0 ? Math.max(...arr) : 0
+              return (
+                <tr key={slot.label}>
+                  <td className="py-1">
+                    <span className="inline-flex items-center gap-1.5 font-medium" style={{ color: slot.color }}>
+                      <img src={`/img/clients/${run.config.instance.client}.jpg`} alt={run.config.instance.client} className="size-3.5 rounded-full object-cover" />
+                      {formatRunLabel(slot, run, labelMode)}
+                    </span>
+                  </td>
+                  <td className="py-1 text-right font-medium text-green-600 dark:text-green-400">{below.length}</td>
+                  <td className="py-1 text-right text-green-600 dark:text-green-400">{below.length > 0 ? `${avg(below).toFixed(1)}%` : '-'}</td>
+                  <td className="py-1 text-right text-green-600 dark:text-green-400">{below.length > 0 ? `${percentile(below, 95).toFixed(1)}%` : '-'}</td>
+                  <td className="py-1 pr-3 text-right text-green-600 dark:text-green-400">{below.length > 0 ? `${max(below).toFixed(1)}%` : '-'}</td>
+                  <td className="border-l border-gray-200 py-1 pl-3 text-right font-medium text-red-600 dark:border-gray-600 dark:text-red-400">{above.length}</td>
+                  <td className="py-1 text-right text-red-600 dark:text-red-400">{above.length > 0 ? `${avg(above).toFixed(1)}%` : '-'}</td>
+                  <td className="py-1 text-right text-red-600 dark:text-red-400">{above.length > 0 ? `${percentile(above, 95).toFixed(1)}%` : '-'}</td>
+                  <td className="py-1 pr-3 text-right text-red-600 dark:text-red-400">{above.length > 0 ? `${max(above).toFixed(1)}%` : '-'}</td>
+                  <td className="border-l border-gray-200 py-1 pl-3 text-right text-gray-500 dark:border-gray-600 dark:text-gray-400">{total}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }

--- a/ui/src/components/compare/GroupBuilder.tsx
+++ b/ui/src/components/compare/GroupBuilder.tsx
@@ -98,9 +98,9 @@ export function GroupBuilder({
           <input
             type="number"
             min={1}
-            max={20}
+            max={50}
             value={sampleSize}
-            onChange={(e) => onSampleSizeChange(Math.max(1, Math.min(20, parseInt(e.target.value, 10) || 5)))}
+            onChange={(e) => onSampleSizeChange(Math.max(1, Math.min(50, parseInt(e.target.value, 10) || 5)))}
             className="w-14 rounded-xs border border-gray-300 bg-white px-2 py-1 text-center text-sm/6 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
           />
           <span className="text-xs text-gray-500 dark:text-gray-400">latest runs per group</span>

--- a/ui/src/components/compare/MGasComparisonChart.tsx
+++ b/ui/src/components/compare/MGasComparisonChart.tsx
@@ -271,6 +271,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
           style={{ height: '300px', width: '100%' }}
           opts={{ renderer: 'svg' }}
           onEvents={onEvents}
+          notMerge
         />
       </div>
     </div>

--- a/ui/src/components/compare/MGasComparisonChart.tsx
+++ b/ui/src/components/compare/MGasComparisonChart.tsx
@@ -4,6 +4,7 @@ import { Flame } from 'lucide-react'
 import type { RunResult, SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
+import { useChartAreaClick } from './useChartAreaClick'
 
 export interface ZoomRange {
   start: number
@@ -19,6 +20,7 @@ interface MGasComparisonChartProps {
   zoomRange?: ZoomRange
   onZoomChange?: (range: ZoomRange) => void
   chartType?: ChartType
+  onTestClick?: (testName: string) => void
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -72,7 +74,7 @@ function buildMGasData(
   return entries.map((e, i) => ({ testIndex: i + 1, testOrder: e.order, testName: e.name, mgas: e.mgas }))
 }
 
-export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line' }: MGasComparisonChartProps) {
+export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line', onTestClick }: MGasComparisonChartProps) {
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -102,6 +104,8 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
     () => runs.map((r) => r.result ? buildMGasData(r.result, suiteTests, stepFilter, testNameFilter) : []),
     [runs, suiteTests, stepFilter, testNameFilter],
   )
+
+  const { highlightedTestRef, handleMouseDown, handleClick, cursor } = useChartAreaClick(onTestClick)
 
   const option = useMemo(() => {
     const textColor = isDark ? '#ffffff' : '#374151'
@@ -141,6 +145,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
           if (!params.length) return ''
           const testOrder = params[0].value[3]
           const testName = params[0].value[2]
+          highlightedTestRef.current = testName
           let content = `<strong>Test #${testOrder}</strong>`
           if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
           content += '<br/>'
@@ -218,6 +223,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
           name: `Run ${formatRunLabel(slot, runs[i], labelMode)}`,
           data,
           itemStyle: { color: slot.color },
+          cursor: onTestClick ? 'pointer' : 'default',
         }
         if (chartType === 'bar') {
           return { ...base, type: 'bar' as const, barMaxWidth: 6 }
@@ -236,7 +242,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
         }
       }),
     }
-  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, onTestClick, highlightedTestRef])
 
   if (pointsPerRun.every((p) => p.length === 0)) return null
 
@@ -259,12 +265,14 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
           })}
         </div>
       </div>
-      <ReactECharts
-        option={option}
-        style={{ height: '300px', width: '100%' }}
-        opts={{ renderer: 'svg' }}
-        onEvents={onEvents}
-      />
+      <div onMouseDown={handleMouseDown} onClick={handleClick} style={{ cursor }}>
+        <ReactECharts
+          option={option}
+          style={{ height: '300px', width: '100%' }}
+          opts={{ renderer: 'svg' }}
+          onEvents={onEvents}
+        />
+      </div>
     </div>
   )
 }

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -5,6 +5,7 @@ import type { SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 import type { ZoomRange } from './MGasComparisonChart'
+import { useChartAreaClick } from './useChartAreaClick'
 
 interface PercentageDiffChartProps {
   runs: CompareRun[]
@@ -19,6 +20,7 @@ interface PercentageDiffChartProps {
   zoomRange?: ZoomRange
   onZoomChange?: (range: ZoomRange) => void
   chartType?: ChartType
+  onTestClick?: (testName: string) => void
 }
 
 function calculateMGasPerSec(stats: AggregatedStats | undefined): number | undefined {
@@ -113,7 +115,7 @@ function buildDiffData(
   }))
 }
 
-export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode, diffFilter, onDiffFilterChange, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line' }: PercentageDiffChartProps) {
+export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode, diffFilter, onDiffFilterChange, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line', onTestClick }: PercentageDiffChartProps) {
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -150,6 +152,8 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
     [runs, baselineIdx, suiteTests, stepFilter, testNameFilter],
   )
 
+  const { highlightedTestRef, handleMouseDown, handleClick, cursor } = useChartAreaClick(onTestClick)
+
   const option = useMemo(() => {
     const textColor = isDark ? '#ffffff' : '#374151'
     const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
@@ -183,6 +187,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
           const testName = params[0].value[2]
           const baseValue = params[0].value[3]
           const testOrder = params[0].value[5]
+          highlightedTestRef.current = testName
           const baseSlot = RUN_SLOTS[baselineIdx]
           const baseClient = runs[baselineIdx].config.instance.client
           const baseImg = `<img src="/img/clients/${baseClient}.jpg" style="display:inline-block;width:14px;height:14px;border-radius:50%;object-fit:cover;vertical-align:middle;margin-right:4px;" />`
@@ -298,6 +303,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
             name: `vs ${formatRunLabel(slot, runs[runIdx], labelMode)}`,
             data,
             itemStyle: { color: slot.color },
+            cursor: onTestClick ? 'pointer' : 'default',
           }
           if (chartType === 'bar') {
             return { ...base, type: 'bar' as const, barMaxWidth: 6 }
@@ -317,7 +323,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
         }),
       ],
     }
-  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange, labelMode, diffFilter, chartType])
+  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange, labelMode, diffFilter, chartType, onTestClick, highlightedTestRef])
 
   if (runs.every((r) => r.result === null)) return null
 
@@ -396,12 +402,14 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
           ))}
         </div>
       </div>
-      <ReactECharts
-        option={option}
-        style={{ height: '300px', width: '100%' }}
-        opts={{ renderer: 'svg' }}
-        onEvents={onEvents}
-      />
+      <div onMouseDown={handleMouseDown} onClick={handleClick} style={{ cursor }}>
+        <ReactECharts
+          option={option}
+          style={{ height: '300px', width: '100%' }}
+          opts={{ renderer: 'svg' }}
+          onEvents={onEvents}
+        />
+      </div>
       <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700">
         <table className="w-full text-xs/5">
           <thead>

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -408,6 +408,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
           style={{ height: '300px', width: '100%' }}
           opts={{ renderer: 'svg' }}
           onEvents={onEvents}
+          notMerge
         />
       </div>
       <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700">

--- a/ui/src/components/compare/ResourceComparisonCharts.tsx
+++ b/ui/src/components/compare/ResourceComparisonCharts.tsx
@@ -186,6 +186,7 @@ function ChartSection({ title, option, onZoom, onTestClick, highlightedTestRef }
           style={{ height: '200px', width: '100%' }}
           opts={{ renderer: 'svg' }}
           onEvents={onEvents}
+          notMerge
         />
       </div>
     </div>

--- a/ui/src/components/compare/ResourceComparisonCharts.tsx
+++ b/ui/src/components/compare/ResourceComparisonCharts.tsx
@@ -5,6 +5,7 @@ import type { TestEntry, ResourceTotals, SuiteTest } from '@/api/types'
 import { formatBytes } from '@/utils/format'
 import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 import type { ZoomRange } from './MGasComparisonChart'
+import { useChartAreaClick } from './useChartAreaClick'
 
 interface AggregatedResourceData {
   totals: ResourceTotals
@@ -82,6 +83,7 @@ interface ResourceComparisonChartsProps {
   zoomRange?: ZoomRange
   onZoomChange?: (range: ZoomRange) => void
   chartType?: ChartType
+  onTestClick?: (testName: string) => void
 }
 
 interface ResourceDataPoint {
@@ -155,9 +157,11 @@ interface ChartSectionProps {
   title: string
   option: object
   onZoom: (start: number, end: number) => void
+  onTestClick?: (testName: string) => void
+  highlightedTestRef: React.MutableRefObject<string | null>
 }
 
-function ChartSection({ title, option, onZoom }: ChartSectionProps) {
+function ChartSection({ title, option, onZoom, onTestClick, highlightedTestRef }: ChartSectionProps) {
   const onEvents = useMemo(
     () => ({
       datazoom: (params: { start?: number; end?: number; batch?: Array<{ start: number; end: number }> }) => {
@@ -171,20 +175,24 @@ function ChartSection({ title, option, onZoom }: ChartSectionProps) {
     [onZoom],
   )
 
+  const { handleMouseDown, handleClick, cursor } = useChartAreaClick(onTestClick, highlightedTestRef)
+
   return (
     <div className="rounded-xs bg-gray-50 p-3 dark:bg-gray-700/50">
       <h4 className="mb-2 text-xs font-medium text-gray-700 dark:text-gray-300">{title}</h4>
-      <ReactECharts
-        option={option}
-        style={{ height: '200px', width: '100%' }}
-        opts={{ renderer: 'svg' }}
-        onEvents={onEvents}
-      />
+      <div onMouseDown={handleMouseDown} onClick={handleClick} style={{ cursor }}>
+        <ReactECharts
+          option={option}
+          style={{ height: '200px', width: '100%' }}
+          opts={{ renderer: 'svg' }}
+          onEvents={onEvents}
+        />
+      </div>
     </div>
   )
 }
 
-export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suiteTests, zoomRange: externalZoom, onZoomChange, chartType = 'line' }: ResourceComparisonChartsProps) {
+export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suiteTests, zoomRange: externalZoom, onZoomChange, chartType = 'line', onTestClick }: ResourceComparisonChartsProps) {
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -203,6 +211,8 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suit
     () => runs.map((r) => r.result ? buildDataPoints(r.result.tests, testNameFilter, suiteTests) : []),
     [runs, testNameFilter, suiteTests],
   )
+
+  const highlightedTestRef = useRef<string | null>(null)
 
   const hasData = pointsPerRun.some((p) => p.length > 0)
 
@@ -312,6 +322,7 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suit
         if (!params.length) return ''
         const testName = params[0].value[2]
         const testOrder = params[0].value[3]
+        highlightedTestRef.current = testName
         let content = `<strong>Test #${testOrder}</strong>`
         if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
         content += '<br/>'
@@ -343,6 +354,7 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suit
           ...createSeriesStyle(),
           data: points.map((d) => [d.testIndex, d[field], d.testName, d.testOrder]),
           itemStyle: { color: slot.color },
+          cursor: onTestClick ? 'pointer' : 'default',
           ...(chartType === 'line' ? { areaStyle: { opacity: 0.08, color: slot.color } } : {}),
         }
       })
@@ -404,7 +416,7 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suit
     }
 
     return { cpuPercentOption, memoryMBOption, cpuTimeOption, memoryDeltaOption, diskReadBytesOption, diskWriteBytesOption, diskReadOpsOption, diskWriteOpsOption }
-  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, onTestClick, highlightedTestRef])
 
   if (!hasData) return null
 
@@ -427,14 +439,14 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suit
       </div>
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <ChartSection title="CPU Usage %" option={chartOptions.cpuPercentOption} onZoom={handleZoom} />
-        <ChartSection title="Memory Usage (MB)" option={chartOptions.memoryMBOption} onZoom={handleZoom} />
-        <ChartSection title="CPU Time" option={chartOptions.cpuTimeOption} onZoom={handleZoom} />
-        <ChartSection title="Memory Delta" option={chartOptions.memoryDeltaOption} onZoom={handleZoom} />
-        <ChartSection title="Disk Read (Bytes)" option={chartOptions.diskReadBytesOption} onZoom={handleZoom} />
-        <ChartSection title="Disk Write (Bytes)" option={chartOptions.diskWriteBytesOption} onZoom={handleZoom} />
-        <ChartSection title="Disk Read IOPS" option={chartOptions.diskReadOpsOption} onZoom={handleZoom} />
-        <ChartSection title="Disk Write IOPS" option={chartOptions.diskWriteOpsOption} onZoom={handleZoom} />
+        <ChartSection title="CPU Usage %" option={chartOptions.cpuPercentOption} onZoom={handleZoom} onTestClick={onTestClick} highlightedTestRef={highlightedTestRef} />
+        <ChartSection title="Memory Usage (MB)" option={chartOptions.memoryMBOption} onZoom={handleZoom} onTestClick={onTestClick} highlightedTestRef={highlightedTestRef} />
+        <ChartSection title="CPU Time" option={chartOptions.cpuTimeOption} onZoom={handleZoom} onTestClick={onTestClick} highlightedTestRef={highlightedTestRef} />
+        <ChartSection title="Memory Delta" option={chartOptions.memoryDeltaOption} onZoom={handleZoom} onTestClick={onTestClick} highlightedTestRef={highlightedTestRef} />
+        <ChartSection title="Disk Read (Bytes)" option={chartOptions.diskReadBytesOption} onZoom={handleZoom} onTestClick={onTestClick} highlightedTestRef={highlightedTestRef} />
+        <ChartSection title="Disk Write (Bytes)" option={chartOptions.diskWriteBytesOption} onZoom={handleZoom} onTestClick={onTestClick} highlightedTestRef={highlightedTestRef} />
+        <ChartSection title="Disk Read IOPS" option={chartOptions.diskReadOpsOption} onZoom={handleZoom} onTestClick={onTestClick} highlightedTestRef={highlightedTestRef} />
+        <ChartSection title="Disk Write IOPS" option={chartOptions.diskWriteOpsOption} onZoom={handleZoom} onTestClick={onTestClick} highlightedTestRef={highlightedTestRef} />
       </div>
 
       <p className="mt-4 text-center text-xs/5 text-gray-500 dark:text-gray-400">

--- a/ui/src/components/compare/TestDetailModal.tsx
+++ b/ui/src/components/compare/TestDetailModal.tsx
@@ -107,17 +107,24 @@ export function TestDetailModal({
       })
 
       const mgasValues = runs.map((r) => r.mgas).filter((v): v is number => v !== undefined)
-      const mean = mgasValues.length > 0 ? mgasValues.reduce((a, b) => a + b, 0) / mgasValues.length : undefined
+      const average = mgasValues.length > 0 ? mgasValues.reduce((a, b) => a + b, 0) / mgasValues.length : undefined
+      const median = mgasValues.length > 0
+        ? (() => {
+            const sorted = [...mgasValues].sort((a, b) => a - b)
+            const mid = Math.floor(sorted.length / 2)
+            return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+          })()
+        : undefined
       const min = mgasValues.length > 0 ? Math.min(...mgasValues) : undefined
       const max = mgasValues.length > 0 ? Math.max(...mgasValues) : undefined
-      const stddev = mgasValues.length >= 2 && mean !== undefined
-        ? Math.sqrt(mgasValues.reduce((sum, v) => sum + (v - mean) ** 2, 0) / (mgasValues.length - 1))
+      const stddev = mgasValues.length >= 2 && average !== undefined
+        ? Math.sqrt(mgasValues.reduce((sum, v) => sum + (v - average) ** 2, 0) / (mgasValues.length - 1))
         : undefined
 
       const metaStr = Object.entries(group.metadata).map(([k, v]) => `${k}=${v}`).join(', ')
       const label = metaStr || group.client
 
-      return { label, client: group.client, runs, mean, min, max, stddev, mgasValues }
+      return { label, client: group.client, runs, average, median, min, max, stddev, mgasValues }
     })
   }, [groups, groupResults, groupTimestamps, groupRunIds, stepFilter, sampleSize, testName])
 
@@ -166,12 +173,6 @@ export function TestDetailModal({
                   <span className={clsx('text-sm/6 font-medium', SLOT_COLORS[gi % SLOT_COLORS.length])}>
                     {group.label}
                   </span>
-                  {group.mean !== undefined && (
-                    <span className="text-xs text-gray-500 dark:text-gray-400">
-                      mean: {group.mean.toFixed(2)} MGas/s
-                      {group.stddev !== undefined && <> · σ: {group.stddev.toFixed(2)}</>}
-                    </span>
-                  )}
                 </div>
 
                 {/* Dot chart — each dot is one run's MGas/s for this test */}
@@ -194,13 +195,16 @@ export function TestDetailModal({
 
                 {/* Stats summary */}
                 {group.min !== undefined && (
-                  <div className="mt-4 flex gap-3 border-t border-gray-200 pt-2 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                  <div className="mt-4 flex flex-wrap gap-x-3 gap-y-1 border-t border-gray-200 pt-2 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                    {group.average !== undefined && <span>Avg: {group.average.toFixed(2)}</span>}
+                    {group.median !== undefined && <span>Median: {group.median.toFixed(2)}</span>}
                     <span>Min: {group.min.toFixed(2)}</span>
                     <span>Max: {group.max?.toFixed(2)}</span>
                     <span>Range: {((group.max ?? 0) - (group.min ?? 0)).toFixed(2)}</span>
-                    {group.stddev !== undefined && group.mean !== undefined && group.mean > 0 && (
-                      <span title="Coefficient of Variation — standard deviation as a percentage of the mean. Lower = more consistent across runs.">
-                        CV: {((group.stddev / group.mean) * 100).toFixed(1)}%
+                    {group.stddev !== undefined && <span>σ: {group.stddev.toFixed(2)}</span>}
+                    {group.stddev !== undefined && group.average !== undefined && group.average > 0 && (
+                      <span title="Coefficient of Variation — standard deviation as a percentage of the average. Lower = more consistent across runs.">
+                        CV: {((group.stddev / group.average) * 100).toFixed(1)}%
                       </span>
                     )}
                   </div>

--- a/ui/src/components/compare/TestDetailModal.tsx
+++ b/ui/src/components/compare/TestDetailModal.tsx
@@ -195,18 +195,44 @@ export function TestDetailModal({
 
                 {/* Stats summary */}
                 {group.min !== undefined && (
-                  <div className="mt-4 flex flex-wrap gap-x-3 gap-y-1 border-t border-gray-200 pt-2 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
-                    {group.average !== undefined && <span>Avg: {group.average.toFixed(2)}</span>}
-                    {group.median !== undefined && <span>Median: {group.median.toFixed(2)}</span>}
-                    <span>Min: {group.min.toFixed(2)}</span>
-                    <span>Max: {group.max?.toFixed(2)}</span>
-                    <span>Range: {((group.max ?? 0) - (group.min ?? 0)).toFixed(2)}</span>
-                    {group.stddev !== undefined && <span>σ: {group.stddev.toFixed(2)}</span>}
-                    {group.stddev !== undefined && group.average !== undefined && group.average > 0 && (
-                      <span title="Coefficient of Variation — standard deviation as a percentage of the average. Lower = more consistent across runs.">
-                        CV: {((group.stddev / group.average) * 100).toFixed(1)}%
-                      </span>
-                    )}
+                  <div className="mt-4 grid grid-cols-7 gap-x-2 border-t border-gray-200 pt-2 text-xs dark:border-gray-700">
+                    <StatCell
+                      label="Avg"
+                      value={group.average?.toFixed(2)}
+                      title="Arithmetic mean of MGas/s across the sampled runs in this group."
+                    />
+                    <StatCell
+                      label="Median"
+                      value={group.median?.toFixed(2)}
+                      title="Middle value of MGas/s across the sampled runs. Less sensitive to outliers than the average."
+                    />
+                    <StatCell
+                      label="Min"
+                      value={group.min.toFixed(2)}
+                      title="Lowest MGas/s observed across the sampled runs."
+                    />
+                    <StatCell
+                      label="Max"
+                      value={group.max?.toFixed(2)}
+                      title="Highest MGas/s observed across the sampled runs."
+                    />
+                    <StatCell
+                      label="Range"
+                      value={((group.max ?? 0) - (group.min ?? 0)).toFixed(2)}
+                      title="Max minus min — the spread of MGas/s across the sampled runs."
+                    />
+                    <StatCell
+                      label="σ"
+                      value={group.stddev?.toFixed(2)}
+                      title="Sample standard deviation of MGas/s. How much individual runs typically deviate from the average."
+                    />
+                    <StatCell
+                      label="CV"
+                      value={group.stddev !== undefined && group.average !== undefined && group.average > 0
+                        ? `${((group.stddev / group.average) * 100).toFixed(1)}%`
+                        : undefined}
+                      title="Coefficient of Variation — standard deviation as a percentage of the average. Lower = more consistent across runs."
+                    />
                   </div>
                 )}
 
@@ -338,6 +364,15 @@ function SortableHeader({ label, sortKey, currentKey, currentDir, onSort, align 
     >
       {label}{arrow}
     </th>
+  )
+}
+
+function StatCell({ label, value, title }: { label: string; value?: string; title?: string }) {
+  return (
+    <div className="flex flex-col" title={title}>
+      <span className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">{label}</span>
+      <span className="font-mono tabular-nums text-gray-700 dark:text-gray-200">{value ?? '—'}</span>
+    </div>
   )
 }
 

--- a/ui/src/components/compare/TestDetailModal.tsx
+++ b/ui/src/components/compare/TestDetailModal.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from 'react'
-import { Check, Copy, X } from 'lucide-react'
+import { useNavigate } from '@tanstack/react-router'
+import { Check, Copy, GitCompareArrows, X } from 'lucide-react'
 import clsx from 'clsx'
 import type { RunResult } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { formatTimestamp } from '@/utils/date'
 import { type GroupDef } from './groupUtils'
+import { MAX_COMPARE_RUNS, MIN_COMPARE_RUNS } from './constants'
 
 interface TestDetailModalProps {
   testName: string
@@ -39,6 +41,8 @@ export function TestDetailModal({
 }: TestDetailModalProps) {
   const SLOT_COLORS = ['text-blue-700 dark:text-blue-300', 'text-orange-700 dark:text-orange-300', 'text-purple-700 dark:text-purple-300', 'text-green-700 dark:text-green-300', 'text-red-700 dark:text-red-300']
 
+  const navigate = useNavigate()
+
   const [expandedGroups, setExpandedGroups] = useState<Set<number>>(new Set())
   const toggleGroupExpand = (gi: number) => {
     setExpandedGroups((prev) => {
@@ -46,6 +50,25 @@ export function TestDetailModal({
       if (next.has(gi)) next.delete(gi); else next.add(gi)
       return next
     })
+  }
+
+  const [selectedRunIds, setSelectedRunIds] = useState<Set<string>>(new Set())
+  const toggleRunSelected = (runId: string) => {
+    setSelectedRunIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(runId)) {
+        next.delete(runId)
+      } else {
+        if (next.size >= MAX_COMPARE_RUNS) return prev
+        next.add(runId)
+      }
+      return next
+    })
+  }
+  const clearSelection = () => setSelectedRunIds(new Set())
+  const handleCompare = () => {
+    if (selectedRunIds.size < MIN_COMPARE_RUNS) return
+    navigate({ to: '/compare', search: { runs: Array.from(selectedRunIds).join(',') } })
   }
 
   type SortKey = 'run' | 'mgas' | 'gasUsed' | 'duration'
@@ -129,7 +152,7 @@ export function TestDetailModal({
         </div>
 
         {/* Body */}
-        <div className="flex-1 overflow-y-auto px-5 py-4">
+        <div className="flex-1 overflow-y-auto px-5 py-4 pb-20">
           <div className="flex flex-col gap-6">
             {groupData.map((group, gi) => (
               <div key={gi} className="flex flex-col gap-2">
@@ -195,6 +218,7 @@ export function TestDetailModal({
                 {expandedGroups.has(gi) && <table className="w-full text-xs">
                   <thead>
                     <tr className="border-b border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                      <th className="w-6 px-2 py-1"></th>
                       <SortableHeader label="Run" sortKey="run" currentKey={sortKey} currentDir={sortDir} onSort={toggleSort} align="left" />
                       <SortableHeader label="MGas/s" sortKey="mgas" currentKey={sortKey} currentDir={sortDir} onSort={toggleSort} align="right" />
                       <SortableHeader label="Gas Used" sortKey="gasUsed" currentKey={sortKey} currentDir={sortDir} onSort={toggleSort} align="right" />
@@ -211,24 +235,39 @@ export function TestDetailModal({
                         case 'duration': cmp = a.duration - b.duration; break
                       }
                       return sortDir === 'asc' ? cmp : -cmp
-                    }).map((run, ri) => (
-                      <tr
-                        key={ri}
-                        className="cursor-pointer border-b border-gray-100 last:border-0 hover:bg-gray-50 dark:border-gray-700/50 dark:hover:bg-gray-700/50"
-                        onClick={() => { if (run.runId) window.open(`/runs/${run.runId}?testModal=${encodeURIComponent(testName)}`, '_blank') }}
-                      >
-                        <td className="px-2 py-1">{run.timestamp ? formatTimestamp(run.timestamp) : `Run ${ri + 1}`}</td>
-                        <td className="px-2 py-1 text-right font-mono">
-                          {run.mgas !== undefined ? run.mgas.toFixed(2) : '-'}
-                        </td>
-                        <td className="px-2 py-1 text-right font-mono">
-                          {run.gasUsed > 0 ? `${(run.gasUsed / 1_000_000).toFixed(1)}M` : '-'}
-                        </td>
-                        <td className="px-2 py-1 text-right font-mono">
-                          {run.duration > 0 ? `${(run.duration / 1_000_000_000).toFixed(2)}s` : '-'}
-                        </td>
-                      </tr>
-                    ))}
+                    }).map((run, ri) => {
+                      const isSelected = !!run.runId && selectedRunIds.has(run.runId)
+                      const selectable = !!run.runId
+                      const atCap = selectedRunIds.size >= MAX_COMPARE_RUNS && !isSelected
+                      return (
+                        <tr
+                          key={ri}
+                          className="cursor-pointer border-b border-gray-100 last:border-0 hover:bg-gray-50 dark:border-gray-700/50 dark:hover:bg-gray-700/50"
+                          onClick={() => { if (run.runId) window.open(`/runs/${run.runId}?testModal=${encodeURIComponent(testName)}`, '_blank') }}
+                        >
+                          <td className="px-2 py-1" onClick={(e) => e.stopPropagation()}>
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              disabled={!selectable || atCap}
+                              onChange={() => run.runId && toggleRunSelected(run.runId)}
+                              title={atCap ? `Maximum ${MAX_COMPARE_RUNS} runs can be compared` : 'Select for comparison'}
+                              className="size-3.5 cursor-pointer accent-blue-600 disabled:cursor-not-allowed disabled:opacity-40 dark:accent-blue-500"
+                            />
+                          </td>
+                          <td className="px-2 py-1">{run.timestamp ? formatTimestamp(run.timestamp) : `Run ${ri + 1}`}</td>
+                          <td className="px-2 py-1 text-right font-mono">
+                            {run.mgas !== undefined ? run.mgas.toFixed(2) : '-'}
+                          </td>
+                          <td className="px-2 py-1 text-right font-mono">
+                            {run.gasUsed > 0 ? `${(run.gasUsed / 1_000_000).toFixed(1)}M` : '-'}
+                          </td>
+                          <td className="px-2 py-1 text-right font-mono">
+                            {run.duration > 0 ? `${(run.duration / 1_000_000_000).toFixed(2)}s` : '-'}
+                          </td>
+                        </tr>
+                      )
+                    })}
                   </tbody>
                 </table>}
 
@@ -236,6 +275,38 @@ export function TestDetailModal({
             ))}
           </div>
         </div>
+
+        {/* Footer — comparison action bar */}
+        {selectedRunIds.size > 0 && (
+          <div className="flex items-center justify-between gap-3 border-t border-gray-200 bg-gray-50 px-5 py-3 dark:border-gray-700 dark:bg-gray-700/40">
+            <span className="text-xs/5 text-gray-600 dark:text-gray-300">
+              {selectedRunIds.size} of {MAX_COMPARE_RUNS} selected
+              {selectedRunIds.size < MIN_COMPARE_RUNS && (
+                <span className="ml-1 text-gray-400 dark:text-gray-500">
+                  · select at least {MIN_COMPARE_RUNS} to compare
+                </span>
+              )}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={clearSelection}
+                className="rounded-xs px-2 py-1 text-xs/5 font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-600 dark:hover:text-gray-200"
+              >
+                Clear
+              </button>
+              <button
+                type="button"
+                onClick={handleCompare}
+                disabled={selectedRunIds.size < MIN_COMPARE_RUNS}
+                className="inline-flex items-center gap-1.5 rounded-xs bg-blue-600 px-2.5 py-1 text-xs/5 font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-500 dark:disabled:bg-gray-600 dark:disabled:text-gray-400"
+              >
+                <GitCompareArrows className="size-3.5" />
+                Compare {selectedRunIds.size} run{selectedRunIds.size === 1 ? '' : 's'}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/ui/src/components/compare/useChartAreaClick.ts
+++ b/ui/src/components/compare/useChartAreaClick.ts
@@ -1,0 +1,59 @@
+import { useCallback, useRef } from 'react'
+import type { MouseEvent as ReactMouseEvent, MutableRefObject } from 'react'
+
+/**
+ * useChartAreaClick wires a "click anywhere on the chart opens the
+ * currently-highlighted test" behavior. Same approach used by the
+ * run-detail resource charts.
+ *
+ * Usage:
+ *   const { highlightedTestRef, handleMouseDown, handleClick, cursor } =
+ *     useChartAreaClick(onTestClick)
+ *
+ *   // In the tooltip formatter (trigger: 'axis'), stash the hovered test:
+ *   highlightedTestRef.current = testName
+ *
+ *   // Wrap <ReactECharts> in a div that forwards the mouse handlers:
+ *   <div onMouseDown={handleMouseDown} onClick={handleClick} style={{ cursor }}>
+ *     <ReactECharts ... />
+ *   </div>
+ *
+ * The mouse-down/click pair suppresses accidental triggers when the
+ * user drags the data-zoom slider — only a click without movement
+ * opens the modal.
+ */
+export function useChartAreaClick(
+  onTestClick?: (testName: string) => void,
+  externalRef?: MutableRefObject<string | null>,
+): {
+  highlightedTestRef: MutableRefObject<string | null>
+  handleMouseDown: (e: ReactMouseEvent) => void
+  handleClick: (e: ReactMouseEvent) => void
+  cursor: 'pointer' | 'default'
+} {
+  const internalRef = useRef<string | null>(null)
+  const highlightedTestRef = externalRef ?? internalRef
+  const mouseDownPos = useRef<{ x: number; y: number } | null>(null)
+
+  const handleMouseDown = useCallback((e: ReactMouseEvent) => {
+    mouseDownPos.current = { x: e.clientX, y: e.clientY }
+  }, [])
+
+  const handleClick = useCallback((e: ReactMouseEvent) => {
+    if (mouseDownPos.current) {
+      const dx = Math.abs(e.clientX - mouseDownPos.current.x)
+      const dy = Math.abs(e.clientY - mouseDownPos.current.y)
+      if (dx > 5 || dy > 5) return
+    }
+    if (onTestClick && highlightedTestRef.current) {
+      onTestClick(highlightedTestRef.current)
+    }
+  }, [onTestClick, highlightedTestRef])
+
+  return {
+    highlightedTestRef,
+    handleMouseDown,
+    handleClick,
+    cursor: onTestClick ? 'pointer' : 'default',
+  }
+}

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -12,6 +12,7 @@ import { type StepTypeOption, ALL_STEP_TYPES, DEFAULT_STEP_FILTER } from '@/page
 import { type CompareRun, type ChartType, CHART_TYPE_OPTIONS } from '@/components/compare/constants'
 import { MetricsComparison } from '@/components/compare/MetricsComparison'
 import { MGasComparisonChart } from '@/components/compare/MGasComparisonChart'
+import { CVComparisonChart } from '@/components/compare/CVComparisonChart'
 import { PercentageDiffChart } from '@/components/compare/PercentageDiffChart'
 import { TestComparisonTable } from '@/components/compare/TestComparisonTable'
 import { ResourceComparisonCharts } from '@/components/compare/ResourceComparisonCharts'
@@ -160,7 +161,7 @@ export function CompareGroupsPage() {
     if (groups.length === 0 || isLoading) return { syntheticRuns: [] as CompareRun[], varianceMap: new Map() }
 
     const runs: CompareRun[] = []
-    const varMap = new Map<number, Record<string, { mgasStddev: number; mgasMin: number; mgasMax: number }>>()
+    const varMap = new Map<number, Record<string, { mgasStddev: number; mgasMean: number; mgasMin: number; mgasMax: number }>>()
     let resultOffset = 0
 
     for (let gi = 0; gi < groups.length; gi++) {
@@ -204,8 +205,6 @@ export function CompareGroupsPage() {
 
     return { syntheticRuns: runs, varianceMap: varMap }
   }, [groups, groupRuns, configQueries, resultQueries, stepFilter, aggMode, isLoading])
-
-  void varianceMap // will be used for variance display in phase 2
 
   // ─── Available suites + clients for the builder ────────────────
   const availableSuites = useMemo(() => {
@@ -659,6 +658,17 @@ export function CompareGroupsPage() {
             zoomRange={sharedZoom ? chartZoom : undefined}
             onZoomChange={sharedZoom ? setChartZoom : undefined}
             chartType={chartType}
+          />
+
+          <CVComparisonChart
+            runs={syntheticRuns}
+            suiteTests={suite?.tests}
+            labelMode="instance-id"
+            testNameFilter={testNameFilter}
+            zoomRange={sharedZoom ? chartZoom : undefined}
+            onZoomChange={sharedZoom ? setChartZoom : undefined}
+            chartType={chartType}
+            varianceByRunIndex={varianceMap}
           />
 
           <ResourceComparisonCharts

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -43,6 +43,7 @@ export function CompareGroupsPage() {
     filter?: string
     filterRegex?: string
     gasBuckets?: string
+    diffFilter?: string
   }
 
   const suiteHash = search.suite ?? ''
@@ -72,6 +73,7 @@ export function CompareGroupsPage() {
           filter: search.filter,
           filterRegex: search.filterRegex,
           gasBuckets: search.gasBuckets,
+          diffFilter: search.diffFilter,
           ...patch,
         },
         replace: true,
@@ -667,8 +669,8 @@ export function CompareGroupsPage() {
               baselineIdx={baselineIdx}
               onBaselineChange={(idx) => updateSearch({ baseline: idx > 0 ? String(idx) : undefined })}
               labelMode="instance-id"
-              diffFilter="all"
-              onDiffFilterChange={() => {}}
+              diffFilter={search.diffFilter === 'faster' || search.diffFilter === 'slower' ? search.diffFilter : 'all'}
+              onDiffFilterChange={(val) => updateSearch({ diffFilter: val === 'all' ? undefined : val })}
               testNameFilter={testNameFilter}
               zoomRange={sharedZoom ? chartZoom : undefined}
               onZoomChange={sharedZoom ? setChartZoom : undefined}

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -643,6 +643,7 @@ export function CompareGroupsPage() {
             zoomRange={sharedZoom ? chartZoom : undefined}
             onZoomChange={sharedZoom ? setChartZoom : undefined}
             chartType={chartType}
+            onTestClick={setSelectedTest}
           />
 
           <PercentageDiffChart
@@ -658,6 +659,7 @@ export function CompareGroupsPage() {
             zoomRange={sharedZoom ? chartZoom : undefined}
             onZoomChange={sharedZoom ? setChartZoom : undefined}
             chartType={chartType}
+            onTestClick={setSelectedTest}
           />
 
           <CVComparisonChart
@@ -669,6 +671,7 @@ export function CompareGroupsPage() {
             onZoomChange={sharedZoom ? setChartZoom : undefined}
             chartType={chartType}
             varianceByRunIndex={varianceMap}
+            onTestClick={setSelectedTest}
           />
 
           <ResourceComparisonCharts
@@ -679,6 +682,7 @@ export function CompareGroupsPage() {
             zoomRange={sharedZoom ? chartZoom : undefined}
             onZoomChange={sharedZoom ? setChartZoom : undefined}
             chartType={chartType}
+            onTestClick={setSelectedTest}
           />
 
           <TestComparisonTable

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -47,7 +47,7 @@ export function CompareGroupsPage() {
 
   const suiteHash = search.suite ?? ''
   const groups = useMemo(() => parseGroupsParam(search.groups), [search.groups])
-  const sampleSize = Math.max(1, Math.min(20, parseInt(search.sample ?? '5', 10) || 5))
+  const sampleSize = Math.max(1, Math.min(50, parseInt(search.sample ?? '5', 10) || 5))
   const aggMode = (search.agg === 'median' ? 'median' : 'avg') as 'avg' | 'median'
   const stepFilter = parseStepFilter(search.steps)
 
@@ -323,7 +323,7 @@ export function CompareGroupsPage() {
     return (name: string) => textFn!(name) && gasFn!(name)
   }, [testFilter, testFilterRegex, selectedGasBuckets, testGasMap, GAS_BUCKET_STEP])
 
-  const hasResults = syntheticRuns.length >= 2 && syntheticRuns.every((r) => r.result !== null)
+  const hasResults = syntheticRuns.length >= 1 && syntheticRuns.every((r) => r.result !== null)
 
   // ─── Sticky bar ────────────────────────────────────────────────
   const sentinelRef = useRef<HTMLDivElement>(null)
@@ -416,15 +416,28 @@ export function CompareGroupsPage() {
             <div className="flex items-center justify-center gap-4">
               {groups.map((group, gi) => {
                 const metaStr = Object.entries(group.metadata).map(([k, v]) => `${k}=${v}`).join(', ')
+                const runCount = groupRuns[gi]?.length ?? 0
                 return (
                   <span key={gi} className="inline-flex items-center gap-1.5 rounded-sm bg-gray-100 px-2 py-0.5 text-xs/5 font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200">
                     <img src={`/img/clients/${group.client}.jpg`} alt={group.client} className="size-3.5 rounded-full object-cover" />
                     {metaStr || group.client}
+                    <span className="font-mono text-gray-400 dark:text-gray-500" title={`${runCount} run${runCount === 1 ? '' : 's'} sampled`}>
+                      ({runCount})
+                    </span>
                   </span>
                 )
               })}
-              <span className="text-xs text-gray-400 dark:text-gray-500">
-                {aggMode === 'avg' ? 'Average' : 'Median'} of {sampleSize}
+              <span className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+                {aggMode === 'avg' ? 'Average' : 'Median'} of
+                <input
+                  type="number"
+                  min={1}
+                  max={50}
+                  value={sampleSize}
+                  onChange={(e) => setSampleSize(Math.max(1, Math.min(50, parseInt(e.target.value, 10) || 5)))}
+                  title="Sample size — latest runs per group"
+                  className="w-12 rounded-xs border border-gray-300 bg-white px-1 py-0.5 text-center text-xs/5 text-gray-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+                />
               </span>
             </div>
             <div className="flex items-center justify-center gap-4 text-xs/5 text-gray-500 dark:text-gray-400">
@@ -646,21 +659,23 @@ export function CompareGroupsPage() {
             onTestClick={setSelectedTest}
           />
 
-          <PercentageDiffChart
-            runs={syntheticRuns}
-            suiteTests={suite?.tests}
-            stepFilter={stepFilter}
-            baselineIdx={baselineIdx}
-            onBaselineChange={(idx) => updateSearch({ baseline: idx > 0 ? String(idx) : undefined })}
-            labelMode="instance-id"
-            diffFilter="all"
-            onDiffFilterChange={() => {}}
-            testNameFilter={testNameFilter}
-            zoomRange={sharedZoom ? chartZoom : undefined}
-            onZoomChange={sharedZoom ? setChartZoom : undefined}
-            chartType={chartType}
-            onTestClick={setSelectedTest}
-          />
+          {syntheticRuns.length >= 2 && (
+            <PercentageDiffChart
+              runs={syntheticRuns}
+              suiteTests={suite?.tests}
+              stepFilter={stepFilter}
+              baselineIdx={baselineIdx}
+              onBaselineChange={(idx) => updateSearch({ baseline: idx > 0 ? String(idx) : undefined })}
+              labelMode="instance-id"
+              diffFilter="all"
+              onDiffFilterChange={() => {}}
+              testNameFilter={testNameFilter}
+              zoomRange={sharedZoom ? chartZoom : undefined}
+              onZoomChange={sharedZoom ? setChartZoom : undefined}
+              chartType={chartType}
+              onTestClick={setSelectedTest}
+            />
+          )}
 
           <CVComparisonChart
             runs={syntheticRuns}
@@ -701,7 +716,7 @@ export function CompareGroupsPage() {
         </>
       )}
 
-      {!isLoading && groups.length >= 2 && allRunIds.length > 0 && !hasResults && (
+      {!isLoading && groups.length >= 1 && allRunIds.length > 0 && !hasResults && (
         <div className="rounded-sm bg-yellow-50 p-4 text-sm/6 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300">
           Not enough result data to compare. Make sure the selected runs have completed with results.
         </div>

--- a/ui/src/utils/averageResults.ts
+++ b/ui/src/utils/averageResults.ts
@@ -3,8 +3,8 @@ import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 
 export interface AveragedResult {
   result: RunResult
-  // Per-test variance on MGas/s for error-bar display.
-  variance: Record<string, { mgasStddev: number; mgasMin: number; mgasMax: number }>
+  // Per-test variance on MGas/s for error-bar and CV% display.
+  variance: Record<string, { mgasStddev: number; mgasMean: number; mgasMin: number; mgasMax: number }>
 }
 
 /**
@@ -152,6 +152,7 @@ export function averageResults(
     const mgasStddev = stddev(mgasValues, mgasAvg)
     variance[name] = {
       mgasStddev,
+      mgasMean: mgasAvg,
       mgasMin: Math.min(...mgasValues),
       mgasMax: Math.max(...mgasValues),
     }


### PR DESCRIPTION
## Summary
- **Coefficient of Variation chart** added to the group comparison page, mirroring the MGas/s chart. Includes a configurable threshold line (0–50% slider, default 20%) with a dashed reference marker, plus a per-group summary table showing tests below/above the threshold (count + avg/P95/max CV%).
- **Click anywhere on any compare chart** (MGas/s, %-diff, CV%, resource charts) now opens the test detail modal for whichever test the tooltip is currently showing — using the same ref-in-formatter pattern as the run-detail resource charts, with drag-detection so the data-zoom slider isn't affected.
- **Test detail modal** gains per-row checkboxes and a footer action bar for selecting 2–5 runs and jumping to \`/compare\`. Stats row is now a 7-column grid (Avg · Median · Min · Max · Range · σ · CV) with hover tooltips on every cell.
- **Single-group rendering** supported: the page no longer requires ≥2 groups. The %-diff chart is hidden when only one group exists (since it needs a baseline).
- **Sample size** cap raised from 20 to 50 and exposed inline on the sticky top bar (which also shows each group's sampled run count).
- **Wire the diff filter buttons** (\`Show All\` / \`Faster\` / \`Slower\`) to a new \`diffFilter\` URL param — previously hard-coded with a no-op handler.
- **\`notMerge\` on all compare charts** so removing a group clears its series instead of leaving stale ones behind.

## Test plan
- [x] CV% chart renders with correct values; threshold slider updates the reference line and the below/above stats table live.
- [x] Click on empty area of any chart opens the modal for the test under the tooltip; dragging the zoom slider does not trigger the modal.
- [x] In the test modal, select 2–5 runs across groups and click Compare — lands on \`/compare?runs=...\` with the selected IDs.
- [x] Single-group setup renders MGas/s + CV% + resource + table; %-diff chart is hidden.
- [x] Removing a group from the builder immediately removes its series from all charts.
- [x] Show All / Faster / Slower buttons on the %-diff chart filter the series and the selection persists across reload.
- [x] Sticky top bar shows \`(N)\` next to each group label and lets you change the sample size inline; URL reflects the new value.