### PR TITLE
feat(ui): decompose EEST test names with global raw/decomposed toggle

### DIFF
--- a/ui/src/components/compare/StickyRunBar.tsx
+++ b/ui/src/components/compare/StickyRunBar.tsx
@@ -76,7 +76,10 @@ export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, 
         <div className="flex items-center gap-1.5">
           <span>Filter:</span>
           <FilterInput
-            placeholder={testFilterRegex ? 'Regex...' : 'Filter...'}
+            placeholder={testFilterRegex ? 'Regex...' : 'Filter or e.g. opcode:ORIGIN'}
+            title={testFilterRegex
+              ? 'Regex against the raw test name.'
+              : 'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
             value={testFilter}
             onValueChange={onTestFilterChange}
             className={clsx(

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -5,6 +5,7 @@ import { Table } from 'lucide-react'
 import type { SuiteTest, AggregatedStats, BlockLogs, BlockLogEntry } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { Pagination } from '@/components/shared/Pagination'
+import { TestName } from '@/components/shared/TestName'
 import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 
 interface TestComparisonTableProps {
@@ -401,8 +402,8 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
                   <td className="whitespace-nowrap px-3 py-2 text-center text-xs/5 text-gray-400 dark:text-gray-500">
                     {test.order || '-'}
                   </td>
-                  <td className="max-w-sm truncate px-4 py-2 text-sm/6 text-gray-900 dark:text-gray-100" title={test.name}>
-                    {test.name}
+                  <td className="max-w-sm truncate px-4 py-2 text-sm/6 text-gray-900 dark:text-gray-100">
+                    <TestName name={test.name} />
                   </td>
                   <td className="whitespace-nowrap px-4 py-2 text-right text-xs/5 text-gray-500 dark:text-gray-400">
                     {test.gasUsed !== undefined ? `${Math.round(test.gasUsed / 1_000_000)}M` : '-'}

--- a/ui/src/components/compare/TestDetailModal.tsx
+++ b/ui/src/components/compare/TestDetailModal.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
-import { Check, Copy, GitCompareArrows, X } from 'lucide-react'
+import { GitCompareArrows, X } from 'lucide-react'
 import clsx from 'clsx'
 import type { RunResult } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
@@ -147,9 +147,8 @@ export function TestDetailModal({
             <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
               {testOrder !== undefined ? `Test #${testOrder}` : 'Test Detail'}
             </h3>
-            <div className="mt-0.5 flex items-start gap-1.5 text-xs text-gray-500 dark:text-gray-400">
-              <TestName name={testName} showRawBelow />
-              <CopyButton text={testName} />
+            <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+              <TestName name={testName} showRawBelow showCopy />
             </div>
           </div>
           <button onClick={onClose} className="shrink-0 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300">
@@ -375,22 +374,3 @@ function StatCell({ label, value, title }: { label: string; value?: string; titl
   )
 }
 
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false)
-
-  return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation()
-        navigator.clipboard.writeText(text)
-        setCopied(true)
-        setTimeout(() => setCopied(false), 1500)
-      }}
-      className="shrink-0 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-      title="Copy test name"
-    >
-      {copied ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
-    </button>
-  )
-}

--- a/ui/src/components/compare/TestDetailModal.tsx
+++ b/ui/src/components/compare/TestDetailModal.tsx
@@ -4,6 +4,7 @@ import { Check, Copy, GitCompareArrows, X } from 'lucide-react'
 import clsx from 'clsx'
 import type { RunResult } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
+import { TestName } from '@/components/shared/TestName'
 import { formatTimestamp } from '@/utils/date'
 import { type GroupDef } from './groupUtils'
 import { MAX_COMPARE_RUNS, MIN_COMPARE_RUNS } from './constants'
@@ -146,10 +147,8 @@ export function TestDetailModal({
             <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
               {testOrder !== undefined ? `Test #${testOrder}` : 'Test Detail'}
             </h3>
-            <div className="mt-0.5 flex items-start gap-1.5">
-              <p className="break-all font-mono text-xs text-gray-500 dark:text-gray-400">
-                {testName}
-              </p>
+            <div className="mt-0.5 flex items-start gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+              <TestName name={testName} showRawBelow />
               <CopyButton text={testName} />
             </div>
           </div>

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react'
 import { Link, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import clsx from 'clsx'
-import { Sun, Moon, LogIn, LogOut, Shield, User, Menu, X, FileText, Search, TextCursorInput } from 'lucide-react'
+import { Sun, Moon, LogIn, LogOut, Shield, User, Menu, X, FileText, Search, Tags, Code2, Check, Settings } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
-import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
+import { useNameDisplayMode, type NameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 function NavLink({ to, children, onClick }: { to: string; children: React.ReactNode; onClick?: () => void }) {
   const matchRoute = useMatchRoute()
@@ -25,50 +25,107 @@ function NavLink({ to, children, onClick }: { to: string; children: React.ReactN
   )
 }
 
-function NameModeSwitcher() {
-  const { mode, toggle } = useNameDisplayMode()
-  const decomposed = mode === 'decomposed'
+type Theme = 'light' | 'dark'
+
+const NAME_MODE_OPTIONS: { value: NameDisplayMode; label: string; icon: typeof Tags }[] = [
+  { value: 'decomposed', label: 'Decomposed', icon: Tags },
+  { value: 'raw', label: 'Raw', icon: Code2 },
+]
+
+const THEME_OPTIONS: { value: Theme; label: string; icon: typeof Sun }[] = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+]
+
+function MenuOption<T extends string>({ active, onClick, icon: Icon, label }: {
+  active: boolean
+  onClick: () => void
+  icon: typeof Tags
+  label: string
+  value: T
+}) {
   return (
     <button
-      onClick={toggle}
+      onClick={onClick}
       className={clsx(
-        'flex items-center gap-1.5 rounded-sm px-2 py-1.5 text-xs/5 font-medium transition-colors',
-        decomposed
-          ? 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700'
-          : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200',
+        'flex w-full items-center gap-2 px-3 py-2 text-left text-sm',
+        active
+          ? 'bg-gray-50 text-gray-900 dark:bg-gray-700/50 dark:text-gray-100'
+          : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700/50',
       )}
-      title={decomposed ? 'Showing decomposed test names — click for raw' : 'Showing raw test names — click for decomposed'}
     >
-      <TextCursorInput className="size-4" />
-      <span className="hidden sm:inline">{decomposed ? 'decomposed' : 'raw'}</span>
+      <Icon className="size-3.5 shrink-0" />
+      <span className="flex-1">{label}</span>
+      {active && <Check className="size-3.5 text-blue-500" />}
     </button>
   )
 }
 
-function ThemeSwitcher() {
-  const [isDark, setIsDark] = useState(() => {
-    if (typeof window === 'undefined') return false
-    return document.documentElement.classList.contains('dark')
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-3 pb-1 pt-0.5 text-[10px]/4 font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+      {children}
+    </div>
+  )
+}
+
+function SettingsMenu() {
+  const { mode: nameMode, setMode: setNameMode } = useNameDisplayMode()
+  const [open, setOpen] = useState(false)
+  const [theme, setThemeState] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'light'
+    return document.documentElement.classList.contains('dark') ? 'dark' : 'light'
   })
 
   useEffect(() => {
-    if (isDark) {
+    if (theme === 'dark') {
       document.documentElement.classList.add('dark')
-      localStorage.setItem('theme', 'dark')
     } else {
       document.documentElement.classList.remove('dark')
-      localStorage.setItem('theme', 'light')
     }
-  }, [isDark])
+    localStorage.setItem('theme', theme)
+  }, [theme])
 
   return (
-    <button
-      onClick={() => setIsDark(!isDark)}
-      className="rounded-sm p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-    >
-      {isDark ? <Sun className="size-5" /> : <Moon className="size-5" />}
-    </button>
+    <div className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="rounded-sm p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+        title="Settings"
+      >
+        <Settings className="size-5" />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 z-50 mt-1 w-44 rounded-sm border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800">
+            <SectionHeader>Test names</SectionHeader>
+            {NAME_MODE_OPTIONS.map((opt) => (
+              <MenuOption
+                key={opt.value}
+                value={opt.value}
+                label={opt.label}
+                icon={opt.icon}
+                active={nameMode === opt.value}
+                onClick={() => { setNameMode(opt.value); setOpen(false) }}
+              />
+            ))}
+            <div className="my-1 border-t border-gray-200 dark:border-gray-700" />
+            <SectionHeader>Theme</SectionHeader>
+            {THEME_OPTIONS.map((opt) => (
+              <MenuOption
+                key={opt.value}
+                value={opt.value}
+                label={opt.label}
+                icon={opt.icon}
+                active={theme === opt.value}
+                onClick={() => { setThemeState(opt.value); setOpen(false) }}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
   )
 }
 
@@ -273,8 +330,7 @@ export function Header() {
         </nav>
         <div className="ml-auto hidden items-center gap-2 md:flex">
           <AuthControls />
-          <NameModeSwitcher />
-          <ThemeSwitcher />
+          <SettingsMenu />
         </div>
 
         {/* Mobile hamburger */}
@@ -297,8 +353,7 @@ export function Header() {
           <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700">
             <AuthControls onNavigate={closeMobile} variant="mobile" />
             <div className="mt-2 flex items-center justify-end gap-2">
-              <NameModeSwitcher />
-              <ThemeSwitcher />
+              <SettingsMenu />
             </div>
           </div>
         </div>

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react'
 import { Link, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import clsx from 'clsx'
-import { Sun, Moon, LogIn, LogOut, Shield, User, Menu, X, FileText, Search } from 'lucide-react'
+import { Sun, Moon, LogIn, LogOut, Shield, User, Menu, X, FileText, Search, TextCursorInput } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 function NavLink({ to, children, onClick }: { to: string; children: React.ReactNode; onClick?: () => void }) {
   const matchRoute = useMatchRoute()
@@ -21,6 +22,26 @@ function NavLink({ to, children, onClick }: { to: string; children: React.ReactN
     >
       {children}
     </Link>
+  )
+}
+
+function NameModeSwitcher() {
+  const { mode, toggle } = useNameDisplayMode()
+  const decomposed = mode === 'decomposed'
+  return (
+    <button
+      onClick={toggle}
+      className={clsx(
+        'flex items-center gap-1.5 rounded-sm px-2 py-1.5 text-xs/5 font-medium transition-colors',
+        decomposed
+          ? 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700'
+          : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200',
+      )}
+      title={decomposed ? 'Showing decomposed test names — click for raw' : 'Showing raw test names — click for decomposed'}
+    >
+      <TextCursorInput className="size-4" />
+      <span className="hidden sm:inline">{decomposed ? 'decomposed' : 'raw'}</span>
+    </button>
   )
 }
 
@@ -252,6 +273,7 @@ export function Header() {
         </nav>
         <div className="ml-auto hidden items-center gap-2 md:flex">
           <AuthControls />
+          <NameModeSwitcher />
           <ThemeSwitcher />
         </div>
 
@@ -274,7 +296,8 @@ export function Header() {
           </nav>
           <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700">
             <AuthControls onNavigate={closeMobile} variant="mobile" />
-            <div className="mt-2 flex items-center justify-end">
+            <div className="mt-2 flex items-center justify-end gap-2">
+              <NameModeSwitcher />
               <ThemeSwitcher />
             </div>
           </div>

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -6,6 +6,7 @@ import type { TestEntry, SuiteTest, AggregatedStats, MethodsAggregated, StepResu
 import { fetchHead } from '@/api/client'
 import { Modal } from '@/components/shared/Modal'
 import { TestName } from '@/components/shared/TestName'
+import { testNameMatches } from '@/utils/eestNameFilter'
 import { TimeBreakdown } from './TimeBreakdown'
 import { MGasBreakdown } from './MGasBreakdown'
 import { ExecutionsList } from './ExecutionsList'
@@ -311,7 +312,7 @@ function HeatmapCell({
     // ran-and-failed tests cleanly.
     (!test.notProcessed && statusFilter === 'passed' && !test.hasFail) ||
     (!test.notProcessed && statusFilter === 'failed' && test.hasFail)
-  const matchesSearchQuery = !searchQuery || test.testKey.toLowerCase().includes(searchQuery.toLowerCase())
+  const matchesSearchQuery = !searchQuery || testNameMatches(test.testKey, searchQuery)
   const matchesFilter = matchesStatusFilter && matchesSearchQuery
   let baseStyle: React.CSSProperties
   if (test.notProcessed) {

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -944,10 +944,8 @@ export function TestHeatmap({
             <div className="flex flex-col gap-6">
               <div className="flex flex-col gap-2">
                 <div>
-                  <div className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Test Name</div>
-                  <div className="flex items-start gap-2 text-sm/6 text-gray-900 dark:text-gray-100">
-                    <TestName name={selectedTest} showRawBelow className="min-w-0" />
-                    <CopyButton text={selectedTest} />
+                  <div className="text-sm/6 text-gray-900 dark:text-gray-100">
+                    <TestName name={selectedTest} showRawBelow showCopy className="min-w-0" />
                   </div>
                 </div>
                 {entry.dir && (

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -6,7 +6,6 @@ import type { TestEntry, SuiteTest, AggregatedStats, MethodsAggregated, StepResu
 import { fetchHead } from '@/api/client'
 import { Modal } from '@/components/shared/Modal'
 import { TestName } from '@/components/shared/TestName'
-import { useFormattedTestName } from '@/hooks/useNameDisplayMode'
 import { TimeBreakdown } from './TimeBreakdown'
 import { MGasBreakdown } from './MGasBreakdown'
 import { ExecutionsList } from './ExecutionsList'
@@ -354,8 +353,11 @@ function HeatmapCell({
 }
 
 function TooltipFilename({ name }: { name: string }) {
-  const formatted = useFormattedTestName(name)
-  return <div className="w-48 break-all text-gray-500 dark:text-gray-400">{formatted}</div>
+  return (
+    <div className="w-64 max-w-[80vw]">
+      <TestName name={name} />
+    </div>
+  )
 }
 
 export function TestHeatmap({

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -5,6 +5,8 @@ import { Check, Copy, Download } from 'lucide-react'
 import type { TestEntry, SuiteTest, AggregatedStats, MethodsAggregated, StepResult, PostTestRPCCallConfig } from '@/api/types'
 import { fetchHead } from '@/api/client'
 import { Modal } from '@/components/shared/Modal'
+import { TestName } from '@/components/shared/TestName'
+import { useFormattedTestName } from '@/hooks/useNameDisplayMode'
 import { TimeBreakdown } from './TimeBreakdown'
 import { MGasBreakdown } from './MGasBreakdown'
 import { ExecutionsList } from './ExecutionsList'
@@ -349,6 +351,11 @@ function HeatmapCell({
       style={style}
     />
   )
+}
+
+function TooltipFilename({ name }: { name: string }) {
+  const formatted = useFormattedTestName(name)
+  return <div className="w-48 break-all text-gray-500 dark:text-gray-400">{formatted}</div>
 }
 
 export function TestHeatmap({
@@ -905,7 +912,7 @@ export function TestHeatmap({
               </>
             )}
             <div className="text-gray-500 dark:text-gray-400">Based on steps: {stepFilter.join(', ')}</div>
-            <div className="w-48 break-all text-gray-500 dark:text-gray-400">{tooltip.test.filename}</div>
+            <TooltipFilename name={tooltip.test.filename} />
             {tooltip.test.notProcessed ? (
               <div className="text-gray-500 dark:text-gray-400">Test was not run</div>
             ) : tooltip.test.noData ? (
@@ -935,8 +942,8 @@ export function TestHeatmap({
               <div className="flex flex-col gap-2">
                 <div>
                   <div className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Test Name</div>
-                  <div className="flex items-center gap-2 text-sm/6 text-gray-900 dark:text-gray-100">
-                    <span className="min-w-0 break-all">{selectedTest}</span>
+                  <div className="flex items-start gap-2 text-sm/6 text-gray-900 dark:text-gray-100">
+                    <TestName name={selectedTest} showRawBelow className="min-w-0" />
                     <CopyButton text={selectedTest} />
                   </div>
                 </div>

--- a/ui/src/components/run-detail/TestsTable.tsx
+++ b/ui/src/components/run-detail/TestsTable.tsx
@@ -5,6 +5,7 @@ import type { TestEntry, SuiteTest, AggregatedStats, StepResult } from '@/api/ty
 import { Badge } from '@/components/shared/Badge'
 import { Duration } from '@/components/shared/Duration'
 import { Pagination } from '@/components/shared/Pagination'
+import { TestName } from '@/components/shared/TestName'
 import { type StepTypeOption, ALL_STEP_TYPES } from '@/pages/RunDetailPage'
 
 export type TestSortColumn = 'order' | 'name' | 'genesis' | 'time' | 'mgas' | 'passed' | 'failed'
@@ -357,9 +358,7 @@ export function TestsTable({
                     {executionOrder.get(testName) ?? '-'}
                   </td>
                   <td className="max-w-md px-4 py-3">
-                    <div className="truncate text-sm/6 font-medium text-gray-900 dark:text-gray-100" title={testName}>
-                      {testName}
-                    </div>
+                    <TestName name={testName} className="text-sm/6 font-medium text-gray-900 dark:text-gray-100" />
                     {entry.dir && (
                       <div className="truncate text-xs/5 text-gray-500 dark:text-gray-400" title={entry.dir}>
                         {entry.dir}

--- a/ui/src/components/run-detail/TestsTable.tsx
+++ b/ui/src/components/run-detail/TestsTable.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/shared/Badge'
 import { Duration } from '@/components/shared/Duration'
 import { Pagination } from '@/components/shared/Pagination'
 import { TestName } from '@/components/shared/TestName'
+import { testNameMatches } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES } from '@/pages/RunDetailPage'
 
 export type TestSortColumn = 'order' | 'name' | 'genesis' | 'time' | 'mgas' | 'passed' | 'failed'
@@ -177,8 +178,7 @@ export function TestsTable({
     let filtered = Object.entries(tests)
 
     if (searchQuery) {
-      const query = searchQuery.toLowerCase()
-      filtered = filtered.filter(([name]) => name.toLowerCase().includes(query))
+      filtered = filtered.filter(([name]) => testNameMatches(name, searchQuery))
     }
 
     // Genesis filter
@@ -309,10 +309,11 @@ export function TestsTable({
           )}
           <input
             type="text"
-            placeholder="Search tests..."
+            placeholder="Search… or e.g. opcode:ORIGIN gas:90M"
+            title={`Free text matches anywhere in the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.`}
             value={searchQuery}
             onChange={(e) => handleSearchInput(e.target.value)}
-            className="w-64 rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
+            className="w-72 rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
       </div>

--- a/ui/src/components/shared/TestName.tsx
+++ b/ui/src/components/shared/TestName.tsx
@@ -107,7 +107,7 @@ export function TestName({ name, variant = 'full', showCopy = false, showRawBelo
         <span className="truncate text-sm/5 font-medium text-gray-900 dark:text-gray-100">
           {parsed.fn}
         </span>
-        {showCopy && <CopyButton value={name} />}
+        {showCopy && !showRawBelow && <CopyButton value={name} />}
       </span>
       {hasChips && (
         <span className="inline-flex flex-wrap items-baseline gap-1">
@@ -133,7 +133,13 @@ export function TestName({ name, variant = 'full', showCopy = false, showRawBelo
         </span>
       )}
       {showRawBelow && (
-        <code className="break-all font-mono text-[11px]/4 text-gray-400 dark:text-gray-500">{name}</code>
+        <span className="mt-3 flex flex-col gap-0.5">
+          <span className="text-[10px]/4 font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">Test name:</span>
+          <span className="flex items-start gap-1.5">
+            <code className="min-w-0 break-all font-mono text-[11px]/4 text-gray-400 dark:text-gray-500">{name}</code>
+            {showCopy && <CopyButton value={name} />}
+          </span>
+        </span>
       )}
     </span>
   )

--- a/ui/src/components/shared/TestName.tsx
+++ b/ui/src/components/shared/TestName.tsx
@@ -66,8 +66,8 @@ export function TestName({ name, variant = 'full', showCopy = false, showRawBelo
 
   if (mode === 'raw' || !parsed?.isEEST) {
     return (
-      <span className={clsx('inline-flex min-w-0 items-baseline gap-1.5', className)} title={name}>
-        <code className={clsx('truncate font-mono text-xs/5 text-gray-700 dark:text-gray-300')}>
+      <span className={clsx('flex min-w-0 items-baseline gap-1.5', className)} title={name}>
+        <code className={clsx('min-w-0 flex-1 truncate font-mono text-xs/5 text-gray-700 dark:text-gray-300')}>
           {name}
         </code>
         {showCopy && <CopyButton value={name} />}

--- a/ui/src/components/shared/TestName.tsx
+++ b/ui/src/components/shared/TestName.tsx
@@ -94,6 +94,12 @@ export function TestName({ name, variant = 'full', showCopy = false, showRawBelo
   return (
     <span className={clsx('flex min-w-0 flex-col gap-1', className)} title={name}>
       <span className="inline-flex min-w-0 items-baseline gap-1">
+        {parsed.path && (
+          <>
+            <span className="truncate font-mono text-xs/5 text-gray-400 dark:text-gray-500">{parsed.path}</span>
+            <span className="text-xs/5 text-gray-300 dark:text-gray-600">/</span>
+          </>
+        )}
         {parsed.file && (
           <span className="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">{parsed.file}</span>
         )}

--- a/ui/src/components/shared/TestName.tsx
+++ b/ui/src/components/shared/TestName.tsx
@@ -52,7 +52,7 @@ function CopyButton({ value, className }: { value: string; className?: string })
 }
 
 const chipBase =
-  'inline-flex items-center gap-1 rounded-xs px-1.5 py-0 font-mono text-[11px]/5 font-medium ring-1 ring-inset'
+  'inline-flex max-w-full items-center gap-1 break-all rounded-xs px-1.5 py-0 font-mono text-[11px]/5 font-medium ring-1 ring-inset'
 const chipNeutral =
   'bg-gray-100 text-gray-700 ring-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:ring-gray-600'
 const chipAccent =
@@ -84,8 +84,15 @@ export function TestName({ name, variant = 'full', showCopy = false, showRawBelo
     )
   }
 
-  const decomposed = (
-    <span className="inline-flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1">
+  const hasChips =
+    parsed.opcode != null ||
+    parsed.benchmark != null ||
+    parsed.fork != null ||
+    parsed.params.length > 0 ||
+    parsed.labels.length > 0
+
+  return (
+    <span className={clsx('flex min-w-0 flex-col gap-1', className)} title={name}>
       <span className="inline-flex min-w-0 items-baseline gap-1">
         {parsed.file && (
           <span className="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">{parsed.file}</span>
@@ -94,44 +101,34 @@ export function TestName({ name, variant = 'full', showCopy = false, showRawBelo
         <span className="truncate text-sm/5 font-medium text-gray-900 dark:text-gray-100">
           {parsed.fn}
         </span>
+        {showCopy && <CopyButton value={name} />}
       </span>
-      <span className="inline-flex flex-wrap items-baseline gap-1">
-        {parsed.opcode && (
-          <span className={clsx(chipBase, chipAccent)}>{parsed.opcode}</span>
-        )}
-        {parsed.benchmark && (
-          <span className={clsx(chipBase, chipGas)}>{parsed.benchmark}</span>
-        )}
-        {parsed.fork && (
-          <span className={clsx(chipBase, chipNeutral)}>fork:{parsed.fork}</span>
-        )}
-        {parsed.params.map(({ key, value }) => (
-          <span key={`${key}=${value}`} className={clsx(chipBase, chipNeutral)}>
-            {key}:{value}
-          </span>
-        ))}
-        {parsed.labels.map((label) => (
-          <span key={label} className={clsx(chipBase, chipNeutral)}>
-            {label}
-          </span>
-        ))}
-      </span>
-      {showCopy && <CopyButton value={name} />}
-    </span>
-  )
-
-  if (!showRawBelow) {
-    return (
-      <span className={clsx('inline-flex min-w-0 items-baseline', className)} title={name}>
-        {decomposed}
-      </span>
-    )
-  }
-
-  return (
-    <span className={clsx('flex min-w-0 flex-col gap-0.5', className)} title={name}>
-      {decomposed}
-      <code className="break-all font-mono text-[11px]/4 text-gray-400 dark:text-gray-500">{name}</code>
+      {hasChips && (
+        <span className="inline-flex flex-wrap items-baseline gap-1">
+          {parsed.benchmark && (
+            <span className={clsx(chipBase, chipGas)}>{parsed.benchmark}</span>
+          )}
+          {parsed.opcode && (
+            <span className={clsx(chipBase, chipAccent)}>{parsed.opcode}</span>
+          )}
+          {parsed.fork && (
+            <span className={clsx(chipBase, chipNeutral)}>fork:{parsed.fork}</span>
+          )}
+          {parsed.params.map(({ key, value }) => (
+            <span key={`${key}=${value}`} className={clsx(chipBase, chipNeutral)}>
+              {key}:{value}
+            </span>
+          ))}
+          {parsed.labels.map((label) => (
+            <span key={label} className={clsx(chipBase, chipNeutral)}>
+              {label}
+            </span>
+          ))}
+        </span>
+      )}
+      {showRawBelow && (
+        <code className="break-all font-mono text-[11px]/4 text-gray-400 dark:text-gray-500">{name}</code>
+      )}
     </span>
   )
 }

--- a/ui/src/components/shared/TestName.tsx
+++ b/ui/src/components/shared/TestName.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react'
+import clsx from 'clsx'
+import { Check, Copy } from 'lucide-react'
+import { parseEESTName } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
+
+interface TestNameProps {
+  /** Raw test name. Always preserved as the source of truth. */
+  name: string
+  /**
+   * - `full`: file path prefix + function + all chips (tables, modals).
+   * - `compact`: one-line `<fn> · <opcode> · <gas>` (heatmap row labels).
+   */
+  variant?: 'full' | 'compact'
+  /** Show a copy-to-clipboard affordance (default: false). */
+  showCopy?: boolean
+  /**
+   * Render the raw name on a muted second line. Only visible in decomposed
+   * mode (in raw mode the primary line already shows the raw name).
+   */
+  showRawBelow?: boolean
+  className?: string
+}
+
+function CopyButton({ value, className }: { value: string; className?: string }) {
+  const [copied, setCopied] = useState(false)
+  const onCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1200)
+    } catch {
+      // ignore
+    }
+  }
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      className={clsx(
+        'inline-flex shrink-0 items-center justify-center rounded-xs p-0.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-gray-200',
+        className,
+      )}
+      title={copied ? 'Copied!' : 'Copy raw name'}
+      aria-label="Copy raw name"
+    >
+      {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+    </button>
+  )
+}
+
+const chipBase =
+  'inline-flex items-center gap-1 rounded-xs px-1.5 py-0 font-mono text-[11px]/5 font-medium ring-1 ring-inset'
+const chipNeutral =
+  'bg-gray-100 text-gray-700 ring-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:ring-gray-600'
+const chipAccent =
+  'bg-indigo-50 text-indigo-700 ring-indigo-200 dark:bg-indigo-950/50 dark:text-indigo-300 dark:ring-indigo-800'
+const chipGas =
+  'bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-950/50 dark:text-emerald-300 dark:ring-emerald-800'
+
+export function TestName({ name, variant = 'full', showCopy = false, showRawBelow = false, className }: TestNameProps) {
+  const { mode } = useNameDisplayMode()
+  const parsed = mode === 'decomposed' ? parseEESTName(name) : null
+
+  if (mode === 'raw' || !parsed?.isEEST) {
+    return (
+      <span className={clsx('inline-flex min-w-0 items-baseline gap-1.5', className)} title={name}>
+        <code className={clsx('truncate font-mono text-xs/5 text-gray-700 dark:text-gray-300')}>
+          {name}
+        </code>
+        {showCopy && <CopyButton value={name} />}
+      </span>
+    )
+  }
+
+  if (variant === 'compact') {
+    return (
+      <span className={clsx('inline-flex min-w-0 items-baseline gap-1.5', className)} title={name}>
+        <span className="truncate text-sm/5 text-gray-900 dark:text-gray-100">{parsed.short}</span>
+        {showCopy && <CopyButton value={name} />}
+      </span>
+    )
+  }
+
+  const decomposed = (
+    <span className="inline-flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1">
+      <span className="inline-flex min-w-0 items-baseline gap-1">
+        {parsed.file && (
+          <span className="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">{parsed.file}</span>
+        )}
+        {parsed.file && <span className="text-xs/5 text-gray-400 dark:text-gray-500">›</span>}
+        <span className="truncate text-sm/5 font-medium text-gray-900 dark:text-gray-100">
+          {parsed.fn}
+        </span>
+      </span>
+      <span className="inline-flex flex-wrap items-baseline gap-1">
+        {parsed.opcode && (
+          <span className={clsx(chipBase, chipAccent)}>{parsed.opcode}</span>
+        )}
+        {parsed.benchmark && (
+          <span className={clsx(chipBase, chipGas)}>{parsed.benchmark}</span>
+        )}
+        {parsed.fork && (
+          <span className={clsx(chipBase, chipNeutral)}>fork:{parsed.fork}</span>
+        )}
+        {parsed.params.map(({ key, value }) => (
+          <span key={`${key}=${value}`} className={clsx(chipBase, chipNeutral)}>
+            {key}:{value}
+          </span>
+        ))}
+        {parsed.labels.map((label) => (
+          <span key={label} className={clsx(chipBase, chipNeutral)}>
+            {label}
+          </span>
+        ))}
+      </span>
+      {showCopy && <CopyButton value={name} />}
+    </span>
+  )
+
+  if (!showRawBelow) {
+    return (
+      <span className={clsx('inline-flex min-w-0 items-baseline', className)} title={name}>
+        {decomposed}
+      </span>
+    )
+  }
+
+  return (
+    <span className={clsx('flex min-w-0 flex-col gap-0.5', className)} title={name}>
+      {decomposed}
+      <code className="break-all font-mono text-[11px]/4 text-gray-400 dark:text-gray-500">{name}</code>
+    </span>
+  )
+}

--- a/ui/src/components/suite-detail/OpcodeHeatmap.tsx
+++ b/ui/src/components/suite-detail/OpcodeHeatmap.tsx
@@ -3,6 +3,8 @@ import { Grid3X3, X, Maximize2 } from 'lucide-react'
 import type { SuiteTest } from '@/api/types'
 import { getGroupedOpcodes, getCategoryColor } from '@/utils/opcodeCategories'
 import type { CategorySpan, GroupedResult } from '@/utils/opcodeCategories'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
+import { formatTestName } from '@/utils/eestName'
 
 /** Returns the opcode count map from the top-level field or EEST info fallback. */
 function getOpcodeCount(test: SuiteTest): Record<string, number> | undefined {
@@ -127,6 +129,7 @@ interface HeatmapCanvasProps {
 }
 
 function HeatmapCanvas({ filteredTests, columns, maxPerColumn, isDark, maxHeight, expanded, categorySpans, getCount, sortCol, onSortChange, onTestClick, extraColumns = [] }: HeatmapCanvasProps) {
+  const { mode: nameMode } = useNameDisplayMode()
   const containerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [tooltip, setTooltip] = useState<{ lines: { text: string; bold?: boolean }[]; x: number; y: number } | null>(null)
@@ -549,7 +552,7 @@ function HeatmapCanvas({ filteredTests, columns, maxPerColumn, isDark, maxHeight
                   lines: [
                     { text: `Test #${filteredTests[row].index + 1}` },
                     { text: `${ec.name}: ${formatted}`, bold: true },
-                    { text: filteredTests[row].test.name },
+                    { text: formatTestName(filteredTests[row].test.name, nameMode) },
                   ],
                   x: e.clientX,
                   y: e.clientY - 12,
@@ -630,7 +633,7 @@ function HeatmapCanvas({ filteredTests, columns, maxPerColumn, isDark, maxHeight
             lines: [
               { text: `Test #${filteredTests[row].index + 1}` },
               { text: `${colName}: ${count.toLocaleString()}`, bold: true },
-              { text: test.name },
+              { text: formatTestName(test.name, nameMode) },
             ],
             x: e.clientX,
             y: e.clientY - 12,
@@ -643,7 +646,7 @@ function HeatmapCanvas({ filteredTests, columns, maxPerColumn, isDark, maxHeight
       }
       setTooltip(null)
     },
-    [filteredTests, columns, scheduleRedraw, headerHeight, getCount, expanded, categorySpans, extraColumns, leftWidth],
+    [filteredTests, columns, scheduleRedraw, headerHeight, getCount, expanded, categorySpans, extraColumns, leftWidth, nameMode],
   )
 
   const handleClick = useCallback(

--- a/ui/src/components/suite-detail/OpcodeHeatmap.tsx
+++ b/ui/src/components/suite-detail/OpcodeHeatmap.tsx
@@ -5,6 +5,7 @@ import type { SuiteTest } from '@/api/types'
 import { getGroupedOpcodes, getCategoryColor } from '@/utils/opcodeCategories'
 import type { CategorySpan, GroupedResult } from '@/utils/opcodeCategories'
 import { TestName } from '@/components/shared/TestName'
+import { testNameMatches } from '@/utils/eestNameFilter'
 
 /** Returns the opcode count map from the top-level field or EEST info fallback. */
 function getOpcodeCount(test: SuiteTest): Record<string, number> | undefined {
@@ -773,8 +774,7 @@ export function OpcodeHeatmap({ tests, onTestClick, extraColumns = [], searchQue
 
   const filteredTests = useMemo(() => {
     if (!search) return testsWithOpcodes
-    const q = search.toLowerCase()
-    return testsWithOpcodes.filter((t) => t.test.name.toLowerCase().includes(q))
+    return testsWithOpcodes.filter((t) => testNameMatches(t.test.name, search))
   }, [testsWithOpcodes, search])
 
   const allOpcodes = useMemo(() => {
@@ -944,7 +944,8 @@ export function OpcodeHeatmap({ tests, onTestClick, extraColumns = [], searchQue
         <div className="flex items-center gap-2">
           <input
             type="text"
-            placeholder="Filter tests..."
+            placeholder="Filter… or e.g. opcode:ORIGIN"
+            title={'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"

--- a/ui/src/components/suite-detail/OpcodeHeatmap.tsx
+++ b/ui/src/components/suite-detail/OpcodeHeatmap.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import clsx from 'clsx'
 import { Grid3X3, X, Maximize2 } from 'lucide-react'
 import type { SuiteTest } from '@/api/types'
 import { getGroupedOpcodes, getCategoryColor } from '@/utils/opcodeCategories'
 import type { CategorySpan, GroupedResult } from '@/utils/opcodeCategories'
-import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
-import { formatTestName } from '@/utils/eestName'
+import { TestName } from '@/components/shared/TestName'
 
 /** Returns the opcode count map from the top-level field or EEST info fallback. */
 function getOpcodeCount(test: SuiteTest): Record<string, number> | undefined {
@@ -129,10 +129,9 @@ interface HeatmapCanvasProps {
 }
 
 function HeatmapCanvas({ filteredTests, columns, maxPerColumn, isDark, maxHeight, expanded, categorySpans, getCount, sortCol, onSortChange, onTestClick, extraColumns = [] }: HeatmapCanvasProps) {
-  const { mode: nameMode } = useNameDisplayMode()
   const containerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const [tooltip, setTooltip] = useState<{ lines: { text: string; bold?: boolean }[]; x: number; y: number } | null>(null)
+  const [tooltip, setTooltip] = useState<{ lines: { text: string; bold?: boolean }[]; testName?: string; x: number; y: number } | null>(null)
   const hoverRef = useRef<{ row: number; col: number } | null>(null)
   const rafRef = useRef(0)
 
@@ -552,8 +551,8 @@ function HeatmapCanvas({ filteredTests, columns, maxPerColumn, isDark, maxHeight
                   lines: [
                     { text: `Test #${filteredTests[row].index + 1}` },
                     { text: `${ec.name}: ${formatted}`, bold: true },
-                    { text: formatTestName(filteredTests[row].test.name, nameMode) },
                   ],
+                  testName: filteredTests[row].test.name,
                   x: e.clientX,
                   y: e.clientY - 12,
                 })
@@ -633,8 +632,8 @@ function HeatmapCanvas({ filteredTests, columns, maxPerColumn, isDark, maxHeight
             lines: [
               { text: `Test #${filteredTests[row].index + 1}` },
               { text: `${colName}: ${count.toLocaleString()}`, bold: true },
-              { text: formatTestName(test.name, nameMode) },
             ],
+            testName: test.name,
             x: e.clientX,
             y: e.clientY - 12,
           })
@@ -646,7 +645,7 @@ function HeatmapCanvas({ filteredTests, columns, maxPerColumn, isDark, maxHeight
       }
       setTooltip(null)
     },
-    [filteredTests, columns, scheduleRedraw, headerHeight, getCount, expanded, categorySpans, extraColumns, leftWidth, nameMode],
+    [filteredTests, columns, scheduleRedraw, headerHeight, getCount, expanded, categorySpans, extraColumns, leftWidth],
   )
 
   const handleClick = useCallback(
@@ -720,12 +719,17 @@ function HeatmapCanvas({ filteredTests, columns, maxPerColumn, isDark, maxHeight
       </div>
       {tooltip && (
         <div
-          className="pointer-events-none fixed z-50 flex max-w-sm flex-col gap-1 break-all rounded-xs bg-gray-900 px-2 py-1.5 text-xs text-white shadow-xs dark:bg-gray-700"
+          className="pointer-events-none fixed z-50 flex max-w-sm flex-col gap-1 rounded-xs bg-gray-900 px-2 py-1.5 text-xs text-white shadow-xs dark:bg-gray-700"
           style={{ left: tooltip.x, top: tooltip.y, transform: 'translate(-50%, -100%)' }}
         >
           {tooltip.lines.map((line, i) => (
-            <div key={i} className={line.bold ? 'font-bold' : undefined}>{line.text}</div>
+            <div key={i} className={clsx('break-all', line.bold && 'font-bold')}>{line.text}</div>
           ))}
+          {tooltip.testName && (
+            <div className="border-t border-white/10 pt-1 text-white">
+              <TestName name={tooltip.testName} />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/ui/src/components/suite-detail/TestHeatmap.tsx
+++ b/ui/src/components/suite-detail/TestHeatmap.tsx
@@ -8,6 +8,7 @@ import { JDenticon } from '@/components/shared/JDenticon'
 import { Pagination } from '@/components/shared/Pagination'
 import { Spinner } from '@/components/shared/Spinner'
 import { TestName } from '@/components/shared/TestName'
+import { testNameMatches } from '@/utils/eestNameFilter'
 import { formatTimestamp } from '@/utils/date'
 
 const DEFAULT_PAGE_SIZE = 20
@@ -405,8 +406,9 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
         return allTests
       }
     }
-    const lower = search.toLowerCase()
-    return allTests.filter((t) => t.name.toLowerCase().includes(lower))
+    return allTests.filter((t) => testNameMatches(t.name, search))
+  // When useRegex is on, the early return above handles filtering; this
+  // branch only fires in text mode.
   }, [allTests, search, useRegex])
 
   // Sort and paginate
@@ -525,7 +527,10 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
           type="text"
           value={search}
           onChange={(e) => handleSearchChange(e.target.value)}
-          placeholder={useRegex ? 'Regex...' : 'Filter...'}
+          placeholder={useRegex ? 'Regex...' : 'Filter or e.g. opcode:ORIGIN'}
+          title={useRegex
+            ? 'Regex against the raw test name.'
+            : 'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
           className={clsx(
             'w-28 rounded-xs border bg-white px-2 py-1 text-sm placeholder-gray-400 focus:outline-hidden focus:ring-1 sm:w-auto sm:px-3 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
             useRegex && search && (() => { try { new RegExp(search); return false } catch { return true } })()

--- a/ui/src/components/suite-detail/TestHeatmap.tsx
+++ b/ui/src/components/suite-detail/TestHeatmap.tsx
@@ -729,7 +729,7 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
                         <HighlightedName name={test.name} search={search} useRegex={useRegex} />
                       </span>
                     ) : (
-                      <TestName name={test.name} variant="compact" />
+                      <TestName name={test.name} />
                     )}
                   </td>
                 </tr>

--- a/ui/src/components/suite-detail/TestHeatmap.tsx
+++ b/ui/src/components/suite-detail/TestHeatmap.tsx
@@ -7,6 +7,7 @@ import { ClientBadge } from '@/components/shared/ClientBadge'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { Pagination } from '@/components/shared/Pagination'
 import { Spinner } from '@/components/shared/Spinner'
+import { TestName } from '@/components/shared/TestName'
 import { formatTimestamp } from '@/utils/date'
 
 const DEFAULT_PAGE_SIZE = 20
@@ -719,11 +720,17 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
                 <tr className="border-t border-gray-100 bg-gray-50/80 dark:border-gray-700/50 dark:bg-gray-900/60">
                   <td
                     colSpan={clients.length + 1 + STAT_COLUMNS.length}
-                    className="truncate px-3 py-1 font-mono text-xs/5 text-gray-400 dark:text-gray-500"
+                    className="truncate px-3 py-1 text-xs/5 text-gray-400 dark:text-gray-500"
                     title={test.name}
                   >
                     <span className="mr-1.5 font-sans text-gray-300 dark:text-gray-600">&#9656;</span>
-                    <HighlightedName name={test.name} search={search} useRegex={useRegex} />
+                    {search ? (
+                      <span className="font-mono">
+                        <HighlightedName name={test.name} search={search} useRegex={useRegex} />
+                      </span>
+                    ) : (
+                      <TestName name={test.name} variant="compact" />
+                    )}
                   </td>
                 </tr>
               )}

--- a/ui/src/hooks/useNameDisplayMode.ts
+++ b/ui/src/hooks/useNameDisplayMode.ts
@@ -1,0 +1,80 @@
+import { useSyncExternalStore } from 'react'
+import { formatTestName } from '@/utils/eestName'
+
+export type NameDisplayMode = 'decomposed' | 'raw'
+
+const STORAGE_KEY = 'benchmarkoor:name-display'
+const URL_PARAM = 'names'
+const DEFAULT_MODE: NameDisplayMode = 'decomposed'
+
+function readFromUrl(): NameDisplayMode | undefined {
+  if (typeof window === 'undefined') return undefined
+  const v = new URLSearchParams(window.location.search).get(URL_PARAM)
+  return v === 'raw' || v === 'decomposed' ? v : undefined
+}
+
+function readFromStorage(): NameDisplayMode | undefined {
+  if (typeof window === 'undefined') return undefined
+  const v = localStorage.getItem(STORAGE_KEY)
+  return v === 'raw' || v === 'decomposed' ? v : undefined
+}
+
+// URL beats localStorage so a shared link is honored even if the recipient
+// has a different preference saved.
+let currentMode: NameDisplayMode = (() => {
+  if (typeof window === 'undefined') return DEFAULT_MODE
+  return readFromUrl() ?? readFromStorage() ?? DEFAULT_MODE
+})()
+
+const listeners = new Set<() => void>()
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function getSnapshot(): NameDisplayMode {
+  return currentMode
+}
+
+function getServerSnapshot(): NameDisplayMode {
+  return DEFAULT_MODE
+}
+
+export function setNameDisplayMode(next: NameDisplayMode): void {
+  if (next === currentMode) return
+  currentMode = next
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, next)
+    const url = new URL(window.location.href)
+    // Keep URLs clean when at the default; only persist `raw` explicitly.
+    if (next === DEFAULT_MODE) url.searchParams.delete(URL_PARAM)
+    else url.searchParams.set(URL_PARAM, next)
+    window.history.replaceState(null, '', url)
+  }
+  listeners.forEach((l) => l())
+}
+
+export function useNameDisplayMode(): {
+  mode: NameDisplayMode
+  setMode: (mode: NameDisplayMode) => void
+  toggle: () => void
+} {
+  const mode = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+  return {
+    mode,
+    setMode: setNameDisplayMode,
+    toggle: () => setNameDisplayMode(mode === 'decomposed' ? 'raw' : 'decomposed'),
+  }
+}
+
+/**
+ * Returns the test name formatted for plain-text contexts (heatmap row
+ * labels, hover tooltips), respecting the global display mode.
+ */
+export function useFormattedTestName(name: string): string {
+  const mode = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+  return formatTestName(name, mode)
+}

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -4,6 +4,7 @@ import { useQueries } from '@tanstack/react-query'
 import clsx from 'clsx'
 import type { RunConfig, RunResult } from '@/api/types'
 import { fetchData } from '@/api/client'
+import { testNameMatches } from '@/utils/eestNameFilter'
 import { useIndex } from '@/api/hooks/useIndex'
 import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
@@ -305,8 +306,7 @@ export function CompareGroupsPage() {
           return undefined
         }
       }
-      const q = testFilter.toLowerCase()
-      return (name: string) => name.toLowerCase().includes(q)
+      return (name: string) => testNameMatches(name, testFilter)
     })()
 
     const needsGasFilter = selectedGasBuckets.size > 0
@@ -447,7 +447,10 @@ export function CompareGroupsPage() {
                 <span>Filter:</span>
                 <input
                   type="text"
-                  placeholder={testFilterRegex ? 'Regex...' : 'Filter...'}
+                  placeholder={testFilterRegex ? 'Regex...' : 'Filter or e.g. opcode:ORIGIN'}
+                  title={testFilterRegex
+                    ? 'Regex against the raw test name.'
+                    : 'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
                   value={testFilter}
                   onChange={(e) => updateSearch({ filter: e.target.value || undefined })}
                   className={clsx(
@@ -575,7 +578,10 @@ export function CompareGroupsPage() {
               <span>Filter:</span>
               <input
                 type="text"
-                placeholder={testFilterRegex ? 'Regex pattern...' : 'Filter tests...'}
+                placeholder={testFilterRegex ? 'Regex pattern...' : 'Filter… or e.g. opcode:ORIGIN'}
+                title={testFilterRegex
+                  ? 'Regex against the raw test name.'
+                  : 'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
                 value={testFilter}
                 onChange={(e) => updateSearch({ filter: e.target.value || undefined })}
                 className={clsx(

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -5,6 +5,7 @@ import { useQueries } from '@tanstack/react-query'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES } from '@/api/types'
 import type { BlockLogs, RunConfig, RunResult } from '@/api/types'
 import { fetchData } from '@/api/client'
+import { testNameMatches } from '@/utils/eestNameFilter'
 import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
@@ -181,8 +182,7 @@ export function ComparePage() {
           return undefined
         }
       }
-      const q = testFilter.toLowerCase()
-      return (name: string) => name.toLowerCase().includes(q)
+      return (name: string) => testNameMatches(name, testFilter)
     })()
 
     const gasFn = selectedGasBuckets.size > 0
@@ -375,7 +375,10 @@ export function ComparePage() {
         <div className="flex items-center gap-1.5">
           <span>Filter:</span>
           <FilterInput
-            placeholder={testFilterRegex ? 'Regex pattern...' : 'Filter tests...'}
+            placeholder={testFilterRegex ? 'Regex pattern...' : 'Filter… or e.g. opcode:ORIGIN'}
+            title={testFilterRegex
+              ? 'Regex against the raw test name.'
+              : 'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
             value={testFilter}
             onValueChange={setTestFilter}
             className={clsx(

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -739,10 +739,11 @@ export function RunDetailPage() {
                 Performance Heatmap
               </h3>
               <FilterInput
-                placeholder="Filter tests..."
+                placeholder="Search… or e.g. opcode:ORIGIN gas:90M"
+                title={`Free text matches anywhere in the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.`}
                 value={q}
                 onValueChange={handleSearchChange}
-                className="rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
+                className="w-72 rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
               />
             </div>
             <TestHeatmap

--- a/ui/src/utils/eestName.ts
+++ b/ui/src/utils/eestName.ts
@@ -1,0 +1,105 @@
+// Parser for Ethereum Execution Specification Tests (EEST) test names.
+//
+// Format observed across the test corpus:
+//   test_<file>.py__test_<fn>[<param>-<param>-...].txt
+//
+// Each <param> is dash-joined and is usually `<key>_<value>` (with the key
+// possibly containing underscores — we split on the LAST `_`). A few params
+// are free-form descriptive labels with spaces (e.g. `0 bytes without value`)
+// or no underscore at all; these go into `labels`.
+//
+// We lift well-known keys (fork / opcode / benchmark gas amount) into named
+// fields and drop the always-present `benchmark_test` marker since it carries
+// no information. Anything else stays as a generic `{key, value}` chip.
+
+export interface EESTNameParts {
+  /** Original input, unchanged — always available as source of truth. */
+  raw: string
+  /** True if the input matched the EEST file/function format. */
+  isEEST: boolean
+  /** File slug (without `test_` prefix and `.py` suffix). e.g. `tx_context` */
+  file?: string
+  /** Function slug (without `test_` prefix). e.g. `call_frame_context_ops` */
+  fn?: string
+  /** Fork name from `fork_<X>`. e.g. `Amsterdam` */
+  fork?: string
+  /** Opcode under test from `opcode_<X>`. e.g. `ORIGIN`, `LOG1` */
+  opcode?: string
+  /** Benchmark gas amount from `benchmark_<N>M`. e.g. `90M`, `300M` */
+  benchmark?: string
+  /** Other key/value params not captured above. */
+  params: { key: string; value: string }[]
+  /** Tokens that aren't `key_value`-shaped (free-form labels). */
+  labels: string[]
+  /** Compact one-line summary for use in tooltips and tight cells. */
+  short: string
+}
+
+const FILE_FN_RE = /^test_(.+?)\.py__test_(.+?)(?:\[(.*)\])?(?:\.txt)?$/
+const BENCHMARK_GAS_RE = /^\d+[KMG]?$/
+
+export function parseEESTName(raw: string): EESTNameParts {
+  const m = FILE_FN_RE.exec(raw)
+  if (!m) {
+    return { raw, isEEST: false, params: [], labels: [], short: raw }
+  }
+
+  const [, file, fn, paramBlock = ''] = m
+  const tokens = paramBlock ? paramBlock.split('-') : []
+
+  let fork: string | undefined
+  let opcode: string | undefined
+  let benchmark: string | undefined
+  const params: { key: string; value: string }[] = []
+  const labels: string[] = []
+
+  for (const token of tokens) {
+    if (!token) continue
+    const lastUnderscore = token.lastIndexOf('_')
+    // No underscore, key would be empty, key has whitespace, or value is empty
+    // → treat the whole token as a free-form label.
+    if (
+      lastUnderscore <= 0 ||
+      lastUnderscore === token.length - 1 ||
+      /\s/.test(token.slice(0, lastUnderscore))
+    ) {
+      labels.push(token)
+      continue
+    }
+
+    const key = token.slice(0, lastUnderscore)
+    const value = token.slice(lastUnderscore + 1)
+
+    if (key === 'fork') {
+      fork = value
+    } else if (key === 'opcode') {
+      opcode = value
+    } else if (key === 'benchmark') {
+      if (BENCHMARK_GAS_RE.test(value)) {
+        benchmark = value
+      } else if (value !== 'test') {
+        // `benchmark_test` is the always-present EEST marker — drop it.
+        params.push({ key, value })
+      }
+    } else {
+      params.push({ key, value })
+    }
+  }
+
+  const shortParts: string[] = []
+  if (fn) shortParts.push(fn)
+  if (opcode) shortParts.push(opcode)
+  if (benchmark) shortParts.push(benchmark)
+  const short = shortParts.length > 0 ? shortParts.join(' · ') : raw
+
+  return { raw, isEEST: true, file, fn, fork, opcode, benchmark, params, labels, short }
+}
+
+/**
+ * Pure formatter usable from non-React contexts (e.g. canvas drawing).
+ * Returns a short single-line string suitable for tooltips and tight cells.
+ */
+export function formatTestName(name: string, mode: 'raw' | 'decomposed'): string {
+  if (mode === 'raw') return name
+  return parseEESTName(name).short
+}

--- a/ui/src/utils/eestName.ts
+++ b/ui/src/utils/eestName.ts
@@ -1,22 +1,34 @@
 // Parser for Ethereum Execution Specification Tests (EEST) test names.
 //
-// Format observed across the test corpus:
-//   test_<file>.py__test_<fn>[<param>-<param>-...].txt
+// Two formats observed across the corpus:
 //
-// Each <param> is dash-joined and is usually `<key>_<value>` (with the key
-// possibly containing underscores — we split on the LAST `_`). A few params
-// are free-form descriptive labels with spaces (e.g. `0 bytes without value`)
-// or no underscore at all; these go into `labels`.
+//   1. `[<run_id>/]test_<file>.py__test_<fn>[<params>].txt`
+//   2. `<path>/test_<file>.py::test_<fn>[<params>]`
 //
-// We lift well-known keys (fork / opcode / benchmark gas amount) into named
-// fields and drop the always-present `benchmark_test` marker since it carries
-// no information. Anything else stays as a generic `{key, value}` chip.
+// Plus a rare variant where the gas amount sits *outside* the closing
+// bracket: `...test_fn[<params>]_<N>M.txt`.
+//
+// Each <param> is dash-joined and usually `<key>_<value>` (the key may
+// contain underscores, so we split on the LAST `_`). Some are free-form
+// descriptive labels with spaces (`0 bytes without value`) or no
+// underscore at all; those go into `labels`.
+//
+// We lift well-known keys (fork / opcode / benchmark gas) into named
+// fields, drop noisy always-present markers (`benchmark_test`,
+// `blockchain_test_engine_x`, standalone `benchmark`/`gas`), and recognize
+// the gas amount in three places: `benchmark_<N>M`, `value_<N>M` (the new
+// `benchmark-gas-value_<N>M` triple), and the trailing `]_<N>M.txt` form.
 
 export interface EESTNameParts {
   /** Original input, unchanged — always available as source of truth. */
   raw: string
   /** True if the input matched the EEST file/function format. */
   isEEST: boolean
+  /**
+   * Optional directory prefix (e.g. `benchmark/compute/instruction`).
+   * Run-id-style numeric prefixes like `000001` are hidden as noise.
+   */
+  path?: string
   /** File slug (without `test_` prefix and `.py` suffix). e.g. `tx_context` */
   file?: string
   /** Function slug (without `test_` prefix). e.g. `call_frame_context_ops` */
@@ -25,7 +37,7 @@ export interface EESTNameParts {
   fork?: string
   /** Opcode under test from `opcode_<X>`. e.g. `ORIGIN`, `LOG1` */
   opcode?: string
-  /** Benchmark gas amount from `benchmark_<N>M`. e.g. `90M`, `300M` */
+  /** Benchmark gas amount. e.g. `90M`, `300M` */
   benchmark?: string
   /** Other key/value params not captured above. */
   params: { key: string; value: string }[]
@@ -35,8 +47,19 @@ export interface EESTNameParts {
   short: string
 }
 
-const FILE_FN_RE = /^test_(.+?)\.py__test_(.+?)(?:\[(.*)\])?(?:\.txt)?$/
+// Match either `__` (old) or `::` (new) between file and function, with an
+// optional path prefix and an optional `]_<N>M` trailer before `.txt`.
+const FILE_FN_RE = /^(?:(.+?)\/)?test_(.+?)\.py(?:__|::)test_(.+?)(?:\[(.*?)\])?(?:_(\d+[KMG]))?(?:\.txt)?$/
 const BENCHMARK_GAS_RE = /^\d+[KMG]?$/
+const VALUE_GAS_RE = /^\d+[KMG]$/
+
+const IGNORE_TOKENS = new Set([
+  'benchmark_test',
+  'blockchain_test',
+  'blockchain_test_engine_x',
+  'benchmark',
+  'gas',
+])
 
 export function parseEESTName(raw: string): EESTNameParts {
   const m = FILE_FN_RE.exec(raw)
@@ -44,8 +67,11 @@ export function parseEESTName(raw: string): EESTNameParts {
     return { raw, isEEST: false, params: [], labels: [], short: raw }
   }
 
-  const [, file, fn, paramBlock = ''] = m
-  const tokens = paramBlock ? paramBlock.split('-') : []
+  const [, pathRaw, file, fn, paramBlock = '', trailingGas] = m
+
+  // Hide run-id-style numeric path prefixes (e.g. `000001`) — they're not
+  // useful to display and clutter the chip line.
+  const path = pathRaw && !/^\d+$/.test(pathRaw) ? pathRaw : undefined
 
   let fork: string | undefined
   let opcode: string | undefined
@@ -53,8 +79,10 @@ export function parseEESTName(raw: string): EESTNameParts {
   const params: { key: string; value: string }[] = []
   const labels: string[] = []
 
-  for (const token of tokens) {
+  for (const token of (paramBlock ? paramBlock.split('-') : [])) {
     if (!token) continue
+    if (IGNORE_TOKENS.has(token)) continue
+
     const lastUnderscore = token.lastIndexOf('_')
     // No underscore, key would be empty, key has whitespace, or value is empty
     // → treat the whole token as a free-form label.
@@ -78,13 +106,19 @@ export function parseEESTName(raw: string): EESTNameParts {
       if (BENCHMARK_GAS_RE.test(value)) {
         benchmark = value
       } else if (value !== 'test') {
-        // `benchmark_test` is the always-present EEST marker — drop it.
         params.push({ key, value })
       }
+    } else if (key === 'value' && VALUE_GAS_RE.test(value)) {
+      // New EEST format: gas as the `value_<N>M` tail of the
+      // `benchmark-gas-value_<N>M` triple.
+      benchmark = value
     } else {
       params.push({ key, value })
     }
   }
+
+  // Trailing `]_<N>M.txt` form, only used when no in-bracket gas was found.
+  if (!benchmark && trailingGas) benchmark = trailingGas
 
   const shortParts: string[] = []
   if (fn) shortParts.push(fn)
@@ -92,7 +126,7 @@ export function parseEESTName(raw: string): EESTNameParts {
   if (opcode) shortParts.push(opcode)
   const short = shortParts.length > 0 ? shortParts.join(' · ') : raw
 
-  return { raw, isEEST: true, file, fn, fork, opcode, benchmark, params, labels, short }
+  return { raw, isEEST: true, path, file, fn, fork, opcode, benchmark, params, labels, short }
 }
 
 /**

--- a/ui/src/utils/eestName.ts
+++ b/ui/src/utils/eestName.ts
@@ -88,8 +88,8 @@ export function parseEESTName(raw: string): EESTNameParts {
 
   const shortParts: string[] = []
   if (fn) shortParts.push(fn)
-  if (opcode) shortParts.push(opcode)
   if (benchmark) shortParts.push(benchmark)
+  if (opcode) shortParts.push(opcode)
   const short = shortParts.length > 0 ? shortParts.join(' · ') : raw
 
   return { raw, isEEST: true, file, fn, fork, opcode, benchmark, params, labels, short }

--- a/ui/src/utils/eestNameFilter.ts
+++ b/ui/src/utils/eestNameFilter.ts
@@ -1,0 +1,74 @@
+import { parseEESTName, type EESTNameParts } from './eestName'
+
+// Aliases let users type the more natural word and we normalize internally.
+const FIELD_ALIASES: Record<string, string> = {
+  fn: 'fn',
+  function: 'fn',
+  file: 'file',
+  path: 'path',
+  fork: 'fork',
+  opcode: 'opcode',
+  gas: 'benchmark',
+  benchmark: 'benchmark',
+  label: 'label',
+}
+
+/**
+ * Returns true when `name` matches the search `query`.
+ *
+ * - Free-text terms: case-insensitive substring matches against the raw
+ *   test name (decomposed parts are subsets of the raw name).
+ * - `key:value` terms: filter on a specific decomposed field. Recognized
+ *   keys: `opcode`, `fork`, `gas`/`benchmark`, `file`, `fn`/`function`,
+ *   `path`, `label`. Any other `key:value` is matched against the parsed
+ *   params array (e.g. `mem_size:1024`, `code_size:0`).
+ *
+ * Multiple terms are combined with AND. Whitespace separates terms.
+ */
+export function testNameMatches(name: string, query: string): boolean {
+  const trimmed = query.trim()
+  if (!trimmed) return true
+
+  const lowerName = name.toLowerCase()
+  let parsed: EESTNameParts | null = null
+  const ensureParsed = (): EESTNameParts => parsed ?? (parsed = parseEESTName(name))
+
+  for (const term of trimmed.split(/\s+/)) {
+    const colon = term.indexOf(':')
+    if (colon > 0 && colon < term.length - 1) {
+      const rawKey = term.slice(0, colon).toLowerCase()
+      const value = term.slice(colon + 1).toLowerCase()
+      if (!matchesField(ensureParsed(), rawKey, value)) return false
+    } else {
+      if (!lowerName.includes(term.toLowerCase())) return false
+    }
+  }
+  return true
+}
+
+function matchesField(parsed: EESTNameParts, rawKey: string, value: string): boolean {
+  if (!value) return true
+  const key = FIELD_ALIASES[rawKey] ?? rawKey
+  switch (key) {
+    case 'fn':
+      return parsed.fn?.toLowerCase().includes(value) ?? false
+    case 'file':
+      return parsed.file?.toLowerCase().includes(value) ?? false
+    case 'path':
+      return parsed.path?.toLowerCase().includes(value) ?? false
+    case 'fork':
+      return parsed.fork?.toLowerCase().includes(value) ?? false
+    case 'opcode':
+      return parsed.opcode?.toLowerCase().includes(value) ?? false
+    case 'benchmark':
+      return parsed.benchmark?.toLowerCase().includes(value) ?? false
+    case 'label':
+      return parsed.labels.some((l) => l.toLowerCase().includes(value))
+    default:
+      // Treat unknown keys as a param-key filter (`mem_size:1024`).
+      // Exact key match, substring on value.
+      return parsed.params.some(
+        ({ key: k, value: v }) => k.toLowerCase() === rawKey && v.toLowerCase().includes(value),
+      )
+  }
+}


### PR DESCRIPTION
## Summary
EEST test names like `test_tx_context.py__test_call_frame_context_ops[fork_Amsterdam-benchmark_test-opcode_ORIGIN-benchmark_90M].txt` (and the newer `benchmark/compute/instruction/test_system.py::test_selfdestruct_created[fork_Osaka-blockchain_test_engine_x-value_bearing_False-benchmark-gas-value_10M]` form) now render as readable chips wherever a test name is shown, with a global toggle to fall back to raw.

## What's new
- **Parser** (`utils/eestName.ts`) — pure `parseEESTName` lifts well-known fields (file, fn, fork, opcode, gas, optional path) and keeps everything else as `{key,value}` chips or free-form labels. Handles both `__` and `::` separators, optional path prefix, and the rare `]_<N>M.txt` trailing-gas form. Drops noisy markers (`benchmark_test`, `blockchain_test_engine_x`, standalone `benchmark` / `gas`) and run-id-style numeric paths.
- **Toggle** in the page header (next to theme) — `decomposed` (default) ↔ `raw`. Persists via `?names=raw` URL search param + localStorage.
- **`<TestName>` component** — chip view (file ›  fn + gas/opcode/fork chips + params/labels), `compact` variant for tight cells, optional `showRawBelow` to render `Test name:` + raw on a muted second line.
- **Wirings** — Tests table, run-detail Performance Heatmap (tooltip + modal), Live heatmap (inherits), suite-detail Performance Heatmap (row labels + tooltip), suite-detail Opcode Heatmap (tooltip), comparison table, comparison detail modal.
- **Structured search** (`utils/eestNameFilter.ts`, `testNameMatches`) — every filter input now supports `key:value` terms alongside free text. Recognized keys: `opcode`, `fork`, `gas`/`benchmark`, `file`, `fn`/`function`, `path`, `label`. Anything else (e.g. `mem_size:1024`) hits parsed params. Multiple terms are AND. Each input has the same hint placeholder + tooltip cheat-sheet. Wired into TestsTable, both heatmaps, the opcode heatmap, the comparison page filter, and the sticky filter bar; suite-detail TestHeatmap regex mode is preserved.

## Test plan
- [x] Toggle in the header flips chips ↔ raw across every test-name display, persists across navigation, and the `?names=raw` URL is shareable.
- [x] Chips wrap onto a new line under `<file› <fn>` in the tests table; long single chips (e.g. `return_data_style:ReturnDataStyle.IDENTITY`) wrap inside their pill instead of overflowing the heatmap tooltip.
- [x] Filter `opcode:ORIGIN gas:90M` narrows tests in the tests table, run-detail heatmap, suite-detail heatmap (text mode), opcode heatmap, and comparison pages.
- [x] Run-detail and compare modals show decomposed name + `TEST NAME:` label + raw + copy icon next to the raw line.
- [ ] In raw mode, the name column in the tests table no longer overflows neighbouring columns.