### PR TITLE
feat: retry_new_payloads_failed_state + apply retries to pre-runs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -881,7 +881,7 @@ Both this and `retry_new_payloads_failed_state` (below) apply to **all** `engine
 
 ##### Retry New Payloads Failed State
 
-Catch-all retry for `engine_newPayload*` calls that fail for any reason **other than** SYNCING — RPC/network errors, JSON-RPC errors (e.g. `-32603 Server error`), `INVALID` / `INVALID_BLOCK_HASH` payload statuses, or unparseable responses. Useful for transient client-side flakiness, where a single retry usually succeeds.
+Catch-all retry for `engine_newPayload*` calls that fail for any reason **other than** SYNCING — RPC/network errors, JSON-RPC errors (e.g. `-32603 Server error`), `INVALID` / `INVALID_BLOCK_HASH` payload statuses, or unparsable responses. Useful for transient client-side flakiness, where a single retry usually succeeds.
 
 ```yaml
 runner:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -652,6 +652,7 @@ runner:
 | `wait_after_rpc_ready` | string | - | Duration to wait after RPC becomes ready (see below) |
 | `run_timeout` | string | - | Maximum duration for test execution before the run is timed out (see below) |
 | `retry_new_payloads_syncing_state` | object | - | Retry config for SYNCING responses (see below) |
