### PR TITLE
feat: add --stop-after-prerun flag to keep instance up after pre-run

### DIFF
--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/client"
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
@@ -28,6 +29,7 @@ var (
 	limitInstanceClients []string
 	metadataLabels       []string
 	stopAfterPrerun      bool
+	preRunStepSleep      time.Duration
 )
 
 var runCmd = &cobra.Command{
@@ -48,6 +50,9 @@ func init() {
 	runCmd.Flags().BoolVar(&stopAfterPrerun, "stop-after-prerun", false,
 		"Exit after pre-run setup for each instance (RPC ready, bootstrap FCU done) "+
 			"without running tests. Leaves containers and data directories intact.")
+	runCmd.Flags().DurationVar(&preRunStepSleep, "prerun-step-sleep", 0,
+		"Sleep between each RPC call within pre-run step files (e.g. 10ms, 1s). "+
+			"Default 0 disables sleeping.")
 }
 
 func runBenchmark(cmd *cobra.Command, args []string) error {
@@ -327,6 +332,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 			TestFilter:         cfg.Runner.Benchmark.Tests.Filter,
 			FullConfig:         cfg,
 			StopAfterPrerun:    stopAfterPrerun,
+			PreRunStepSleep:    preRunStepSleep,
 		}
 
 		r := runner.NewRunner(log, runnerCfg, containerMgr, registry, exec, cpufreqMgr, resultsUploader, preRunLogBuffer)

--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -47,10 +47,10 @@ func init() {
 		"Limit to instances with these client types (comma-separated or repeated flag)")
 	runCmd.Flags().StringSliceVar(&metadataLabels, "metadata.label", nil,
 		"Add metadata label as key=value (can be repeated)")
-	runCmd.Flags().BoolVar(&stopAfterPrerun, "stop-after-prerun", false,
+	runCmd.Flags().BoolVar(&stopAfterPrerun, "debug.stop-after-prerun", false,
 		"Exit after pre-run setup for each instance (RPC ready, bootstrap FCU done) "+
 			"without running tests. Leaves containers and data directories intact.")
-	runCmd.Flags().DurationVar(&preRunStepSleep, "prerun-step-sleep", 0,
+	runCmd.Flags().DurationVar(&preRunStepSleep, "debug.prerun-step-sleep", 0,
 		"Sleep between each RPC call within pre-run step files (e.g. 10ms, 1s). "+
 			"Default 0 disables sleeping.")
 }

--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -27,6 +27,7 @@ var (
 	limitInstanceIDs     []string
 	limitInstanceClients []string
 	metadataLabels       []string
+	stopAfterPrerun      bool
 )
 
 var runCmd = &cobra.Command{
@@ -44,6 +45,9 @@ func init() {
 		"Limit to instances with these client types (comma-separated or repeated flag)")
 	runCmd.Flags().StringSliceVar(&metadataLabels, "metadata.label", nil,
 		"Add metadata label as key=value (can be repeated)")
+	runCmd.Flags().BoolVar(&stopAfterPrerun, "stop-after-prerun", false,
+		"Exit after pre-run setup for each instance (RPC ready, bootstrap FCU done) "+
+			"without running tests. Leaves containers and data directories intact.")
 }
 
 func runBenchmark(cmd *cobra.Command, args []string) error {
@@ -322,6 +326,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 			TmpCacheDir:        cfg.Runner.Directories.TmpCacheDir,
 			TestFilter:         cfg.Runner.Benchmark.Tests.Filter,
 			FullConfig:         cfg,
+			StopAfterPrerun:    stopAfterPrerun,
 		}
 
 		r := runner.NewRunner(log, runnerCfg, containerMgr, registry, exec, cpufreqMgr, resultsUploader, preRunLogBuffer)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -111,6 +111,7 @@ type ExecuteOptions struct {
 	RetryNewPayloadsSyncingConfig *config.RetryNewPayloadsSyncingConfig // Retry config for SYNCING responses.
 	PostTestRPCCalls              []config.PostTestRPCCall              // Arbitrary RPC calls to execute after the test step.
 	PostTestSleepDuration         time.Duration                         // Sleep duration after each test (0 = disabled).
+	FailFast                      bool                                  // If true, return an error from runStepLines on the first failed RPC call.
 }
 
 // ExecutionResult contains the overall execution summary.
@@ -367,6 +368,11 @@ func (e *executor) RunPreRunSteps(ctx context.Context, opts *ExecuteOptions) (in
 
 		preRunResult := NewTestResult(step.Name)
 		if err := e.runStepFile(ctx, opts, step, preRunResult, false); err != nil {
+			// FailFast: surface the error to the caller without writing partial results.
+			if opts.FailFast {
+				return 0, fmt.Errorf("pre-run step %q failed: %w", step.Name, err)
+			}
+
 			log.WithError(err).Warn("Pre-run step failed")
 
 			if ctx.Err() != nil {
@@ -815,6 +821,8 @@ func (e *executor) runStepLines(
 	result *TestResult,
 	captureBlockLogs bool,
 ) error {
+	stepStart := time.Now()
+
 	for lineNum, line := range lines {
 		select {
 		case <-ctx.Done():
@@ -834,6 +842,13 @@ func (e *executor) runStepLines(
 				result.AddResult("unknown", line, "", 0, false, nil)
 			}
 
+			if opts.FailFast {
+				return fmt.Errorf(
+					"step %q line %d: failed to parse JSON-RPC payload: %w",
+					stepName, lineNum+1, err,
+				)
+			}
+
 			continue
 		}
 
@@ -850,6 +865,10 @@ func (e *executor) runStepLines(
 		succeeded := err == nil
 
 		e.log.WithFields(logrus.Fields{
+			"step":          stepName,
+			"pos":           fmt.Sprintf("%d/%d", lineNum+1, len(lines)),
+			"progress":      fmt.Sprintf("%.1f%%", float64(lineNum+1)*100/float64(len(lines))),
+			"eta":           estimateETA(stepStart, lineNum+1, len(lines)),
 			"method":        method,
 			"duration":      time.Duration(duration),
 			"full_duration": time.Duration(fullDuration),
@@ -903,9 +922,29 @@ func (e *executor) runStepLines(
 		if result != nil {
 			result.AddResult(method, line, response, duration, succeeded, resourceDelta)
 		}
+
+		if !succeeded && opts.FailFast {
+			return fmt.Errorf(
+				"step %q line %d: RPC call %s failed",
+				stepName, lineNum+1, method,
+			)
+		}
 	}
 
 	return nil
+}
+
+// estimateETA returns the projected remaining duration to finish a step,
+// based on the average time per call so far. Returns 0 when there is no
+// data yet (first call) or no work remains.
+func estimateETA(start time.Time, completed, total int) time.Duration {
+	if completed <= 0 || completed >= total {
+		return 0
+	}
+
+	avg := time.Since(start) / time.Duration(completed)
+
+	return (avg * time.Duration(total-completed)).Round(time.Second)
 }
 
 // retryNewPayloadSyncing retries an engine_newPayload call when it returns SYNCING status.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -112,6 +112,7 @@ type ExecuteOptions struct {
 	PostTestRPCCalls              []config.PostTestRPCCall              // Arbitrary RPC calls to execute after the test step.
 	PostTestSleepDuration         time.Duration                         // Sleep duration after each test (0 = disabled).
 	FailFast                      bool                                  // If true, return an error from runStepLines on the first failed RPC call.
+	PreRunStepSleep               time.Duration                         // Sleep between each RPC call within pre-run step files (0 = disabled).
 }
 
 // ExecutionResult contains the overall execution summary.
@@ -367,7 +368,7 @@ func (e *executor) RunPreRunSteps(ctx context.Context, opts *ExecuteOptions) (in
 		log.Info("Running pre-run step")
 
 		preRunResult := NewTestResult(step.Name)
-		if err := e.runStepFile(ctx, opts, step, preRunResult, false); err != nil {
+		if err := e.runStepFile(ctx, opts, step, preRunResult, false, opts.PreRunStepSleep); err != nil {
 			// FailFast: surface the error to the caller without writing partial results.
 			if opts.FailFast {
 				return 0, fmt.Errorf("pre-run step %q failed: %w", step.Name, err)
@@ -462,7 +463,7 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 			log.Info("Running pre-run step")
 
 			preRunResult := NewTestResult(step.Name)
-			if err := e.runStepFile(ctx, opts, step, preRunResult, false); err != nil {
+			if err := e.runStepFile(ctx, opts, step, preRunResult, false, opts.PreRunStepSleep); err != nil {
 				log.WithError(err).Warn("Pre-run step failed")
 
 				// Check if the failure was due to context cancellation.
@@ -545,7 +546,7 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 
 			setupResult := NewTestResult(test.Name)
 
-			if err := e.runStepFile(ctx, opts, test.Setup, setupResult, false); err != nil {
+			if err := e.runStepFile(ctx, opts, test.Setup, setupResult, false, 0); err != nil {
 				log.WithError(err).Error("Setup step failed")
 				testPassed = false
 
@@ -581,7 +582,7 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 
 			testResult := NewTestResult(test.Name)
 
-			if err := e.runStepFile(ctx, opts, test.Test, testResult, true); err != nil {
+			if err := e.runStepFile(ctx, opts, test.Test, testResult, true, 0); err != nil {
 				log.WithError(err).Error("Test step failed")
 				testPassed = false
 
@@ -631,7 +632,7 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 
 			cleanupResult := NewTestResult(test.Name)
 
-			if err := e.runStepFile(ctx, opts, test.Cleanup, cleanupResult, false); err != nil {
+			if err := e.runStepFile(ctx, opts, test.Cleanup, cleanupResult, false, 0); err != nil {
 				log.WithError(err).Error("Cleanup step failed")
 				testPassed = false
 
@@ -757,19 +758,21 @@ writeResults:
 
 // runStepFile executes a single step file or provider.
 // If captureBlockLogs is true, blockHashes from engine_newPayload calls are registered for log matching.
+// betweenLineSleep, when > 0, sleeps for that duration between each RPC call.
 func (e *executor) runStepFile(
 	ctx context.Context,
 	opts *ExecuteOptions,
 	step *StepFile,
 	result *TestResult,
 	captureBlockLogs bool,
+	betweenLineSleep time.Duration,
 ) error {
 	// Use provider if available, otherwise read from file.
 	if step.Provider != nil {
-		return e.runStepLines(ctx, opts, step.Name, step.Provider.Lines(), result, captureBlockLogs)
+		return e.runStepLines(ctx, opts, step.Name, step.Provider.Lines(), result, captureBlockLogs, betweenLineSleep)
 	}
 
-	return e.runStepFromFile(ctx, opts, step, result, captureBlockLogs)
+	return e.runStepFromFile(ctx, opts, step, result, captureBlockLogs, betweenLineSleep)
 }
 
 // runStepFromFile reads and executes lines from a file.
@@ -779,6 +782,7 @@ func (e *executor) runStepFromFile(
 	step *StepFile,
 	result *TestResult,
 	captureBlockLogs bool,
+	betweenLineSleep time.Duration,
 ) error {
 	file, err := os.Open(step.Path)
 	if err != nil {
@@ -808,11 +812,13 @@ func (e *executor) runStepFromFile(
 		}
 	}
 
-	return e.runStepLines(ctx, opts, step.Name, lines, result, captureBlockLogs)
+	return e.runStepLines(ctx, opts, step.Name, lines, result, captureBlockLogs, betweenLineSleep)
 }
 
 // runStepLines executes JSON-RPC lines.
 // If captureBlockLogs is true, blockHashes from engine_newPayload calls are registered for log matching.
+// betweenLineSleep, when > 0, sleeps for that duration between each RPC call (after the call completes,
+// before the next one starts). Skipped after the final call. Cancellable via ctx.
 func (e *executor) runStepLines(
 	ctx context.Context,
 	opts *ExecuteOptions,
@@ -820,6 +826,7 @@ func (e *executor) runStepLines(
 	lines []string,
 	result *TestResult,
 	captureBlockLogs bool,
+	betweenLineSleep time.Duration,
 ) error {
 	stepStart := time.Now()
 
@@ -928,6 +935,15 @@ func (e *executor) runStepLines(
 				"step %q line %d: RPC call %s failed",
 				stepName, lineNum+1, method,
 			)
+		}
+
+		// Pace the replay if requested. Skip the wait after the final call.
+		if betweenLineSleep > 0 && lineNum < len(lines)-1 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(betweenLineSleep):
+			}
 		}
 	}
 

--- a/pkg/executor/source.go
+++ b/pkg/executor/source.go
@@ -505,8 +505,8 @@ func expandGlobPattern(basePath, pattern, filter string) ([]*StepFile, string, e
 			continue
 		}
 
-		// Only include .txt files.
-		if !strings.HasSuffix(match, ".txt") {
+		// Only include .txt and .jsonl files.
+		if !strings.HasSuffix(match, ".txt") && !strings.HasSuffix(match, ".jsonl") {
 			continue
 		}
 

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -999,6 +999,46 @@ func (r *runner) runContainerLifecycle(
 		params.LiveState.SetConfig(runConfig)
 	}
 
+	// Stop after pre-run if requested: clear localCleanupFuncs first so
+	// the deferred cleanup loop is a no-op on every exit path (success
+	// or pre-run failure), leaving the container, volume/datadir, temp
+	// files, and CPU frequency settings intact for inspection. Then run
+	// the suite's pre-run steps (if any) with FailFast set so any
+	// failure surfaces immediately.
+	if r.cfg.StopAfterPrerun {
+		localCleanupFuncs = nil
+
+		if r.executor != nil {
+			preRunOpts := &executor.ExecuteOptions{
+				EngineEndpoint: fmt.Sprintf(
+					"http://%s:%d", containerIP, spec.EnginePort(),
+				),
+				JWT:        r.cfg.JWT,
+				ResultsDir: runResultsDir,
+				FailFast:   true,
+			}
+
+			if n, err := r.executor.RunPreRunSteps(execCtx, preRunOpts); err != nil {
+				return fmt.Errorf("running pre-run steps: %w", err)
+			} else if n > 0 {
+				log.WithField("steps", n).Info("Pre-run steps completed")
+			}
+		}
+
+		log.WithFields(logrus.Fields{
+			"container_id": containerID,
+			"container_ip": containerIP,
+			"rpc_endpoint": fmt.Sprintf("http://%s:%d", containerIP, spec.RPCPort()),
+			"engine_endpoint": fmt.Sprintf(
+				"http://%s:%d", containerIP, spec.EnginePort(),
+			),
+			"data_mount": dataMount.Source,
+			"run_dir":    runResultsDir,
+		}).Info("--stop-after-prerun set; exiting without running tests, leaving resources intact")
+
+		return nil
+	}
+
 	// Execute tests if executor is configured.
 	if r.executor != nil {
 		log.Info("Starting test execution")

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -1013,9 +1013,10 @@ func (r *runner) runContainerLifecycle(
 				EngineEndpoint: fmt.Sprintf(
 					"http://%s:%d", containerIP, spec.EnginePort(),
 				),
-				JWT:        r.cfg.JWT,
-				ResultsDir: runResultsDir,
-				FailFast:   true,
+				JWT:             r.cfg.JWT,
+				ResultsDir:      runResultsDir,
+				FailFast:        true,
+				PreRunStepSleep: r.cfg.PreRunStepSleep,
 			}
 
 			if n, err := r.executor.RunPreRunSteps(execCtx, preRunOpts); err != nil {
@@ -1120,6 +1121,7 @@ func (r *runner) runContainerLifecycle(
 				RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(instance),
 				PostTestRPCCalls:              r.cfg.FullConfig.GetPostTestRPCCalls(instance),
 				PostTestSleepDuration:         r.cfg.FullConfig.GetPostTestSleepDuration(instance),
+				PreRunStepSleep:               r.cfg.PreRunStepSleep,
 			}
 
 			result, execErr = r.executor.ExecuteTests(execCtx, execOpts)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -69,6 +69,10 @@ type Config struct {
 	// tests, leaving containers, volumes, and data directories intact for
 	// inspection.
 	StopAfterPrerun bool
+	// PreRunStepSleep, when > 0, inserts a sleep between each RPC call
+	// within pre-run step files. Useful for pacing replay against the
+	// engine API. 0 disables sleeping.
+	PreRunStepSleep time.Duration
 }
 
 // TestCounts contains test count statistics for a run.

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -64,6 +64,11 @@ type Config struct {
 	ReadyTimeout       time.Duration
 	TestFilter         string
 	FullConfig         *config.Config // Full config for resolving per-instance settings
+	// StopAfterPrerun, when true, causes each instance lifecycle to exit
+	// after pre-run setup (RPC ready, bootstrap FCU done) without running
+	// tests, leaving containers, volumes, and data directories intact for
+	// inspection.
+	StopAfterPrerun bool
 }
 
 // TestCounts contains test count statistics for a run.

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -178,9 +178,10 @@ func (r *runner) runTestsWithCheckpointRestore(
 	engineEndpoint := fmt.Sprintf("http://%s:%d", containerIP, spec.EnginePort())
 
 	preRunOpts := &executor.ExecuteOptions{
-		EngineEndpoint: engineEndpoint,
-		JWT:            r.cfg.JWT,
-		ResultsDir:     resultsDir,
+		EngineEndpoint:  engineEndpoint,
+		JWT:             r.cfg.JWT,
+		ResultsDir:      resultsDir,
+		PreRunStepSleep: r.cfg.PreRunStepSleep,
 	}
 
 	if n, err := r.executor.RunPreRunSteps(ctx, preRunOpts); err != nil {

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -88,9 +88,10 @@ func (r *runner) runTestsWithContainerStrategy(
 		)
 
 		preRunOpts := &executor.ExecuteOptions{
-			EngineEndpoint: engineEndpoint,
-			JWT:            r.cfg.JWT,
-			ResultsDir:     resultsDir,
+			EngineEndpoint:  engineEndpoint,
+			JWT:             r.cfg.JWT,
+			ResultsDir:      resultsDir,
+			PreRunStepSleep: r.cfg.PreRunStepSleep,
 		}
 
 		if n, err := r.executor.RunPreRunSteps(ctx, preRunOpts); err != nil {
@@ -732,8 +733,9 @@ func (r *runner) runTestsWithContainerStrategy(
 				EngineEndpoint: fmt.Sprintf(
 					"http://%s:%d", currentContainerIP, spec.EnginePort(),
 				),
-				JWT:        r.cfg.JWT,
-				ResultsDir: resultsDir,
+				JWT:             r.cfg.JWT,
+				ResultsDir:      resultsDir,
+				PreRunStepSleep: r.cfg.PreRunStepSleep,
 			}
 
 			if n, err := r.executor.RunPreRunSteps(ctx, preRunOpts); err != nil {


### PR DESCRIPTION
## Summary
Adds two debug-only flags to `benchmarkoor run` to support inspecting and pacing pre-run RPC replay against a live client:

- **`--debug.stop-after-prerun`** — for each instance, runs the suite's `pre_run_steps` against the live container with fail-fast semantics, then exits without executing tests. Cleanup is skipped on every exit path so containers, volumes, and data directories stay up for inspection.
- **`--debug.prerun-step-sleep <duration>`** — sleeps between each RPC call within pre-run step files (e.g. `10ms`, `1s`). Default `0` disables. Applies to all pre-run paths (stop-after-prerun, ZFS-snapshot, checkpoint-restore, and the inline pre-run loop in normal benchmark execution); test setup/test/cleanup steps are unaffected.

Drive-by improvements:
- Pre-run step file matcher now accepts `.jsonl` alongside `.txt` — both formats are read line-by-line as JSON-RPC payloads, only the suffix gate differed.
- Per-call RPC log gains `step`, `pos` (`X/Y`), `progress` (`XX.X%`), and `eta` fields so long pre-run replays show progression.

## Test plan
- [x] `go build`, `go vet`, and `golangci-lint run --new-from-rev="origin/master"` clean
- [x] Existing `pkg/executor` tests pass
- [ ] End-to-end: `benchmarkoor run --config <cfg> --debug.stop-after-prerun --debug.prerun-step-sleep=10ms --limit-instance-id=<id>` against a real Docker/Podman setup — verify pre-run executes, sleep paces calls, container stays up after exit, and a forced failure mid pre-run aborts immediately while leaving the container intact