### PR TITLE
feat(ui): click-to-filter chips on test names

### DIFF
--- a/ui/src/components/compare/StickyRunBar.tsx
+++ b/ui/src/components/compare/StickyRunBar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
 import { type CompareRun, type LabelMode, buildLabelModeOptions, RUN_SLOTS, formatRunLabel } from './constants'
 import { FilterInput } from '@/components/shared/FilterInput'
+import { TEST_FILTER_HINT } from '@/utils/eestNameFilter'
 
 interface StickyRunBarProps {
   runs: CompareRun[]
@@ -77,9 +78,7 @@ export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, 
           <span>Filter:</span>
           <FilterInput
             placeholder={testFilterRegex ? 'Regex...' : 'Filter or e.g. opcode:ORIGIN'}
-            title={testFilterRegex
-              ? 'Regex against the raw test name.'
-              : 'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
+            title={testFilterRegex ? 'Regex against the raw test name.' : TEST_FILTER_HINT}
             value={testFilter}
             onValueChange={onTestFilterChange}
             className={clsx(

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -20,6 +20,10 @@ interface TestComparisonTableProps {
   sortDir: SortDirection
   onSortChange: (column: SortColumn, direction: SortDirection) => void
   testNameFilter?: (name: string) => boolean
+  /** Current search query string used to highlight matching chips. */
+  searchQuery?: string
+  /** Toggle a `key:value` term in the page-level search. */
+  onChipFilterToggle?: (term: string) => void
   /** When provided, clicking a row calls this with the test name (for opening a detail modal). */
   onTestClick?: (testName: string) => void
 }
@@ -134,7 +138,7 @@ function SortableHeader({
 
 const PAGE_SIZE = 50
 
-export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun, labelMode, tableBaseline, onTableBaselineChange, sortBy, sortDir, onSortChange, testNameFilter, onTestClick }: TestComparisonTableProps) {
+export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPerRun, labelMode, tableBaseline, onTableBaselineChange, sortBy, sortDir, onSortChange, testNameFilter, searchQuery, onChipFilterToggle, onTestClick }: TestComparisonTableProps) {
   const [activeTab, setActiveTab] = useState('mgas')
   const [currentPage, setCurrentPage] = useState(1)
 
@@ -403,7 +407,7 @@ export function TestComparisonTable({ runs, suiteTests, stepFilter, blockLogsPer
                     {test.order || '-'}
                   </td>
                   <td className="max-w-sm truncate px-4 py-2 text-sm/6 text-gray-900 dark:text-gray-100">
-                    <TestName name={test.name} />
+                    <TestName name={test.name} onChipClick={onChipFilterToggle} activeQuery={searchQuery} />
                   </td>
                   <td className="whitespace-nowrap px-4 py-2 text-right text-xs/5 text-gray-500 dark:text-gray-400">
                     {test.gasUsed !== undefined ? `${Math.round(test.gasUsed / 1_000_000)}M` : '-'}

--- a/ui/src/components/compare/TestDetailModal.tsx
+++ b/ui/src/components/compare/TestDetailModal.tsx
@@ -21,6 +21,10 @@ interface TestDetailModalProps {
   groupRunIds: string[][]
   stepFilter: StepTypeOption[]
   sampleSize: number
+  /** Current page-level search query (used to highlight active chips). */
+  searchQuery?: string
+  /** Toggle a `key:value` term in the page-level search. */
+  onChipFilterToggle?: (term: string) => void
   onClose: () => void
 }
 
@@ -38,6 +42,8 @@ export function TestDetailModal({
   groupRunIds,
   stepFilter,
   sampleSize,
+  searchQuery,
+  onChipFilterToggle,
   onClose,
 }: TestDetailModalProps) {
   const SLOT_COLORS = ['text-blue-700 dark:text-blue-300', 'text-orange-700 dark:text-orange-300', 'text-purple-700 dark:text-purple-300', 'text-green-700 dark:text-green-300', 'text-red-700 dark:text-red-300']
@@ -148,7 +154,7 @@ export function TestDetailModal({
               {testOrder !== undefined ? `Test #${testOrder}` : 'Test Detail'}
             </h3>
             <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-              <TestName name={testName} showRawBelow showCopy />
+              <TestName name={testName} showRawBelow showCopy onChipClick={onChipFilterToggle} activeQuery={searchQuery} />
             </div>
           </div>
           <button onClick={onClose} className="shrink-0 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300">

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -6,7 +6,7 @@ import type { TestEntry, SuiteTest, AggregatedStats, MethodsAggregated, StepResu
 import { fetchHead } from '@/api/client'
 import { Modal } from '@/components/shared/Modal'
 import { TestName } from '@/components/shared/TestName'
-import { testNameMatches } from '@/utils/eestNameFilter'
+import { testNameMatches, toggleSearchTerm } from '@/utils/eestNameFilter'
 import { TimeBreakdown } from './TimeBreakdown'
 import { MGasBreakdown } from './MGasBreakdown'
 import { ExecutionsList } from './ExecutionsList'
@@ -377,6 +377,7 @@ export function TestHeatmap({
   postTestRPCCalls,
   inProgressTestKey,
   onSelectedTestChange,
+  onSearchChange,
   onSortModeChange,
   onGroupModeChange,
   onThresholdChange,
@@ -945,7 +946,14 @@ export function TestHeatmap({
               <div className="flex flex-col gap-2">
                 <div>
                   <div className="text-sm/6 text-gray-900 dark:text-gray-100">
-                    <TestName name={selectedTest} showRawBelow showCopy className="min-w-0" />
+                    <TestName
+                      name={selectedTest}
+                      showRawBelow
+                      showCopy
+                      onChipClick={onSearchChange ? (term) => onSearchChange(toggleSearchTerm(searchQuery, term)) : undefined}
+                      activeQuery={searchQuery}
+                      className="min-w-0"
+                    />
                   </div>
                 </div>
                 {entry.dir && (

--- a/ui/src/components/run-detail/TestsTable.tsx
+++ b/ui/src/components/run-detail/TestsTable.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/shared/Badge'
 import { Duration } from '@/components/shared/Duration'
 import { Pagination } from '@/components/shared/Pagination'
 import { TestName } from '@/components/shared/TestName'
-import { testNameMatches } from '@/utils/eestNameFilter'
+import { testNameMatches, toggleSearchTerm, TEST_FILTER_HINT } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES } from '@/pages/RunDetailPage'
 
 export type TestSortColumn = 'order' | 'name' | 'genesis' | 'time' | 'mgas' | 'passed' | 'failed'
@@ -310,7 +310,7 @@ export function TestsTable({
           <input
             type="text"
             placeholder="Search… or e.g. opcode:ORIGIN gas:90M"
-            title={`Free text matches anywhere in the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.`}
+            title={TEST_FILTER_HINT}
             value={searchQuery}
             onChange={(e) => handleSearchInput(e.target.value)}
             className="w-72 rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
@@ -359,7 +359,12 @@ export function TestsTable({
                     {executionOrder.get(testName) ?? '-'}
                   </td>
                   <td className="max-w-md px-4 py-3">
-                    <TestName name={testName} className="text-sm/6 font-medium text-gray-900 dark:text-gray-100" />
+                    <TestName
+                      name={testName}
+                      onChipClick={onSearchChange ? (term) => onSearchChange(toggleSearchTerm(searchQuery, term)) : undefined}
+                      activeQuery={searchQuery}
+                      className="text-sm/6 font-medium text-gray-900 dark:text-gray-100"
+                    />
                     {entry.dir && (
                       <div className="truncate text-xs/5 text-gray-500 dark:text-gray-400" title={entry.dir}>
                         {entry.dir}

--- a/ui/src/components/shared/TestName.tsx
+++ b/ui/src/components/shared/TestName.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import clsx from 'clsx'
 import { Check, Copy } from 'lucide-react'
 import { parseEESTName } from '@/utils/eestName'
+import { searchQueryContains } from '@/utils/eestNameFilter'
 import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 interface TestNameProps {
@@ -19,6 +20,16 @@ interface TestNameProps {
    * mode (in raw mode the primary line already shows the raw name).
    */
   showRawBelow?: boolean
+  /**
+   * If provided, chips become buttons. Called with the search-query term
+   * to toggle (e.g. `opcode:ORIGIN`, `gas:90M`, `mem_size:1024`).
+   */
+  onChipClick?: (term: string) => void
+  /**
+   * Current search query. Chips whose term is present here render with
+   * an "active" style so users can see what's pinned.
+   */
+  activeQuery?: string
   className?: string
 }
 
@@ -59,8 +70,53 @@ const chipAccent =
   'bg-indigo-50 text-indigo-700 ring-indigo-200 dark:bg-indigo-950/50 dark:text-indigo-300 dark:ring-indigo-800'
 const chipGas =
   'bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-950/50 dark:text-emerald-300 dark:ring-emerald-800'
+const chipActive =
+  'bg-blue-500 text-white ring-blue-500 dark:bg-blue-500 dark:text-white dark:ring-blue-500'
 
-export function TestName({ name, variant = 'full', showCopy = false, showRawBelow = false, className }: TestNameProps) {
+function Chip({
+  variant,
+  label,
+  term,
+  onClick,
+  active,
+}: {
+  variant: 'gas' | 'accent' | 'neutral'
+  label: string
+  term: string
+  onClick?: (term: string) => void
+  active?: boolean
+}) {
+  const variantClasses =
+    active ? chipActive
+      : variant === 'gas' ? chipGas
+        : variant === 'accent' ? chipAccent
+          : chipNeutral
+
+  if (!onClick) {
+    return <span className={clsx(chipBase, variantClasses)}>{label}</span>
+  }
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        e.preventDefault()
+        onClick(term)
+      }}
+      className={clsx(
+        chipBase,
+        variantClasses,
+        'cursor-pointer transition-colors',
+        !active && 'hover:bg-blue-100 hover:text-blue-700 hover:ring-blue-300 dark:hover:bg-blue-950/60 dark:hover:text-blue-300 dark:hover:ring-blue-700',
+      )}
+      title={active ? `Click to remove ${term} from filter` : `Click to filter by ${term}`}
+    >
+      {label}
+    </button>
+  )
+}
+
+export function TestName({ name, variant = 'full', showCopy = false, showRawBelow = false, onChipClick, activeQuery, className }: TestNameProps) {
   const { mode } = useNameDisplayMode()
   const parsed = mode === 'decomposed' ? parseEESTName(name) : null
 
@@ -112,24 +168,58 @@ export function TestName({ name, variant = 'full', showCopy = false, showRawBelo
       {hasChips && (
         <span className="inline-flex flex-wrap items-baseline gap-1">
           {parsed.benchmark && (
-            <span className={clsx(chipBase, chipGas)}>{parsed.benchmark}</span>
+            <Chip
+              variant="gas"
+              label={parsed.benchmark}
+              term={`gas=${parsed.benchmark}`}
+              onClick={onChipClick}
+              active={!!activeQuery && searchQueryContains(activeQuery, `gas=${parsed.benchmark}`)}
+            />
           )}
           {parsed.opcode && (
-            <span className={clsx(chipBase, chipAccent)}>{parsed.opcode}</span>
+            <Chip
+              variant="accent"
+              label={parsed.opcode}
+              term={`opcode=${parsed.opcode}`}
+              onClick={onChipClick}
+              active={!!activeQuery && searchQueryContains(activeQuery, `opcode=${parsed.opcode}`)}
+            />
           )}
           {parsed.fork && (
-            <span className={clsx(chipBase, chipNeutral)}>fork:{parsed.fork}</span>
+            <Chip
+              variant="neutral"
+              label={`fork:${parsed.fork}`}
+              term={`fork=${parsed.fork}`}
+              onClick={onChipClick}
+              active={!!activeQuery && searchQueryContains(activeQuery, `fork=${parsed.fork}`)}
+            />
           )}
-          {parsed.params.map(({ key, value }) => (
-            <span key={`${key}=${value}`} className={clsx(chipBase, chipNeutral)}>
-              {key}:{value}
-            </span>
-          ))}
-          {parsed.labels.map((label) => (
-            <span key={label} className={clsx(chipBase, chipNeutral)}>
-              {label}
-            </span>
-          ))}
+          {parsed.params.map(({ key, value }) => {
+            const term = `${key}=${value}`
+            return (
+              <Chip
+                key={term}
+                variant="neutral"
+                label={`${key}:${value}`}
+                term={term}
+                onClick={onChipClick}
+                active={!!activeQuery && searchQueryContains(activeQuery, term)}
+              />
+            )
+          })}
+          {parsed.labels.map((label) => {
+            const term = `label=${label}`
+            return (
+              <Chip
+                key={label}
+                variant="neutral"
+                label={label}
+                term={term}
+                onClick={onChipClick}
+                active={!!activeQuery && searchQueryContains(activeQuery, term)}
+              />
+            )
+          })}
         </span>
       )}
       {showRawBelow && (

--- a/ui/src/components/suite-detail/OpcodeHeatmap.tsx
+++ b/ui/src/components/suite-detail/OpcodeHeatmap.tsx
@@ -5,7 +5,7 @@ import type { SuiteTest } from '@/api/types'
 import { getGroupedOpcodes, getCategoryColor } from '@/utils/opcodeCategories'
 import type { CategorySpan, GroupedResult } from '@/utils/opcodeCategories'
 import { TestName } from '@/components/shared/TestName'
-import { testNameMatches } from '@/utils/eestNameFilter'
+import { testNameMatches, TEST_FILTER_HINT } from '@/utils/eestNameFilter'
 
 /** Returns the opcode count map from the top-level field or EEST info fallback. */
 function getOpcodeCount(test: SuiteTest): Record<string, number> | undefined {
@@ -945,7 +945,7 @@ export function OpcodeHeatmap({ tests, onTestClick, extraColumns = [], searchQue
           <input
             type="text"
             placeholder="Filter… or e.g. opcode:ORIGIN"
-            title={'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
+            title={TEST_FILTER_HINT}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"

--- a/ui/src/components/suite-detail/TestHeatmap.tsx
+++ b/ui/src/components/suite-detail/TestHeatmap.tsx
@@ -8,7 +8,7 @@ import { JDenticon } from '@/components/shared/JDenticon'
 import { Pagination } from '@/components/shared/Pagination'
 import { Spinner } from '@/components/shared/Spinner'
 import { TestName } from '@/components/shared/TestName'
-import { testNameMatches } from '@/utils/eestNameFilter'
+import { testNameMatches, toggleSearchTerm, TEST_FILTER_HINT } from '@/utils/eestNameFilter'
 import { formatTimestamp } from '@/utils/date'
 
 const DEFAULT_PAGE_SIZE = 20
@@ -528,9 +528,7 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
           value={search}
           onChange={(e) => handleSearchChange(e.target.value)}
           placeholder={useRegex ? 'Regex...' : 'Filter or e.g. opcode:ORIGIN'}
-          title={useRegex
-            ? 'Regex against the raw test name.'
-            : 'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
+          title={useRegex ? 'Regex against the raw test name.' : TEST_FILTER_HINT}
           className={clsx(
             'w-28 rounded-xs border bg-white px-2 py-1 text-sm placeholder-gray-400 focus:outline-hidden focus:ring-1 sm:w-auto sm:px-3 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
             useRegex && search && (() => { try { new RegExp(search); return false } catch { return true } })()
@@ -734,7 +732,11 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
                         <HighlightedName name={test.name} search={search} useRegex={useRegex} />
                       </span>
                     ) : (
-                      <TestName name={test.name} />
+                      <TestName
+                        name={test.name}
+                        onChipClick={(term) => onSearchChange?.(toggleSearchTerm(search, term) || undefined)}
+                        activeQuery={search}
+                      />
                     )}
                   </td>
                 </tr>

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -4,7 +4,7 @@ import { useQueries } from '@tanstack/react-query'
 import clsx from 'clsx'
 import type { RunConfig, RunResult } from '@/api/types'
 import { fetchData } from '@/api/client'
-import { testNameMatches } from '@/utils/eestNameFilter'
+import { testNameMatches, toggleSearchTerm, TEST_FILTER_HINT } from '@/utils/eestNameFilter'
 import { useIndex } from '@/api/hooks/useIndex'
 import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
@@ -450,7 +450,7 @@ export function CompareGroupsPage() {
                   placeholder={testFilterRegex ? 'Regex...' : 'Filter or e.g. opcode:ORIGIN'}
                   title={testFilterRegex
                     ? 'Regex against the raw test name.'
-                    : 'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
+                    : TEST_FILTER_HINT}
                   value={testFilter}
                   onChange={(e) => updateSearch({ filter: e.target.value || undefined })}
                   className={clsx(
@@ -579,9 +579,7 @@ export function CompareGroupsPage() {
               <input
                 type="text"
                 placeholder={testFilterRegex ? 'Regex pattern...' : 'Filter… or e.g. opcode:ORIGIN'}
-                title={testFilterRegex
-                  ? 'Regex against the raw test name.'
-                  : 'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
+                title={testFilterRegex ? 'Regex against the raw test name.' : TEST_FILTER_HINT}
                 value={testFilter}
                 onChange={(e) => updateSearch({ filter: e.target.value || undefined })}
                 className={clsx(
@@ -741,6 +739,8 @@ export function CompareGroupsPage() {
           groupRunIds={groupRuns}
           stepFilter={stepFilter}
           sampleSize={sampleSize}
+          searchQuery={testFilter}
+          onChipFilterToggle={(term) => updateSearch({ filter: toggleSearchTerm(testFilter, term) || undefined })}
           onClose={() => setSelectedTest(null)}
         />
       )}

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -5,7 +5,7 @@ import { useQueries } from '@tanstack/react-query'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES } from '@/api/types'
 import type { BlockLogs, RunConfig, RunResult } from '@/api/types'
 import { fetchData } from '@/api/client'
-import { testNameMatches } from '@/utils/eestNameFilter'
+import { testNameMatches, toggleSearchTerm, TEST_FILTER_HINT } from '@/utils/eestNameFilter'
 import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
@@ -376,9 +376,7 @@ export function ComparePage() {
           <span>Filter:</span>
           <FilterInput
             placeholder={testFilterRegex ? 'Regex pattern...' : 'Filter… or e.g. opcode:ORIGIN'}
-            title={testFilterRegex
-              ? 'Regex against the raw test name.'
-              : 'Free text matches the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.'}
+            title={testFilterRegex ? 'Regex against the raw test name.' : TEST_FILTER_HINT}
             value={testFilter}
             onValueChange={setTestFilter}
             className={clsx(
@@ -466,7 +464,7 @@ export function ComparePage() {
       {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} suiteTests={suite?.tests} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} chartType={chartType} />}
 
       {allResults && (
-        <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} tableBaseline={tableBaseline} onTableBaselineChange={setTableBaseline} sortBy={tableSortBy} sortDir={tableSortDir} onSortChange={setTableSort} testNameFilter={testNameFilter} />
+        <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} tableBaseline={tableBaseline} onTableBaselineChange={setTableBaseline} sortBy={tableSortBy} sortDir={tableSortDir} onSortChange={setTableSort} testNameFilter={testNameFilter} searchQuery={testFilter} onChipFilterToggle={(term) => setTestFilter(toggleSearchTerm(testFilter, term))} />
       )}
 
       <ConfigDiff runs={runs} labelMode={labelMode} />

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -24,6 +24,7 @@ import { Duration } from '@/components/shared/Duration'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { StatusAlert } from '@/components/shared/StatusBadge'
 import { FilterInput } from '@/components/shared/FilterInput'
+import { TEST_FILTER_HINT } from '@/utils/eestNameFilter'
 import { formatTimestamp, formatDurationSeconds } from '@/utils/date'
 import { formatNumber, formatBytes } from '@/utils/format'
 import { useIndex, useLiveRuns } from '@/api/hooks/useIndex'
@@ -740,7 +741,7 @@ export function RunDetailPage() {
               </h3>
               <FilterInput
                 placeholder="Search… or e.g. opcode:ORIGIN gas:90M"
-                title={`Free text matches anywhere in the raw name. Or filter by extracted fields:\nopcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\nUnrecognized keys hit params: mem_size:1024  code_size:0\nMultiple terms are AND.`}
+                title={TEST_FILTER_HINT}
                 value={q}
                 onValueChange={handleSearchChange}
                 className="w-72 rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"

--- a/ui/src/utils/eestNameFilter.ts
+++ b/ui/src/utils/eestNameFilter.ts
@@ -14,14 +14,60 @@ const FIELD_ALIASES: Record<string, string> = {
 }
 
 /**
+ * Hint text for filter input tooltips. Kept here so every search box stays
+ * in sync as we tweak supported syntax.
+ */
+export const TEST_FILTER_HINT =
+  'Free text matches the raw name. Or filter by extracted fields:\n' +
+  'opcode:ORIGIN  gas:90M  fork:Amsterdam  file:tx_context  fn:codecopy  path:compute  label:LOG1\n' +
+  'Unrecognized keys hit params: mem_size:1024  code_size:0\n' +
+  'Use `=` for exact match instead of substring (chip clicks use this): opcode=ORIGIN  code_size=0\n' +
+  'Multiple terms are AND.'
+
+type StructuredTerm = { key: string; value: string; exact: boolean }
+
+/**
+ * Parse a structured term. `key:value` is substring match (default for typed
+ * queries). `key=value` is an exact match (used by chip clicks). Returns null
+ * for free-text or malformed terms.
+ */
+function parseStructuredTerm(term: string): StructuredTerm | null {
+  const colonIdx = term.indexOf(':')
+  const eqIdx = term.indexOf('=')
+
+  let sepIdx = -1
+  let exact = false
+  if (eqIdx > 0 && (colonIdx < 0 || eqIdx < colonIdx)) {
+    sepIdx = eqIdx
+    exact = true
+  } else if (colonIdx > 0) {
+    sepIdx = colonIdx
+    exact = false
+  } else {
+    return null
+  }
+  if (sepIdx === term.length - 1) return null
+
+  return {
+    key: term.slice(0, sepIdx).toLowerCase(),
+    value: term.slice(sepIdx + 1).toLowerCase(),
+    exact,
+  }
+}
+
+/**
  * Returns true when `name` matches the search `query`.
  *
  * - Free-text terms: case-insensitive substring matches against the raw
  *   test name (decomposed parts are subsets of the raw name).
- * - `key:value` terms: filter on a specific decomposed field. Recognized
- *   keys: `opcode`, `fork`, `gas`/`benchmark`, `file`, `fn`/`function`,
- *   `path`, `label`. Any other `key:value` is matched against the parsed
- *   params array (e.g. `mem_size:1024`, `code_size:0`).
+ * - `key:value` terms: substring match on a specific decomposed field
+ *   (e.g. `opcode:ORIG` matches ORIGIN).
+ * - `key=value` terms: exact match on the field (e.g. `calldata_size=0`
+ *   only matches calldata_size_0, not calldata_size_1024). Chip clicks
+ *   produce this form.
+ *
+ * Recognized keys: `opcode`, `fork`, `gas`/`benchmark`, `file`,
+ * `fn`/`function`, `path`, `label`. Any other key hits the parsed params.
  *
  * Multiple terms are combined with AND. Whitespace separates terms.
  */
@@ -34,11 +80,9 @@ export function testNameMatches(name: string, query: string): boolean {
   const ensureParsed = (): EESTNameParts => parsed ?? (parsed = parseEESTName(name))
 
   for (const term of trimmed.split(/\s+/)) {
-    const colon = term.indexOf(':')
-    if (colon > 0 && colon < term.length - 1) {
-      const rawKey = term.slice(0, colon).toLowerCase()
-      const value = term.slice(colon + 1).toLowerCase()
-      if (!matchesField(ensureParsed(), rawKey, value)) return false
+    const structured = parseStructuredTerm(term)
+    if (structured) {
+      if (!matchesField(ensureParsed(), structured)) return false
     } else {
       if (!lowerName.includes(term.toLowerCase())) return false
     }
@@ -46,29 +90,58 @@ export function testNameMatches(name: string, query: string): boolean {
   return true
 }
 
-function matchesField(parsed: EESTNameParts, rawKey: string, value: string): boolean {
-  if (!value) return true
-  const key = FIELD_ALIASES[rawKey] ?? rawKey
+/** Split a query string into whitespace-separated terms. */
+export function splitQuery(query: string): string[] {
+  return query.trim().split(/\s+/).filter(Boolean)
+}
+
+/** Returns true if the query already contains the given term (case-insensitive). */
+export function searchQueryContains(query: string, term: string): boolean {
+  const target = term.toLowerCase()
+  return splitQuery(query).some((t) => t.toLowerCase() === target)
+}
+
+/**
+ * Toggle a term in the query. If present (case-insensitive), it's removed;
+ * otherwise it's appended. Whitespace is normalized to single spaces.
+ */
+export function toggleSearchTerm(query: string, term: string): string {
+  const target = term.toLowerCase()
+  const tokens = splitQuery(query)
+  const idx = tokens.findIndex((t) => t.toLowerCase() === target)
+  if (idx >= 0) tokens.splice(idx, 1)
+  else tokens.push(term)
+  return tokens.join(' ')
+}
+
+function matchesField(parsed: EESTNameParts, term: StructuredTerm): boolean {
+  if (!term.value) return true
+  const key = FIELD_ALIASES[term.key] ?? term.key
+  const cmp = (haystack: string | undefined): boolean => {
+    if (haystack === undefined) return false
+    const h = haystack.toLowerCase()
+    return term.exact ? h === term.value : h.includes(term.value)
+  }
   switch (key) {
     case 'fn':
-      return parsed.fn?.toLowerCase().includes(value) ?? false
+      return cmp(parsed.fn)
     case 'file':
-      return parsed.file?.toLowerCase().includes(value) ?? false
+      return cmp(parsed.file)
     case 'path':
-      return parsed.path?.toLowerCase().includes(value) ?? false
+      return cmp(parsed.path)
     case 'fork':
-      return parsed.fork?.toLowerCase().includes(value) ?? false
+      return cmp(parsed.fork)
     case 'opcode':
-      return parsed.opcode?.toLowerCase().includes(value) ?? false
+      return cmp(parsed.opcode)
     case 'benchmark':
-      return parsed.benchmark?.toLowerCase().includes(value) ?? false
+      return cmp(parsed.benchmark)
     case 'label':
-      return parsed.labels.some((l) => l.toLowerCase().includes(value))
+      return parsed.labels.some((l) => cmp(l))
     default:
-      // Treat unknown keys as a param-key filter (`mem_size:1024`).
-      // Exact key match, substring on value.
+      // Param-key filter (`mem_size:1024` or `mem_size=1024`). Exact key
+      // match, substring or exact on value depending on the separator.
       return parsed.params.some(
-        ({ key: k, value: v }) => k.toLowerCase() === rawKey && v.toLowerCase().includes(value),
+        ({ key: k, value: v }) => k.toLowerCase() === term.key && cmp(v),
       )
   }
 }


### PR DESCRIPTION
## Summary
Each chip on a test name (gas, opcode, fork, params, labels) is now a button. Click toggles the matching term in the page search; the chip lights up blue while that term is pinned. Lets you drill into "all 90M tests" or "all ORIGIN tests" without typing.

To make chip filters precise without losing typed-search convenience, the filter syntax now supports two separators:
- **`key:value`** — substring (existing behavior). `opcode:ORIG` matches `ORIGIN`.
- **`key=value`** — exact match. `calldata_size=0` matches only `calldata_size_0`, not `calldata_size_1024`. Chip clicks emit this form.

A shared `TEST_FILTER_HINT` constant feeds every search-box tooltip so they stay in sync.

## Wired in
- `run-detail/TestsTable` name cell
- `run-detail/TestHeatmap` modal
- `suite-detail/TestHeatmap` row labels
- `compare/TestComparisonTable` (plumbed from ComparePage)
- `compare/TestDetailModal` (plumbed from CompareGroupsPage)

Heatmap tooltips stay non-interactive on purpose (`pointer-events-none`).

## Test plan
- [ ] Click an `ORIGIN` opcode chip in the tests table — `opcode=ORIGIN` is added to the search, chip turns blue, the table filters. Click again — term removed, chip un-styled.
- [ ] Type `opcode:ORIG` manually — table filters by substring; chips don't light up since the typed term is the substring form.
- [ ] Click `0` on a `calldata_size:0` chip — only `calldata_size_0` rows remain (not `calldata_size_1024`).
- [ ] Click a chip in the run-detail heatmap modal and the compare detail modal — both pin the term to the page filter.
- [ ] Active chips stay highlighted across name-mode and theme toggles.