+| `retry_new_payloads_failed_state` | object | - | Retry config for any non-SYNCING `engine_newPayload*` failure (see below) |
 | `resource_limits` | object | - | Container resource constraints (see [Resource Limits](#resource-limits)) |
 | `post_test_rpc_calls` | []object | - | Arbitrary RPC calls to execute after each test step (see [Post-Test RPC Calls](#post-test-rpc-calls)) |
 | `post_test_sleep_duration` | string | - | Sleep duration after each test, e.g. `200ms`, `1s` (see below) |
@@ -876,6 +877,34 @@ runner:
 - When using pre-populated data directories where clients may need time to validate chain state
 - Combined with `wait_after_rpc_ready` for clients with complex initialization
 
+Both this and `retry_new_payloads_failed_state` (below) apply to **all** `engine_newPayload*` calls — pre-run steps, setup steps, and test steps alike.
+
+##### Retry New Payloads Failed State
+
+Catch-all retry for `engine_newPayload*` calls that fail for any reason **other than** SYNCING — RPC/network errors, JSON-RPC errors (e.g. `-32603 Server error`), `INVALID` / `INVALID_BLOCK_HASH` payload statuses, or unparseable responses. Useful for transient client-side flakiness, where a single retry usually succeeds.
+
+```yaml
+runner:
+  client:
+    config:
+      retry_new_payloads_failed_state:
+        enabled: true
+        max_retries: 3
+        backoff: 500ms
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `enabled` | bool | Yes | Enable retry behavior |
+| `max_retries` | int | Yes | Maximum number of retry attempts (must be ≥ 1) |
+| `backoff` | string | Yes | Delay between retries (Go duration string) |
+
+When both `retry_new_payloads_syncing_state` and `retry_new_payloads_failed_state` are enabled, SYNCING errors take the SYNCING retry path and everything else takes the failed-state retry path.
+
+**When to use:**
+- Recovering from transient JSON-RPC errors during long pre-run replays
+- Suppressing one-off failures when clients are momentarily under load (e.g. cache warm-up)
+
 
 ##### Bootstrap FCU
 
@@ -1020,6 +1049,7 @@ runner:
 | `wait_after_rpc_ready` | string | No | From `runner.client.config` | Instance-specific RPC ready wait duration |
 | `run_timeout` | string | No | From `runner.client.config` | Instance-specific run timeout duration |
 | `retry_new_payloads_syncing_state` | object | No | From `runner.client.config` | Instance-specific retry config for SYNCING responses |
+| `retry_new_payloads_failed_state` | object | No | From `runner.client.config` | Instance-specific retry config for non-SYNCING failures |
 | `resource_limits` | object | No | From `runner.client.config` | Instance-specific resource limits |
 | `post_test_rpc_calls` | []object | No | From `runner.client.config` | Instance-specific post-test RPC calls (replaces global) |
 | `post_test_sleep_duration` | string | No | From `runner.client.config` | Instance-specific post-test sleep duration |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -490,6 +490,17 @@ type RetryNewPayloadsSyncingConfig struct {
 	Backoff    string `yaml:"backoff" mapstructure:"backoff" json:"backoff"`
 }
 
+// RetryNewPayloadsFailedConfig configures retry behavior when engine_newPayload
+// fails for any reason other than SYNCING (RPC/network error, JSON-RPC error,
+// non-VALID payload status, etc.). When both this and the SYNCING config are
+// enabled, SYNCING errors take the SYNCING retry path and everything else
+// takes this path.
+type RetryNewPayloadsFailedConfig struct {
+	Enabled    bool   `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
+	MaxRetries int    `yaml:"max_retries" mapstructure:"max_retries" json:"max_retries"`
+	Backoff    string `yaml:"backoff" mapstructure:"backoff" json:"backoff"`
+}
+
 // CheckpointRestoreStrategyOptions configures options for the checkpoint-restore
 // rollback strategy (CRIU-based checkpoint/restore with Podman).
 type CheckpointRestoreStrategyOptions struct {
@@ -723,6 +734,7 @@ type ClientDefaults struct {
 	RollbackStrategy                 string                            `yaml:"rollback_strategy,omitempty" mapstructure:"rollback_strategy"`
 	ResourceLimits                   *ResourceLimits                   `yaml:"resource_limits,omitempty" mapstructure:"resource_limits"`
 	RetryNewPayloadsSyncingState     *RetryNewPayloadsSyncingConfig    `yaml:"retry_new_payloads_syncing_state,omitempty" mapstructure:"retry_new_payloads_syncing_state"`
+	RetryNewPayloadsFailedState      *RetryNewPayloadsFailedConfig     `yaml:"retry_new_payloads_failed_state,omitempty" mapstructure:"retry_new_payloads_failed_state"`
 	WaitAfterRPCReady                string                            `yaml:"wait_after_rpc_ready,omitempty" mapstructure:"wait_after_rpc_ready"`
 	RunTimeout                       string                            `yaml:"run_timeout,omitempty" mapstructure:"run_timeout"`
 	PostTestRPCCalls                 []PostTestRPCCall                 `yaml:"post_test_rpc_calls,omitempty" mapstructure:"post_test_rpc_calls"`
@@ -749,6 +761,7 @@ type ClientInstance struct {
 	RollbackStrategy                 string                            `yaml:"rollback_strategy,omitempty" mapstructure:"rollback_strategy"`
 	ResourceLimits                   *ResourceLimits                   `yaml:"resource_limits,omitempty" mapstructure:"resource_limits"`
 	RetryNewPayloadsSyncingState     *RetryNewPayloadsSyncingConfig    `yaml:"retry_new_payloads_syncing_state,omitempty" mapstructure:"retry_new_payloads_syncing_state"`
+	RetryNewPayloadsFailedState      *RetryNewPayloadsFailedConfig     `yaml:"retry_new_payloads_failed_state,omitempty" mapstructure:"retry_new_payloads_failed_state"`
 	WaitAfterRPCReady                string                            `yaml:"wait_after_rpc_ready,omitempty" mapstructure:"wait_after_rpc_ready"`
 	RunTimeout                       string                            `yaml:"run_timeout,omitempty" mapstructure:"run_timeout"`
 	PostTestRPCCalls                 []PostTestRPCCall                 `yaml:"post_test_rpc_calls,omitempty" mapstructure:"post_test_rpc_calls"`
@@ -1172,6 +1185,11 @@ func (c *Config) Validate(opts ...ValidateOpts) error {
 		return err
 	}
 
+	// Validate retry_new_payloads_failed_state settings.
+	if err := c.validateRetryNewPayloadsFailedState(); err != nil {
+		return err
+	}
+
 	// Validate wait_after_rpc_ready settings.
 	if err := c.validateWaitAfterRPCReady(); err != nil {
 		return err
@@ -1490,6 +1508,17 @@ func (c *Config) GetRetryNewPayloadsSyncingState(instance *ClientInstance) *Retr
 	}
 
 	return c.Runner.Client.Config.RetryNewPayloadsSyncingState
+}
+
+// GetRetryNewPayloadsFailedState returns the failed-state retry config for an
+// instance. Instance-level config takes precedence over global defaults.
+// Returns nil if no config is set.
+func (c *Config) GetRetryNewPayloadsFailedState(instance *ClientInstance) *RetryNewPayloadsFailedConfig {
+	if instance.RetryNewPayloadsFailedState != nil {
+		return instance.RetryNewPayloadsFailedState
+	}
+
+	return c.Runner.Client.Config.RetryNewPayloadsFailedState
 }
 
 // GetWaitAfterRPCReady returns the duration to wait after RPC becomes ready.
@@ -1934,6 +1963,33 @@ func (c *Config) validateRetryNewPayloadsSyncingState() error {
 
 		if _, err := time.ParseDuration(cfg.Backoff); err != nil {
 			return fmt.Errorf("instance %q: invalid retry_new_payloads_syncing_state.backoff %q: %w",
+				instance.ID, cfg.Backoff, err)
+		}
+	}
+
+	return nil
+}
+
+// validateRetryNewPayloadsFailedState validates retry_new_payloads_failed_state settings.
+func (c *Config) validateRetryNewPayloadsFailedState() error {
+	for _, instance := range c.Runner.Instances {
+		cfg := c.GetRetryNewPayloadsFailedState(&instance)
+		if cfg == nil || !cfg.Enabled {
+			continue
+		}
+
+		if cfg.MaxRetries < 1 {
+			return fmt.Errorf("instance %q: retry_new_payloads_failed_state.max_retries must be at least 1",
+				instance.ID)
+		}
+
+		if cfg.Backoff == "" {
+			return fmt.Errorf("instance %q: retry_new_payloads_failed_state.backoff is required when enabled",
+				instance.ID)
+		}
+
+		if _, err := time.ParseDuration(cfg.Backoff); err != nil {
+			return fmt.Errorf("instance %q: invalid retry_new_payloads_failed_state.backoff %q: %w",
 				instance.ID, cfg.Backoff, err)
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2673,3 +2673,118 @@ func TestValidateRunTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRetryNewPayloadsFailedState(t *testing.T) {
+	tests := []struct {
+		name     string
+		global   *RetryNewPayloadsFailedConfig
+		instance *RetryNewPayloadsFailedConfig
+		expected *RetryNewPayloadsFailedConfig
+	}{
+		{
+			name:     "both nil returns nil",
+			global:   nil,
+			instance: nil,
+			expected: nil,
+		},
+		{
+			name:     "global set, instance nil inherits",
+			global:   &RetryNewPayloadsFailedConfig{Enabled: true, MaxRetries: 5, Backoff: "1s"},
+			instance: nil,
+			expected: &RetryNewPayloadsFailedConfig{Enabled: true, MaxRetries: 5, Backoff: "1s"},
+		},
+		{
+			name:     "instance overrides global",
+			global:   &RetryNewPayloadsFailedConfig{Enabled: true, MaxRetries: 5, Backoff: "1s"},
+			instance: &RetryNewPayloadsFailedConfig{Enabled: true, MaxRetries: 1, Backoff: "5s"},
+			expected: &RetryNewPayloadsFailedConfig{Enabled: true, MaxRetries: 1, Backoff: "5s"},
+		},
+		{
+			name:     "instance disabled overrides global enabled",
+			global:   &RetryNewPayloadsFailedConfig{Enabled: true, MaxRetries: 5, Backoff: "1s"},
+			instance: &RetryNewPayloadsFailedConfig{Enabled: false},
+			expected: &RetryNewPayloadsFailedConfig{Enabled: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Runner: RunnerConfig{
+					Client: ClientConfig{
+						Config: ClientDefaults{
+							RetryNewPayloadsFailedState: tt.global,
+						},
+					},
+				},
+			}
+			instance := &ClientInstance{
+				RetryNewPayloadsFailedState: tt.instance,
+			}
+			result := cfg.GetRetryNewPayloadsFailedState(instance)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestValidateRetryNewPayloadsFailedState(t *testing.T) {
+	tests := []struct {
+		name      string
+		global    *RetryNewPayloadsFailedConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "disabled is valid",
+			global:  &RetryNewPayloadsFailedConfig{Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "valid enabled config",
+			global:  &RetryNewPayloadsFailedConfig{Enabled: true, MaxRetries: 3, Backoff: "500ms"},
+			wantErr: false,
+		},
+		{
+			name:      "max_retries zero",
+			global:    &RetryNewPayloadsFailedConfig{Enabled: true, MaxRetries: 0, Backoff: "1s"},
+			wantErr:   true,
+			errSubstr: "max_retries must be at least 1",
+		},
+		{
+			name:      "missing backoff",
+			global:    &RetryNewPayloadsFailedConfig{Enabled: true, MaxRetries: 3, Backoff: ""},
+			wantErr:   true,
+			errSubstr: "backoff is required",
+		},
+		{
+			name:      "invalid backoff",
+			global:    &RetryNewPayloadsFailedConfig{Enabled: true, MaxRetries: 3, Backoff: "not-a-duration"},
+			wantErr:   true,
+			errSubstr: "invalid retry_new_payloads_failed_state.backoff",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Runner: RunnerConfig{
+					Client: ClientConfig{
+						Config: ClientDefaults{
+							RetryNewPayloadsFailedState: tt.global,
+						},
+					},
+					Instances: []ClientInstance{
+						{ID: "test", Client: "geth"},
+					},
+				},
+			}
+			err := cfg.validateRetryNewPayloadsFailedState()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -109,6 +109,7 @@ type ExecuteOptions struct {
 	Tests                         []*TestWithSteps                      // Optional subset of tests to run (nil = run all).
 	BlockLogCollector             BlockLogCollector                     // Optional collector for capturing block logs from client.
 	RetryNewPayloadsSyncingConfig *config.RetryNewPayloadsSyncingConfig // Retry config for SYNCING responses.
+	RetryNewPayloadsFailedConfig  *config.RetryNewPayloadsFailedConfig  // Retry config for any non-SYNCING newPayload failure (RPC error, validation error, INVALID status).
 	PostTestRPCCalls              []config.PostTestRPCCall              // Arbitrary RPC calls to execute after the test step.
 	PostTestSleepDuration         time.Duration                         // Sleep duration after each test (0 = disabled).
 	FailFast                      bool                                  // If true, return an error from runStepLines on the first failed RPC call.
@@ -926,7 +927,11 @@ func (e *executor) runStepLines(
 			}).WithError(err).Warn("RPC call failed")
 		}
 
-		// Validate response AFTER timing, BEFORE storing result.
+		// Validate response AFTER timing, BEFORE storing result. Track the
+		// validation error so the retry decision below can distinguish
+		// SYNCING from other failure modes.
+		var validationErr error
+
 		if succeeded && e.validator != nil && response != "" {
 			if resp, parseErr := jsonrpc.Parse(response); parseErr != nil {
 				e.log.WithFields(logrus.Fields{
@@ -936,30 +941,56 @@ func (e *executor) runStepLines(
 				}).WithError(parseErr).Warn("Failed to parse JSON-RPC response")
 
 				succeeded = false
-			} else if validationErr := e.validator.Validate(method, resp); validationErr != nil {
-				// Check if this is a SYNCING error and retry is enabled.
-				if jsonrpc.IsSyncingError(validationErr) && opts.RetryNewPayloadsSyncingConfig != nil &&
-					opts.RetryNewPayloadsSyncingConfig.Enabled {
-					retrySucceeded, retryResponse, retryDuration := e.retryNewPayloadSyncing(
-						ctx, opts, line, method, stepName, lineNum,
-					)
-					if retrySucceeded {
-						succeeded = true
-						response = retryResponse
-						duration = retryDuration
-					} else {
-						succeeded = false
-					}
-				} else {
+			} else if validationErr = e.validator.Validate(method, resp); validationErr != nil {
+				succeeded = false
+			}
+		}
+
+		// Decide retry policy when a newPayload call failed. SYNCING errors
+		// take the SYNCING retry config when enabled; everything else
+		// (RPC/network error, parse error, INVALID/INVALID_BLOCK_HASH,
+		// JSON-RPC error) takes the failed-state retry config when enabled.
+		// Non-newPayload methods are not retried.
+		if !succeeded && strings.HasPrefix(method, "engine_newPayload") {
+			isSyncing := validationErr != nil && jsonrpc.IsSyncingError(validationErr)
+
+			switch {
+			case isSyncing && opts.RetryNewPayloadsSyncingConfig != nil &&
+				opts.RetryNewPayloadsSyncingConfig.Enabled:
+				retrySucceeded, retryResponse, retryDuration := e.retryNewPayloadSyncing(
+					ctx, opts, line, method, stepName, lineNum,
+				)
+				if retrySucceeded {
+					succeeded = true
+					response = retryResponse
+					duration = retryDuration
+				}
+			case opts.RetryNewPayloadsFailedConfig != nil &&
+				opts.RetryNewPayloadsFailedConfig.Enabled:
+				retrySucceeded, retryResponse, retryDuration := e.retryNewPayloadFailed(
+					ctx, opts, line, method, stepName, lineNum,
+				)
+				if retrySucceeded {
+					succeeded = true
+					response = retryResponse
+					duration = retryDuration
+				}
+			default:
+				if validationErr != nil {
 					e.log.WithFields(logrus.Fields{
 						"line":   lineNum + 1,
 						"method": method,
 						"step":   stepName,
 					}).WithError(validationErr).Warn("Response validation failed")
-
-					succeeded = false
 				}
 			}
+		} else if !succeeded && validationErr != nil {
+			// Non-newPayload validation failure: log without retry.
+			e.log.WithFields(logrus.Fields{
+				"line":   lineNum + 1,
+				"method": method,
+				"step":   stepName,
+			}).WithError(validationErr).Warn("Response validation failed")
 		}
 
 		if result != nil {
@@ -997,6 +1028,91 @@ func estimateETA(start time.Time, completed, total int) time.Duration {
 	avg := time.Since(start) / time.Duration(completed)
 
 	return (avg * time.Duration(total-completed)).Round(time.Second)
+}
+
+// retryNewPayloadFailed retries an engine_newPayload call after any kind of
+// failure (RPC/network error, parse error, validation error including
+// SYNCING). Each attempt counts toward MaxRetries regardless of the failure
+// mode. Returns whether one of the retries succeeded along with that
+// attempt's response and duration; on exhaustion it returns false.
+func (e *executor) retryNewPayloadFailed(
+	ctx context.Context,
+	opts *ExecuteOptions,
+	payload, method, stepName string,
+	lineNum int,
+) (succeeded bool, response string, duration int64) {
+	cfg := opts.RetryNewPayloadsFailedConfig
+	backoff, _ := time.ParseDuration(cfg.Backoff) // Already validated in config
+
+	for attempt := 1; attempt <= cfg.MaxRetries; attempt++ {
+		e.log.WithFields(logrus.Fields{
+			"line":        lineNum + 1,
+			"method":      method,
+			"step":        stepName,
+			"attempt":     attempt,
+			"max_retries": cfg.MaxRetries,
+			"backoff":     backoff,
+		}).Info("Retrying newPayload after failure")
+
+		select {
+		case <-ctx.Done():
+			return false, "", 0
+		case <-time.After(backoff):
+		}
+
+		retryResponse, retryDuration, _, _, rpcErr := e.executeRPC(ctx, opts.EngineEndpoint, opts.JWT, payload)
+		if rpcErr != nil {
+			e.log.WithFields(logrus.Fields{
+				"line":    lineNum + 1,
+				"method":  method,
+				"step":    stepName,
+				"attempt": attempt,
+			}).WithError(rpcErr).Warn("Retry RPC call failed")
+
+			continue
+		}
+
+		resp, parseErr := jsonrpc.Parse(retryResponse)
+		if parseErr != nil {
+			e.log.WithFields(logrus.Fields{
+				"line":    lineNum + 1,
+				"method":  method,
+				"step":    stepName,
+				"attempt": attempt,
+			}).WithError(parseErr).Warn("Failed to parse retry response")
+
+			continue
+		}
+
+		if validationErr := e.validator.Validate(method, resp); validationErr != nil {
+			e.log.WithFields(logrus.Fields{
+				"line":    lineNum + 1,
+				"method":  method,
+				"step":    stepName,
+				"attempt": attempt,
+			}).WithError(validationErr).Debug("Retry validation failed, will retry")
+
+			continue
+		}
+
+		e.log.WithFields(logrus.Fields{
+			"line":    lineNum + 1,
+			"method":  method,
+			"step":    stepName,
+			"attempt": attempt,
+		}).Info("Retry succeeded")
+
+		return true, retryResponse, retryDuration
+	}
+
+	e.log.WithFields(logrus.Fields{
+		"line":        lineNum + 1,
+		"method":      method,
+		"step":        stepName,
+		"max_retries": cfg.MaxRetries,
+	}).Warn("Max retries exceeded for failed newPayload")
+
+	return false, "", 0
 }
 
 // retryNewPayloadSyncing retries an engine_newPayload call when it returns SYNCING status.

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -598,6 +598,12 @@ func (r *runner) runContainerLifecycle(
 				}
 				return nil
 			}(),
+			RetryNewPayloadsFailedState: func() *config.RetryNewPayloadsFailedConfig {
+				if r.cfg.FullConfig != nil {
+					return r.cfg.FullConfig.GetRetryNewPayloadsFailedState(instance)
+				}
+				return nil
+			}(),
 			ResourceLimits: resolvedResourceLimits,
 			PostTestRPCCalls: func() []config.PostTestRPCCall {
 				if r.cfg.FullConfig != nil {
@@ -1013,11 +1019,13 @@ func (r *runner) runContainerLifecycle(
 				EngineEndpoint: fmt.Sprintf(
 					"http://%s:%d", containerIP, spec.EnginePort(),
 				),
-				JWT:                  r.cfg.JWT,
-				ResultsDir:           runResultsDir,
-				FailFast:             true,
-				PreRunStepSleep:      r.cfg.PreRunStepSleep,
-				SkipUntilBlockNumber: blockNum,
+				JWT:                           r.cfg.JWT,
+				ResultsDir:                    runResultsDir,
+				FailFast:                      true,
+				PreRunStepSleep:               r.cfg.PreRunStepSleep,
+				SkipUntilBlockNumber:          blockNum,
+				RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(instance),
+				RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(instance),
 			}
 
 			if n, err := r.executor.RunPreRunSteps(execCtx, preRunOpts); err != nil {
@@ -1120,6 +1128,7 @@ func (r *runner) runContainerLifecycle(
 				Tests:                         params.Tests,
 				BlockLogCollector:             params.BlockLogCollector,
 				RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(instance),
+				RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(instance),
 				PostTestRPCCalls:              r.cfg.FullConfig.GetPostTestRPCCalls(instance),
 				PostTestSleepDuration:         r.cfg.FullConfig.GetPostTestSleepDuration(instance),
 				PreRunStepSleep:               r.cfg.PreRunStepSleep,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -183,6 +183,7 @@ type ResolvedInstance struct {
 	WaitAfterRPCReady                string                                   `json:"wait_after_rpc_ready,omitempty"`
 	RunTimeout                       string                                   `json:"run_timeout,omitempty"`
 	RetryNewPayloadsSyncingState     *config.RetryNewPayloadsSyncingConfig    `json:"retry_new_payloads_syncing_state,omitempty"`
+	RetryNewPayloadsFailedState      *config.RetryNewPayloadsFailedConfig     `json:"retry_new_payloads_failed_state,omitempty"`
 	ResourceLimits                   *ResolvedResourceLimits                  `json:"resource_limits,omitempty"`
 	PostTestRPCCalls                 []config.PostTestRPCCall                 `json:"post_test_rpc_calls,omitempty"`
 	PostTestSleepDuration            string                                   `json:"post_test_sleep_duration,omitempty"`

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -178,10 +178,12 @@ func (r *runner) runTestsWithCheckpointRestore(
 	engineEndpoint := fmt.Sprintf("http://%s:%d", containerIP, spec.EnginePort())
 
 	preRunOpts := &executor.ExecuteOptions{
-		EngineEndpoint:  engineEndpoint,
-		JWT:             r.cfg.JWT,
-		ResultsDir:      resultsDir,
-		PreRunStepSleep: r.cfg.PreRunStepSleep,
+		EngineEndpoint:                engineEndpoint,
+		JWT:                           r.cfg.JWT,
+		ResultsDir:                    resultsDir,
+		PreRunStepSleep:               r.cfg.PreRunStepSleep,
+		RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(params.Instance),
+		RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(params.Instance),
 	}
 
 	if n, err := r.executor.RunPreRunSteps(ctx, preRunOpts); err != nil {
@@ -510,6 +512,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 			Tests:                         []*executor.TestWithSteps{test},
 			BlockLogCollector:             params.BlockLogCollector,
 			RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(params.Instance),
+			RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(params.Instance),
 			PostTestRPCCalls:              r.cfg.FullConfig.GetPostTestRPCCalls(params.Instance),
 			PostTestSleepDuration:         r.cfg.FullConfig.GetPostTestSleepDuration(params.Instance),
 		}

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -88,10 +88,12 @@ func (r *runner) runTestsWithContainerStrategy(
 		)
 
 		preRunOpts := &executor.ExecuteOptions{
-			EngineEndpoint:  engineEndpoint,
-			JWT:             r.cfg.JWT,
-			ResultsDir:      resultsDir,
-			PreRunStepSleep: r.cfg.PreRunStepSleep,
+			EngineEndpoint:                engineEndpoint,
+			JWT:                           r.cfg.JWT,
+			ResultsDir:                    resultsDir,
+			PreRunStepSleep:               r.cfg.PreRunStepSleep,
+			RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(params.Instance),
+			RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(params.Instance),
 		}
 
 		if n, err := r.executor.RunPreRunSteps(ctx, preRunOpts); err != nil {
@@ -733,9 +735,11 @@ func (r *runner) runTestsWithContainerStrategy(
 				EngineEndpoint: fmt.Sprintf(
 					"http://%s:%d", currentContainerIP, spec.EnginePort(),
 				),
-				JWT:             r.cfg.JWT,
-				ResultsDir:      resultsDir,
-				PreRunStepSleep: r.cfg.PreRunStepSleep,
+				JWT:                           r.cfg.JWT,
+				ResultsDir:                    resultsDir,
+				PreRunStepSleep:               r.cfg.PreRunStepSleep,
+				RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(params.Instance),
+				RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(params.Instance),
 			}
 
 			if n, err := r.executor.RunPreRunSteps(ctx, preRunOpts); err != nil {
@@ -772,6 +776,7 @@ func (r *runner) runTestsWithContainerStrategy(
 			Tests:                         []*executor.TestWithSteps{test},
 			BlockLogCollector:             params.BlockLogCollector,
 			RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(params.Instance),
+			RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(params.Instance),
 			PostTestRPCCalls:              r.cfg.FullConfig.GetPostTestRPCCalls(params.Instance),
 			PostTestSleepDuration:         r.cfg.FullConfig.GetPostTestSleepDuration(params.Instance),
 		}

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -241,6 +241,12 @@ export interface RetryNewPayloadsSyncingConfig {
   backoff: string
 }
 
+export interface RetryNewPayloadsFailedConfig {
+  enabled: boolean
+  max_retries: number
+  backoff: string
+}
+
 export interface DumpConfig {
   enabled: boolean
   filename?: string
@@ -280,6 +286,7 @@ export interface InstanceConfig {
   wait_after_rpc_ready?: string
   run_timeout?: string
   retry_new_payloads_syncing_state?: RetryNewPayloadsSyncingConfig
+  retry_new_payloads_failed_state?: RetryNewPayloadsFailedConfig
   resource_limits?: ResourceLimitsConfig
   post_test_rpc_calls?: PostTestRPCCallConfig[]
   post_test_sleep_duration?: string

--- a/ui/src/components/compare/ConfigDiff.tsx
+++ b/ui/src/components/compare/ConfigDiff.tsx
@@ -40,6 +40,8 @@ export function ConfigDiff({ runs, labelMode }: ConfigDiffProps) {
       inst.image !== first.image
       || inst.client !== first.client
       || inst.rollback_strategy !== first.rollback_strategy
+      || JSON.stringify(inst.retry_new_payloads_syncing_state) !== JSON.stringify(first.retry_new_payloads_syncing_state)
+      || JSON.stringify(inst.retry_new_payloads_failed_state) !== JSON.stringify(first.retry_new_payloads_failed_state)
       || JSON.stringify(inst.command) !== JSON.stringify(first.command)
       || JSON.stringify(inst.environment) !== JSON.stringify(first.environment),
     ) || systems.some((sys) =>
@@ -108,6 +110,26 @@ export function ConfigDiff({ runs, labelMode }: ConfigDiffProps) {
               )}
               {instances.some((i) => i.rollback_strategy) && (
                 <DiffRow label="Rollback Strategy" values={instances.map((i) => i.rollback_strategy ?? 'none')} />
+              )}
+              {instances.some((i) => i.retry_new_payloads_syncing_state) && (
+                <DiffRow
+                  label="Retry on SYNCING"
+                  values={instances.map((i) => {
+                    const r = i.retry_new_payloads_syncing_state
+                    if (!r || !r.enabled) return 'disabled'
+                    return `enabled (max=${r.max_retries}, backoff=${r.backoff})`
+                  })}
+                />
+              )}
+              {instances.some((i) => i.retry_new_payloads_failed_state) && (
+                <DiffRow
+                  label="Retry on Failure"
+                  values={instances.map((i) => {
+                    const r = i.retry_new_payloads_failed_state
+                    if (!r || !r.enabled) return 'disabled'
+                    return `enabled (max=${r.max_retries}, backoff=${r.backoff})`
+                  })}
+                />
               )}
               {instances.some((i) => i.environment) && (
                 <DiffRow

--- a/ui/src/components/run-detail/RunConfiguration.tsx
+++ b/ui/src/components/run-detail/RunConfiguration.tsx
@@ -355,6 +355,31 @@ export function RunConfiguration({ instance, system, startBlock, metadata, bench
                 </div>
               )}
 
+              {instance.retry_new_payloads_failed_state?.enabled && (
+                <div>
+                  <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">
+                    Retry on Failed Response
+                  </dt>
+                  <dd className="mt-1 overflow-x-auto rounded-sm bg-gray-100 p-2 dark:bg-gray-900">
+                    <div className="flex flex-col gap-1 font-mono text-xs/5 text-gray-900 dark:text-gray-100">
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">max_retries: </span>
+                        {instance.retry_new_payloads_failed_state.max_retries}
+                      </div>
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">backoff: </span>
+                        {instance.retry_new_payloads_failed_state.backoff}
+                      </div>
+                    </div>
+                    <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                      Retries engine_newPayload calls on any non-SYNCING failure
+                      (RPC error, JSON-RPC error, INVALID status). When SYNCING retry
+                      is also enabled, SYNCING errors take that path instead.
+                    </p>
+                  </dd>
+                </div>
+              )}
+
               {instance.post_test_rpc_calls && instance.post_test_rpc_calls.length > 0 && (
                 <div>
                   <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary

Adds a catch-all retry config for `engine_newPayload*` calls that fail for any reason **other than** SYNCING — RPC/network errors, JSON-RPC errors (e.g. `-32603 Server error`), `INVALID` / `INVALID_BLOCK_HASH` statuses, unparseable responses.

```yaml
runner:
  client:
    config:
      retry_new_payloads_failed_state:
        enabled: true
        max_retries: 3
        backoff: 500ms
```

Standard global / instance-override pattern. Same `{enabled, max_retries, backoff}` shape as `retry_new_payloads_syncing_state`. When both are enabled, SYNCING errors take the SYNCING retry path and everything else takes the failed-state path. When only the failed retry is enabled, it also covers SYNCING.

**Bug fix:** neither retry config was being threaded into the four pre-run `ExecuteOptions` sites (StopAfterPrerun lifecycle, checkpoint strategy, ZFS-snapshot path, per-test recreate path), so retries silently never fired during pre-run replay. Both retry configs now apply to pre-run, setup, and test steps alike.

### Files

- `pkg/config/config.go`: `RetryNewPayloadsFailedConfig` struct, fields on `ClientDefaults` + `ClientInstance`, `GetRetryNewPayloadsFailedState(instance)` getter, `validateRetryNewPayloadsFailedState()` validator hooked into `Validate()`.
- `pkg/executor/executor.go`: new `RetryNewPayloadsFailedConfig` on `ExecuteOptions`. `runStepLines` retry decision restructured: SYNCING + SYNCING-config → SYNCING retry; else + failed-config → new failed-state retry; else log + record failure. New `retryNewPayloadFailed` helper alongside the existing `retryNewPayloadSyncing`.
- `pkg/runner/lifecycle.go`, `strategy_checkpoint.go`, `strategy_container.go`: both retry configs threaded through every `ExecuteOptions` site (4 pre-run + 3 test). `ResolvedInstance.RetryNewPayloadsFailedState` lands in `config.json`.
- `ui/src/api/types.ts`: `RetryNewPayloadsFailedConfig` interface + field on `InstanceConfig`.
- `ui/src/components/run-detail/RunConfiguration.tsx`: "Retry on Failed Response" card next to the SYNCING one.
- `ui/src/components/compare/ConfigDiff.tsx`: rows for both SYNCING and failed retry (the SYNCING row was missing too); both included in `hasDifferences`.
- `docs/configuration.md`: new section + entries in global / instance-override tables, plus an explicit note that retries now apply to pre-run.

### Tests

- [x] `go test ./pkg/config/... ./pkg/executor/... ./pkg/runner/...` passes (incl. new getter + validator tests)
- [x] `go build ./...` clean
- [x] `golangci-lint run --new-from-rev="origin/master"` clean
- [x] `tsc -b` clean

## Test plan

- [ ] Run a benchmark with `retry_new_payloads_failed_state.enabled: true` against a client known to occasionally return `-32603` and confirm the line is retried (look for `Retrying newPayload after failure` log lines)
- [ ] Run a pre-run replay with the same config and confirm retries fire for any failed lines (previously silent)
- [ ] Run with both SYNCING and failed retry enabled and confirm SYNCING errors take the SYNCING path while other failures take the failed-state path