### PR TITLE
feat(opcode-extraction): per-test opcode counts via debug_traceBlockByNumber

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -395,6 +395,13 @@ runner:
       #   enabled: true
       #   max_retries: 30
       #   backoff: 1s
+      # Optional: Run debug_traceBlockByNumber against every engine_newPayload* in
+      # the test step with a JS opcode-counting tracer, sum per-tx counts (uppercased)
+      # and write a `test-opcodes.json` at the run results dir in the same shape that
+      # `runner.benchmark.tests.opcode_source` consumes. Per-instance override allowed.
+      # opcode_extraction:
+      #   enabled: true
+      #   timeout: 2m   # per-block trace timeout; default 2m
       # Optional: Container resource limits (applied to all instances by default).
       # resource_limits:
       #   # CPU pinning - use ONE of the following:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -689,6 +689,7 @@ runner:
 | `post_test_rpc_calls` | []object | - | Arbitrary RPC calls to execute after each test step (see [Post-Test RPC Calls](#post-test-rpc-calls)) |
 | `post_test_sleep_duration` | string | - | Sleep duration after each test, e.g. `200ms`, `1s` (see below) |
 | `bootstrap_fcu` | bool/object | - | Send an `engine_forkchoiceUpdatedV3` after RPC is ready to confirm the client is fully synced (see [Bootstrap FCU](#bootstrap-fcu)) |
+| `opcode_extraction` | object | - | Extract per-test opcode counts via `debug_traceBlockByNumber` after each test step (see [Opcode Extraction](#opcode-extraction)) |
 | `genesis` | map | - | Genesis file URLs keyed by client type |
 
 ##### Drop Memory Caches
@@ -978,6 +979,44 @@ When using the `container-recreate` rollback strategy, the bootstrap FCU is sent
 - When starting from pre-populated data directories where the client needs time to validate state before processing Engine API requests
 - When you observe test failures due to the client returning errors or SYNCING responses on the first Engine API calls
 
+##### Opcode Extraction
+
+The `opcode_extraction` option captures per-test opcode counts as a side effect of running tests. After each test step, the runner walks the test's `engine_newPayload*` calls and runs `debug_traceBlockByNumber` against each block with a JS opcode-counting tracer. Per-tx counts are summed (and uppercased) into one map per newPayload, then appended to a per-test array. At the end of the run all the data lands in a single `test-opcodes.json` at the run results dir, in the same shape that `runner.benchmark.tests.opcode_source` expects.
+
+```yaml
+runner:
+  client:
+    config:
+      opcode_extraction:
+        enabled: true
+        timeout: 2m   # per-block trace timeout; default 2m
+```
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `enabled` | bool | Yes | `false` | Enable the post-test extraction step |
+| `timeout` | string | No | `2m` | Per-block `debug_traceBlockByNumber` timeout (Go duration). Long traces on fat blocks may need a higher value |
+
+`opcode_extraction` can be set globally under `runner.client.config` and/or per-instance under `runner.instances[]`. Instance-level config (when non-nil) fully replaces the global default. The output file shape is:
+
+```json
+{
+  "test-name.txt": [
+    { "PUSH1": 23432, "DUP1": 11231, "SSTORE": 3321 }
+  ]
+}
+```
+
+(One entry per `engine_newPayload*` in the test step, summed across all txs in that block.)
+
+**Requirements:**
+- The client must accept JS tracers via `debug_traceBlockByNumber`. Geth, Erigon, and Nethermind support them; coverage on Reth/Besu/Nimbus/ethrex varies — check your client docs.
+- The trace runs against the EL state right after the test step, before rollback, so the client must still have the block.
+
+**When to use:**
+- When you want a ground-truth opcode profile of every benchmarked test (instead of relying on `opcode_source` JSON shipped from a separate pipeline)
+- When investigating client-vs-client divergence in EVM execution paths
+
 #### Data Directories
 
 The `runner.client.datadirs` section configures pre-populated data directories per client type. When configured, the init container is skipped and data is mounted directly.
@@ -1086,6 +1125,7 @@ runner:
 | `post_test_rpc_calls` | []object | No | From `runner.client.config` | Instance-specific post-test RPC calls (replaces global) |
 | `post_test_sleep_duration` | string | No | From `runner.client.config` | Instance-specific post-test sleep duration |
 | `bootstrap_fcu` | bool/object | No | From `runner.client.config` | Instance-specific bootstrap FCU setting |
+| `opcode_extraction` | object | No | From `runner.client.config` | Instance-specific opcode extraction setting (replaces global) |
 
 ## Resource Limits
 

--- a/pkg/client/nethermind.go
+++ b/pkg/client/nethermind.go
@@ -33,6 +33,7 @@ func (s *nethermindSpec) DefaultCommand() []string {
 		"--JsonRpc.Host=0.0.0.0",
 		"--JsonRpc.Port=8545",
 		"--JsonRpc.EnabledModules=Net,Eth,Consensus,Subscribe,Web3,Admin,Debug,Rpc,Health,TxPool",
+		"--JsonRpc.Timeout=600000",
 		// "Engine" JSON RPC API
 		"--JsonRpc.JwtSecretFile=/tmp/jwtsecret",
 		"--JsonRpc.EngineHost=0.0.0.0",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -520,6 +520,41 @@ type BootstrapFCUConfig struct {
 	HeadBlockHash string `yaml:"head_block_hash" mapstructure:"head_block_hash" json:"head_block_hash,omitempty"`
 }
 
+// DefaultOpcodeExtractionTimeout is the per-block trace timeout applied
+// when opcode_extraction.timeout is unset. debug_traceBlockByNumber on
+// fat blocks can run for many seconds; 2 minutes covers most cases
+// without leaving a runaway trace stuck forever.
+const DefaultOpcodeExtractionTimeout = "2m"
+
+// OpcodeExtractionConfig configures the post-test opcode-extraction
+// step that runs debug_traceBlockByNumber against each engine_newPayload*
+// in the test step using a JS tracer that counts opcodes per tx. Counts
+// are summed across txs (and uppercased) and written into a single
+// test-opcodes.json file at the end of the run.
+type OpcodeExtractionConfig struct {
+	Enabled bool   `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
+	Timeout string `yaml:"timeout,omitempty" mapstructure:"timeout" json:"timeout,omitempty"`
+}
+
+// EffectiveTimeout returns the per-block trace timeout, defaulting to
+// DefaultOpcodeExtractionTimeout when unset/empty.
+func (c *OpcodeExtractionConfig) EffectiveTimeout() time.Duration {
+	if c == nil || c.Timeout == "" {
+		d, _ := time.ParseDuration(DefaultOpcodeExtractionTimeout)
+
+		return d
+	}
+
+	d, err := time.ParseDuration(c.Timeout)
+	if err != nil {
+		fallback, _ := time.ParseDuration(DefaultOpcodeExtractionTimeout)
+
+		return fallback
+	}
+
+	return d
+}
+
 // PostTestRPCCall defines an arbitrary RPC call to execute after the test step.
 type PostTestRPCCall struct {
 	Method  string     `yaml:"method" mapstructure:"method" json:"method"`
@@ -742,6 +777,7 @@ type ClientDefaults struct {
 	PostTestSleepDuration            string                            `yaml:"post_test_sleep_duration,omitempty" mapstructure:"post_test_sleep_duration"`
 	BootstrapFCU                     *BootstrapFCUConfig               `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
 	CheckpointRestoreStrategyOptions *CheckpointRestoreStrategyOptions `yaml:"checkpoint_restore_strategy_options,omitempty" mapstructure:"checkpoint_restore_strategy_options"`
+	OpcodeExtraction                 *OpcodeExtractionConfig           `yaml:"opcode_extraction,omitempty" mapstructure:"opcode_extraction"`
 	Metadata                         MetadataConfig                    `yaml:"metadata,omitempty" mapstructure:"metadata"`
 }
 
@@ -769,6 +805,7 @@ type ClientInstance struct {
 	PostTestSleepDuration            string                            `yaml:"post_test_sleep_duration,omitempty" mapstructure:"post_test_sleep_duration"`
 	BootstrapFCU                     *BootstrapFCUConfig               `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
 	CheckpointRestoreStrategyOptions *CheckpointRestoreStrategyOptions `yaml:"checkpoint_restore_strategy_options,omitempty" mapstructure:"checkpoint_restore_strategy_options"`
+	OpcodeExtraction                 *OpcodeExtractionConfig           `yaml:"opcode_extraction,omitempty" mapstructure:"opcode_extraction"`
 	Metadata                         MetadataConfig                    `yaml:"metadata,omitempty" mapstructure:"metadata"`
 }
 
@@ -1216,6 +1253,11 @@ func (c *Config) Validate(opts ...ValidateOpts) error {
 		return err
 	}
 
+	// Validate opcode_extraction settings.
+	if err := c.validateOpcodeExtraction(); err != nil {
+		return err
+	}
+
 	// Validate results_upload settings.
 	if err := c.validateResultsUpload(); err != nil {
 		return err
@@ -1657,6 +1699,17 @@ func (c *Config) GetBootstrapFCU(instance *ClientInstance) *BootstrapFCUConfig {
 	}
 
 	return c.Runner.Client.Config.BootstrapFCU
+}
+
+// GetOpcodeExtraction returns the opcode-extraction config for an instance.
+// Instance-level config (when non-nil) fully replaces the global default.
+// Returns nil if not configured at either level.
+func (c *Config) GetOpcodeExtraction(instance *ClientInstance) *OpcodeExtractionConfig {
+	if instance.OpcodeExtraction != nil {
+		return instance.OpcodeExtraction
+	}
+
+	return c.Runner.Client.Config.OpcodeExtraction
 }
 
 // GetCheckpointRestoreStrategyOptions returns the checkpoint-restore strategy
@@ -2167,6 +2220,39 @@ func (c *Config) validateBootstrapFCU() error {
 						" 32-byte hex string, got %q", instance.ID, cfg.HeadBlockHash,
 				)
 			}
+		}
+	}
+
+	return nil
+}
+
+// validateOpcodeExtraction validates opcode_extraction settings.
+// Timeout (when set) must parse as a positive Go duration. An empty
+// timeout falls back to DefaultOpcodeExtractionTimeout.
+func (c *Config) validateOpcodeExtraction() error {
+	for _, instance := range c.Runner.Instances {
+		cfg := c.GetOpcodeExtraction(&instance)
+		if cfg == nil || !cfg.Enabled {
+			continue
+		}
+
+		if cfg.Timeout == "" {
+			continue
+		}
+
+		d, err := time.ParseDuration(cfg.Timeout)
+		if err != nil {
+			return fmt.Errorf(
+				"instance %q: invalid opcode_extraction.timeout %q: %w",
+				instance.ID, cfg.Timeout, err,
+			)
+		}
+
+		if d <= 0 {
+			return fmt.Errorf(
+				"instance %q: opcode_extraction.timeout must be positive, got %q",
+				instance.ID, cfg.Timeout,
+			)
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2846,3 +2846,106 @@ func TestValidateTestFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOpcodeExtraction(t *testing.T) {
+	tests := []struct {
+		name     string
+		global   *OpcodeExtractionConfig
+		instance *OpcodeExtractionConfig
+		expected *OpcodeExtractionConfig
+	}{
+		{name: "both nil returns nil", global: nil, instance: nil, expected: nil},
+		{
+			name:     "global set, instance nil inherits",
+			global:   &OpcodeExtractionConfig{Enabled: true, Timeout: "5m"},
+			instance: nil,
+			expected: &OpcodeExtractionConfig{Enabled: true, Timeout: "5m"},
+		},
+		{
+			name:     "instance overrides global",
+			global:   &OpcodeExtractionConfig{Enabled: true, Timeout: "5m"},
+			instance: &OpcodeExtractionConfig{Enabled: false},
+			expected: &OpcodeExtractionConfig{Enabled: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Runner: RunnerConfig{
+					Client: ClientConfig{
+						Config: ClientDefaults{OpcodeExtraction: tt.global},
+					},
+				},
+			}
+			instance := &ClientInstance{OpcodeExtraction: tt.instance}
+			assert.Equal(t, tt.expected, cfg.GetOpcodeExtraction(instance))
+		})
+	}
+}
+
+func TestOpcodeExtractionConfig_EffectiveTimeout(t *testing.T) {
+	def, _ := time.ParseDuration(DefaultOpcodeExtractionTimeout)
+
+	tests := []struct {
+		name     string
+		cfg      *OpcodeExtractionConfig
+		expected time.Duration
+	}{
+		{name: "nil returns default", cfg: nil, expected: def},
+		{name: "empty returns default", cfg: &OpcodeExtractionConfig{Timeout: ""}, expected: def},
+		{name: "invalid returns default", cfg: &OpcodeExtractionConfig{Timeout: "not-a-duration"}, expected: def},
+		{name: "valid returns parsed", cfg: &OpcodeExtractionConfig{Timeout: "10m"}, expected: 10 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.cfg.EffectiveTimeout())
+		})
+	}
+}
+
+func TestValidateOpcodeExtraction(t *testing.T) {
+	tests := []struct {
+		name      string
+		global    *OpcodeExtractionConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "disabled is always valid", global: &OpcodeExtractionConfig{Enabled: false, Timeout: "garbage"}, wantErr: false},
+		{name: "enabled with empty timeout is valid (defaults)", global: &OpcodeExtractionConfig{Enabled: true}, wantErr: false},
+		{name: "enabled with valid timeout is valid", global: &OpcodeExtractionConfig{Enabled: true, Timeout: "5m"}, wantErr: false},
+		{
+			name:      "enabled with invalid timeout",
+			global:    &OpcodeExtractionConfig{Enabled: true, Timeout: "abc"},
+			wantErr:   true,
+			errSubstr: "invalid opcode_extraction.timeout",
+		},
+		{
+			name:      "enabled with non-positive timeout",
+			global:    &OpcodeExtractionConfig{Enabled: true, Timeout: "0s"},
+			wantErr:   true,
+			errSubstr: "must be positive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Runner: RunnerConfig{
+					Client: ClientConfig{
+						Config: ClientDefaults{OpcodeExtraction: tt.global},
+					},
+					Instances: []ClientInstance{{ID: "test", Client: "geth"}},
+				},
+			}
+			err := cfg.validateOpcodeExtraction()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -111,6 +111,7 @@ type ExecuteOptions struct {
 	RetryNewPayloadsSyncingConfig *config.RetryNewPayloadsSyncingConfig // Retry config for SYNCING responses.
 	RetryNewPayloadsFailedConfig  *config.RetryNewPayloadsFailedConfig  // Retry config for any non-SYNCING newPayload failure (RPC error, validation error, INVALID status).
 	PostTestRPCCalls              []config.PostTestRPCCall              // Arbitrary RPC calls to execute after the test step.
+	OpcodeExtraction              *config.OpcodeExtractionConfig        // When enabled, run debug_traceBlockByNumber per newPayload after the test step and aggregate per-test opcode counts.
 	PostTestSleepDuration         time.Duration                         // Sleep duration after each test (0 = disabled).
 	FailFast                      bool                                  // If true, return an error from runStepLines on the first failed RPC call.
 	PreRunStepSleep               time.Duration                         // Sleep between each RPC call within pre-run step files (0 = disabled).
@@ -173,6 +174,13 @@ type executor struct {
 	// Performance Heatmap that grows as tests complete.
 	liveTestsMu sync.RWMutex
 	liveTests   map[string]LiveTestStats
+
+	// Per-test aggregated opcode counts captured by extractTestOpcodes
+	// when opcode_extraction is enabled. The slice has one entry per
+	// engine_newPayload* in the test step, each entry summing per-tx
+	// counts across that block's transactions (uppercased).
+	opcodesMu   sync.Mutex
+	testOpcodes map[string][]map[string]int
 }
 
 // Ensure interface compliance.
@@ -629,6 +637,12 @@ func (e *executor) ExecuteTests(ctx context.Context, opts *ExecuteOptions) (*Exe
 			e.executePostTestRPCCalls(ctx, opts, test.Name, log)
 		}
 
+		// Extract per-newPayload opcode counts via debug_traceBlockByNumber.
+		// Best-effort: failures are logged but never abort the test.
+		if opts.OpcodeExtraction != nil && opts.OpcodeExtraction.Enabled && opts.RPCEndpoint != "" {
+			e.extractTestOpcodes(ctx, opts, test, log)
+		}
+
 		// Drop caches between test and cleanup.
 		if dropBetweenSteps && test.Test != nil && test.Cleanup != nil {
 			if err := e.dropMemoryCaches(dropCachesPath); err != nil {
@@ -761,6 +775,25 @@ writeResults:
 
 	if interrupted {
 		e.log.WithField("reason", interruptReason).Warn("Test execution was interrupted")
+	}
+
+	// Persist aggregated opcode counts (when extraction was enabled).
+	// This rewrites the file on every ExecuteTests call so multi-call
+	// strategies (container-recreate, checkpoint-restore) accumulate
+	// across calls without losing earlier tests.
+	e.opcodesMu.Lock()
+	opcodesSnapshot := make(map[string][]map[string]int, len(e.testOpcodes))
+	for k, v := range e.testOpcodes {
+		opcodesSnapshot[k] = v
+	}
+	e.opcodesMu.Unlock()
+
+	if len(opcodesSnapshot) > 0 {
+		if err := WriteTestOpcodes(opts.ResultsDir, opcodesSnapshot, e.cfg.ResultsOwner); err != nil {
+			e.log.WithError(err).Warn("Failed to write test-opcodes.json")
+		} else {
+			e.log.WithField("tests", len(opcodesSnapshot)).Info("Wrote test-opcodes.json")
+		}
 	}
 
 	return result, nil

--- a/pkg/executor/opcode_extraction.go
+++ b/pkg/executor/opcode_extraction.go
@@ -1,0 +1,272 @@
+package executor
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/fsutil"
+	"github.com/sirupsen/logrus"
+)
+
+// TestOpcodesFilename is the basename of the per-run aggregated opcodes
+// dump written under the run results directory.
+const TestOpcodesFilename = "test-opcodes.json"
+
+// opcodeCountTracerJS is the JavaScript tracer passed to
+// debug_traceBlockByNumber. It increments a per-opcode counter for
+// every executed step and returns the final map. Compatible with
+// clients that support `eth.JSTracerKind` style tracers (geth,
+// erigon, nethermind via JS-tracer support, etc.).
+const opcodeCountTracerJS = `{ counts: {}, ` +
+	`step: function(log){ var op = log.op.toString(); this.counts[op] = (this.counts[op]||0)+1 }, ` +
+	`fault: function(){}, ` +
+	`result: function(){ return this.counts } }`
+
+// debugTraceBlockResponse models the relevant slice of the
+// debug_traceBlockByNumber response we care about. Each entry is one
+// transaction in the block.
+type debugTraceBlockResponse struct {
+	Result []debugTraceBlockEntry `json:"result"`
+	Error  *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// debugTraceBlockEntry is the per-tx trace entry. The opcode-count
+// tracer returns a map[string]int as `result`.
+type debugTraceBlockEntry struct {
+	TxHash string         `json:"txHash"`
+	Result map[string]int `json:"result"`
+}
+
+// extractTestOpcodes runs debug_traceBlockByNumber against every
+// engine_newPayload* line in the test step and aggregates the per-tx
+// opcode counts into a single map per newPayload (uppercased). Each
+// newPayload becomes one entry in the per-test array stored on the
+// executor. Errors are logged but never abort the test; opcode
+// extraction is best-effort.
+func (e *executor) extractTestOpcodes(
+	ctx context.Context,
+	opts *ExecuteOptions,
+	test *TestWithSteps,
+	log logrus.FieldLogger,
+) {
+	if test.Test == nil || opts.RPCEndpoint == "" {
+		return
+	}
+
+	cfg := opts.OpcodeExtraction
+	if cfg == nil || !cfg.Enabled {
+		return
+	}
+
+	lines, err := readStepFileLines(test.Test)
+	if err != nil {
+		log.WithError(err).Warn("opcode_extraction: failed to read test step lines")
+
+		return
+	}
+
+	timeout := cfg.EffectiveTimeout()
+
+	var perPayload []map[string]int
+
+	for lineNum, line := range lines {
+		select {
+		case <-ctx.Done():
+			log.Warn("opcode_extraction: context cancelled mid-extraction")
+
+			return
+		default:
+		}
+
+		method, err := extractMethod(line)
+		if err != nil {
+			continue
+		}
+
+		if !strings.HasPrefix(method, "engine_newPayload") {
+			continue
+		}
+
+		blockNum, ok := extractBlockNumber(line)
+		if !ok {
+			log.WithField("line", lineNum+1).Debug(
+				"opcode_extraction: skipping newPayload without parseable blockNumber",
+			)
+
+			continue
+		}
+
+		blockNumberHex := fmt.Sprintf("0x%x", blockNum)
+
+		callLog := log.WithFields(logrus.Fields{
+			"block_number": blockNumberHex,
+			"line":         lineNum + 1,
+		})
+
+		counts, err := e.traceBlockOpcodes(ctx, opts.RPCEndpoint, blockNumberHex, timeout)
+		if err != nil {
+			callLog.WithError(err).Warn("opcode_extraction: trace failed")
+
+			continue
+		}
+
+		perPayload = append(perPayload, counts)
+	}
+
+	if len(perPayload) == 0 {
+		return
+	}
+
+	e.opcodesMu.Lock()
+	if e.testOpcodes == nil {
+		e.testOpcodes = make(map[string][]map[string]int)
+	}
+
+	e.testOpcodes[test.Name] = append(e.testOpcodes[test.Name], perPayload...)
+	e.opcodesMu.Unlock()
+}
+
+// traceBlockOpcodes calls debug_traceBlockByNumber with the JS
+// opcode-count tracer and returns the summed (uppercase) opcode counts
+// across all transactions in the block.
+func (e *executor) traceBlockOpcodes(
+	ctx context.Context,
+	endpoint, blockNumberHex string,
+	timeout time.Duration,
+) (map[string]int, error) {
+	tracerArg := map[string]any{
+		"tracer":          opcodeCountTracerJS,
+		"timeout":         timeout.String(),
+		"borTraceEnabled": false,
+	}
+
+	payload := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"debug_traceBlockByNumber","params":[%q,%s]}`,
+		blockNumberHex, mustMarshal(tracerArg),
+	)
+
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	rawResp, err := executeSimpleRPC(callCtx, endpoint, payload)
+	if err != nil {
+		return nil, fmt.Errorf("rpc: %w", err)
+	}
+
+	return aggregateBlockOpcodes(rawResp)
+}
+
+// aggregateBlockOpcodes parses a debug_traceBlockByNumber response,
+// sums per-tx opcode counts into a single map, and uppercases the
+// opcode names. Returns an error when the response carries a JSON-RPC
+// error, can't be parsed, or contains no traces.
+func aggregateBlockOpcodes(rawResp string) (map[string]int, error) {
+	var resp debugTraceBlockResponse
+	if err := json.Unmarshal([]byte(rawResp), &resp); err != nil {
+		return nil, fmt.Errorf("parse trace response: %w", err)
+	}
+
+	if resp.Error != nil {
+		return nil, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)
+	}
+
+	if len(resp.Result) == 0 {
+		return nil, fmt.Errorf("trace response had no entries")
+	}
+
+	out := make(map[string]int, 32)
+
+	for _, entry := range resp.Result {
+		for op, count := range entry.Result {
+			out[strings.ToUpper(op)] += count
+		}
+	}
+
+	return out, nil
+}
+
+// WriteTestOpcodes writes the aggregated per-test opcode map to
+// resultsDir/test-opcodes.json. A nil/empty map is a no-op.
+func WriteTestOpcodes(
+	resultsDir string,
+	opcodes map[string][]map[string]int,
+	owner *fsutil.OwnerConfig,
+) error {
+	if len(opcodes) == 0 {
+		return nil
+	}
+
+	data, err := json.MarshalIndent(opcodes, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling test opcodes: %w", err)
+	}
+
+	path := filepath.Join(resultsDir, TestOpcodesFilename)
+	if err := fsutil.WriteFile(path, data, 0644, owner); err != nil {
+		return fmt.Errorf("writing %s: %w", TestOpcodesFilename, err)
+	}
+
+	return nil
+}
+
+// readStepFileLines reads non-empty trimmed lines from a step file or
+// provider. Mirrors the loop in runStepFromFile but exposed as a
+// standalone helper so opcode extraction can scan the test step
+// without re-running it.
+func readStepFileLines(step *StepFile) ([]string, error) {
+	if step.Provider != nil {
+		return step.Provider.Lines(), nil
+	}
+
+	file, err := os.Open(step.Path)
+	if err != nil {
+		return nil, fmt.Errorf("opening step file: %w", err)
+	}
+
+	defer func() { _ = file.Close() }()
+
+	reader := bufio.NewReader(file)
+
+	var lines []string
+
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			if trimmed := strings.TrimSpace(line); trimmed != "" {
+				lines = append(lines, trimmed)
+			}
+		}
+
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return nil, fmt.Errorf("reading step file: %w", err)
+		}
+	}
+
+	return lines, nil
+}
+
+// mustMarshal is a tiny helper for embedding a small Go value as JSON
+// inside a literal string. Panics only on programmer error (the input
+// shape is fully under our control).
+func mustMarshal(v any) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Sprintf("opcode_extraction: marshal: %v", err))
+	}
+
+	return string(data)
+}

