### PR TITLE
fix: 0.0.9 compute tests release changed the genesis subdirs

### DIFF
--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -32,8 +32,8 @@ jobs:
                   filter: "bn128_mul-benchmark"
                   source:
                     eest_fixtures:
-                      github_repo: ethereum/execution-spec-tests
-                      github_release: benchmark@v0.0.7
+                      github_repo: ethereum/execution-specs
+                      github_release: tests-benchmark@v0.0.9
 
               client:
                 config:
@@ -76,8 +76,8 @@ jobs:
                   filter: "bn128_mul-benchmark"
                   source:
                     eest_fixtures:
-                      github_repo: ethereum/execution-spec-tests
-                      github_release: benchmark@v0.0.7
+                      github_repo: ethereum/execution-specs
+                      github_release: tests-benchmark@v0.0.9
 
               client:
                 config:
@@ -116,8 +116,8 @@ jobs:
                   filter: "bn128_mul-benchmark"
                   source:
                     eest_fixtures:
-                      github_repo: ethereum/execution-spec-tests
-                      github_release: benchmark@v0.0.7
+                      github_repo: ethereum/execution-specs
+                      github_release: tests-benchmark@v0.0.9
 
               client:
                 config:

--- a/config.example.docker.yaml
+++ b/config.example.docker.yaml
@@ -15,8 +15,8 @@ runner:
       filter: "bn128"
       source:
         eest_fixtures:
-          github_repo: ethereum/execution-spec-tests
-          github_release: benchmark@v0.0.7
+          github_repo: ethereum/execution-specs
+          github_release: tests-benchmark@v0.0.9
 
   client:
     config:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -170,8 +170,8 @@ runner:
     #     # Downloads fixtures directly from ethereum/execution-spec-tests releases.
     #     # Genesis files are auto-resolved per client type from the release.
     #     # eest_fixtures:
-    #     #   github_repo: ethereum/execution-spec-tests
-    #     #   github_release: benchmark@v0.0.7
+    #     #   github_repo: ethereum/execution-specs
+    #     #   github_release: tests-benchmark@v0.0.9
     #     #   # Optional: Override the subdirectory within fixtures tarball.
     #     #   # fixtures_subdir: fixtures/blockchain_tests_engine_x  # default
     #     #   # Optional: Override URLs for fixtures/genesis tarballs.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -424,16 +424,16 @@ EEST (Ethereum Execution Spec Tests) fixtures can be loaded from GitHub releases
 ```yaml
 tests:
   source:
-    eest_fixtures:
-      github_repo: ethereum/execution-spec-tests
-      github_release: benchmark@v0.0.7
+      eest_fixtures:
+        github_repo: ethereum/execution-specs
+        github_release: tests-benchmark@v0.0.9
       fixtures_subdir: fixtures/blockchain_tests_engine_x
 ```
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
-| `github_repo` | string | Yes | - | GitHub repository (e.g., `ethereum/execution-spec-tests`) |
-| `github_release` | string | Yes* | - | Release tag (e.g., `benchmark@v0.0.7`) |
+| `github_repo` | string | Yes | - | GitHub repository (e.g., `ethereum/execution-specs`) |
+| `github_release` | string | Yes* | - | Release tag (e.g., `test-benchmark@v0.0.9`) |
 | `fixtures_subdir` | string | No | `fixtures/blockchain_tests_engine_x` | Subdirectory within the fixtures tarball to search |
 | `fixtures_url` | string | No | Auto-generated | Override URL for fixtures tarball |
 | `genesis_url` | string | No | Auto-generated | Override URL for genesis tarball |
@@ -543,8 +543,8 @@ runner:
       filter: "bn128"  # Only run tests matching "bn128"
       source:
         eest_fixtures:
