### PR TITLE
feat(filter): add regex: prefix support to runner.benchmark.tests.filter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -250,7 +250,7 @@ runner:
 | `generate_results_index_method` | string | `local` | Method for index generation: `local` (filesystem) or `s3` (read runs from S3, upload index back). Requires `results_upload.s3` when set to `s3` |
 | `generate_suite_stats` | bool | `false` | Generate `stats.json` per suite for UI heatmaps |
 | `generate_suite_stats_method` | string | `local` | Method for suite stats generation: `local` (filesystem) or `s3` (read runs from S3, upload stats back). Requires `results_upload.s3` when set to `s3` |
-| `tests.filter` | string | - | Run only tests matching this pattern |
+| `tests.filter` | string | - | Run only tests whose name (or file path) matches this pattern. Plain values match by substring; values prefixed with `regex:` match the trailing expression as a Go regular expression. See [Test Filter](#test-filter) |
 | `tests.metadata.labels` | map[string]string | - | Arbitrary key-value labels for the test suite (see [Suite Metadata Labels](#suite-metadata-labels)) |
 | `tests.source` | object | - | Test source configuration (see below) |
 
@@ -546,6 +546,38 @@ runner:
           github_repo: ethereum/execution-spec-tests
           github_release: benchmark@v0.0.7
 ```
+
+#### Test Filter
+
+The `runner.benchmark.tests.filter` selects which tests run. Two modes:
+
+| Mode | Syntax | Behavior |
+|------|--------|----------|
+| Substring (default) | `filter: "bn128"` | Test/file path must contain the literal string. Regex metacharacters are matched literally (e.g. `filter: "test.*name"` only matches paths that contain the seven-character string `test.*name`) |
+| Regex | `filter: "regex:<expr>"` | The trailing expression is compiled as a [Go regular expression](https://pkg.go.dev/regexp/syntax) and tested with `MatchString`. Anchor with `^` / `$` if you need full-string matches; flags like `(?i)` for case-insensitive are supported |
+
+Examples:
+
+```yaml
+# Substring — matches any test path containing "keccak"
+filter: "keccak"
+
+# Regex — matches "test_sstore_bloated…benchmark_300M" anywhere in the path
+filter: "regex:test_sstore_bloated.*benchmark_300M"
+
+# Regex with case-insensitive flag
+filter: "regex:(?i)KECCAK|sha256"
+
+# Regex anchored to end of path
+filter: "regex:bn128_pairing\\.txt$"
+```
+
+The filter is applied to:
+- file paths returned from glob expansion (substring match against the absolute path),
+- EEST fixture test names,
+- opcode source entries.
+
+A bad regex (e.g. unclosed character class) is rejected at config-load time with a `runner.benchmark.tests.filter: invalid regex …` error.
 
 #### Results Upload
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1225,9 +1226,37 @@ func (c *Config) Validate(opts ...ValidateOpts) error {
 		return err
 	}
 
+	// Validate test filter (regex syntax if "regex:" prefixed).
+	if err := c.validateTestFilter(); err != nil {
+		return err
+	}
+
 	// Validate API settings.
 	if err := c.ValidateAPI(); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// TestFilterRegexPrefix opts the test filter into regex matching when the
+// configured value starts with this prefix. Without the prefix, the filter
+// is treated as a substring match.
+const TestFilterRegexPrefix = "regex:"
+
+// validateTestFilter ensures that, when the test filter uses the "regex:"
+// prefix, the trailing expression compiles as a Go regular expression.
+// Substring filters are always valid.
+func (c *Config) validateTestFilter() error {
+	filter := c.Runner.Benchmark.Tests.Filter
+
+	expr, ok := strings.CutPrefix(filter, TestFilterRegexPrefix)
+	if !ok {
+		return nil
+	}
+
+	if _, err := regexp.Compile(expr); err != nil {
+		return fmt.Errorf("runner.benchmark.tests.filter: invalid regex %q: %w", expr, err)
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2788,3 +2788,61 @@ func TestValidateRetryNewPayloadsFailedState(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateTestFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		filter    string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "empty is valid", filter: "", wantErr: false},
+		{name: "substring is always valid", filter: "test_keccak", wantErr: false},
+		{
+			name:    "substring with regex metachars is valid",
+			filter:  "test.*name[0]",
+			wantErr: false,
+		},
+		{
+			name:    "regex prefix with valid expression",
+			filter:  "regex:test_sstore_bloated.*benchmark_300M",
+			wantErr: false,
+		},
+		{
+			name:    "regex prefix with empty expression",
+			filter:  "regex:",
+			wantErr: false,
+		},
+		{
+			name:      "regex prefix with unclosed character class",
+			filter:    "regex:[unclosed",
+			wantErr:   true,
+			errSubstr: "invalid regex",
+		},
+		{
+			name:      "regex prefix with invalid quantifier",
+			filter:    "regex:*invalid",
+			wantErr:   true,
+			errSubstr: "invalid regex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Runner: RunnerConfig{
+					Benchmark: BenchmarkConfig{
+						Tests: TestsConfig{Filter: tt.filter},
+					},
+				},
+			}
+			err := cfg.validateTestFilter()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/executor/archive_source.go
+++ b/pkg/executor/archive_source.go
@@ -27,7 +27,7 @@ type ArchiveSource struct {
 	log         logrus.FieldLogger
 	cfg         *config.ArchiveSourceConfig
 	cacheDir    string
-	filter      string
+	filter      *filterMatcher
 	githubToken string
 	basePath    string // temp directory where archive was extracted
 }

--- a/pkg/executor/eest_source.go
+++ b/pkg/executor/eest_source.go
@@ -23,7 +23,7 @@ type EESTSource struct {
 	log           logrus.FieldLogger
 	cfg           *config.EESTFixturesSource
 	cacheDir      string
-	filter        string
+	filter        *filterMatcher
 	githubToken   string
 	fixturesDir   string
 	genesisDir    string
@@ -42,7 +42,7 @@ type preAllocFile struct {
 }
 
 // NewEESTSource creates a new EEST source.
-func NewEESTSource(log logrus.FieldLogger, cfg *config.EESTFixturesSource, cacheDir, filter, githubToken string) *EESTSource {
+func NewEESTSource(log logrus.FieldLogger, cfg *config.EESTFixturesSource, cacheDir string, filter *filterMatcher, githubToken string) *EESTSource {
 	return &EESTSource{
 		log:         log.WithField("source", "eest"),
 		cfg:         cfg,
@@ -639,7 +639,7 @@ func (s *EESTSource) discoverTests() (*PreparedSource, error) {
 			}
 
 			// Apply filter to individual test names too.
-			if s.filter != "" && !strings.Contains(name, s.filter) {
+			if !s.filter.match(name) {
 				continue
 			}
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -158,6 +158,7 @@ type executor struct {
 	suiteHash   string
 	validator   jsonrpc.Validator
 	statsReader stats.Reader
+	filter      *filterMatcher // compiled once from cfg.Filter
 
 	// Live progress counters updated during ExecuteTests. Safe to read
 	// concurrently via GetProgress().
@@ -179,7 +180,14 @@ var _ Executor = (*executor)(nil)
 
 // Start initializes the executor and prepares test sources.
 func (e *executor) Start(ctx context.Context) error {
-	e.source = NewSource(e.log, e.cfg.Source, e.cfg.CacheDir, e.cfg.Filter, e.cfg.GitHubToken)
+	filter, err := CompileFilter(e.cfg.Filter)
+	if err != nil {
+		return fmt.Errorf("compiling test filter: %w", err)
+	}
+
+	e.filter = filter
+
+	e.source = NewSource(e.log, e.cfg.Source, e.cfg.CacheDir, filter, e.cfg.GitHubToken)
 	if e.source == nil {
 		return fmt.Errorf("no test source configured")
 	}

--- a/pkg/executor/filter.go
+++ b/pkg/executor/filter.go
@@ -1,0 +1,91 @@
+package executor
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// FilterRegexPrefix opts the test filter into regex matching when the value
+// starts with this prefix. Without the prefix, the filter is treated as a
+// plain substring match (existing behavior).
+const FilterRegexPrefix = "regex:"
+
+// filterMatcher decides whether a string passes the test filter. An empty
+// matcher (or nil) matches everything. Constructed once per source so the
+// regex (if any) is compiled a single time.
+type filterMatcher struct {
+	raw string
+	sub string         // substring (when no regex prefix)
+	re  *regexp.Regexp // compiled regex (when prefixed with FilterRegexPrefix)
+}
+
+// CompileFilter parses a filter string into a matcher.
+// "regex:<expr>" → compiled regex; anything else → substring match.
+// An empty string matches everything.
+func CompileFilter(filter string) (*filterMatcher, error) {
+	m := &filterMatcher{raw: filter}
+
+	if filter == "" {
+		return m, nil
+	}
+
+	if expr, ok := strings.CutPrefix(filter, FilterRegexPrefix); ok {
+		re, err := regexp.Compile(expr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex filter %q: %w", expr, err)
+		}
+
+		m.re = re
+
+		return m, nil
+	}
+
+	m.sub = filter
+
+	return m, nil
+}
+
+// Empty reports whether the matcher imposes no constraint (nil, empty
+// substring, or empty regex pattern). Useful for callers that branch on
+// "no filter applied" — like opcode counting that wants to short-circuit
+// the per-entry check when nothing has been requested.
+func (m *filterMatcher) Empty() bool {
+	if m == nil {
+		return true
+	}
+
+	if m.re != nil {
+		// An empty regex matches everything; treat as "no filter".
+		return m.re.String() == ""
+	}
+
+	return m.sub == ""
+}
+
+// match returns true when the input passes the filter. An empty/nil
+// matcher always returns true.
+func (m *filterMatcher) match(s string) bool {
+	if m == nil {
+		return true
+	}
+
+	if m.re != nil {
+		return m.re.MatchString(s)
+	}
+
+	if m.sub == "" {
+		return true
+	}
+
+	return strings.Contains(s, m.sub)
+}
+
+// String returns the original filter string for logging.
+func (m *filterMatcher) String() string {
+	if m == nil {
+		return ""
+	}
+
+	return m.raw
+}

--- a/pkg/executor/filter_test.go
+++ b/pkg/executor/filter_test.go
@@ -1,0 +1,80 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileFilter_Empty(t *testing.T) {
+	m, err := CompileFilter("")
+	require.NoError(t, err)
+	assert.True(t, m.match("anything"))
+	assert.True(t, m.match(""))
+}
+
+func TestCompileFilter_NilMatcherMatchesAll(t *testing.T) {
+	var m *filterMatcher
+	assert.True(t, m.match("anything"))
+}
+
+func TestCompileFilter_Substring(t *testing.T) {
+	m, err := CompileFilter("keccak")
+	require.NoError(t, err)
+	assert.True(t, m.match("test_keccak_diff_sizes.txt"))
+	assert.True(t, m.match("keccak"))
+	assert.False(t, m.match("test_sstore_bloated.txt"))
+}
+
+func TestCompileFilter_SubstringWithRegexMetachars(t *testing.T) {
+	// Without the prefix, regex metachars are treated literally.
+	m, err := CompileFilter("test.*name")
+	require.NoError(t, err)
+	assert.True(t, m.match("test.*name"))
+	assert.False(t, m.match("test_my_name"))
+}
+
+func TestCompileFilter_Regex(t *testing.T) {
+	m, err := CompileFilter("regex:test_sstore_bloated.*benchmark_300M")
+	require.NoError(t, err)
+
+	assert.True(t, m.match("tests_test_sstore_bloated[fork]-benchmark_300M.txt"))
+	assert.True(t, m.match("test_sstore_bloated_benchmark_300M"))
+	assert.False(t, m.match("test_keccak_benchmark_100M"))
+}
+
+func TestCompileFilter_RegexInvalid(t *testing.T) {
+	_, err := CompileFilter("regex:[unclosed")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid regex filter")
+}
+
+func TestCompileFilter_RegexEmptyMatchesAll(t *testing.T) {
+	m, err := CompileFilter("regex:")
+	require.NoError(t, err)
+	// An empty regex matches every string.
+	assert.True(t, m.match("anything"))
+	assert.True(t, m.match(""))
+}
+
+func TestCompileFilter_RegexCaseInsensitiveFlag(t *testing.T) {
+	m, err := CompileFilter("regex:(?i)keccak")
+	require.NoError(t, err)
+	assert.True(t, m.match("KECCAK_test"))
+	assert.True(t, m.match("Keccak_test"))
+	assert.True(t, m.match("test_keccak_lower"))
+}
+
+func TestFilterMatcher_String(t *testing.T) {
+	m, err := CompileFilter("regex:foo.*bar")
+	require.NoError(t, err)
+	assert.Equal(t, "regex:foo.*bar", m.String())
+
+	m2, err := CompileFilter("plain")
+	require.NoError(t, err)
+	assert.Equal(t, "plain", m2.String())
+
+	var nilM *filterMatcher
+	assert.Equal(t, "", nilM.String())
+}

--- a/pkg/executor/opcode.go
+++ b/pkg/executor/opcode.go
@@ -69,11 +69,11 @@ func (e *executor) loadOpcodes(ctx context.Context) error {
 
 	// Count opcode entries that are relevant (pass the filter) but didn't match a test.
 	filtered := len(opcodeMap)
-	if e.cfg.Filter != "" {
+	if !e.filter.Empty() {
 		filtered = 0
 
 		for key := range opcodeMap {
-			if strings.Contains(key, e.cfg.Filter) {
+			if e.filter.match(key) {
 				filtered++
 			}
 		}

--- a/pkg/executor/source.go
+++ b/pkg/executor/source.go
@@ -95,7 +95,7 @@ type GenesisGroupProvider interface {
 }
 
 // NewSource creates a Source from the configuration.
-func NewSource(log logrus.FieldLogger, cfg *config.SourceConfig, cacheDir, filter, githubToken string) Source {
+func NewSource(log logrus.FieldLogger, cfg *config.SourceConfig, cacheDir string, filter *filterMatcher, githubToken string) Source {
 	if cfg.Local != nil {
 		return &LocalSource{
 			log:    log.WithField("source", "local"),
@@ -134,7 +134,7 @@ func NewSource(log logrus.FieldLogger, cfg *config.SourceConfig, cacheDir, filte
 type LocalSource struct {
 	log      logrus.FieldLogger
 	cfg      *config.LocalSourceV2
-	filter   string
+	filter   *filterMatcher
 	basePath string
 }
 
@@ -183,7 +183,7 @@ type GitSource struct {
 	log      logrus.FieldLogger
 	cfg      *config.GitSourceV2
 	cacheDir string
-	filter   string
+	filter   *filterMatcher
 	basePath string
 }
 
@@ -391,7 +391,7 @@ func discoverTestsFromConfig(
 	basePath string,
 	preRunStepPatterns []string,
 	steps *config.StepsConfig,
-	filter string,
+	filter *filterMatcher,
 	log logrus.FieldLogger,
 ) (*PreparedSource, error) {
 	result := &PreparedSource{
@@ -404,7 +404,7 @@ func discoverTestsFromConfig(
 	// Patterns are processed in the order they appear in the config.
 	// Within each pattern, filepath.Glob returns files in lexicographic order.
 	for _, pattern := range preRunStepPatterns {
-		files, _, err := expandGlobPattern(basePath, pattern, "")
+		files, _, err := expandGlobPattern(basePath, pattern, nil)
 		if err != nil {
 			return nil, fmt.Errorf("expanding pre_run_steps pattern %q: %w", pattern, err)
 		}
@@ -455,7 +455,7 @@ func discoverTestsFromConfig(
 
 // expandGlobPatterns expands multiple glob patterns and returns unique files
 // along with the collected static prefixes from all patterns.
-func expandGlobPatterns(basePath string, patterns []string, filter string) ([]*StepFile, []string, error) {
+func expandGlobPatterns(basePath string, patterns []string, filter *filterMatcher) ([]*StepFile, []string, error) {
 	seen := make(map[string]struct{}, len(patterns)*10)
 	result := make([]*StepFile, 0, len(patterns)*10)
 	prefixes := make([]string, 0, len(patterns))
@@ -483,7 +483,7 @@ func expandGlobPatterns(basePath string, patterns []string, filter string) ([]*S
 
 // expandGlobPattern expands a single glob pattern and returns matching files
 // along with the static prefix extracted from the pattern.
-func expandGlobPattern(basePath, pattern, filter string) ([]*StepFile, string, error) {
+func expandGlobPattern(basePath, pattern string, filter *filterMatcher) ([]*StepFile, string, error) {
 	fullPattern := filepath.Join(basePath, pattern)
 	staticPrefix := extractStaticPrefix(pattern)
 
@@ -511,7 +511,7 @@ func expandGlobPattern(basePath, pattern, filter string) ([]*StepFile, string, e
 		}
 
 		// Apply filter if provided.
-		if filter != "" && !strings.Contains(match, filter) {
+		if !filter.match(match) {
 			continue
 		}
 

--- a/pkg/executor/source_test.go
+++ b/pkg/executor/source_test.go
@@ -31,13 +31,16 @@ func TestDiscoverTestsFromConfig_PreRunStepsNotFiltered(t *testing.T) {
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
 
+	bn128Filter, err := CompileFilter("bn128")
+	require.NoError(t, err)
+
 	result, err := discoverTestsFromConfig(
 		base,
 		[]string{"bloatnet/funding.txt", "bloatnet/gas-bump.txt"},
 		&config.StepsConfig{
 			Test: []string{"testing/*/*"},
 		},
-		"bn128", // filter that does NOT match pre_run_step paths
+		bn128Filter, // filter that does NOT match pre_run_step paths
 		log,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Adds regex matching to the `runner.benchmark.tests.filter` config. Plain values keep their existing substring semantics; values prefixed with `regex:` compile the trailing expression as a [Go regular expression](https://pkg.go.dev/regexp/syntax).

```yaml
# substring (today's behavior)
filter: "keccak"

# regex — would have produced 0 matches before this PR
filter: "regex:test_sstore_bloated.*benchmark_300M"

# regex with flags / anchors
filter: "regex:(?i)KECCAK|sha256"
filter: "regex:bn128_pairing\\.txt$"
```

The matcher is compiled once per executor at `Start` and threaded through `NewSource` into the local / git / archive / EEST sources. Filter is applied to:
- file paths returned from glob expansion (`expandGlobPattern` in `source.go`),
- EEST fixture test names (`eest_source.go`),
- opcode source entries (`opcode.go`).

Bad regex syntax is caught at config-load time via a new `validateTestFilter()` check that produces:

```
runner.benchmark.tests.filter: invalid regex "...": ...
```

### Files

- `pkg/executor/filter.go` (new): `filterMatcher` + `CompileFilter(s)`. `match()`, `Empty()`, `String()`. Empty/nil matcher matches everything.
- `pkg/executor/source.go`, `archive_source.go`, `eest_source.go`: source structs and helper signatures use `*filterMatcher` instead of `string`.
- `pkg/executor/executor.go`: compiles `e.filter` once at `Start`, passes to `NewSource`, available for `opcode.go`.
- `pkg/executor/opcode.go`: uses the matcher.
- `pkg/config/config.go`: `validateTestFilter()` hook into `Validate()`. New `TestFilterRegexPrefix` constant.
- `docs/configuration.md`: new "Test Filter" subsection with substring vs regex table, examples, and notes on where the filter is applied + the validator's load-time error.

### Tests

- `pkg/executor/filter_test.go` (new): covers empty, nil, substring, substring-with-regex-metachars (matched literally — backward compat), regex, invalid regex, empty regex, case-insensitive flag, `String()`.
- `TestValidateTestFilter` in `config_test.go`: same shape at validator level (substring with metachars valid; bad regex rejected with `invalid regex` error).
- Existing `source_test.go` updated to compile a substring filter via `CompileFilter`.

`go test ./pkg/config/... ./pkg/executor/...`, `golangci-lint run --new-from-rev="origin/master"`, and full repo build are clean.

## Test plan

- [x] All new unit tests pass (`go test ./pkg/config/... ./pkg/executor/...`)
- [x] `golangci-lint run --new-from-rev="origin/master"` clean
- [x] Run a real benchmark with `filter: "regex:test_sstore_bloated.*benchmark_300M"` against an archive source and confirm matches happen (was 0 before)
- [x] Run with a substring filter that contains regex metachars (e.g. `filter: "test.txt"`) and confirm only paths literally containing `test.txt` match — i.e. the dot is NOT treated as wildcard (substring backward compat)
- [x] Run with `filter: "regex:[unclosed"` and confirm config loading fails fast with the `invalid regex` message