--- a/pkg/executor/opcode_extraction.go
+++ b/pkg/executor/opcode_extraction.go
@@ -75,9 +75,32 @@ func (e *executor) extractTestOpcodes(
 		return
 	}
 
+	// Pre-count newPayload* lines so progress logs can show "i/total"
+	// instead of just the absolute line number, which is more useful
+	// when a step has interleaved FCUs we skip over.
+	totalPayloads := 0
+
+	for _, l := range lines {
+		if m, err := extractMethod(l); err == nil && strings.HasPrefix(m, "engine_newPayload") {
+			totalPayloads++
+		}
+	}
+
+	if totalPayloads == 0 {
+		return
+	}
+
 	timeout := cfg.EffectiveTimeout()
 
+	log.WithFields(logrus.Fields{
+		"payloads": totalPayloads,
+		"timeout":  timeout,
+	}).Info("Extracting opcode counts")
+
 	var perPayload []map[string]int
+
+	startedAll := time.Now()
+	processed := 0
 
 	for lineNum, line := range lines {
 		select {
@@ -107,11 +130,14 @@ func (e *executor) extractTestOpcodes(
 		}
 
 		blockNumberHex := fmt.Sprintf("0x%x", blockNum)
+		processed++
 
 		callLog := log.WithFields(logrus.Fields{
 			"block_number": blockNumberHex,
-			"line":         lineNum + 1,
+			"pos":          fmt.Sprintf("%d/%d", processed, totalPayloads),
 		})
+
+		traceStart := time.Now()
 
 		counts, err := e.traceBlockOpcodes(ctx, opts.RPCEndpoint, blockNumberHex, timeout)
 		if err != nil {
@@ -120,8 +146,19 @@ func (e *executor) extractTestOpcodes(
 			continue
 		}
 
+		callLog.WithFields(logrus.Fields{
+			"opcodes":  len(counts),
+			"duration": time.Since(traceStart),
+		}).Info("Traced block opcodes")
+
 		perPayload = append(perPayload, counts)
 	}
+
+	log.WithFields(logrus.Fields{
+		"payloads_traced": len(perPayload),
+		"payloads_total":  totalPayloads,
+		"duration":        time.Since(startedAll),
+	}).Info("Opcode extraction completed")
 
 	if len(perPayload) == 0 {
 		return
@@ -133,7 +170,21 @@ func (e *executor) extractTestOpcodes(
 	}
 
 	e.testOpcodes[test.Name] = append(e.testOpcodes[test.Name], perPayload...)
+	// Snapshot under the lock so the file write below sees a consistent
+	// view, then drop the lock before doing I/O.
+	snapshot := make(map[string][]map[string]int, len(e.testOpcodes))
+	for k, v := range e.testOpcodes {
+		snapshot[k] = v
+	}
 	e.opcodesMu.Unlock()
+
+	// Flush the cumulative map after every successful extraction so a
+	// cancelled run still leaves test-opcodes.json on disk with all the
+	// tests that finished before the cancel landed. The end-of-run write
+	// in ExecuteTests stays as a final safety net.
+	if err := WriteTestOpcodes(opts.ResultsDir, snapshot, e.cfg.ResultsOwner); err != nil {
+		log.WithError(err).Warn("opcode_extraction: failed to flush test-opcodes.json")
+	}
 }
 
 // traceBlockOpcodes calls debug_traceBlockByNumber with the JS

--- a/pkg/executor/opcode_extraction_test.go
+++ b/pkg/executor/opcode_extraction_test.go
@@ -1,0 +1,58 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateBlockOpcodes_SumsAcrossTransactions(t *testing.T) {
+	resp := `{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"result": [
+			{"txHash": "0xaaa", "result": {"PUSH1": 10, "MSTORE": 2, "STOP": 1}},
+			{"txHash": "0xbbb", "result": {"PUSH1": 5,  "DUP1":   3, "STOP": 1}}
+		]
+	}`
+
+	got, err := aggregateBlockOpcodes(resp)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int{
+		"PUSH1":  15,
+		"MSTORE": 2,
+		"STOP":   2,
+		"DUP1":   3,
+	}, got)
+}
+
+func TestAggregateBlockOpcodes_UppercasesNames(t *testing.T) {
+	resp := `{"result":[{"txHash":"0xa","result":{"push1":4,"Push1":1,"PUSH1":2}}]}`
+
+	got, err := aggregateBlockOpcodes(resp)
+	require.NoError(t, err)
+	// All three should fold into "PUSH1" via uppercase normalization.
+	assert.Equal(t, map[string]int{"PUSH1": 7}, got)
+}
+
+func TestAggregateBlockOpcodes_RPCError(t *testing.T) {
+	resp := `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"trace failed"}}`
+
+	_, err := aggregateBlockOpcodes(resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trace failed")
+}
+
+func TestAggregateBlockOpcodes_EmptyResult(t *testing.T) {
+	resp := `{"jsonrpc":"2.0","id":1,"result":[]}`
+
+	_, err := aggregateBlockOpcodes(resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no entries")
+}
+
+func TestAggregateBlockOpcodes_InvalidJSON(t *testing.T) {
+	_, err := aggregateBlockOpcodes(`not json`)
+	require.Error(t, err)
+}

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -631,6 +631,12 @@ func (r *runner) runContainerLifecycle(
 				}
 				return nil
 			}(),
+			OpcodeExtraction: func() *config.OpcodeExtractionConfig {
+				if r.cfg.FullConfig != nil {
+					return r.cfg.FullConfig.GetOpcodeExtraction(instance)
+				}
+				return nil
+			}(),
 		},
 	}
 
