### PR TITLE
ci: multi-arch docker build with native arm64 runners

### DIFF
--- a/.github/workflows/deploy-docker.core.yaml
+++ b/.github/workflows/deploy-docker.core.yaml
@@ -7,41 +7,191 @@ on:
     tags:
       - 'v*.*.*'
 
+env:
+  GHCR_REPO: ghcr.io/${{ github.repository }}
+  DOCKERFILE: Dockerfile
+
 jobs:
-  build-and-push-image:
+  meta:
+    name: Compute tags and build info
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: write
-
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+      tag_prefix: ${{ steps.vars.outputs.tag_prefix }}
+      additional_tags: ${{ steps.vars.outputs.additional_tags }}
+      version: ${{ steps.vars.outputs.version }}
+      commit: ${{ steps.vars.outputs.commit }}
+      date: ${{ steps.vars.outputs.date }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - name: Set build version info
+      - id: vars
         run: |
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          echo "sha_short=$SHA_SHORT" >> $GITHUB_OUTPUT
+          if [[ "${{ github.ref }}" == refs/tags/v*.*.* ]]; then
+            VERSION_TAG="${GITHUB_REF#refs/tags/}"
+            echo "tag_prefix=$VERSION_TAG" >> $GITHUB_OUTPUT
+            echo "additional_tags=[\"$VERSION_TAG\",\"latest\"]" >> $GITHUB_OUTPUT
+          else
+            echo "tag_prefix=master" >> $GITHUB_OUTPUT
+            echo "additional_tags=[\"master\",\"master-latest\"]" >> $GITHUB_OUTPUT
+          fi
           VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-          COMMIT=$(git rev-parse --short HEAD)
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
-          echo "COMMIT=${COMMIT}" >> "$GITHUB_ENV"
-          echo "DATE=${DATE}" >> "$GITHUB_ENV"
-          echo "Build version: VERSION=${VERSION} COMMIT=${COMMIT} DATE=${DATE}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "commit=$SHA_SHORT" >> $GITHUB_OUTPUT
+          echo "date=$DATE" >> $GITHUB_OUTPUT
 
-      - name: Deploy docker images
-        uses: ethpandaops/actions/docker-build-push@99b48ca2b233a2eff93e6a6df76e46b718aca108
+  build_amd64:
+    name: Build amd64 image
+    needs: meta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
-          registry_username: ${{ github.actor }}
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          image_name: ${{ github.repository }}
-          push: true
-          platforms: linux/amd64,linux/arm64
-          file: Dockerfile
-          build-args: |
-            VERSION=${{ env.VERSION }}
-            COMMIT=${{ env.COMMIT }}
-            DATE=${{ env.DATE }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build amd64 docker image
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+          VERSION: ${{ needs.meta.outputs.version }}
+          COMMIT: ${{ needs.meta.outputs.commit }}
+          DATE: ${{ needs.meta.outputs.date }}
+        run: |
+          docker build . --file "$DOCKERFILE" \
+            --tag "${GHCR_REPO}:${PREFIX}-amd64" \
+            --tag "${GHCR_REPO}:${PREFIX}-${SHA}-amd64" \
+            --platform=linux/amd64 \
+            --build-arg VERSION="$VERSION" \
+            --build-arg COMMIT="$COMMIT" \
+            --build-arg DATE="$DATE"
+
+      - name: Push amd64 docker images
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker push "${GHCR_REPO}:${PREFIX}-amd64"
+          docker push "${GHCR_REPO}:${PREFIX}-${SHA}-amd64"
+
+  build_arm64:
+    name: Build arm64 image
+    needs: meta
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build arm64 docker image
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+          VERSION: ${{ needs.meta.outputs.version }}
+          COMMIT: ${{ needs.meta.outputs.commit }}
+          DATE: ${{ needs.meta.outputs.date }}
+        run: |
+          docker build . --file "$DOCKERFILE" \
+            --tag "${GHCR_REPO}:${PREFIX}-arm64" \
+            --tag "${GHCR_REPO}:${PREFIX}-${SHA}-arm64" \
+            --platform=linux/arm64 \
+            --build-arg VERSION="$VERSION" \
+            --build-arg COMMIT="$COMMIT" \
+            --build-arg DATE="$DATE"
+
+      - name: Push arm64 docker images
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker push "${GHCR_REPO}:${PREFIX}-arm64"
+          docker push "${GHCR_REPO}:${PREFIX}-${SHA}-arm64"
+
+  manifest_sha:
+    name: Multi-arch sha manifest
+    needs: [meta, build_amd64, build_arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch sha manifest
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker buildx imagetools create -t "${GHCR_REPO}:${PREFIX}-${SHA}" \
+            "${GHCR_REPO}:${PREFIX}-${SHA}-amd64" \
+            "${GHCR_REPO}:${PREFIX}-${SHA}-arm64"
+
+  manifest_extra:
+    name: Multi-arch additional manifests
+    needs: [meta, build_amd64, build_arm64]
+    if: ${{ needs.meta.outputs.additional_tags != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        tag: ${{ fromJSON(needs.meta.outputs.additional_tags) }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest ${{ matrix.tag }}
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+          TAG: ${{ matrix.tag }}
+        run: |
+          docker buildx imagetools create -t "${GHCR_REPO}:${TAG}" \
+            "${GHCR_REPO}:${PREFIX}-${SHA}-amd64" \
+            "${GHCR_REPO}:${PREFIX}-${SHA}-arm64"

--- a/.github/workflows/deploy-docker.ui.yaml
+++ b/.github/workflows/deploy-docker.ui.yaml
@@ -7,35 +7,178 @@ on:
     tags:
       - 'v*.*.*'
 
+env:
+  GHCR_REPO: ghcr.io/${{ github.repository }}-ui
+  DOCKERFILE: Dockerfile.ui
+
 jobs:
-  build-and-push-image:
+  meta:
+    name: Compute tags and build info
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: write
-
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+      tag_prefix: ${{ steps.vars.outputs.tag_prefix }}
+      additional_tags: ${{ steps.vars.outputs.additional_tags }}
+      app_version: ${{ steps.vars.outputs.app_version }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - name: Set app version from git
+      - id: vars
         run: |
-          VERSION=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)
-          echo "Setting APP_VERSION=${VERSION}"
-          echo "APP_VERSION=${VERSION}" >> "$GITHUB_ENV"
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          echo "sha_short=$SHA_SHORT" >> $GITHUB_OUTPUT
+          if [[ "${{ github.ref }}" == refs/tags/v*.*.* ]]; then
+            VERSION_TAG="${GITHUB_REF#refs/tags/}"
+            echo "tag_prefix=$VERSION_TAG" >> $GITHUB_OUTPUT
+            echo "additional_tags=[\"$VERSION_TAG\",\"latest\"]" >> $GITHUB_OUTPUT
+          else
+            echo "tag_prefix=master" >> $GITHUB_OUTPUT
+            echo "additional_tags=[\"master\",\"master-latest\"]" >> $GITHUB_OUTPUT
+          fi
+          APP_VERSION=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)
+          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Deploy docker images
-        uses: ethpandaops/actions/docker-build-push@99b48ca2b233a2eff93e6a6df76e46b718aca108
+  build_amd64:
+    name: Build amd64 image
+    needs: meta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
-          registry_username: ${{ github.actor }}
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          image_name: ${{ github.repository }}-ui
-          push: true
-          platforms: linux/amd64,linux/arm64
-          file: Dockerfile.ui
-          build-args: |
-            APP_VERSION=${{ env.APP_VERSION }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build amd64 docker image
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+          APP_VERSION: ${{ needs.meta.outputs.app_version }}
+        run: |
+          docker build . --file "$DOCKERFILE" \
+            --tag "${GHCR_REPO}:${PREFIX}-amd64" \
+            --tag "${GHCR_REPO}:${PREFIX}-${SHA}-amd64" \
+            --platform=linux/amd64 \
+            --build-arg APP_VERSION="$APP_VERSION"
+
+      - name: Push amd64 docker images
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker push "${GHCR_REPO}:${PREFIX}-amd64"
+          docker push "${GHCR_REPO}:${PREFIX}-${SHA}-amd64"
+
+  build_arm64:
+    name: Build arm64 image
+    needs: meta
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build arm64 docker image
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+          APP_VERSION: ${{ needs.meta.outputs.app_version }}
+        run: |
+          docker build . --file "$DOCKERFILE" \
+            --tag "${GHCR_REPO}:${PREFIX}-arm64" \
+            --tag "${GHCR_REPO}:${PREFIX}-${SHA}-arm64" \
+            --platform=linux/arm64 \
+            --build-arg APP_VERSION="$APP_VERSION"
+
+      - name: Push arm64 docker images
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker push "${GHCR_REPO}:${PREFIX}-arm64"
+          docker push "${GHCR_REPO}:${PREFIX}-${SHA}-arm64"
+
+  manifest_sha:
+    name: Multi-arch sha manifest
+    needs: [meta, build_amd64, build_arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch sha manifest
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+        run: |
+          docker buildx imagetools create -t "${GHCR_REPO}:${PREFIX}-${SHA}" \
+            "${GHCR_REPO}:${PREFIX}-${SHA}-amd64" \
+            "${GHCR_REPO}:${PREFIX}-${SHA}-arm64"
+
+  manifest_extra:
+    name: Multi-arch additional manifests
+    needs: [meta, build_amd64, build_arm64]
+    if: ${{ needs.meta.outputs.additional_tags != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        tag: ${{ fromJSON(needs.meta.outputs.additional_tags) }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest ${{ matrix.tag }}
+        env:
+          PREFIX: ${{ needs.meta.outputs.tag_prefix }}
+          SHA: ${{ needs.meta.outputs.sha_short }}
+          TAG: ${{ matrix.tag }}
+        run: |
+          docker buildx imagetools create -t "${GHCR_REPO}:${TAG}" \
+            "${GHCR_REPO}:${PREFIX}-${SHA}-amd64" \
+            "${GHCR_REPO}:${PREFIX}-${SHA}-arm64"


### PR DESCRIPTION
## Summary
Restructures `deploy-docker.core.yaml` and `deploy-docker.ui.yaml` to match the dora/syncoor build pattern (mirrors [ethpandaops/syncoor#149](https://github.com/ethpandaops/syncoor/pull/149), GHCR-only):

- **Native per-arch jobs**: amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`. No QEMU emulation — cuts arm64 build time roughly in half.
- **Two-phase**: each arch is built and pushed with its own `-amd64`/`-arm64` suffix; a final `manifest_*` job fuses them into multi-arch manifests via `docker buildx imagetools create`.
- **Immutable `<tag>-<sha>` pins** for downstream pinning.
- Preserves existing build-args: `VERSION`/`COMMIT`/`DATE` for core, `APP_VERSION` for ui.

### Tags produced

**master push (same shape for `-ui`):**
```
ghcr.io/ethpandaops/benchmarkoor:master-amd64
ghcr.io/ethpandaops/benchmarkoor:master-arm64
ghcr.io/ethpandaops/benchmarkoor:master-<sha>-amd64
ghcr.io/ethpandaops/benchmarkoor:master-<sha>-arm64
ghcr.io/ethpandaops/benchmarkoor:master-<sha>         (multi-arch)
ghcr.io/ethpandaops/benchmarkoor:master               (multi-arch)
ghcr.io/ethpandaops/benchmarkoor:master-latest        (multi-arch alias)
```

**v*.*.* push:** same shape, with `master` replaced by the version and `master-latest` replaced by `latest`.

## Test plan
- [ ] On merge, observe `build_amd64`, `build_arm64`, `manifest_sha`, `manifest_extra` all green for both workflows.
- [ ] `docker buildx imagetools inspect ghcr.io/ethpandaops/benchmarkoor:master` shows both linux/amd64 and linux/arm64.
- [ ] Same check for `ghcr.io/ethpandaops/benchmarkoor-ui:master`.
- [ ] Pull `ghcr.io/ethpandaops/benchmarkoor:master-<sha>` from an arm64 host and from an amd64 host — both succeed.