### PR TITLE
fix(podman): pass bare RLIMIT type to specgen

### DIFF
--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -254,10 +254,14 @@ func (m *manager) CreateContainer(
 
 	// Bump RLIMIT_NOFILE to the kernel's hard ceiling so EL clients
 	// don't trip "too many open files" errors during long benchmark
-	// runs. Applied to every container we create.
+	// runs. Applied to every container we create. Note: Podman's
+	// addRlimits prepends "RLIMIT_" to whatever Type we pass, so the
+	// value here must be the bare suffix ("NOFILE"), not the full
+	// "RLIMIT_NOFILE" — passing the full form yields RLIMIT_RLIMIT_NOFILE
+	// at the OCI runtime layer, which runc rejects.
 	nofile := docker.HostMaxNofile()
 	s.Rlimits = append(s.Rlimits, specs.POSIXRlimit{
-		Type: "RLIMIT_NOFILE",
+		Type: "NOFILE",
 		Hard: nofile,
 		Soft: nofile,
 	})


### PR DESCRIPTION
## Summary

Follow-up to #225. After the nofile bump merged, podman runs started failing with:

```
runc create failed: wrong rlimit value: RLIMIT_RLIMIT_NOFILE: OCI runtime error
```

### Root cause

Podman's `addRlimits` ([pkg/specgen/generate/oci.go:21](https://github.com/containers/podman/blob/v5.8.0/pkg/specgen/generate/oci.go#L21)) prepends `RLIMIT_` to whatever `Type` we set on `specs.POSIXRlimit` before writing it into the OCI bundle:

```go
name := "RLIMIT_" + strings.ToUpper(u.Type)
```

We were passing `Type: "RLIMIT_NOFILE"`, so the OCI spec ended up with `RLIMIT_RLIMIT_NOFILE` and runc rejected it.

### Fix

Pass the bare suffix `"NOFILE"` so podman appends the prefix exactly once. Docker's path is unaffected — it uses `units.Ulimit{Name: "nofile"}` (lowercase, no prefix logic), and the OCI runtime sees `RLIMIT_NOFILE` correctly there.

### Test plan

- [ ] `podman inspect <bench-container>` shows `.HostConfig.Ulimits` containing `{"Name":"nofile","Soft":1048576,"Hard":1048576}` (or the host's `cat /proc/sys/fs/nr_open`)
- [ ] Run a benchmark with `runner.container_runtime: podman` and confirm containers start (no more `runc create failed` error)
- [ ] Docker run still produces the same `RLIMIT_NOFILE` value as before this PR