@@ -1130,6 +1136,7 @@ func (r *runner) runContainerLifecycle(
 				RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(instance),
 				RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(instance),
 				PostTestRPCCalls:              r.cfg.FullConfig.GetPostTestRPCCalls(instance),
+				OpcodeExtraction:              r.cfg.FullConfig.GetOpcodeExtraction(instance),
 				PostTestSleepDuration:         r.cfg.FullConfig.GetPostTestSleepDuration(instance),
 				PreRunStepSleep:               r.cfg.PreRunStepSleep,
 				SkipUntilBlockNumber:          blockNum,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -189,6 +189,7 @@ type ResolvedInstance struct {
 	PostTestSleepDuration            string                                   `json:"post_test_sleep_duration,omitempty"`
 	BootstrapFCU                     *config.BootstrapFCUConfig               `json:"bootstrap_fcu,omitempty"`
 	CheckpointRestoreStrategyOptions *config.CheckpointRestoreStrategyOptions `json:"checkpoint_restore_strategy_options,omitempty"`
+	OpcodeExtraction                 *config.OpcodeExtractionConfig           `json:"opcode_extraction,omitempty"`
 }
 
 // NewRunner creates a new runner instance.

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -514,6 +514,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 			RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(params.Instance),
 			RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(params.Instance),
 			PostTestRPCCalls:              r.cfg.FullConfig.GetPostTestRPCCalls(params.Instance),
+			OpcodeExtraction:              r.cfg.FullConfig.GetOpcodeExtraction(params.Instance),
 			PostTestSleepDuration:         r.cfg.FullConfig.GetPostTestSleepDuration(params.Instance),
 		}
 

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -778,6 +778,7 @@ func (r *runner) runTestsWithContainerStrategy(
 			RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(params.Instance),
 			RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(params.Instance),
 			PostTestRPCCalls:              r.cfg.FullConfig.GetPostTestRPCCalls(params.Instance),
+			OpcodeExtraction:              r.cfg.FullConfig.GetOpcodeExtraction(params.Instance),
 			PostTestSleepDuration:         r.cfg.FullConfig.GetPostTestSleepDuration(params.Instance),
 		}
 