-          github_repo: ethereum/execution-spec-tests
-          github_release: benchmark@v0.0.7
+          github_repo: ethereum/execution-specs
+          github_release: tests-benchmark@v0.0.9
 ```
 
 #### Test Filter
@@ -1415,8 +1415,8 @@ runner:
       filter: "bn128"  # Optional: filter tests by name
       source:
         eest_fixtures:
-          github_repo: ethereum/execution-spec-tests
-          github_release: benchmark@v0.0.7
+          github_repo: ethereum/execution-specs
+          github_release: tests-benchmark@v0.0.9
 
   client:
     config:

--- a/examples/configuration/config.stateless.eest.yaml
+++ b/examples/configuration/config.stateless.eest.yaml
@@ -21,8 +21,8 @@ runner:
       source:
         # Run using github release fixtures.
         eest_fixtures:
-          github_repo: ethereum/execution-spec-tests
-          github_release: benchmark@v0.0.7
+          github_repo: ethereum/execution-specs
+          github_release: tests-benchmark@v0.0.9
         # Run using github actions artifact fixtures
         # (Requires local "gh" cli. Or setting runner.github_token)
         # eest_fixtures:

--- a/pkg/executor/eest_source.go
+++ b/pkg/executor/eest_source.go
@@ -858,43 +858,50 @@ func (s *EESTSource) GetGenesisGroups() []*GenesisGroup {
 // GetGenesisPathForGroup returns the genesis file path for a specific
 // genesis hash and client type.
 func (s *EESTSource) GetGenesisPathForGroup(genesisHash, clientType string) string {
-	clientDir, filename := s.resolveClientGenesis(clientType)
+	clientDirs, filename := s.resolveClientGenesis(clientType)
 
-	genesisPath := filepath.Join(
-		s.genesisDir, "genesis", genesisHash, clientDir, filename,
-	)
-
-	if _, err := os.Stat(genesisPath); err == nil {
-		return genesisPath
+	tried := make([]string, 0, len(clientDirs))
+	for _, clientDir := range clientDirs {
+		genesisPath := filepath.Join(
+			s.genesisDir, "genesis", genesisHash, clientDir, filename,
+		)
+		if _, err := os.Stat(genesisPath); err == nil {
+			return genesisPath
+		}
+		tried = append(tried, genesisPath)
 	}
 
 	s.log.WithFields(logrus.Fields{
 		"genesis_hash": genesisHash,
 		"client":       clientType,
-		"path":         genesisPath,
+		"tried":        tried,
 	}).Warn("Genesis file not found for group")
 
 	return ""
 }
 
-// resolveClientGenesis maps a client type to its genesis directory and filename.
-func (s *EESTSource) resolveClientGenesis(clientType string) (string, string) {
+// resolveClientGenesis maps a client type to its candidate genesis
+// directories (in priority order) and filename. Newer EEST releases
+// suffix the dir with `_default` (e.g. `go-ethereum_default`); older
+// releases use the bare client name. We try the new layout first and
+// fall back to the old one so both work.
+func (s *EESTSource) resolveClientGenesis(clientType string) ([]string, string) {
 	switch clientType {
 	case "geth", "erigon", "reth", "nimbus", "ethrex":
-		return "go-ethereum", "genesis.json"
+		return []string{"go-ethereum_default", "go-ethereum"}, "genesis.json"
 	case "nethermind":
-		return "nethermind", "chainspec.json"
+		return []string{"nethermind_default", "nethermind"}, "chainspec.json"
 	case "besu":
-		return "besu", "genesis.json"
+		return []string{"besu_default", "besu"}, "genesis.json"
 	default:
-		return "go-ethereum", "genesis.json"
+		return []string{"go-ethereum_default", "go-ethereum"}, "genesis.json"
 	}
 }
 
 // GetGenesisPath returns the genesis file path for a client type.
 // Maps client types to their genesis directories in the EEST release.
 func (s *EESTSource) GetGenesisPath(clientType string) string {
-	clientDir, filename := s.resolveClientGenesis(clientType)
+	clientDirs, filename := s.resolveClientGenesis(clientType)
 
 	// Genesis files are in genesis/genesis/<hash>/<client>/<filename>
 	// Find the hash subdirectory (there should typically be one).
@@ -909,7 +916,10 @@ func (s *EESTSource) GetGenesisPath(clientType string) string {
 
 	// Find the first directory (the hash directory).
 	for _, entry := range entries {
-		if entry.IsDir() {
+		if !entry.IsDir() {
+			continue
+		}
+		for _, clientDir := range clientDirs {
 			genesisPath := filepath.Join(
 				genesisBaseDir, entry.Name(), clientDir, filename,
 			)


### PR DESCRIPTION
Example: `/go-ethereum/` is now `/go-ethereum_default/`