### PR TITLE
fix: create executor cache directory if missing

### DIFF
--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -34,10 +34,16 @@ type ArchiveSource struct {
 
 // Prepare downloads (if URL) and extracts the archive, then discovers tests.
 func (s *ArchiveSource) Prepare(ctx context.Context) (*PreparedSource, error) {
-	// Create temp directory for extraction.
+	// Create temp directory for extraction. MkdirTemp requires the parent to
+	// exist, so ensure the cache dir is created (e.g. ~/.cache/benchmarkoor on
+	// a fresh host).
 	parentDir := s.cacheDir
 	if parentDir == "" {
 		parentDir = os.TempDir()
+	}
+
+	if err := os.MkdirAll(parentDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating cache directory: %w", err)
 	}
 
 	tmpDir, err := os.MkdirTemp(parentDir, "archive-*")


### PR DESCRIPTION
## Summary
- `os.MkdirTemp` in `ArchiveSource.Prepare` failed on hosts where the default cache dir (e.g. `/root/.cache/benchmarkoor`) didn't yet exist, since `MkdirTemp` does not create parent directories.
- Add an `os.MkdirAll` before the `MkdirTemp` call, matching the pattern already used by `resolvePartsFile` and the git/eest sources.

Fixes the runtime error:
```
FATL | Failed to execute command error=starting executor: preparing source: creating temp directory: stat /root/.cache/benchmarkoor: no such file or directory
```

## Test plan
- [x] `go build ./pkg/executor/`
- [x] `go test ./pkg/executor/ -run TestArchive`
- [x] Run on a fresh host where `~/.cache/benchmarkoor` does not exist and confirm the executor starts.