--- a/ui/src/api/hooks/useRunOpcodes.ts
+++ b/ui/src/api/hooks/useRunOpcodes.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchData } from '../client'
+import type { RunTestOpcodes } from '../types'
+
+/**
+ * useRunOpcodes fetches a run's test-opcodes.json (written when the
+ * runner had `opcode_extraction.enabled = true`). Returns null when
+ * the file is absent, which is the common case (extraction is opt-in).
+ */
+export function useRunOpcodes(runId: string, enabled = true) {
+  return useQuery({
+    queryKey: ['run', runId, 'opcodes'],
+    queryFn: async () => {
+      const { data } = await fetchData<RunTestOpcodes>(`runs/${runId}/test-opcodes.json`)
+      return data ?? null
+    },
+    enabled: !!runId && enabled,
+  })
+}

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -265,6 +265,19 @@ export interface CheckpointRestoreStrategyOptions {
   restart_container?: boolean
 }
 
+export interface OpcodeExtractionConfig {
+  enabled: boolean
+  timeout?: string
+}
+
+/**
+ * Shape of the per-run `test-opcodes.json` written when
+ * `opcode_extraction.enabled` is true. One entry per test name; each
+ * entry is an array with one map per `engine_newPayload*` in that test
+ * (per-tx counts are summed and the opcode names are uppercased).
+ */
+export type RunTestOpcodes = Record<string, Array<Record<string, number>>>
+
 export interface InstanceConfig {
   id: string
   client: string
@@ -291,6 +304,7 @@ export interface InstanceConfig {
   post_test_rpc_calls?: PostTestRPCCallConfig[]
   post_test_sleep_duration?: string
   checkpoint_restore_strategy_options?: CheckpointRestoreStrategyOptions
+  opcode_extraction?: OpcodeExtractionConfig
 }
 
 // result.json per run

--- a/ui/src/components/run-detail/OpcodeDiffPanel.tsx
+++ b/ui/src/components/run-detail/OpcodeDiffPanel.tsx
@@ -1,0 +1,56 @@
+/**
+ * OpcodeDiffPanel renders a per-opcode diff table comparing the
+ * suite-defined opcode counts to the ones extracted at run-time
+ * (test-opcodes.json). Only opcodes where the counts disagree are
+ * rendered, sorted by absolute delta. Callers compute the rows.
+ */
+
+export interface OpcodeDiffRow {
+  opcode: string
+  suite: number
+  run: number
+  delta: number
+}
+
+interface OpcodeDiffPanelProps {
+  rows: OpcodeDiffRow[]
+  /** Optional caption shown above the table (e.g. test name). */
+  caption?: string
+  className?: string
+}
+
+export function OpcodeDiffPanel({ rows, caption, className }: OpcodeDiffPanelProps) {
+  if (rows.length === 0) return null
+
+  return (
+    <div className={className}>
+      {caption && (
+        <div className="mb-1 break-all font-mono text-xs/5 font-medium text-gray-900 dark:text-gray-100">
+          {caption}
+        </div>
+      )}
+      <table className="min-w-full font-mono text-xs/5">
+        <thead>
+          <tr className="border-b border-gray-200 text-left text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <th className="px-2 py-1 font-medium">Opcode</th>
+            <th className="px-2 py-1 text-right font-medium">Suite</th>
+            <th className="px-2 py-1 text-right font-medium">Run</th>
+            <th className="px-2 py-1 text-right font-medium">Δ</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 dark:divide-gray-700/50">
+          {rows.map((r) => (
+            <tr key={r.opcode}>
+              <td className="px-2 py-1 text-gray-900 dark:text-gray-100">{r.opcode}</td>
+              <td className="px-2 py-1 text-right text-gray-700 dark:text-gray-300">{r.suite.toLocaleString()}</td>
+              <td className="px-2 py-1 text-right text-gray-700 dark:text-gray-300">{r.run.toLocaleString()}</td>
+              <td className={`px-2 py-1 text-right font-medium ${r.delta > 0 ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}`}>
+                {r.delta > 0 ? '+' : ''}{r.delta.toLocaleString()}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/ui/src/components/run-detail/RunConfiguration.tsx
+++ b/ui/src/components/run-detail/RunConfiguration.tsx
@@ -332,6 +332,30 @@ export function RunConfiguration({ instance, system, startBlock, metadata, bench
                 </div>
               )}
 
+              {instance.opcode_extraction?.enabled && (
+                <div>
+                  <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">
+                    Opcode Extraction
+                  </dt>
+                  <dd className="mt-1 overflow-x-auto rounded-sm bg-gray-100 p-2 dark:bg-gray-900">
+                    <div className="flex flex-col gap-1 font-mono text-xs/5 text-gray-900 dark:text-gray-100">
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">enabled: </span>
+                        true
+                      </div>
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">timeout: </span>
+                        {instance.opcode_extraction.timeout || '2m'}
+                      </div>
+                    </div>
+                    <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                      Captures per-test opcode counts via debug_traceBlockByNumber after each
+                      test step. Output: <code className="font-mono">test-opcodes.json</code> at the run dir.
+                    </p>
+                  </dd>
+                </div>
+              )}
+
               {instance.retry_new_payloads_syncing_state?.enabled && (
                 <div>
                   <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -13,6 +13,7 @@ import type { TestStatusFilter } from './TestsTable'
 import { type StepTypeOption, ALL_STEP_TYPES } from '@/pages/RunDetailPage'
 import { formatDuration, formatBytes } from '@/utils/format'
 import { EESTInfoContent, type OpcodeSortMode } from '@/components/suite-detail/TestFilesList'
+import { OpcodeDiffPanel, type OpcodeDiffRow } from './OpcodeDiffPanel'
 import { useBlockLogs } from '@/api/hooks/useBlockLogs'
 
 // Aggregate stats from selected steps of a test entry
@@ -100,6 +101,13 @@ function formatGasGroup(gasGroup: number): string {
 interface TestHeatmapProps {
   tests: Record<string, TestEntry>
   suiteTests?: SuiteTest[]
+  /**
+   * Per-test opcode diffs between this run's extracted counts and the
+   * suite-defined counts. When the selected test has an entry, a
+   * compact diff table is rendered inside its modal. Caller (the run
+   * detail page) computes this from useRunOpcodes + suite.tests.
+   */
+  opcodeDiffByTest?: Record<string, OpcodeDiffRow[]>
   runId: string
   suiteHash?: string
   selectedTest?: string
@@ -346,6 +354,7 @@ function HeatmapCell({
 export function TestHeatmap({
   tests,
   suiteTests,
+  opcodeDiffByTest,
   runId,
   suiteHash,
   selectedTest,
@@ -954,6 +963,25 @@ export function TestHeatmap({
                 const matchingSuiteTest = suiteTests?.find((t) => t.name === selectedTest)
                 if (!matchingSuiteTest) return null
                 return <EESTInfoContent test={matchingSuiteTest} opcodeSort={opcodeSort} onOpcodeSortChange={setOpcodeSort} />
+              })()}
+              {(() => {
+                const diffRows = opcodeDiffByTest?.[selectedTest]
+                if (!diffRows || diffRows.length === 0) return null
+                return (
+                  <div className="flex flex-col gap-2">
+                    <div className="flex items-center gap-2 text-xs/5 text-yellow-800 dark:text-yellow-200">
+                      <span className="inline-flex items-center rounded-xs bg-yellow-100 px-1.5 py-0.5 font-medium dark:bg-yellow-900/50">
+                        ⚠ Opcode counts differ from suite
+                      </span>
+                      <span className="text-gray-500 dark:text-gray-400">
+                        {diffRows.length} opcode{diffRows.length === 1 ? '' : 's'} with non-zero Δ; sorted by absolute delta
+                      </span>
+                    </div>
+                    <div className="max-h-72 overflow-y-auto rounded-xs border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-gray-900">
+                      <OpcodeDiffPanel rows={diffRows} />
+                    </div>
+                  </div>
+                )
               })()}
               {blockLogs?.[selectedTest] && (
                 <BlockLogDetails blockLog={blockLogs[selectedTest]} />

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -16,6 +16,7 @@ import { TestsTable, type TestSortColumn, type TestSortDirection, type TestStatu
 import { PreRunStepsTable } from '@/components/run-detail/PreRunStepsTable'
 import { TestHeatmap, type SortMode, type GroupMode } from '@/components/run-detail/TestHeatmap'
 import { OpcodeHeatmap } from '@/components/suite-detail/OpcodeHeatmap'
+import { OpcodeDiffPanel, type OpcodeDiffRow } from '@/components/run-detail/OpcodeDiffPanel'
 import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { ClientStat } from '@/components/shared/ClientStat'
@@ -38,16 +39,9 @@ import { useDeleteRuns } from '@/api/hooks/useAdmin'
 
 // Per-test opcode diff between this run and the suite. Only opcodes
 // where suite count != run count are listed.
-interface OpcodeRow {
-  opcode: string
-  suite: number
-  run: number
-  delta: number
-}
-
 interface OpcodeTestDiff {
   name: string
-  rows: OpcodeRow[]
+  rows: OpcodeDiffRow[]
 }
 
 // Step types that can be included in MGas/s calculation
@@ -230,8 +224,14 @@ export function RunDetailPage() {
   // available. Per-test, sum counts across the array of newPayloads
   // (one entry per engine_newPayload* in the test step). If only the
   // suite has counts, the suite values are kept as-is.
-  const { mergedSuiteTests, opcodeDiffs } = useMemo(() => {
-    if (!suite?.tests) return { mergedSuiteTests: undefined, opcodeDiffs: [] as OpcodeTestDiff[] }
+  const { mergedSuiteTests, opcodeDiffs, opcodeDiffByTest } = useMemo(() => {
+    if (!suite?.tests) {
+      return {
+        mergedSuiteTests: undefined,
+        opcodeDiffs: [] as OpcodeTestDiff[],
+        opcodeDiffByTest: {} as Record<string, OpcodeDiffRow[]>,
+      }
+    }
 
     const sumPayloads = (entries: Array<Record<string, number>>): Record<string, number> => {
       const out: Record<string, number> = {}
@@ -243,9 +243,9 @@ export function RunDetailPage() {
       return out
     }
 
-    const diffOpcodes = (suiteCounts: Record<string, number>, runCounts: Record<string, number>): OpcodeRow[] => {
+    const diffOpcodes = (suiteCounts: Record<string, number>, runCounts: Record<string, number>): OpcodeDiffRow[] => {
       const all = new Set<string>([...Object.keys(suiteCounts), ...Object.keys(runCounts)])
-      const rows: OpcodeRow[] = []
+      const rows: OpcodeDiffRow[] = []
       for (const op of all) {
         const s = suiteCounts[op] ?? 0
         const r = runCounts[op] ?? 0
@@ -257,6 +257,7 @@ export function RunDetailPage() {
     }
 
     const diffs: OpcodeTestDiff[] = []
+    const byTest: Record<string, OpcodeDiffRow[]> = {}
     const merged = suite.tests.map((t) => {
       const runEntries = runOpcodes?.[t.name]
       if (!runEntries || runEntries.length === 0) return t
@@ -267,12 +268,13 @@ export function RunDetailPage() {
         const rows = diffOpcodes(suiteCounts, runCounts)
         if (rows.length > 0) {
           diffs.push({ name: t.name, rows })
+          byTest[t.name] = rows
         }
       }
       return { ...t, opcode_count: runCounts }
     })
 
-    return { mergedSuiteTests: merged, opcodeDiffs: diffs }
+    return { mergedSuiteTests: merged, opcodeDiffs: diffs, opcodeDiffByTest: byTest }
   }, [suite, runOpcodes])
 
   const updateSearch = (updates: Partial<typeof search>) => {
@@ -745,7 +747,8 @@ export function RunDetailPage() {
             </div>
             <TestHeatmap
               tests={result.tests}
-              suiteTests={suite?.tests}
+              suiteTests={mergedSuiteTests ?? suite?.tests}
+              opcodeDiffByTest={opcodeDiffByTest}
               runId={runId}
               suiteHash={config.suite_hash}
               selectedTest={testModal}
@@ -793,33 +796,7 @@ export function RunDetailPage() {
                     <div className="mt-3 max-h-96 overflow-y-auto rounded-xs border border-blue-200 bg-white p-2 text-gray-900 dark:border-blue-900/50 dark:bg-gray-900 dark:text-gray-100">
                       <div className="flex flex-col gap-3">
                         {opcodeDiffs.map((d) => (
-                          <div key={d.name}>
-                            <div className="mb-1 break-all font-mono text-xs/5 font-medium text-gray-900 dark:text-gray-100">
-                              {d.name}
-                            </div>
-                            <table className="min-w-full font-mono text-xs/5">
-                              <thead>
-                                <tr className="border-b border-gray-200 text-left text-gray-500 dark:border-gray-700 dark:text-gray-400">
-                                  <th className="px-2 py-1 font-medium">Opcode</th>
-                                  <th className="px-2 py-1 text-right font-medium">Suite</th>
-                                  <th className="px-2 py-1 text-right font-medium">Run</th>
-                                  <th className="px-2 py-1 text-right font-medium">Δ</th>
-                                </tr>
-                              </thead>
-                              <tbody className="divide-y divide-gray-100 dark:divide-gray-700/50">
-                                {d.rows.map((r) => (
-                                  <tr key={r.opcode}>
-                                    <td className="px-2 py-1">{r.opcode}</td>
-                                    <td className="px-2 py-1 text-right text-gray-700 dark:text-gray-300">{r.suite.toLocaleString()}</td>
-                                    <td className="px-2 py-1 text-right text-gray-700 dark:text-gray-300">{r.run.toLocaleString()}</td>
-                                    <td className={`px-2 py-1 text-right font-medium ${r.delta > 0 ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}`}>
-                                      {r.delta > 0 ? '+' : ''}{r.delta.toLocaleString()}
-                                    </td>
-                                  </tr>
-                                ))}
-                              </tbody>
-                            </table>
-                          </div>
+                          <OpcodeDiffPanel key={d.name} caption={d.name} rows={d.rows} />
                         ))}
                       </div>
                     </div>

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -5,6 +5,7 @@ import { fetchHead } from '@/api/client'
 import type { TestEntry, AggregatedStats, StepResult } from '@/api/types'
 import { useRunConfig } from '@/api/hooks/useRunConfig'
 import { useRunResult } from '@/api/hooks/useRunResult'
+import { useRunOpcodes } from '@/api/hooks/useRunOpcodes'
 import { useSuite } from '@/api/hooks/useSuite'
 import { RunConfiguration } from '@/components/run-detail/RunConfiguration'
 import { MetadataLabels } from '@/components/run-detail/MetadataLabels'
@@ -34,6 +35,20 @@ import { Flame, Download, SquareStack, GitCompareArrows, Trash2 } from 'lucide-r
 import { MAX_COMPARE_RUNS, MIN_COMPARE_RUNS } from '@/components/compare/constants'
 import { useAuth } from '@/hooks/useAuth'
 import { useDeleteRuns } from '@/api/hooks/useAdmin'
+
+// Per-test opcode diff between this run and the suite. Only opcodes
+// where suite count != run count are listed.
+interface OpcodeRow {
+  opcode: string
+  suite: number
+  run: number
+  delta: number
+}
+
+interface OpcodeTestDiff {
+  name: string
+  rows: OpcodeRow[]
+}
 
 // Step types that can be included in MGas/s calculation
 export type StepTypeOption = 'setup' | 'test' | 'cleanup'
@@ -158,6 +173,7 @@ export function RunDetailPage() {
   const { data: config, isLoading: configLoading, error: configError, refetch: refetchConfig } = useRunConfig(runId, fetchOnDisk)
   const { data: result, isLoading: resultLoading, refetch: refetchResult } = useRunResult(runId, fetchOnDisk)
   const { data: suite } = useSuite(config?.suite_hash ?? '')
+  const { data: runOpcodes } = useRunOpcodes(runId, fetchOnDisk)
   const { data: index } = useIndex()
   const { data: containerLogHead, isLoading: containerLogLoading } = useQuery({
     queryKey: ['run', runId, 'container-log-head'],
@@ -176,6 +192,7 @@ export function RunDetailPage() {
 
   const [compareMode, setCompareMode] = useState(false)
   const [selectedRunIds, setSelectedRunIds] = useState<Set<string>>(new Set())
+  const [showOpcodeDiff, setShowOpcodeDiff] = useState(false)
 
   const handleSelectionChange = useCallback((id: string, selected: boolean) => {
     setSelectedRunIds((prev) => {
@@ -207,6 +224,56 @@ export function RunDetailPage() {
     const sorted = [...clientRuns].sort((a, b) => b.timestamp - a.timestamp)
     return sorted.slice(0, MAX_COMPARE_RUNS)
   }, [clientRuns])
+
+  // Merge per-run opcode counts (test-opcodes.json) into the suite's
+  // SuiteTest list so OpcodeHeatmap renders run-extracted data when
+  // available. Per-test, sum counts across the array of newPayloads
+  // (one entry per engine_newPayload* in the test step). If only the
+  // suite has counts, the suite values are kept as-is.
+  const { mergedSuiteTests, opcodeDiffs } = useMemo(() => {
+    if (!suite?.tests) return { mergedSuiteTests: undefined, opcodeDiffs: [] as OpcodeTestDiff[] }
+
+    const sumPayloads = (entries: Array<Record<string, number>>): Record<string, number> => {
+      const out: Record<string, number> = {}
+      for (const entry of entries) {
+        for (const [op, count] of Object.entries(entry)) {
+          out[op] = (out[op] ?? 0) + count
+        }
+      }
+      return out
+    }
+
+    const diffOpcodes = (suiteCounts: Record<string, number>, runCounts: Record<string, number>): OpcodeRow[] => {
+      const all = new Set<string>([...Object.keys(suiteCounts), ...Object.keys(runCounts)])
+      const rows: OpcodeRow[] = []
+      for (const op of all) {
+        const s = suiteCounts[op] ?? 0
+        const r = runCounts[op] ?? 0
+        if (s !== r) rows.push({ opcode: op, suite: s, run: r, delta: r - s })
+      }
+      // Sort by largest absolute delta first.
+      rows.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
+      return rows
+    }
+
+    const diffs: OpcodeTestDiff[] = []
+    const merged = suite.tests.map((t) => {
+      const runEntries = runOpcodes?.[t.name]
+      if (!runEntries || runEntries.length === 0) return t
+
+      const runCounts = sumPayloads(runEntries)
+      const suiteCounts = t.opcode_count ?? t.eest?.info?.opcode_count
+      if (suiteCounts && Object.keys(suiteCounts).length > 0) {
+        const rows = diffOpcodes(suiteCounts, runCounts)
+        if (rows.length > 0) {
+          diffs.push({ name: t.name, rows })
+        }
+      }
+      return { ...t, opcode_count: runCounts }
+    })
+
+    return { mergedSuiteTests: merged, opcodeDiffs: diffs }
+  }, [suite, runOpcodes])
 
   const updateSearch = (updates: Partial<typeof search>) => {
     navigate({
@@ -701,14 +768,70 @@ export function RunDetailPage() {
             />
           </div>
 
-          {suite?.tests && suite.tests.length > 0 && (
+          {mergedSuiteTests && mergedSuiteTests.length > 0 && (
             <div className="overflow-hidden rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
+              {runOpcodes && Object.keys(runOpcodes).length > 0 && (
+                <div className="mb-3 rounded-sm border border-blue-200 bg-blue-50 px-3 py-2 text-xs/5 text-blue-800 dark:border-blue-900/50 dark:bg-blue-950/40 dark:text-blue-200">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span>
+                      Showing opcode counts extracted from this run (
+                      <code className="font-mono">test-opcodes.json</code>); suite-defined counts are
+                      overridden where available.
+                    </span>
+                    {opcodeDiffs.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => setShowOpcodeDiff((v) => !v)}
+                        className="inline-flex items-center rounded-xs bg-yellow-100 px-1.5 py-0.5 font-medium text-yellow-800 hover:bg-yellow-200 dark:bg-yellow-900/50 dark:text-yellow-200 dark:hover:bg-yellow-900/70"
+                      >
+                        ⚠ {opcodeDiffs.length} test{opcodeDiffs.length === 1 ? '' : 's'} differ from suite
+                        <span className="ml-1.5 text-yellow-700 dark:text-yellow-300">{showOpcodeDiff ? '▾' : '▸'}</span>
+                      </button>
+                    )}
+                  </div>
+                  {showOpcodeDiff && opcodeDiffs.length > 0 && (
+                    <div className="mt-3 max-h-96 overflow-y-auto rounded-xs border border-blue-200 bg-white p-2 text-gray-900 dark:border-blue-900/50 dark:bg-gray-900 dark:text-gray-100">
+                      <div className="flex flex-col gap-3">
+                        {opcodeDiffs.map((d) => (
+                          <div key={d.name}>
+                            <div className="mb-1 break-all font-mono text-xs/5 font-medium text-gray-900 dark:text-gray-100">
+                              {d.name}
+                            </div>
+                            <table className="min-w-full font-mono text-xs/5">
+                              <thead>
+                                <tr className="border-b border-gray-200 text-left text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                                  <th className="px-2 py-1 font-medium">Opcode</th>
+                                  <th className="px-2 py-1 text-right font-medium">Suite</th>
+                                  <th className="px-2 py-1 text-right font-medium">Run</th>
+                                  <th className="px-2 py-1 text-right font-medium">Δ</th>
+                                </tr>
+                              </thead>
+                              <tbody className="divide-y divide-gray-100 dark:divide-gray-700/50">
+                                {d.rows.map((r) => (
+                                  <tr key={r.opcode}>
+                                    <td className="px-2 py-1">{r.opcode}</td>
+                                    <td className="px-2 py-1 text-right text-gray-700 dark:text-gray-300">{r.suite.toLocaleString()}</td>
+                                    <td className="px-2 py-1 text-right text-gray-700 dark:text-gray-300">{r.run.toLocaleString()}</td>
+                                    <td className={`px-2 py-1 text-right font-medium ${r.delta > 0 ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}`}>
+                                      {r.delta > 0 ? '+' : ''}{r.delta.toLocaleString()}
+                                    </td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
               <OpcodeHeatmap
-                tests={suite.tests}
+                tests={mergedSuiteTests}
                 extraColumns={[{
                   name: 'Mgas/s',
                   getValue: (testIndex: number) => {
-                    const testName = suite.tests[testIndex]?.name
+                    const testName = mergedSuiteTests[testIndex]?.name
                     if (!testName) return undefined
                     const entry = result.tests[testName]
                     if (!entry) return undefined
@@ -719,7 +842,7 @@ export function RunDetailPage() {
                   width: 54,
                   format: (v: number) => v.toFixed(1),
                 }]}
-                onTestClick={(testIndex) => handleTestModalChange(suite.tests[testIndex - 1]?.name)}
+                onTestClick={(testIndex) => handleTestModalChange(mergedSuiteTests[testIndex - 1]?.name)}
                 searchQuery={q}
                 onSearchChange={handleSearchChange}
                 fullscreen={ohFs}


### PR DESCRIPTION
## Summary

Adds `runner.client.config.opcode_extraction` to capture per-test opcode counts as a side effect of running tests, instead of relying on a separate upstream pipeline producing `opcode_source` JSON.

```yaml
runner:
  client:
    config:
      opcode_extraction:
        enabled: true
        timeout: 2m   # per-block trace timeout; default 2m
```

When enabled, after each test step the runner walks the test's `engine_newPayload*` lines and runs `debug_traceBlockByNumber` on each block with a JS opcode-counting tracer. Per-tx counts are summed (and uppercased) into one map per newPayload, appended to a per-test array, and persisted to `<run>/test-opcodes.json`:

```json
{
  "test-name.txt": [
    { "PUSH1": 23432, "DUP1": 11231, "SSTORE": 3321 }
  ]
}
```

The shape matches what `runner.benchmark.tests.opcode_source` consumes, so a run can serve as the upstream pipeline for follow-up runs.

Settable globally and per-instance with the standard override pattern. Resolved value lands in the run's `config.json` so the UI can surface the configured timeout.

### UI

- `useRunOpcodes(runId)` hook fetches `test-opcodes.json`.
- `RunDetailPage` merges run-extracted counts into `SuiteTest.opcode_count` (summed across the array of newPayloads per test) before passing to `OpcodeHeatmap`. Suite-defined counts get overridden where run data is available.
- When run-extracted and suite-defined counts disagree for a test, a yellow `⚠ N tests differ from suite` badge appears in the heatmap banner. **Clicking it toggles a per-test diff panel** showing four columns — Opcode / Suite / Run / Δ — for the differing opcodes only, sorted by absolute delta. Positive deltas green, negative red.
- `RunConfiguration` card surfaces an "Opcode Extraction" entry with the configured timeout when enabled.

### Files

- `pkg/config/config.go` — `OpcodeExtractionConfig{Enabled, Timeout}`, `EffectiveTimeout()`, fields on `ClientDefaults` + `ClientInstance`, `GetOpcodeExtraction()` getter, `validateOpcodeExtraction()` (rejects unparseable / non-positive timeouts when enabled).
- `pkg/executor/opcode_extraction.go` (new) — JS tracer constant, `aggregateBlockOpcodes`, `extractTestOpcodes`, `WriteTestOpcodes`. Adds `OpcodeExtraction` option to `ExecuteOptions` and an `extractedOpcodes` map + mutex on the executor.
- `pkg/executor/executor.go` — hooks the extractor into the test loop right after `executePostTestRPCCalls`, writes `test-opcodes.json` at end of `ExecuteTests` (rewritten on every call so multi-call strategies — container-recreate, checkpoint-restore — accumulate correctly).
- `pkg/runner/{lifecycle,strategy_checkpoint,strategy_container}.go` — `OpcodeExtraction` plumbed through every `ExecuteOptions` site.
- `pkg/runner/runner.go` — `ResolvedInstance.OpcodeExtraction` field.
- `ui/src/api/types.ts` — `OpcodeExtractionConfig` + `RunTestOpcodes` types.
- `ui/src/api/hooks/useRunOpcodes.ts` (new) — react-query hook.
- `ui/src/pages/RunDetailPage.tsx` — merge logic + diff panel + badge.
- `ui/src/components/run-detail/RunConfiguration.tsx` — Opcode Extraction card.
- `docs/configuration.md` + `config.example.yaml` — documented + example.

### Tests

- `pkg/config` — `TestGetOpcodeExtraction`, `TestOpcodeExtractionConfig_EffectiveTimeout`, `TestValidateOpcodeExtraction`.
- `pkg/executor` — `TestAggregateBlockOpcodes_*` covers per-tx summing, uppercase normalisation, RPC errors, empty results, invalid JSON.
- `tsc -b` clean for the UI.
- `golangci-lint run --new-from-rev=origin/master` clean.

### Notes

- Extraction is **best-effort**: trace failures are logged WARN and never abort the test.
- Requires a client that supports JS tracers via `debug_traceBlockByNumber`. Geth/Erigon/Nethermind work; Reth/Besu/Nimbus/ethrex coverage varies — check your client's docs.
- The trace runs against the EL right after the test step (before rollback), so the client must still hold the block.

## Test plan

- [x] Run with `opcode_extraction.enabled: true` against a small EEST suite on geth; confirm `test-opcodes.json` lands in the run dir with the expected shape.
- [x] Verify per-tx counts sum across multi-tx blocks (where applicable).
- [x] In the UI, open the run detail page; confirm the heatmap renders run-extracted counts and the info banner appears.
- [x] Force a divergence (e.g. compare against a suite that already had `opcode_source` from a different pipeline); confirm the `⚠ N tests differ from suite` badge appears, click it, confirm the per-test Opcode/Suite/Run/Δ table renders correctly with sorted rows.