### PR TITLE
feat(ui): dimension breakdown, faceted filtering, sticky run-detail header

### DIFF
--- a/ui/src/components/compare/BlockLogsComparison.tsx
+++ b/ui/src/components/compare/BlockLogsComparison.tsx
@@ -3,6 +3,8 @@ import ReactECharts from 'echarts-for-react'
 import { Blocks } from 'lucide-react'
 import type { BlockLogs, SuiteTest } from '@/api/types'
 import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
+import { formatTestNameLong } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 function useDarkMode() {
   const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'))
@@ -123,6 +125,7 @@ interface BlockLogsComparisonProps {
 }
 
 export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, suiteTests, labelMode, testNameFilter }: BlockLogsComparisonProps) {
+  const { mode: nameMode } = useNameDisplayMode()
   const isDark = useDarkMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const prevZoomRef = useRef(zoomRange)
@@ -249,7 +252,7 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
         const testName = visible[0].value[2]
         const testOrder = visible[0].value[3]
         let content = `<strong>Test #${testOrder}</strong>`
-        if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
+        if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${formatTestNameLong(testName, nameMode)}</span>`
         content += '<br/>'
         visible.forEach((p) => {
           const value = p.value[1] as number
@@ -301,7 +304,7 @@ export function BlockLogsComparison({ runs, blockLogsPerRun, blockLogsLoading, s
       storageCacheHitRate: buildChart('storageCacheHitRate', (v) => `${v.toFixed(0)}%`, (v) => `${v.toFixed(1)}%`),
       codeCacheHitRate: buildChart('codeCacheHitRate', (v) => `${v.toFixed(0)}%`, (v) => `${v.toFixed(1)}%`),
     }
-  }, [pointsPerRun, runs, runsWithData, isDark, zoomRange, unifiedTests, labelMode, suiteTests])
+  }, [pointsPerRun, runs, runsWithData, isDark, zoomRange, unifiedTests, labelMode, suiteTests, nameMode])
 
   if (blockLogsLoading) {
     return (

--- a/ui/src/components/compare/CVComparisonChart.tsx
+++ b/ui/src/components/compare/CVComparisonChart.tsx
@@ -5,6 +5,8 @@ import type { RunResult, SuiteTest } from '@/api/types'
 import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 import type { ZoomRange } from './MGasComparisonChart'
 import { useChartAreaClick } from './useChartAreaClick'
+import { formatTestNameLong } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 interface CVComparisonChartProps {
   runs: CompareRun[]
@@ -68,6 +70,7 @@ function buildCVData(
 }
 
 export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line', varianceByRunIndex, onTestClick }: CVComparisonChartProps) {
+  const { mode: nameMode } = useNameDisplayMode()
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -140,7 +143,7 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
           const testName = params[0].value[2]
           highlightedTestRef.current = testName
           let content = `<strong>Test #${testOrder}</strong>`
-          if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
+          if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${formatTestNameLong(testName, nameMode)}</span>`
           content += '<br/>'
           params.forEach((p) => {
             const value = p.value[1]
@@ -255,7 +258,7 @@ export function CVComparisonChart({ runs, suiteTests, labelMode, testNameFilter,
         }
       }),
     }
-  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, threshold, onTestClick, highlightedTestRef])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, threshold, onTestClick, highlightedTestRef, nameMode])
 
   if (pointsPerRun.every((p) => p.length === 0)) return null
 

--- a/ui/src/components/compare/CompareDimensionInsights.tsx
+++ b/ui/src/components/compare/CompareDimensionInsights.tsx
@@ -1,0 +1,634 @@
+import { useMemo, useState } from 'react'
+import clsx from 'clsx'
+import { BarChart3, ChevronDown, ChevronUp, Table2, X } from 'lucide-react'
+import { parseEESTName } from '@/utils/eestName'
+import { queryTermDimension, searchQueryContains, splitQuery } from '@/utils/eestNameFilter'
+import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
+import { type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
+
+interface CompareDimensionInsightsProps {
+  runs: CompareRun[]
+  stepFilter: StepTypeOption[]
+  baselineIdx: number
+  labelMode: LabelMode
+  testNameFilter?: (name: string) => boolean
+  /** Current search query, used to highlight bars/rows whose value is pinned. */
+  query: string
+  /** Toggle a `key=value` term in the page-level search. */
+  onToggle: (term: string) => void
+  /** Open the test detail modal for a specific test. */
+  onTestClick?: (testName: string) => void
+}
+
+type DimensionDef = { key: string; label: string; emitKey: string }
+
+const PRIMARY_DIMENSIONS: DimensionDef[] = [
+  { key: 'file', label: 'File', emitKey: 'file' },
+  { key: 'fn', label: 'Test', emitKey: 'fn' },
+  { key: 'benchmark', label: 'Gas', emitKey: 'gas' },
+  { key: 'opcode', label: 'Opcode', emitKey: 'opcode' },
+  { key: 'fork', label: 'Fork', emitKey: 'fork' },
+]
+
+const TRAILING_DIMENSIONS: DimensionDef[] = [
+  { key: 'label', label: 'Label', emitKey: 'label' },
+]
+
+const BARS_PREVIEW_KEYS = new Set(['file', 'benchmark'])
+
+/** Per-(dim, value) per-run aggregate. */
+interface RunAgg {
+  /** Mean MGas/s of all tests with this value, in this run. */
+  mean: number | undefined
+  /** How many tests in this bucket from this run. */
+  count: number
+  /** Single test's name when count === 1, for "click → open modal". */
+  singleTestName?: string
+}
+
+interface ValueAgg {
+  value: string
+  perRun: RunAgg[]
+  /** Smallest count across runs (for the chip count display). */
+  minCount: number
+  /** Largest count across runs. */
+  maxCount: number
+  /** Largest baseline-relative absolute delta % across non-baseline runs. */
+  maxAbsDeltaPct: number
+}
+
+interface DimensionAgg {
+  def: DimensionDef
+  values: ValueAgg[]
+}
+
+function calculateMGasPerSec(gas: number, timeNs: number): number | undefined {
+  if (timeNs <= 0 || gas <= 0) return undefined
+  return (gas * 1000) / timeNs
+}
+
+function compareNumeric(a: string, b: string): number {
+  const na = parseInt(a, 10)
+  const nb = parseInt(b, 10)
+  const aIsNum = !Number.isNaN(na) && /^\d/.test(a)
+  const bIsNum = !Number.isNaN(nb) && /^\d/.test(b)
+  if (aIsNum && bIsNum) return na - nb
+  return a.localeCompare(b)
+}
+
+/**
+ * Map a baseline-relative delta % to a colour.
+ * Negative (slower than baseline) → red shades.
+ * Positive (faster than baseline) → green shades.
+ * Zero → grey.
+ */
+function deltaColor(pct: number | undefined): string {
+  if (pct === undefined || !isFinite(pct)) return '#9ca3af'
+  if (Math.abs(pct) < 0.5) return '#9ca3af'
+  if (pct >= 25) return '#16a34a'  // green-600
+  if (pct >= 10) return '#22c55e'  // green-500
+  if (pct >= 0) return '#86efac'   // green-300
+  if (pct >= -10) return '#fca5a5' // red-300
+  if (pct >= -25) return '#ef4444' // red-500
+  return '#dc2626'                 // red-600
+}
+
+function formatDelta(pct: number | undefined): string {
+  if (pct === undefined || !isFinite(pct)) return '—'
+  if (Math.abs(pct) < 0.05) return '0%'
+  const sign = pct >= 0 ? '+' : ''
+  return `${sign}${pct.toFixed(1)}%`
+}
+
+type SortMode = { col: 'value' | 'count' | `run_${number}` | `delta_${number}`; dir: 'asc' | 'desc' }
+
+export function CompareDimensionInsights({
+  runs,
+  stepFilter,
+  baselineIdx,
+  labelMode,
+  testNameFilter,
+  query,
+  onToggle,
+  onTestClick,
+}: CompareDimensionInsightsProps) {
+  const [view, setView] = useState<'bars' | 'table'>('bars')
+  const [barsDir, setBarsDir] = useState<'desc' | 'asc'>('desc')
+  const [showAllBars, setShowAllBars] = useState(false)
+  const [groupByKey, setGroupByKey] = useState<string | null>(null)
+  const [tableSort, setTableSort] = useState<SortMode>({ col: `delta_${runs.findIndex((_, i) => i !== baselineIdx) || 0}`, dir: 'asc' })
+
+  const dimensions = useMemo<DimensionAgg[]>(() => {
+    // 1. Per-run, build per-test mgas samples.
+    const perRunSamples = runs.map((r) => {
+      if (!r.result) return [] as { name: string; mgas: number }[]
+      const out: { name: string; mgas: number }[] = []
+      for (const [name, entry] of Object.entries(r.result.tests)) {
+        if (testNameFilter && !testNameFilter(name)) continue
+        const stats = getAggregatedStats(entry, stepFilter)
+        if (!stats) continue
+        const mgas = calculateMGasPerSec(stats.gas_used_total, stats.gas_used_time_total)
+        if (mgas === undefined) continue
+        out.push({ name, mgas })
+      }
+      return out
+    })
+
+    // 2. Bucket by (dim, value, run) — keep sums + counts + names for single-test deep-link.
+    type Bucket = { sum: number; count: number; names: string[] }
+    const byDim = new Map<string, Map<string, Bucket[]>>()
+    const ensureBuckets = (dim: string, value: string) => {
+      let inner = byDim.get(dim)
+      if (!inner) {
+        inner = new Map()
+        byDim.set(dim, inner)
+      }
+      let arr = inner.get(value)
+      if (!arr) {
+        arr = Array.from({ length: runs.length }, () => ({ sum: 0, count: 0, names: [] }))
+        inner.set(value, arr)
+      }
+      return arr
+    }
+    const bump = (runIdx: number, dim: string, value: string | undefined, name: string, mgas: number) => {
+      if (!value) return
+      const buckets = ensureBuckets(dim, value)
+      buckets[runIdx].sum += mgas
+      buckets[runIdx].count++
+      buckets[runIdx].names.push(name)
+    }
+    for (let runIdx = 0; runIdx < runs.length; runIdx++) {
+      for (const s of perRunSamples[runIdx]) {
+        const p = parseEESTName(s.name)
+        if (!p.isEEST) continue
+        bump(runIdx, 'file', p.file, s.name, s.mgas)
+        bump(runIdx, 'fn', p.fn, s.name, s.mgas)
+        bump(runIdx, 'benchmark', p.benchmark, s.name, s.mgas)
+        bump(runIdx, 'opcode', p.opcode, s.name, s.mgas)
+        bump(runIdx, 'fork', p.fork, s.name, s.mgas)
+        for (const { key, value } of p.params) bump(runIdx, key, value, s.name, s.mgas)
+        for (const label of p.labels) bump(runIdx, 'label', label, s.name, s.mgas)
+      }
+    }
+
+    // 3. Order dimensions: canonical primary + discovered params (alpha) + trailing.
+    const known = new Set([
+      ...PRIMARY_DIMENSIONS.map((d) => d.key),
+      ...TRAILING_DIMENSIONS.map((d) => d.key),
+    ])
+    const paramKeys = [...byDim.keys()].filter((k) => !known.has(k)).sort()
+    const ordered: DimensionDef[] = [
+      ...PRIMARY_DIMENSIONS,
+      ...paramKeys.map((k) => ({ key: k, label: k, emitKey: k })),
+      ...TRAILING_DIMENSIONS,
+    ].filter((d) => byDim.has(d.key))
+
+    // 4. Roll up per-value stats across runs. Skip dims with only one value.
+    const result: DimensionAgg[] = []
+    for (const def of ordered) {
+      const inner = byDim.get(def.key)!
+      if (inner.size < 2) continue
+
+      const values: ValueAgg[] = []
+      for (const [value, buckets] of inner) {
+        const perRun: RunAgg[] = buckets.map((b) => ({
+          mean: b.count > 0 ? b.sum / b.count : undefined,
+          count: b.count,
+          singleTestName: b.count === 1 ? b.names[0] : undefined,
+        }))
+        const counts = perRun.map((r) => r.count)
+        const minCount = Math.min(...counts)
+        const maxCount = Math.max(...counts)
+        const baseline = perRun[baselineIdx]?.mean
+        let maxAbs = 0
+        if (baseline !== undefined && baseline > 0) {
+          for (let i = 0; i < perRun.length; i++) {
+            if (i === baselineIdx) continue
+            const m = perRun[i].mean
+            if (m === undefined) continue
+            const pct = ((m - baseline) / baseline) * 100
+            if (Math.abs(pct) > maxAbs) maxAbs = Math.abs(pct)
+          }
+        }
+        values.push({ value, perRun, minCount, maxCount, maxAbsDeltaPct: maxAbs })
+      }
+      result.push({ def, values })
+    }
+
+    return result
+  }, [runs, stepFilter, testNameFilter, baselineIdx])
+
+  // When the filter narrows down to a single unique test across all runs
+  // there's nothing to break down — surface a deep-link to the test detail
+  // modal instead of the otherwise-useless empty state.
+  const lonelyTestName = useMemo<string | null>(() => {
+    const names = new Set<string>()
+    for (const r of runs) {
+      if (!r.result) continue
+      for (const name of Object.keys(r.result.tests)) {
+        if (testNameFilter && !testNameFilter(name)) continue
+        names.add(name)
+        if (names.size > 1) return null
+      }
+    }
+    return names.size === 1 ? [...names][0] : null
+  }, [runs, testNameFilter])
+
+  // Picker default: first dim that exists.
+  const groupByDim = groupByKey ?? dimensions[0]?.def.key ?? null
+  const tableDim = dimensions.find((d) => d.def.key === groupByDim) ?? dimensions[0]
+
+  const sortedTableValues = useMemo(() => {
+    if (!tableDim) return []
+    const { col, dir } = tableSort
+    const sign = dir === 'asc' ? 1 : -1
+    return [...tableDim.values].sort((a, b) => {
+      if (col === 'value') return sign * compareNumeric(a.value, b.value)
+      if (col === 'count') return sign * (a.maxCount - b.maxCount)
+      if (col.startsWith('run_')) {
+        const idx = parseInt(col.slice(4), 10)
+        const am = a.perRun[idx]?.mean ?? -Infinity
+        const bm = b.perRun[idx]?.mean ?? -Infinity
+        return sign * (am - bm)
+      }
+      // delta_<i>: sort by signed delta vs baseline (most negative first when desc=asc means most negative first → flip dir interpretation).
+      const idx = parseInt(col.slice(6), 10)
+      const baseA = a.perRun[baselineIdx]?.mean
+      const baseB = b.perRun[baselineIdx]?.mean
+      const ma = a.perRun[idx]?.mean
+      const mb = b.perRun[idx]?.mean
+      const da = baseA && baseA > 0 && ma !== undefined ? ((ma - baseA) / baseA) * 100 : 0
+      const db = baseB && baseB > 0 && mb !== undefined ? ((mb - baseB) / baseB) * 100 : 0
+      return sign * (da - db)
+    })
+  }, [tableDim, tableSort, baselineIdx])
+
+  const handleSort = (col: SortMode['col']) => {
+    setTableSort((prev) => {
+      if (prev.col === col) return { col, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+      // Default direction depends on column type — ascending for value/delta (most regressed first),
+      // descending for count/per-run mean (largest first).
+      return { col, dir: col === 'value' || col.startsWith('delta_') ? 'asc' : 'desc' }
+    })
+  }
+
+  const activeTerms = splitQuery(query)
+  const hasFileFilter = activeTerms.some((t) => queryTermDimension(t) === 'file')
+  const previewDims = dimensions.filter(({ def, values }) =>
+    BARS_PREVIEW_KEYS.has(def.key) ||
+    (hasFileFilter && def.key === 'fn') ||
+    values.some((v) => searchQueryContains(query, `${def.emitKey}=${v.value}`)),
+  )
+  const hiddenDims = dimensions.filter((d) => !previewDims.includes(d))
+  const visibleDims = showAllBars ? dimensions : previewDims
+
+  const renderBarsForValue = (def: DimensionDef, v: ValueAgg) => {
+    const term = `${def.emitKey}=${v.value}`
+    const active = searchQueryContains(query, term)
+    const baseline = v.perRun[baselineIdx]?.mean
+    const allMeans = v.perRun.map((r) => r.mean ?? 0)
+    const maxMean = Math.max(...allMeans, 1)
+
+    const onClick = () => {
+      // If the entire row collapses to a single test (every run has 0 or 1
+      // test, with at most one test name across runs), open it.
+      const uniqueNames = new Set<string>()
+      for (const r of v.perRun) for (const n of r.singleTestName ? [r.singleTestName] : []) uniqueNames.add(n)
+      if (!active && onTestClick && uniqueNames.size === 1 && v.maxCount === 1) {
+        onTestClick([...uniqueNames][0])
+      } else {
+        onToggle(term)
+      }
+    }
+
+    return (
+      <button
+        key={v.value}
+        type="button"
+        onClick={onClick}
+        title={active ? `Click to remove ${term}` : `Click to filter by ${term}`}
+        className={clsx(
+          'group flex w-full cursor-pointer flex-col gap-0.5 rounded-xs px-1 py-0.5 text-left text-xs/5 transition-colors',
+          active ? 'bg-blue-50 dark:bg-blue-950/40' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
+        )}
+      >
+        <div className="flex items-baseline gap-2">
+          <span className={clsx('truncate font-mono', active ? 'text-blue-900 dark:text-blue-200' : 'text-gray-700 dark:text-gray-200')}>
+            {v.value}
+          </span>
+          <span className="text-[10px]/4 text-gray-400 dark:text-gray-500">
+            ×{v.minCount === v.maxCount ? v.maxCount : `${v.minCount}-${v.maxCount}`}
+          </span>
+        </div>
+        <div className="flex flex-col gap-0.5">
+          {v.perRun.map((r, i) => {
+            const slot = RUN_SLOTS[i] ?? RUN_SLOTS[0]
+            const widthPct = r.mean !== undefined ? (r.mean / maxMean) * 100 : 0
+            const pct = i !== baselineIdx && baseline !== undefined && baseline > 0 && r.mean !== undefined
+              ? ((r.mean - baseline) / baseline) * 100
+              : undefined
+            const barColor = i === baselineIdx ? slot.color : deltaColor(pct)
+            return (
+              <div key={i} className="grid grid-cols-[8rem_1fr_auto_3rem] items-center gap-2">
+                <span className="flex min-w-0 items-center gap-1 text-[10px]/4 text-gray-500 dark:text-gray-400" title={formatRunLabel(slot, runs[i], labelMode)}>
+                  <img
+                    src={`/img/clients/${runs[i].config.instance.client}.jpg`}
+                    alt={runs[i].config.instance.client}
+                    className="size-3.5 shrink-0 rounded-full object-cover"
+                  />
+                  <span className="truncate">{formatRunLabel(slot, runs[i], labelMode)}</span>
+                  {i === baselineIdx && <span className="shrink-0 text-amber-500" title="Baseline">★</span>}
+                </span>
+                <span className="relative h-2.5 rounded-xs bg-gray-100 dark:bg-gray-700">
+                  <span
+                    className="absolute inset-y-0 left-0 rounded-xs"
+                    style={{ width: `${widthPct}%`, backgroundColor: barColor }}
+                  />
+                </span>
+                <span className="font-mono tabular-nums text-gray-600 dark:text-gray-300">
+                  {r.mean !== undefined ? r.mean.toFixed(1) : '—'}
+                </span>
+                <span className="font-mono tabular-nums text-[10px]/4" style={{ color: i === baselineIdx ? '#9ca3af' : deltaColor(pct) }}>
+                  {i === baselineIdx ? '' : formatDelta(pct)}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      </button>
+    )
+  }
+
+  const renderDim = ({ def, values }: DimensionAgg) => {
+    const sign = barsDir === 'desc' ? -1 : 1
+    const sorted = [...values].sort((a, b) => sign * (a.maxAbsDeltaPct - b.maxAbsDeltaPct))
+    return (
+      <div key={def.key} className="flex flex-col gap-1">
+        <div className="text-[10px]/4 font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+          {def.label}
+          <span className="ml-1 lowercase text-gray-300 dark:text-gray-600">({sorted.length})</span>
+        </div>
+        <div className="flex flex-col gap-1">
+          {sorted.map((v) => renderBarsForValue(def, v))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-sm border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-center gap-2 border-b border-gray-200 px-3 py-2 text-sm/6 font-medium text-gray-900 dark:border-gray-700 dark:text-gray-100">
+        <BarChart3 className="size-4 text-gray-400 dark:text-gray-500" />
+        Dimension breakdown
+        <span className="text-xs/5 text-gray-500 dark:text-gray-400">
+          ({dimensions.length} dimension{dimensions.length === 1 ? '' : 's'}
+          {activeTerms.length > 0 && `, ${activeTerms.length} filter${activeTerms.length === 1 ? '' : 's'}`})
+        </span>
+      </div>
+      <div className="flex flex-col gap-3 p-3">
+        <div className="flex flex-wrap items-center gap-1.5 text-xs/5">
+          <span className="text-[10px]/4 font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">Filters</span>
+          {activeTerms.length === 0 ? (
+            <span className="text-gray-500 dark:text-gray-400">none — comparing all tests</span>
+          ) : (
+            activeTerms.map((term) => (
+              <button
+                key={term}
+                type="button"
+                onClick={() => onToggle(term)}
+                title={`Click to remove ${term}`}
+                className="inline-flex cursor-pointer items-center gap-1 rounded-xs bg-blue-500 px-1.5 py-0 font-mono text-[11px]/5 text-white ring-1 ring-inset ring-blue-500 hover:bg-blue-600"
+              >
+                <span>{term}</span>
+                <X className="size-3" />
+              </button>
+            ))
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1 rounded-xs bg-gray-100 p-0.5 dark:bg-gray-700">
+              {(['bars', 'table'] as const).map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => setView(v)}
+                  className={clsx(
+                    'flex cursor-pointer items-center gap-1.5 rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
+                    view === v
+                      ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
+                      : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
+                  )}
+                >
+                  {v === 'bars' ? <BarChart3 className="size-3.5" /> : <Table2 className="size-3.5" />}
+                  {v === 'bars' ? 'Bars' : 'Table'}
+                </button>
+              ))}
+            </div>
+            {view === 'bars' && (
+              <button
+                type="button"
+                onClick={() => setBarsDir(barsDir === 'desc' ? 'asc' : 'desc')}
+                title={barsDir === 'desc' ? 'Click to sort smallest delta first' : 'Click to sort largest delta first'}
+                className="flex cursor-pointer items-center gap-1 rounded-xs border border-gray-300 bg-white px-2 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:hover:text-gray-100"
+              >
+                {barsDir === 'desc'
+                  ? <><ChevronDown className="size-3.5" /> Largest delta first</>
+                  : <><ChevronUp className="size-3.5" /> Smallest delta first</>}
+              </button>
+            )}
+          </div>
+          {view === 'table' && tableDim && (
+            <div className="flex items-center gap-2 text-xs/5 text-gray-500 dark:text-gray-400">
+              <span>Group by:</span>
+              <select
+                value={tableDim.def.key}
+                onChange={(e) => setGroupByKey(e.target.value)}
+                className="rounded-xs border border-gray-300 bg-white px-2 py-0.5 text-xs/5 text-gray-700 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+              >
+                {dimensions.map((d) => (
+                  <option key={d.def.key} value={d.def.key}>
+                    {d.def.label} ({d.values.length})
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+
+        {dimensions.length === 0 && (
+          lonelyTestName && onTestClick ? (
+            <button
+              type="button"
+              onClick={() => onTestClick(lonelyTestName)}
+              className="flex w-fit cursor-pointer items-center gap-1 rounded-xs px-1.5 py-1 text-xs/5 font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-800 dark:text-blue-400 dark:hover:bg-blue-950/40 dark:hover:text-blue-300"
+            >
+              Only one test matches — click to open its detail
+            </button>
+          ) : (
+            <div className="text-xs/5 text-gray-500 dark:text-gray-400">
+              Not enough data — at least one dimension with two distinct values is required.
+            </div>
+          )
+        )}
+
+        {view === 'bars' && visibleDims.map(renderDim)}
+        {view === 'bars' && hiddenDims.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowAllBars(!showAllBars)}
+            className="flex w-fit cursor-pointer items-center gap-1 rounded-xs px-1.5 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
+          >
+            {showAllBars
+              ? <><ChevronUp className="size-3.5" /> Show fewer dimensions</>
+              : <><ChevronDown className="size-3.5" /> Show more dimensions ({hiddenDims.length})</>}
+          </button>
+        )}
+
+        {view === 'table' && tableDim && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs/5">
+              <thead className="bg-gray-50 dark:bg-gray-900">
+                <tr>
+                  <SortableTh label={tableDim.def.label} col="value" sort={tableSort} onSort={handleSort} align="left" />
+                  <SortableTh label="Count" col="count" sort={tableSort} onSort={handleSort} align="right" />
+                  {runs.map((run, i) => {
+                    const slot = RUN_SLOTS[i] ?? RUN_SLOTS[0]
+                    const isBaseline = i === baselineIdx
+                    return (
+                      <SortableTh
+                        key={`run-${i}`}
+                        col={`run_${i}`}
+                        sort={tableSort}
+                        onSort={handleSort}
+                        align="right"
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          <img
+                            src={`/img/clients/${run.config.instance.client}.jpg`}
+                            alt={run.config.instance.client}
+                            className="size-3.5 rounded-full object-cover"
+                          />
+                          <span>{formatRunLabel(slot, run, labelMode)}</span>
+                          {isBaseline && <span className="text-amber-500" title="Baseline">★</span>}
+                        </span>
+                      </SortableTh>
+                    )
+                  })}
+                  {runs.map((run, i) => {
+                    if (i === baselineIdx) return null
+                    const slot = RUN_SLOTS[i] ?? RUN_SLOTS[0]
+                    return (
+                      <SortableTh
+                        key={`delta-${i}`}
+                        col={`delta_${i}`}
+                        sort={tableSort}
+                        onSort={handleSort}
+                        align="right"
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          <span>Δ</span>
+                          <img
+                            src={`/img/clients/${run.config.instance.client}.jpg`}
+                            alt={run.config.instance.client}
+                            className="size-3.5 rounded-full object-cover"
+                          />
+                          <span>{formatRunLabel(slot, run, labelMode)}</span>
+                        </span>
+                      </SortableTh>
+                    )
+                  })}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                {sortedTableValues.map((v) => {
+                  const term = `${tableDim.def.emitKey}=${v.value}`
+                  const active = searchQueryContains(query, term)
+                  const baseline = v.perRun[baselineIdx]?.mean
+                  const onClick = () => {
+                    const uniqueNames = new Set<string>()
+                    for (const r of v.perRun) for (const n of r.singleTestName ? [r.singleTestName] : []) uniqueNames.add(n)
+                    if (!active && onTestClick && uniqueNames.size === 1 && v.maxCount === 1) {
+                      onTestClick([...uniqueNames][0])
+                    } else {
+                      onToggle(term)
+                    }
+                  }
+                  return (
+                    <tr
+                      key={v.value}
+                      onClick={onClick}
+                      className={clsx(
+                        'cursor-pointer transition-colors',
+                        active ? 'bg-blue-50 dark:bg-blue-950/40' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                      )}
+                      title={active ? `Click to remove ${term}` : `Click to filter by ${term}`}
+                    >
+                      <td className="px-2 py-1 font-mono text-gray-700 dark:text-gray-200">{v.value}</td>
+                      <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">
+                        {v.minCount === v.maxCount ? v.maxCount : `${v.minCount}-${v.maxCount}`}
+                      </td>
+                      {v.perRun.map((r, i) => (
+                        <td key={`run-${i}`} className="px-2 py-1 text-right font-mono tabular-nums text-gray-700 dark:text-gray-200">
+                          {r.mean !== undefined ? r.mean.toFixed(1) : '—'}
+                        </td>
+                      ))}
+                      {v.perRun.map((r, i) => {
+                        if (i === baselineIdx) return null
+                        const pct = baseline !== undefined && baseline > 0 && r.mean !== undefined
+                          ? ((r.mean - baseline) / baseline) * 100
+                          : undefined
+                        return (
+                          <td
+                            key={`delta-${i}`}
+                            className="px-2 py-1 text-right font-mono tabular-nums"
+                            style={{ color: deltaColor(pct) }}
+                          >
+                            {formatDelta(pct)}
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SortableTh({
+  label,
+  children,
+  col,
+  sort,
+  onSort,
+  align,
+}: {
+  label?: string
+  children?: React.ReactNode
+  col: SortMode['col']
+  sort: SortMode
+  onSort: (col: SortMode['col']) => void
+  align: 'left' | 'right'
+}) {
+  const active = sort.col === col
+  return (
+    <th
+      className={clsx(
+        'cursor-pointer px-2 py-1.5 text-[10px]/4 font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+        align === 'left' ? 'text-left' : 'text-right',
+      )}
+      onClick={() => onSort(col)}
+    >
+      <span className="inline-flex items-center gap-0.5">
+        {children ?? label}
+        {active && (sort.dir === 'asc' ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />)}
+      </span>
+    </th>
+  )
+}

--- a/ui/src/components/compare/MGasComparisonChart.tsx
+++ b/ui/src/components/compare/MGasComparisonChart.tsx
@@ -5,6 +5,8 @@ import type { RunResult, SuiteTest, AggregatedStats } from '@/api/types'
 import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 import { useChartAreaClick } from './useChartAreaClick'
+import { formatTestNameLong } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 export interface ZoomRange {
   start: number
@@ -75,6 +77,7 @@ function buildMGasData(
 }
 
 export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line', onTestClick }: MGasComparisonChartProps) {
+  const { mode: nameMode } = useNameDisplayMode()
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -147,7 +150,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
           const testName = params[0].value[2]
           highlightedTestRef.current = testName
           let content = `<strong>Test #${testOrder}</strong>`
-          if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
+          if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${formatTestNameLong(testName, nameMode)}</span>`
           content += '<br/>'
           params.forEach((p) => {
             const value = p.value[1]
@@ -242,7 +245,7 @@ export function MGasComparisonChart({ runs, suiteTests, stepFilter, labelMode, t
         }
       }),
     }
-  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, onTestClick, highlightedTestRef])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, onTestClick, highlightedTestRef, nameMode])
 
   if (pointsPerRun.every((p) => p.length === 0)) return null
 

--- a/ui/src/components/compare/PercentageDiffChart.tsx
+++ b/ui/src/components/compare/PercentageDiffChart.tsx
@@ -6,6 +6,8 @@ import { type StepTypeOption, getAggregatedStats } from '@/pages/RunDetailPage'
 import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 import type { ZoomRange } from './MGasComparisonChart'
 import { useChartAreaClick } from './useChartAreaClick'
+import { formatTestNameLong } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 interface PercentageDiffChartProps {
   runs: CompareRun[]
@@ -116,6 +118,7 @@ function buildDiffData(
 }
 
 export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx, onBaselineChange, labelMode, diffFilter, onDiffFilterChange, testNameFilter, zoomRange: externalZoom, onZoomChange, chartType = 'line', onTestClick }: PercentageDiffChartProps) {
+  const { mode: nameMode } = useNameDisplayMode()
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -193,7 +196,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
           const baseImg = `<img src="/img/clients/${baseClient}.jpg" style="display:inline-block;width:14px;height:14px;border-radius:50%;object-fit:cover;vertical-align:middle;margin-right:4px;" />`
 
           let content = `<strong>Test #${testOrder}</strong>`
-          if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
+          if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${formatTestNameLong(testName, nameMode)}</span>`
           content += `<br/>${baseImg}<span style="font-size: 11px;">Baseline ${baseSlot.label}: ${baseValue.toFixed(2)} MGas/s</span><br/>`
 
           params.forEach((p) => {
@@ -323,7 +326,7 @@ export function PercentageDiffChart({ runs, suiteTests, stepFilter, baselineIdx,
         }),
       ],
     }
-  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange, labelMode, diffFilter, chartType, onTestClick, highlightedTestRef])
+  }, [diffData, runs, otherRunIndices, baselineIdx, isDark, zoomRange, labelMode, diffFilter, chartType, onTestClick, highlightedTestRef, nameMode])
 
   if (runs.every((r) => r.result === null)) return null
 

--- a/ui/src/components/compare/ResourceComparisonCharts.tsx
+++ b/ui/src/components/compare/ResourceComparisonCharts.tsx
@@ -6,6 +6,8 @@ import { formatBytes } from '@/utils/format'
 import { type ChartType, type CompareRun, type LabelMode, RUN_SLOTS, formatRunLabel } from './constants'
 import type { ZoomRange } from './MGasComparisonChart'
 import { useChartAreaClick } from './useChartAreaClick'
+import { formatTestNameLong } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 interface AggregatedResourceData {
   totals: ResourceTotals
@@ -194,6 +196,7 @@ function ChartSection({ title, option, onZoom, onTestClick, highlightedTestRef }
 }
 
 export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suiteTests, zoomRange: externalZoom, onZoomChange, chartType = 'line', onTestClick }: ResourceComparisonChartsProps) {
+  const { mode: nameMode } = useNameDisplayMode()
   const isDark = useDarkMode()
   const [internalZoom, setInternalZoom] = useState({ start: 0, end: 100 })
   const zoomRange = externalZoom ?? internalZoom
@@ -325,7 +328,7 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suit
         const testOrder = params[0].value[3]
         highlightedTestRef.current = testName
         let content = `<strong>Test #${testOrder}</strong>`
-        if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${testName}</span>`
+        if (testName) content += `<br/><span style="font-size: 10px; color: ${isDark ? '#9ca3af' : '#6b7280'};">${formatTestNameLong(testName, nameMode)}</span>`
         content += '<br/>'
         params.forEach((p) => {
           const value = p.value[1]
@@ -417,7 +420,7 @@ export function ResourceComparisonCharts({ runs, labelMode, testNameFilter, suit
     }
 
     return { cpuPercentOption, memoryMBOption, cpuTimeOption, memoryDeltaOption, diskReadBytesOption, diskWriteBytesOption, diskReadOpsOption, diskWriteOpsOption }
-  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, onTestClick, highlightedTestRef])
+  }, [pointsPerRun, runs, isDark, zoomRange, labelMode, chartType, onTestClick, highlightedTestRef, nameMode])
 
   if (!hasData) return null
 

--- a/ui/src/components/compare/StickyRunBar.tsx
+++ b/ui/src/components/compare/StickyRunBar.tsx
@@ -82,7 +82,7 @@ export function StickyRunBar({ runs, sentinelRef, labelMode, onLabelModeChange, 
             value={testFilter}
             onValueChange={onTestFilterChange}
             className={clsx(
-              'w-36 rounded-xs border bg-white px-2 py-0.5 text-xs/5 placeholder-gray-400 focus:outline-hidden focus:ring-1 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
+              'w-80 rounded-xs border bg-white px-2 py-0.5 text-xs/5 placeholder-gray-400 focus:outline-hidden focus:ring-1 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500',
               testFilterRegex && testFilter && (() => { try { new RegExp(testFilter); return false } catch { return true } })()
                 ? 'border-red-400 focus:border-red-500 focus:ring-red-500 dark:border-red-500'
                 : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600',

--- a/ui/src/components/run-detail/DimensionInsights.tsx
+++ b/ui/src/components/run-detail/DimensionInsights.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from 'react'
 import clsx from 'clsx'
-import { BarChart3, ChevronRight, ChevronDown, ChevronUp, Table2 } from 'lucide-react'
+import { BarChart3, ChevronDown, ChevronUp, Table2, X } from 'lucide-react'
 import type { TestEntry } from '@/api/types'
 import { parseEESTName } from '@/utils/eestName'
-import { searchQueryContains, testNameMatches } from '@/utils/eestNameFilter'
+import { searchQueryContains, splitQuery, testNameMatches } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES, getAggregatedStats } from '@/pages/RunDetailPage'
 import { percentile } from './block-logs-dashboard/utils/statistics'
 
@@ -31,6 +31,11 @@ const PRIMARY_DIMENSIONS: DimensionDef[] = [
 const TRAILING_DIMENSIONS: DimensionDef[] = [
   { key: 'label', label: 'Label', emitKey: 'label' },
 ]
+
+// Dimensions visible by default in the Bars view. Anything with an active
+// filter is also forced into the preview so users always see the dim
+// they're filtering by.
+const BARS_PREVIEW_KEYS = new Set(['file', 'benchmark'])
 
 interface ValueAgg {
   value: string
@@ -70,8 +75,9 @@ export function DimensionInsights({
   onToggle,
   query,
 }: DimensionInsightsProps) {
-  const [expanded, setExpanded] = useState(false)
   const [view, setView] = useState<'bars' | 'table'>('bars')
+  const [barsDir, setBarsDir] = useState<'desc' | 'asc'>('asc')
+  const [showAllBars, setShowAllBars] = useState(false)
   const [groupByKey, setGroupByKey] = useState<string | null>(null)
   const [tableSort, setTableSort] = useState<{ col: SortColumn; dir: 'asc' | 'desc' }>({ col: 'mean', dir: 'desc' })
 
@@ -177,40 +183,74 @@ export function DimensionInsights({
     })
   }
 
+  // The page filter terms feeding this breakdown. Free-text terms (no `:`
+  // or `=`) are kept too — they also affect what's counted.
+  const activeTerms = splitQuery(query)
+
   return (
     <div className="overflow-hidden rounded-sm border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-      <button
-        type="button"
-        onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm/6 font-medium text-gray-900 hover:bg-gray-50 dark:text-gray-100 dark:hover:bg-gray-700/50"
-      >
-        <ChevronRight className={clsx('size-4 text-gray-500 transition-transform', expanded && 'rotate-90')} />
+      <div className="flex items-center gap-2 border-b border-gray-200 px-3 py-2 text-sm/6 font-medium text-gray-900 dark:border-gray-700 dark:text-gray-100">
         <BarChart3 className="size-4 text-gray-400 dark:text-gray-500" />
         Dimension breakdown
         <span className="text-xs/5 text-gray-500 dark:text-gray-400">
-          ({dimensions.length} dimension{dimensions.length === 1 ? '' : 's'})
+          ({dimensions.length} dimension{dimensions.length === 1 ? '' : 's'}
+          {activeTerms.length > 0 && `, ${activeTerms.length} filter${activeTerms.length === 1 ? '' : 's'}`})
         </span>
-      </button>
-      {expanded && (
-        <div className="flex flex-col gap-3 border-t border-gray-200 p-3 dark:border-gray-700">
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-1 rounded-xs bg-gray-100 p-0.5 dark:bg-gray-700">
-              {(['bars', 'table'] as const).map((v) => (
+      </div>
+      <div className="flex flex-col gap-3 p-3">
+          <div className="flex flex-wrap items-center gap-1.5 text-xs/5">
+            <span className="text-[10px]/4 font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+              Filters
+            </span>
+            {activeTerms.length === 0 ? (
+              <span className="text-gray-500 dark:text-gray-400">none — showing all tests</span>
+            ) : (
+              activeTerms.map((term) => (
                 <button
-                  key={v}
+                  key={term}
                   type="button"
-                  onClick={() => setView(v)}
-                  className={clsx(
-                    'flex items-center gap-1.5 rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
-                    view === v
-                      ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
-                      : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
-                  )}
+                  onClick={() => onToggle(term)}
+                  title={`Click to remove ${term}`}
+                  className="inline-flex items-center gap-1 rounded-xs bg-blue-500 px-1.5 py-0 font-mono text-[11px]/5 text-white ring-1 ring-inset ring-blue-500 hover:bg-blue-600"
                 >
-                  {v === 'bars' ? <BarChart3 className="size-3.5" /> : <Table2 className="size-3.5" />}
-                  {v === 'bars' ? 'Bars' : 'Table'}
+                  <span>{term}</span>
+                  <X className="size-3" />
                 </button>
-              ))}
+              ))
+            )}
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1 rounded-xs bg-gray-100 p-0.5 dark:bg-gray-700">
+                {(['bars', 'table'] as const).map((v) => (
+                  <button
+                    key={v}
+                    type="button"
+                    onClick={() => setView(v)}
+                    className={clsx(
+                      'flex items-center gap-1.5 rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
+                      view === v
+                        ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
+                        : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
+                    )}
+                  >
+                    {v === 'bars' ? <BarChart3 className="size-3.5" /> : <Table2 className="size-3.5" />}
+                    {v === 'bars' ? 'Bars' : 'Table'}
+                  </button>
+                ))}
+              </div>
+              {view === 'bars' && (
+                <button
+                  type="button"
+                  onClick={() => setBarsDir(barsDir === 'desc' ? 'asc' : 'desc')}
+                  title={barsDir === 'desc' ? 'Click to sort slowest first' : 'Click to sort fastest first'}
+                  className="flex items-center gap-1 rounded-xs border border-gray-300 bg-white px-2 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:hover:text-gray-100"
+                >
+                  {barsDir === 'desc'
+                    ? <><ChevronDown className="size-3.5" /> Fastest first</>
+                    : <><ChevronUp className="size-3.5" /> Slowest first</>}
+                </button>
+              )}
             </div>
             {view === 'table' && tableDim && (
               <div className="flex items-center gap-2 text-xs/5 text-gray-500 dark:text-gray-400">
@@ -236,54 +276,83 @@ export function DimensionInsights({
             </div>
           )}
 
-          {view === 'bars' && dimensions.map(({ def, values }) => {
-            const max = Math.max(...values.map((v) => v.mean))
-            const sorted = [...values].sort((a, b) => b.mean - a.mean)
-            return (
-              <div key={def.key} className="flex flex-col gap-1">
-                <div className="text-[10px]/4 font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
-                  {def.label}
-                  <span className="ml-1 lowercase text-gray-300 dark:text-gray-600">({sorted.length})</span>
-                </div>
-                <div className="flex flex-col gap-0.5">
-                  {sorted.map((v) => {
-                    const term = `${def.emitKey}=${v.value}`
-                    const active = searchQueryContains(query, term)
-                    const widthPct = max > 0 ? (v.mean / max) * 100 : 0
-                    return (
-                      <button
-                        key={v.value}
-                        type="button"
-                        onClick={() => onToggle(term)}
-                        title={`${def.label}: ${v.value} — mean ${v.mean.toFixed(1)} MGas/s, ${v.count} test${v.count === 1 ? '' : 's'}`}
-                        className={clsx(
-                          'group grid grid-cols-[minmax(7rem,12rem)_1fr_auto] items-center gap-2 rounded-xs px-1 py-0.5 text-left text-xs/5 transition-colors',
-                          active ? 'bg-blue-50 text-blue-900 dark:bg-blue-950/40 dark:text-blue-200' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
-                        )}
-                      >
-                        <span className={clsx('truncate font-mono', active ? '' : 'text-gray-700 dark:text-gray-200')}>
-                          {v.value}
-                        </span>
-                        <span className="relative h-3 w-full rounded-xs bg-gray-100 dark:bg-gray-700">
-                          <span
-                            className={clsx(
-                              'absolute inset-y-0 left-0 rounded-xs',
-                              active ? 'bg-blue-500' : 'bg-gray-400/70 dark:bg-gray-500/70',
-                            )}
-                            style={{ width: `${widthPct}%` }}
-                          />
-                        </span>
-                        <span className="flex shrink-0 items-baseline gap-1.5 font-mono tabular-nums text-gray-600 dark:text-gray-300">
-                          <span>{v.mean.toFixed(1)}</span>
-                          <span className="text-[10px]/4 text-gray-400 dark:text-gray-500">×{v.count}</span>
-                        </span>
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
+          {view === 'bars' && (() => {
+            // Force any dimension with an active filter into the preview so
+            // users always see the dim they're filtering by.
+            const previewDims = dimensions.filter(({ def, values }) =>
+              BARS_PREVIEW_KEYS.has(def.key) ||
+              values.some((v) => searchQueryContains(query, `${def.emitKey}=${v.value}`)),
             )
-          })}
+            const hiddenDims = dimensions.filter((d) => !previewDims.includes(d))
+            const visibleDims = showAllBars ? dimensions : previewDims
+
+            const renderDim = ({ def, values }: DimensionAgg) => {
+              const max = Math.max(...values.map((v) => v.mean))
+              const sign = barsDir === 'desc' ? -1 : 1
+              const sorted = [...values].sort((a, b) => sign * (a.mean - b.mean))
+              return (
+                <div key={def.key} className="flex flex-col gap-1">
+                  <div className="text-[10px]/4 font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    {def.label}
+                    <span className="ml-1 lowercase text-gray-300 dark:text-gray-600">({sorted.length})</span>
+                  </div>
+                  <div className="flex flex-col gap-0.5">
+                    {sorted.map((v) => {
+                      const term = `${def.emitKey}=${v.value}`
+                      const active = searchQueryContains(query, term)
+                      const widthPct = max > 0 ? (v.mean / max) * 100 : 0
+                      return (
+                        <button
+                          key={v.value}
+                          type="button"
+                          onClick={() => onToggle(term)}
+                          title={`${def.label}: ${v.value} — mean ${v.mean.toFixed(1)} MGas/s, ${v.count} test${v.count === 1 ? '' : 's'}`}
+                          className={clsx(
+                            'group grid grid-cols-[minmax(7rem,12rem)_1fr_auto] items-center gap-2 rounded-xs px-1 py-0.5 text-left text-xs/5 transition-colors',
+                            active ? 'bg-blue-50 text-blue-900 dark:bg-blue-950/40 dark:text-blue-200' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                          )}
+                        >
+                          <span className={clsx('truncate font-mono', active ? '' : 'text-gray-700 dark:text-gray-200')}>
+                            {v.value}
+                          </span>
+                          <span className="relative h-3 w-full rounded-xs bg-gray-100 dark:bg-gray-700">
+                            <span
+                              className={clsx(
+                                'absolute inset-y-0 left-0 rounded-xs',
+                                active ? 'bg-blue-500' : 'bg-gray-400/70 dark:bg-gray-500/70',
+                              )}
+                              style={{ width: `${widthPct}%` }}
+                            />
+                          </span>
+                          <span className="flex shrink-0 items-baseline gap-1.5 font-mono tabular-nums text-gray-600 dark:text-gray-300">
+                            <span>{v.mean.toFixed(1)}</span>
+                            <span className="text-[10px]/4 text-gray-400 dark:text-gray-500">×{v.count}</span>
+                          </span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
+              )
+            }
+
+            return (
+              <>
+                {visibleDims.map(renderDim)}
+                {hiddenDims.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllBars(!showAllBars)}
+                    className="flex w-fit items-center gap-1 rounded-xs px-1.5 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
+                  >
+                    {showAllBars
+                      ? <><ChevronUp className="size-3.5" /> Show fewer dimensions</>
+                      : <><ChevronDown className="size-3.5" /> Show more dimensions ({hiddenDims.length})</>}
+                  </button>
+                )}
+              </>
+            )
+          })()}
 
           {view === 'table' && tableDim && (
             <div className="overflow-x-auto">
@@ -326,7 +395,6 @@ export function DimensionInsights({
             </div>
           )}
         </div>
-      )}
     </div>
   )
 }

--- a/ui/src/components/run-detail/DimensionInsights.tsx
+++ b/ui/src/components/run-detail/DimensionInsights.tsx
@@ -6,6 +6,7 @@ import { parseEESTName } from '@/utils/eestName'
 import { searchQueryContains, splitQuery, testNameMatches } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES, getAggregatedStats } from '@/pages/RunDetailPage'
 import { percentile } from './block-logs-dashboard/utils/statistics'
+import { DEFAULT_THRESHOLD, MAX_THRESHOLD, MIN_THRESHOLD, getColorByThreshold } from '@/utils/perfThreshold'
 
 interface DimensionInsightsProps {
   tests: Record<string, TestEntry>
@@ -16,6 +17,10 @@ interface DimensionInsightsProps {
   onToggle: (term: string) => void
   /** Current search query, used to highlight bars whose value is pinned. */
   query: string
+  /** Slow-threshold MGas/s (shared with the Performance Heatmap). */
+  threshold?: number
+  /** Update the shared slow threshold. */
+  onThresholdChange?: (threshold: number) => void
 }
 
 type DimensionDef = { key: string; label: string; emitKey: string }
@@ -74,6 +79,8 @@ export function DimensionInsights({
   statusFilter = 'all',
   onToggle,
   query,
+  threshold = DEFAULT_THRESHOLD,
+  onThresholdChange,
 }: DimensionInsightsProps) {
   const [view, setView] = useState<'bars' | 'table'>('bars')
   const [barsDir, setBarsDir] = useState<'desc' | 'asc'>('asc')
@@ -196,6 +203,37 @@ export function DimensionInsights({
           ({dimensions.length} dimension{dimensions.length === 1 ? '' : 's'}
           {activeTerms.length > 0 && `, ${activeTerms.length} filter${activeTerms.length === 1 ? '' : 's'}`})
         </span>
+        {onThresholdChange && (
+          <div className="ml-auto flex items-center gap-2 text-xs/5 font-normal text-gray-500 dark:text-gray-400">
+            <span>Slow threshold:</span>
+            <input
+              type="range"
+              min={MIN_THRESHOLD}
+              max={MAX_THRESHOLD}
+              value={threshold}
+              onChange={(e) => onThresholdChange(Number(e.target.value))}
+              className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-gray-200 accent-blue-500 dark:bg-gray-700"
+            />
+            <input
+              type="number"
+              min={MIN_THRESHOLD}
+              max={MAX_THRESHOLD}
+              value={threshold}
+              onChange={(e) => onThresholdChange(Number(e.target.value))}
+              className="w-16 rounded-sm border border-gray-300 bg-white px-1.5 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+            />
+            <span>MGas/s</span>
+            {threshold !== DEFAULT_THRESHOLD && (
+              <button
+                type="button"
+                onClick={() => onThresholdChange(DEFAULT_THRESHOLD)}
+                className="text-xs/5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                Reset
+              </button>
+            )}
+          </div>
+        )}
       </div>
       <div className="flex flex-col gap-3 p-3">
           <div className="flex flex-wrap items-center gap-1.5 text-xs/5">
@@ -317,11 +355,13 @@ export function DimensionInsights({
                           </span>
                           <span className="relative h-3 w-full rounded-xs bg-gray-100 dark:bg-gray-700">
                             <span
-                              className={clsx(
-                                'absolute inset-y-0 left-0 rounded-xs',
-                                active ? 'bg-blue-500' : 'bg-gray-400/70 dark:bg-gray-500/70',
-                              )}
-                              style={{ width: `${widthPct}%` }}
+                              className="absolute inset-y-0 left-0 rounded-xs"
+                              style={{
+                                width: `${widthPct}%`,
+                                backgroundColor: getColorByThreshold(v.mean, threshold),
+                                outline: active ? '1.5px solid #3b82f6' : 'none',
+                                outlineOffset: '0px',
+                              }}
                             />
                           </span>
                           <span className="flex shrink-0 items-baseline gap-1.5 font-mono tabular-nums text-gray-600 dark:text-gray-300">

--- a/ui/src/components/run-detail/DimensionInsights.tsx
+++ b/ui/src/components/run-detail/DimensionInsights.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import { BarChart3, ChevronDown, ChevronUp, Table2, X } from 'lucide-react'
 import type { TestEntry } from '@/api/types'
 import { parseEESTName } from '@/utils/eestName'
-import { searchQueryContains, splitQuery, testNameMatches } from '@/utils/eestNameFilter'
+import { queryTermDimension, searchQueryContains, splitQuery, testNameMatches } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES, getAggregatedStats } from '@/pages/RunDetailPage'
 import { percentile } from './block-logs-dashboard/utils/statistics'
 import { DEFAULT_THRESHOLD, getColorByThreshold } from '@/utils/perfThreshold'
@@ -215,7 +215,7 @@ export function DimensionInsights({
                   type="button"
                   onClick={() => onToggle(term)}
                   title={`Click to remove ${term}`}
-                  className="inline-flex items-center gap-1 rounded-xs bg-blue-500 px-1.5 py-0 font-mono text-[11px]/5 text-white ring-1 ring-inset ring-blue-500 hover:bg-blue-600"
+                  className="inline-flex cursor-pointer items-center gap-1 rounded-xs bg-blue-500 px-1.5 py-0 font-mono text-[11px]/5 text-white ring-1 ring-inset ring-blue-500 hover:bg-blue-600"
                 >
                   <span>{term}</span>
                   <X className="size-3" />
@@ -232,7 +232,7 @@ export function DimensionInsights({
                     type="button"
                     onClick={() => setView(v)}
                     className={clsx(
-                      'flex items-center gap-1.5 rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
+                      'flex cursor-pointer items-center gap-1.5 rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
                       view === v
                         ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
                         : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
@@ -248,7 +248,7 @@ export function DimensionInsights({
                   type="button"
                   onClick={() => setBarsDir(barsDir === 'desc' ? 'asc' : 'desc')}
                   title={barsDir === 'desc' ? 'Click to sort slowest first' : 'Click to sort fastest first'}
-                  className="flex items-center gap-1 rounded-xs border border-gray-300 bg-white px-2 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:hover:text-gray-100"
+                  className="flex cursor-pointer items-center gap-1 rounded-xs border border-gray-300 bg-white px-2 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:hover:text-gray-100"
                 >
                   {barsDir === 'desc'
                     ? <><ChevronDown className="size-3.5" /> Fastest first</>
@@ -283,8 +283,13 @@ export function DimensionInsights({
           {view === 'bars' && (() => {
             // Force any dimension with an active filter into the preview so
             // users always see the dim they're filtering by.
+            // Once a File filter is active, Test (fn) becomes the natural
+            // next drill-down — surface it in the preview alongside File and
+            // Gas without requiring "Show more dimensions".
+            const hasFileFilter = activeTerms.some((t) => queryTermDimension(t) === 'file')
             const previewDims = dimensions.filter(({ def, values }) =>
               BARS_PREVIEW_KEYS.has(def.key) ||
+              (hasFileFilter && def.key === 'fn') ||
               values.some((v) => searchQueryContains(query, `${def.emitKey}=${v.value}`)),
             )
             const hiddenDims = dimensions.filter((d) => !previewDims.includes(d))
@@ -312,7 +317,7 @@ export function DimensionInsights({
                           onClick={() => onToggle(term)}
                           title={`${def.label}: ${v.value} — mean ${v.mean.toFixed(1)} MGas/s, ${v.count} test${v.count === 1 ? '' : 's'}`}
                           className={clsx(
-                            'group grid grid-cols-[minmax(7rem,12rem)_1fr_auto] items-center gap-2 rounded-xs px-1 py-0.5 text-left text-xs/5 transition-colors',
+                            'group grid cursor-pointer grid-cols-[minmax(7rem,12rem)_1fr_auto] items-center gap-2 rounded-xs px-1 py-0.5 text-left text-xs/5 transition-colors',
                             active ? 'bg-blue-50 text-blue-900 dark:bg-blue-950/40 dark:text-blue-200' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
                           )}
                         >
@@ -349,7 +354,7 @@ export function DimensionInsights({
                   <button
                     type="button"
                     onClick={() => setShowAllBars(!showAllBars)}
-                    className="flex w-fit items-center gap-1 rounded-xs px-1.5 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
+                    className="flex w-fit cursor-pointer items-center gap-1 rounded-xs px-1.5 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
                   >
                     {showAllBars
                       ? <><ChevronUp className="size-3.5" /> Show fewer dimensions</>

--- a/ui/src/components/run-detail/DimensionInsights.tsx
+++ b/ui/src/components/run-detail/DimensionInsights.tsx
@@ -1,0 +1,362 @@
+import { useMemo, useState } from 'react'
+import clsx from 'clsx'
+import { BarChart3, ChevronRight, ChevronDown, ChevronUp, Table2 } from 'lucide-react'
+import type { TestEntry } from '@/api/types'
+import { parseEESTName } from '@/utils/eestName'
+import { searchQueryContains, testNameMatches } from '@/utils/eestNameFilter'
+import { type StepTypeOption, ALL_STEP_TYPES, getAggregatedStats } from '@/pages/RunDetailPage'
+import { percentile } from './block-logs-dashboard/utils/statistics'
+
+interface DimensionInsightsProps {
+  tests: Record<string, TestEntry>
+  stepFilter: StepTypeOption[]
+  searchQuery?: string
+  statusFilter?: 'all' | 'passed' | 'failed'
+  /** Toggle a `key=value` term in the page-level search. */
+  onToggle: (term: string) => void
+  /** Current search query, used to highlight bars whose value is pinned. */
+  query: string
+}
+
+type DimensionDef = { key: string; label: string; emitKey: string }
+
+const PRIMARY_DIMENSIONS: DimensionDef[] = [
+  { key: 'file', label: 'File', emitKey: 'file' },
+  { key: 'fn', label: 'Test', emitKey: 'fn' },
+  { key: 'benchmark', label: 'Gas', emitKey: 'gas' },
+  { key: 'opcode', label: 'Opcode', emitKey: 'opcode' },
+  { key: 'fork', label: 'Fork', emitKey: 'fork' },
+]
+
+const TRAILING_DIMENSIONS: DimensionDef[] = [
+  { key: 'label', label: 'Label', emitKey: 'label' },
+]
+
+interface ValueAgg {
+  value: string
+  count: number
+  mean: number
+  p50: number
+  p95: number
+  p99: number
+}
+
+interface DimensionAgg {
+  def: DimensionDef
+  values: ValueAgg[]
+}
+
+function calculateMGasPerSec(gas: number, timeNs: number): number | undefined {
+  if (timeNs <= 0 || gas <= 0) return undefined
+  return (gas * 1000) / timeNs
+}
+
+function compareNumeric(a: string, b: string): number {
+  const na = parseInt(a, 10)
+  const nb = parseInt(b, 10)
+  const aIsNum = !Number.isNaN(na) && /^\d/.test(a)
+  const bIsNum = !Number.isNaN(nb) && /^\d/.test(b)
+  if (aIsNum && bIsNum) return na - nb
+  return a.localeCompare(b)
+}
+
+type SortColumn = 'value' | 'count' | 'mean' | 'p50' | 'p95' | 'p99'
+
+export function DimensionInsights({
+  tests,
+  stepFilter,
+  searchQuery,
+  statusFilter = 'all',
+  onToggle,
+  query,
+}: DimensionInsightsProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [view, setView] = useState<'bars' | 'table'>('bars')
+  const [groupByKey, setGroupByKey] = useState<string | null>(null)
+  const [tableSort, setTableSort] = useState<{ col: SortColumn; dir: 'asc' | 'desc' }>({ col: 'mean', dir: 'desc' })
+
+  const dimensions = useMemo<DimensionAgg[]>(() => {
+    // 1. Compute mgas per test, applying the same filter as the heatmap.
+    const samples: { name: string; mgas: number }[] = []
+    for (const [name, entry] of Object.entries(tests)) {
+      if (searchQuery && !testNameMatches(name, searchQuery)) continue
+      const stats = getAggregatedStats(entry, stepFilter)
+      if (!stats) continue
+      if (statusFilter !== 'all') {
+        const all = getAggregatedStats(entry, ALL_STEP_TYPES)
+        if (!all) continue
+        if (statusFilter === 'passed' && all.fail !== 0) continue
+        if (statusFilter === 'failed' && all.fail === 0) continue
+      }
+      const mgas = calculateMGasPerSec(stats.gas_used_total, stats.gas_used_time_total)
+      if (mgas === undefined) continue
+      samples.push({ name, mgas })
+    }
+
+    // 2. Bucket samples by (dimension, value).
+    const byDim = new Map<string, Map<string, number[]>>()
+    const bump = (dim: string, value: string | undefined, mgas: number) => {
+      if (!value) return
+      let inner = byDim.get(dim)
+      if (!inner) {
+        inner = new Map()
+        byDim.set(dim, inner)
+      }
+      const arr = inner.get(value) ?? []
+      arr.push(mgas)
+      inner.set(value, arr)
+    }
+    for (const s of samples) {
+      const p = parseEESTName(s.name)
+      if (!p.isEEST) continue
+      bump('file', p.file, s.mgas)
+      bump('fn', p.fn, s.mgas)
+      bump('benchmark', p.benchmark, s.mgas)
+      bump('opcode', p.opcode, s.mgas)
+      bump('fork', p.fork, s.mgas)
+      for (const { key, value } of p.params) bump(key, value, s.mgas)
+      for (const label of p.labels) bump('label', label, s.mgas)
+    }
+
+    // 3. Order dimensions: canonical primary + discovered params (alpha) + trailing.
+    const known = new Set([
+      ...PRIMARY_DIMENSIONS.map((d) => d.key),
+      ...TRAILING_DIMENSIONS.map((d) => d.key),
+    ])
+    const paramKeys = [...byDim.keys()].filter((k) => !known.has(k)).sort()
+    const ordered: DimensionDef[] = [
+      ...PRIMARY_DIMENSIONS,
+      ...paramKeys.map((k) => ({ key: k, label: k, emitKey: k })),
+      ...TRAILING_DIMENSIONS,
+    ].filter((d) => byDim.has(d.key))
+
+    // 4. Roll up per-value stats. Skip dimensions with only one value — no
+    //    comparison to make.
+    const result: DimensionAgg[] = []
+    for (const def of ordered) {
+      const inner = byDim.get(def.key)!
+      if (inner.size < 2) continue
+
+      const values: ValueAgg[] = []
+      for (const [value, arr] of inner) {
+        const sorted = [...arr].sort((a, b) => a - b)
+        const mean = sorted.reduce((s, v) => s + v, 0) / sorted.length
+        values.push({
+          value,
+          count: sorted.length,
+          mean,
+          p50: percentile(sorted, 50),
+          p95: percentile(sorted, 95),
+          p99: percentile(sorted, 99),
+        })
+      }
+      result.push({ def, values })
+    }
+
+    return result
+  }, [tests, stepFilter, searchQuery, statusFilter])
+
+  // Pick a default dimension for the table view once we have data.
+  const groupByDim = groupByKey ?? dimensions[0]?.def.key ?? null
+  const tableDim = dimensions.find((d) => d.def.key === groupByDim) ?? dimensions[0]
+
+  const sortedTableValues = useMemo(() => {
+    if (!tableDim) return []
+    const { col, dir } = tableSort
+    const sign = dir === 'asc' ? 1 : -1
+    return [...tableDim.values].sort((a, b) => {
+      if (col === 'value') return sign * compareNumeric(a.value, b.value)
+      return sign * (a[col] - b[col])
+    })
+  }, [tableDim, tableSort])
+
+  const handleSort = (col: SortColumn) => {
+    setTableSort((prev) => {
+      if (prev.col === col) return { col, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+      return { col, dir: col === 'value' ? 'asc' : 'desc' }
+    })
+  }
+
+  return (
+    <div className="overflow-hidden rounded-sm border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm/6 font-medium text-gray-900 hover:bg-gray-50 dark:text-gray-100 dark:hover:bg-gray-700/50"
+      >
+        <ChevronRight className={clsx('size-4 text-gray-500 transition-transform', expanded && 'rotate-90')} />
+        <BarChart3 className="size-4 text-gray-400 dark:text-gray-500" />
+        Dimension breakdown
+        <span className="text-xs/5 text-gray-500 dark:text-gray-400">
+          ({dimensions.length} dimension{dimensions.length === 1 ? '' : 's'})
+        </span>
+      </button>
+      {expanded && (
+        <div className="flex flex-col gap-3 border-t border-gray-200 p-3 dark:border-gray-700">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1 rounded-xs bg-gray-100 p-0.5 dark:bg-gray-700">
+              {(['bars', 'table'] as const).map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => setView(v)}
+                  className={clsx(
+                    'flex items-center gap-1.5 rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
+                    view === v
+                      ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
+                      : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
+                  )}
+                >
+                  {v === 'bars' ? <BarChart3 className="size-3.5" /> : <Table2 className="size-3.5" />}
+                  {v === 'bars' ? 'Bars' : 'Table'}
+                </button>
+              ))}
+            </div>
+            {view === 'table' && tableDim && (
+              <div className="flex items-center gap-2 text-xs/5 text-gray-500 dark:text-gray-400">
+                <span>Group by:</span>
+                <select
+                  value={tableDim.def.key}
+                  onChange={(e) => setGroupByKey(e.target.value)}
+                  className="rounded-xs border border-gray-300 bg-white px-2 py-0.5 text-xs/5 text-gray-700 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+                >
+                  {dimensions.map((d) => (
+                    <option key={d.def.key} value={d.def.key}>
+                      {d.def.label} ({d.values.length})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+
+          {dimensions.length === 0 && (
+            <div className="text-xs/5 text-gray-500 dark:text-gray-400">
+              Not enough data — at least one dimension with two distinct values is required.
+            </div>
+          )}
+
+          {view === 'bars' && dimensions.map(({ def, values }) => {
+            const max = Math.max(...values.map((v) => v.mean))
+            const sorted = [...values].sort((a, b) => b.mean - a.mean)
+            return (
+              <div key={def.key} className="flex flex-col gap-1">
+                <div className="text-[10px]/4 font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  {def.label}
+                  <span className="ml-1 lowercase text-gray-300 dark:text-gray-600">({sorted.length})</span>
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  {sorted.map((v) => {
+                    const term = `${def.emitKey}=${v.value}`
+                    const active = searchQueryContains(query, term)
+                    const widthPct = max > 0 ? (v.mean / max) * 100 : 0
+                    return (
+                      <button
+                        key={v.value}
+                        type="button"
+                        onClick={() => onToggle(term)}
+                        title={`${def.label}: ${v.value} — mean ${v.mean.toFixed(1)} MGas/s, ${v.count} test${v.count === 1 ? '' : 's'}`}
+                        className={clsx(
+                          'group grid grid-cols-[minmax(7rem,12rem)_1fr_auto] items-center gap-2 rounded-xs px-1 py-0.5 text-left text-xs/5 transition-colors',
+                          active ? 'bg-blue-50 text-blue-900 dark:bg-blue-950/40 dark:text-blue-200' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                        )}
+                      >
+                        <span className={clsx('truncate font-mono', active ? '' : 'text-gray-700 dark:text-gray-200')}>
+                          {v.value}
+                        </span>
+                        <span className="relative h-3 w-full rounded-xs bg-gray-100 dark:bg-gray-700">
+                          <span
+                            className={clsx(
+                              'absolute inset-y-0 left-0 rounded-xs',
+                              active ? 'bg-blue-500' : 'bg-gray-400/70 dark:bg-gray-500/70',
+                            )}
+                            style={{ width: `${widthPct}%` }}
+                          />
+                        </span>
+                        <span className="flex shrink-0 items-baseline gap-1.5 font-mono tabular-nums text-gray-600 dark:text-gray-300">
+                          <span>{v.mean.toFixed(1)}</span>
+                          <span className="text-[10px]/4 text-gray-400 dark:text-gray-500">×{v.count}</span>
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            )
+          })}
+
+          {view === 'table' && tableDim && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs/5">
+                <thead className="bg-gray-50 dark:bg-gray-900">
+                  <tr>
+                    <SortableTh label={tableDim.def.label} col="value" sort={tableSort} onSort={handleSort} align="left" />
+                    <SortableTh label="Count" col="count" sort={tableSort} onSort={handleSort} align="right" />
+                    <SortableTh label="Mean" col="mean" sort={tableSort} onSort={handleSort} align="right" />
+                    <SortableTh label="P50" col="p50" sort={tableSort} onSort={handleSort} align="right" />
+                    <SortableTh label="P95" col="p95" sort={tableSort} onSort={handleSort} align="right" />
+                    <SortableTh label="P99" col="p99" sort={tableSort} onSort={handleSort} align="right" />
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {sortedTableValues.map((v) => {
+                    const term = `${tableDim.def.emitKey}=${v.value}`
+                    const active = searchQueryContains(query, term)
+                    return (
+                      <tr
+                        key={v.value}
+                        onClick={() => onToggle(term)}
+                        className={clsx(
+                          'cursor-pointer transition-colors',
+                          active ? 'bg-blue-50 dark:bg-blue-950/40' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                        )}
+                        title={active ? `Click to remove ${term}` : `Click to filter by ${term}`}
+                      >
+                        <td className="px-2 py-1 font-mono text-gray-700 dark:text-gray-200">{v.value}</td>
+                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{v.count}</td>
+                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-700 dark:text-gray-200">{v.mean.toFixed(1)}</td>
+                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{v.p50.toFixed(1)}</td>
+                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{v.p95.toFixed(1)}</td>
+                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{v.p99.toFixed(1)}</td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SortableTh({
+  label,
+  col,
+  sort,
+  onSort,
+  align,
+}: {
+  label: string
+  col: SortColumn
+  sort: { col: SortColumn; dir: 'asc' | 'desc' }
+  onSort: (col: SortColumn) => void
+  align: 'left' | 'right'
+}) {
+  const active = sort.col === col
+  return (
+    <th
+      className={clsx(
+        'cursor-pointer px-2 py-1.5 text-[10px]/4 font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+        align === 'left' ? 'text-left' : 'text-right',
+      )}
+      onClick={() => onSort(col)}
+    >
+      <span className="inline-flex items-center gap-0.5">
+        {label}
+        {active && (sort.dir === 'asc' ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />)}
+      </span>
+    </th>
+  )
+}

--- a/ui/src/components/run-detail/DimensionInsights.tsx
+++ b/ui/src/components/run-detail/DimensionInsights.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import { BarChart3, ChevronDown, ChevronUp, Table2, X } from 'lucide-react'
 import type { TestEntry } from '@/api/types'
 import { parseEESTName } from '@/utils/eestName'
-import { queryTermDimension, searchQueryContains, splitQuery, testNameMatches } from '@/utils/eestNameFilter'
+import { compileQuery, queryTermDimension, searchQueryContains, splitQuery } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES, getAggregatedStats } from '@/pages/RunDetailPage'
 import { percentile } from './block-logs-dashboard/utils/statistics'
 import { DEFAULT_THRESHOLD, getColorByThreshold } from '@/utils/perfThreshold'
@@ -96,9 +96,10 @@ export function DimensionInsights({
 
   const dimensions = useMemo<DimensionAgg[]>(() => {
     // 1. Compute mgas per test, applying the same filter as the heatmap.
+    const matchesQuery = searchQuery ? compileQuery(searchQuery) : null
     const samples: { name: string; mgas: number }[] = []
     for (const [name, entry] of Object.entries(tests)) {
-      if (searchQuery && !testNameMatches(name, searchQuery)) continue
+      if (matchesQuery && !matchesQuery(name)) continue
       const stats = getAggregatedStats(entry, stepFilter)
       if (!stats) continue
       if (statusFilter !== 'all') {

--- a/ui/src/components/run-detail/DimensionInsights.tsx
+++ b/ui/src/components/run-detail/DimensionInsights.tsx
@@ -6,7 +6,7 @@ import { parseEESTName } from '@/utils/eestName'
 import { searchQueryContains, splitQuery, testNameMatches } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES, getAggregatedStats } from '@/pages/RunDetailPage'
 import { percentile } from './block-logs-dashboard/utils/statistics'
-import { DEFAULT_THRESHOLD, MAX_THRESHOLD, MIN_THRESHOLD, getColorByThreshold } from '@/utils/perfThreshold'
+import { DEFAULT_THRESHOLD, getColorByThreshold } from '@/utils/perfThreshold'
 
 interface DimensionInsightsProps {
   tests: Record<string, TestEntry>
@@ -19,8 +19,6 @@ interface DimensionInsightsProps {
   query: string
   /** Slow-threshold MGas/s (shared with the Performance Heatmap). */
   threshold?: number
-  /** Update the shared slow threshold. */
-  onThresholdChange?: (threshold: number) => void
 }
 
 type DimensionDef = { key: string; label: string; emitKey: string }
@@ -80,7 +78,6 @@ export function DimensionInsights({
   onToggle,
   query,
   threshold = DEFAULT_THRESHOLD,
-  onThresholdChange,
 }: DimensionInsightsProps) {
   const [view, setView] = useState<'bars' | 'table'>('bars')
   const [barsDir, setBarsDir] = useState<'desc' | 'asc'>('asc')
@@ -203,37 +200,6 @@ export function DimensionInsights({
           ({dimensions.length} dimension{dimensions.length === 1 ? '' : 's'}
           {activeTerms.length > 0 && `, ${activeTerms.length} filter${activeTerms.length === 1 ? '' : 's'}`})
         </span>
-        {onThresholdChange && (
-          <div className="ml-auto flex items-center gap-2 text-xs/5 font-normal text-gray-500 dark:text-gray-400">
-            <span>Slow threshold:</span>
-            <input
-              type="range"
-              min={MIN_THRESHOLD}
-              max={MAX_THRESHOLD}
-              value={threshold}
-              onChange={(e) => onThresholdChange(Number(e.target.value))}
-              className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-gray-200 accent-blue-500 dark:bg-gray-700"
-            />
-            <input
-              type="number"
-              min={MIN_THRESHOLD}
-              max={MAX_THRESHOLD}
-              value={threshold}
-              onChange={(e) => onThresholdChange(Number(e.target.value))}
-              className="w-16 rounded-sm border border-gray-300 bg-white px-1.5 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-            />
-            <span>MGas/s</span>
-            {threshold !== DEFAULT_THRESHOLD && (
-              <button
-                type="button"
-                onClick={() => onThresholdChange(DEFAULT_THRESHOLD)}
-                className="text-xs/5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-              >
-                Reset
-              </button>
-            )}
-          </div>
-        )}
       </div>
       <div className="flex flex-col gap-3 p-3">
           <div className="flex flex-wrap items-center gap-1.5 text-xs/5">

--- a/ui/src/components/run-detail/DimensionInsights.tsx
+++ b/ui/src/components/run-detail/DimensionInsights.tsx
@@ -19,6 +19,12 @@ interface DimensionInsightsProps {
   query: string
   /** Slow-threshold MGas/s (shared with the Performance Heatmap). */
   threshold?: number
+  /**
+   * Open the test detail modal for a specific test. When provided and the
+   * user clicks a not-yet-active value with only one matching test, the
+   * modal opens for that test instead of adding a redundant filter.
+   */
+  onTestClick?: (testName: string) => void
 }
 
 type DimensionDef = { key: string; label: string; emitKey: string }
@@ -47,6 +53,8 @@ interface ValueAgg {
   p50: number
   p95: number
   p99: number
+  /** When count === 1, the single test's name. Used for "click to open". */
+  singleTestName?: string
 }
 
 interface DimensionAgg {
@@ -78,6 +86,7 @@ export function DimensionInsights({
   onToggle,
   query,
   threshold = DEFAULT_THRESHOLD,
+  onTestClick,
 }: DimensionInsightsProps) {
   const [view, setView] = useState<'bars' | 'table'>('bars')
   const [barsDir, setBarsDir] = useState<'desc' | 'asc'>('asc')
@@ -103,29 +112,36 @@ export function DimensionInsights({
       samples.push({ name, mgas })
     }
 
-    // 2. Bucket samples by (dimension, value).
-    const byDim = new Map<string, Map<string, number[]>>()
-    const bump = (dim: string, value: string | undefined, mgas: number) => {
+    // 2. Bucket samples by (dimension, value), keeping both the mgas array
+    //    and the source test names so a 1-test bucket can deep-link to the
+    //    test detail modal on click.
+    type Bucket = { mgas: number[]; names: string[] }
+    const byDim = new Map<string, Map<string, Bucket>>()
+    const bump = (dim: string, value: string | undefined, name: string, mgas: number) => {
       if (!value) return
       let inner = byDim.get(dim)
       if (!inner) {
         inner = new Map()
         byDim.set(dim, inner)
       }
-      const arr = inner.get(value) ?? []
-      arr.push(mgas)
-      inner.set(value, arr)
+      let bucket = inner.get(value)
+      if (!bucket) {
+        bucket = { mgas: [], names: [] }
+        inner.set(value, bucket)
+      }
+      bucket.mgas.push(mgas)
+      bucket.names.push(name)
     }
     for (const s of samples) {
       const p = parseEESTName(s.name)
       if (!p.isEEST) continue
-      bump('file', p.file, s.mgas)
-      bump('fn', p.fn, s.mgas)
-      bump('benchmark', p.benchmark, s.mgas)
-      bump('opcode', p.opcode, s.mgas)
-      bump('fork', p.fork, s.mgas)
-      for (const { key, value } of p.params) bump(key, value, s.mgas)
-      for (const label of p.labels) bump('label', label, s.mgas)
+      bump('file', p.file, s.name, s.mgas)
+      bump('fn', p.fn, s.name, s.mgas)
+      bump('benchmark', p.benchmark, s.name, s.mgas)
+      bump('opcode', p.opcode, s.name, s.mgas)
+      bump('fork', p.fork, s.name, s.mgas)
+      for (const { key, value } of p.params) bump(key, value, s.name, s.mgas)
+      for (const label of p.labels) bump('label', label, s.name, s.mgas)
     }
 
     // 3. Order dimensions: canonical primary + discovered params (alpha) + trailing.
@@ -148,8 +164,8 @@ export function DimensionInsights({
       if (inner.size < 2) continue
 
       const values: ValueAgg[] = []
-      for (const [value, arr] of inner) {
-        const sorted = [...arr].sort((a, b) => a - b)
+      for (const [value, bucket] of inner) {
+        const sorted = [...bucket.mgas].sort((a, b) => a - b)
         const mean = sorted.reduce((s, v) => s + v, 0) / sorted.length
         values.push({
           value,
@@ -158,6 +174,7 @@ export function DimensionInsights({
           p50: percentile(sorted, 50),
           p95: percentile(sorted, 95),
           p99: percentile(sorted, 99),
+          singleTestName: bucket.names.length === 1 ? bucket.names[0] : undefined,
         })
       }
       result.push({ def, values })
@@ -314,8 +331,23 @@ export function DimensionInsights({
                         <button
                           key={v.value}
                           type="button"
-                          onClick={() => onToggle(term)}
-                          title={`${def.label}: ${v.value} — mean ${v.mean.toFixed(1)} MGas/s, ${v.count} test${v.count === 1 ? '' : 's'}`}
+                          onClick={() => {
+                            // If this value matches a single test (and the
+                            // chip isn't already active), short-circuit and
+                            // open that test's detail modal instead of
+                            // adding a redundant filter that yields the
+                            // same single test.
+                            if (!active && v.singleTestName && onTestClick) {
+                              onTestClick(v.singleTestName)
+                            } else {
+                              onToggle(term)
+                            }
+                          }}
+                          title={
+                            !active && v.singleTestName
+                              ? `${def.label}: ${v.value} — open the only matching test (${v.mean.toFixed(1)} MGas/s)`
+                              : `${def.label}: ${v.value} — mean ${v.mean.toFixed(1)} MGas/s, ${v.count} test${v.count === 1 ? '' : 's'}`
+                          }
                           className={clsx(
                             'group grid cursor-pointer grid-cols-[minmax(7rem,12rem)_1fr_auto] items-center gap-2 rounded-xs px-1 py-0.5 text-left text-xs/5 transition-colors',
                             active ? 'bg-blue-50 text-blue-900 dark:bg-blue-950/40 dark:text-blue-200' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
@@ -385,12 +417,22 @@ export function DimensionInsights({
                     return (
                       <tr
                         key={v.value}
-                        onClick={() => onToggle(term)}
+                        onClick={() => {
+                          if (!active && v.singleTestName && onTestClick) {
+                            onTestClick(v.singleTestName)
+                          } else {
+                            onToggle(term)
+                          }
+                        }}
                         className={clsx(
                           'cursor-pointer transition-colors',
                           active ? 'bg-blue-50 dark:bg-blue-950/40' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
                         )}
-                        title={active ? `Click to remove ${term}` : `Click to filter by ${term}`}
+                        title={
+                          !active && v.singleTestName
+                            ? `Open the only matching test`
+                            : active ? `Click to remove ${term}` : `Click to filter by ${term}`
+                        }
                       >
                         <td className="px-2 py-1 font-mono text-gray-700 dark:text-gray-200">{v.value}</td>
                         <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{v.count}</td>

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Flame, Loader } from 'lucide-react'
+import { DEFAULT_THRESHOLD, MAX_THRESHOLD, MIN_THRESHOLD } from '@/utils/perfThreshold'
 import type { LiveRun, LiveTestStats, TestEntry, AggregatedStats } from '@/api/types'
 import { ClientStat } from '@/components/shared/ClientStat'
 import { JDenticon } from '@/components/shared/JDenticon'
@@ -291,27 +292,56 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
           runner ships in every snapshot. Renders as soon as we have
           either suite info (un-processed tiles) or completed tests. */}
       {showHeatmap && (
-        <div className="overflow-hidden rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
-          <div className="mb-4 flex items-center justify-between">
+        <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
+          <div className="flex flex-wrap items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
             <h3 className="flex items-center gap-2 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
               <Flame className="size-4 text-gray-400 dark:text-gray-500" />
               Performance Heatmap
             </h3>
+            <div className="ml-auto flex items-center gap-2 text-xs/5 text-gray-500 dark:text-gray-400">
+              <span>Slow threshold:</span>
+              <input
+                type="range"
+                min={MIN_THRESHOLD}
+                max={MAX_THRESHOLD}
+                value={heatmapThreshold ?? DEFAULT_THRESHOLD}
+                onChange={(e) => setHeatmapThreshold(Number(e.target.value))}
+                className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-gray-200 accent-blue-500 dark:bg-gray-700"
+              />
+              <input
+                type="number"
+                min={MIN_THRESHOLD}
+                max={MAX_THRESHOLD}
+                value={heatmapThreshold ?? DEFAULT_THRESHOLD}
+                onChange={(e) => setHeatmapThreshold(Number(e.target.value))}
+                className="w-16 rounded-sm border border-gray-300 bg-white px-1.5 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <span>MGas/s</span>
+              {(heatmapThreshold ?? DEFAULT_THRESHOLD) !== DEFAULT_THRESHOLD && (
+                <button
+                  onClick={() => setHeatmapThreshold(DEFAULT_THRESHOLD)}
+                  className="text-xs/5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  Reset
+                </button>
+              )}
+            </div>
           </div>
-          <TestHeatmap
-            tests={heatmapTests}
-            suiteTests={suite?.tests}
-            runId={run.run_id}
-            suiteHash={run.suite_hash}
-            stepFilter={DEFAULT_INDEX_STEP_FILTER}
-            sortMode={heatmapSort}
-            groupMode={heatmapGroup}
-            threshold={heatmapThreshold}
-            inProgressTestKey={inProgressKey}
-            onSortModeChange={setHeatmapSort}
-            onGroupModeChange={setHeatmapGroup}
-            onThresholdChange={setHeatmapThreshold}
-          />
+          <div className="p-4">
+            <TestHeatmap
+              tests={heatmapTests}
+              suiteTests={suite?.tests}
+              runId={run.run_id}
+              suiteHash={run.suite_hash}
+              stepFilter={DEFAULT_INDEX_STEP_FILTER}
+              sortMode={heatmapSort}
+              groupMode={heatmapGroup}
+              threshold={heatmapThreshold}
+              inProgressTestKey={inProgressKey}
+              onSortModeChange={setHeatmapSort}
+              onGroupModeChange={setHeatmapGroup}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/ui/src/components/run-detail/ResourceUsageCharts.tsx
+++ b/ui/src/components/run-detail/ResourceUsageCharts.tsx
@@ -4,6 +4,8 @@ import { Cpu } from 'lucide-react'
 import type { TestEntry, ResourceTotals, SuiteTest } from '@/api/types'
 import { formatBytes } from '@/utils/format'
 import { testNameMatches } from '@/utils/eestNameFilter'
+import { formatTestNameLong } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 import { getAggregatedStats, ALL_STEP_TYPES } from '@/pages/RunDetailPage'
 
 // Aggregated resource data from all steps of a test entry
@@ -228,6 +230,7 @@ function ChartSection({ title, option, onZoom, onPointClick, highlightedTestRef 
 
 export function ResourceUsageCharts({ tests, suiteTests, searchQuery, statusFilter = 'all', onTestClick, resourceCollectionMethod, cpuCores }: ResourceUsageChartsProps) {
   const isDark = useDarkMode()
+  const { mode: nameMode } = useNameDisplayMode()
   const [zoomRange, setZoomRange] = useState({ start: 0, end: 100 })
   const highlightedTestRef = useRef<string | null>(null)
 
@@ -451,7 +454,7 @@ export function ResourceUsageCharts({ tests, suiteTests, searchQuery, statusFilt
         const testNumber = params[0].value[3]
         // Track the highlighted test for click handling
         highlightedTestRef.current = testName
-        let content = `<strong>Test #${testNumber}</strong><br/><span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${testName}</span><br/>`
+        let content = `<strong>Test #${testNumber}</strong><br/><span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${formatTestNameLong(testName, nameMode)}</span><br/>`
         params.forEach((p) => {
           const value = p.value[1]
           const formatted = formatter(value)
@@ -477,7 +480,7 @@ export function ResourceUsageCharts({ tests, suiteTests, searchQuery, statusFilt
         const testName = params[0].value[2]
         const testNumber = params[0].value[3]
         highlightedTestRef.current = testName
-        let content = `<strong>Test #${testNumber}</strong><br/><span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${testName}</span><br/>`
+        let content = `<strong>Test #${testNumber}</strong><br/><span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${formatTestNameLong(testName, nameMode)}</span><br/>`
         params.forEach((p) => {
           const value = p.value[1]
           const formatted = formatter(value)
@@ -504,7 +507,7 @@ export function ResourceUsageCharts({ tests, suiteTests, searchQuery, statusFilt
         const testNumber = params[0].value[3]
         // Track the highlighted test for click handling
         highlightedTestRef.current = testName
-        let content = `<strong>Test #${testNumber}</strong><br/><span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${testName}</span><br/>`
+        let content = `<strong>Test #${testNumber}</strong><br/><span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${formatTestNameLong(testName, nameMode)}</span><br/>`
         params.forEach((p) => {
           const value = p.value[1]
           const formatted = formatter(value)
@@ -691,7 +694,7 @@ export function ResourceUsageCharts({ tests, suiteTests, searchQuery, statusFilt
     }
 
     return { cpuPercentOption, memoryMBOption, cpuOption, memoryOption, diskBytesOption, diskOpsOption }
-  }, [dataPoints, isDark, summaryStats, zoomRange, cpuCores])
+  }, [dataPoints, isDark, summaryStats, zoomRange, cpuCores, nameMode])
 
   if (!hasResourceData) {
     return null

--- a/ui/src/components/run-detail/ResourceUsageCharts.tsx
+++ b/ui/src/components/run-detail/ResourceUsageCharts.tsx
@@ -3,7 +3,7 @@ import ReactECharts from 'echarts-for-react'
 import { Cpu } from 'lucide-react'
 import type { TestEntry, ResourceTotals, SuiteTest } from '@/api/types'
 import { formatBytes } from '@/utils/format'
-import { testNameMatches } from '@/utils/eestNameFilter'
+import { compileQuery } from '@/utils/eestNameFilter'
 import { formatTestNameLong } from '@/utils/eestName'
 import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 import { getAggregatedStats, ALL_STEP_TYPES } from '@/pages/RunDetailPage'
@@ -262,8 +262,9 @@ export function ResourceUsageCharts({ tests, suiteTests, searchQuery, statusFilt
 
     // Apply the page-level search + status filter so charts reflect what
     // the user is currently looking at on the heatmap and table.
+    const matchesQuery = searchQuery ? compileQuery(searchQuery) : null
     const filteredEntries = Object.entries(tests).filter(([name, entry]) => {
-      if (searchQuery && !testNameMatches(name, searchQuery)) return false
+      if (matchesQuery && !matchesQuery(name)) return false
       if (statusFilter !== 'all') {
         const s = getAggregatedStats(entry, ALL_STEP_TYPES)
         if (!s) return false

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -6,7 +6,7 @@ import type { TestEntry, SuiteTest, AggregatedStats, MethodsAggregated, StepResu
 import { fetchHead } from '@/api/client'
 import { Modal } from '@/components/shared/Modal'
 import { TestName } from '@/components/shared/TestName'
-import { testNameMatches, toggleSearchTerm } from '@/utils/eestNameFilter'
+import { compileQuery, testNameMatches, toggleSearchTerm } from '@/utils/eestNameFilter'
 import { TimeBreakdown } from './TimeBreakdown'
 import { MGasBreakdown } from './MGasBreakdown'
 import { ExecutionsList } from './ExecutionsList'
@@ -563,13 +563,14 @@ export function TestHeatmap({
   // page-level status + search filter so the histogram reflects what the
   // user is actually looking at on the heatmap.
   const filteredTestData = useMemo(() => {
+    const matchesQuery = searchQuery ? compileQuery(searchQuery) : null
     return testData.filter((t) => {
       if (statusFilter !== 'all') {
         if (t.notProcessed) return false
         if (statusFilter === 'passed' && t.hasFail) return false
         if (statusFilter === 'failed' && !t.hasFail) return false
       }
-      if (searchQuery && !testNameMatches(t.testKey, searchQuery)) return false
+      if (matchesQuery && !matchesQuery(t.testKey)) return false
       return true
     })
   }, [testData, statusFilter, searchQuery])

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -17,6 +17,7 @@ import { formatDuration, formatBytes } from '@/utils/format'
 import { EESTInfoContent, type OpcodeSortMode } from '@/components/suite-detail/TestFilesList'
 import { OpcodeDiffPanel, type OpcodeDiffRow } from './OpcodeDiffPanel'
 import { useBlockLogs } from '@/api/hooks/useBlockLogs'
+import { DEFAULT_THRESHOLD, THRESHOLD_COLORS, getColorByThreshold } from '@/utils/perfThreshold'
 
 // Aggregate stats from selected steps of a test entry
 function getAggregatedStats(entry: TestEntry, stepFilter: StepTypeOption[] = ALL_STEP_TYPES): AggregatedStats | undefined {
@@ -128,25 +129,12 @@ interface TestHeatmapProps {
   onSelectedTestChange?: (testName: string | undefined) => void
   onSortModeChange?: (mode: SortMode) => void
   onGroupModeChange?: (mode: GroupMode) => void
-  onThresholdChange?: (threshold: number) => void
   onSearchChange?: (query: string) => void
   activeStepTab?: 'test' | 'setup' | 'cleanup'
   onActiveStepTabChange?: (tab: 'test' | 'setup' | 'cleanup') => void
   expandedExecRows?: Set<number>
   onExpandedExecRowsChange?: (rows: Set<number>) => void
 }
-
-const COLORS = [
-  '#22c55e', // green - best (highest MGas/s)
-  '#84cc16', // lime
-  '#eab308', // yellow
-  '#f97316', // orange
-  '#ef4444', // red - worst (lowest MGas/s)
-]
-
-const MIN_THRESHOLD = 10
-const MAX_THRESHOLD = 1000
-const DEFAULT_THRESHOLD = 60
 
 function calculateMGasPerSec(gasUsedTotal: number, gasUsedTimeTotal: number): number | undefined {
   if (gasUsedTimeTotal <= 0 || gasUsedTotal <= 0) return undefined
@@ -171,17 +159,6 @@ function CopyButton({ text }: { text: string }) {
       {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
     </button>
   )
-}
-
-function getColorByThreshold(value: number, threshold: number): string {
-  // Scale: 0 = threshold (yellow), >threshold = green, <threshold = red
-  // Range: 0 to 2*threshold maps to full color scale
-  const ratio = value / threshold
-  if (ratio >= 2) return COLORS[0] // Very fast - green
-  if (ratio >= 1.5) return COLORS[1] // Fast - lime
-  if (ratio >= 1) return COLORS[2] // At threshold - yellow
-  if (ratio >= 0.5) return COLORS[3] // Slow - orange
-  return COLORS[4] // Very slow - red
 }
 
 interface TestData {
@@ -380,7 +357,6 @@ export function TestHeatmap({
   onSearchChange,
   onSortModeChange,
   onGroupModeChange,
-  onThresholdChange,
   activeStepTab: activeStepTabProp,
   onActiveStepTabChange,
   expandedExecRows,
@@ -412,12 +388,6 @@ export function TestHeatmap({
 
   const handleGroupModeChange = (mode: GroupMode) => {
     onGroupModeChange?.(mode)
-  }
-
-  const handleThresholdChange = (value: number) => {
-    if (value >= MIN_THRESHOLD && value <= MAX_THRESHOLD) {
-      onThresholdChange?.(value)
-    }
   }
 
   const executionOrder = useMemo(() => {
@@ -750,34 +720,6 @@ export function TestHeatmap({
               </button>
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <span className="text-xs/5 text-gray-500 dark:text-gray-400">Slow threshold:</span>
-            <input
-              type="range"
-              min={MIN_THRESHOLD}
-              max={MAX_THRESHOLD}
-              value={threshold}
-              onChange={(e) => handleThresholdChange(Number(e.target.value))}
-              className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-gray-200 accent-blue-500 dark:bg-gray-700"
-            />
-            <input
-              type="number"
-              min={MIN_THRESHOLD}
-              max={MAX_THRESHOLD}
-              value={threshold}
-              onChange={(e) => handleThresholdChange(Number(e.target.value))}
-              className="w-16 rounded-sm border border-gray-300 bg-white px-1.5 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-            />
-            <span className="text-xs/5 text-gray-500 dark:text-gray-400">MGas/s</span>
-            {threshold !== DEFAULT_THRESHOLD && (
-              <button
-                onClick={() => handleThresholdChange(DEFAULT_THRESHOLD)}
-                className="text-xs/5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-              >
-                Reset
-              </button>
-            )}
-          </div>
         </div>
         <div className="text-xs/5 text-gray-500 dark:text-gray-400">
           {(() => {
@@ -892,7 +834,7 @@ export function TestHeatmap({
         <span className="flex items-center gap-1">
           <span>&gt;{threshold * 2}</span>
           <span className="flex gap-0.5">
-            {COLORS.map((color, i) => (
+            {THRESHOLD_COLORS.map((color, i) => (
               <span key={i} className="size-3 rounded-xs" style={{ backgroundColor: color }} />
             ))}
           </span>
@@ -908,7 +850,7 @@ export function TestHeatmap({
           Not processed
         </span>
         <span>
-          <span className="mr-1 inline-block size-3 rounded-xs ring-1 ring-red-500" style={{ backgroundColor: COLORS[2] }} />
+          <span className="mr-1 inline-block size-3 rounded-xs ring-1 ring-red-500" style={{ backgroundColor: THRESHOLD_COLORS[2] }} />
           Has failures
         </span>
       </div>

--- a/ui/src/components/run-detail/TestsTable.tsx
+++ b/ui/src/components/run-detail/TestsTable.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/shared/Badge'
 import { Duration } from '@/components/shared/Duration'
 import { Pagination } from '@/components/shared/Pagination'
 import { TestName } from '@/components/shared/TestName'
-import { testNameMatches, toggleSearchTerm } from '@/utils/eestNameFilter'
+import { compileQuery, toggleSearchTerm } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES } from '@/pages/RunDetailPage'
 
 export type TestSortColumn = 'order' | 'name' | 'genesis' | 'time' | 'mgas' | 'passed' | 'failed'
@@ -178,7 +178,8 @@ export function TestsTable({
     let filtered = Object.entries(tests)
 
     if (searchQuery) {
-      filtered = filtered.filter(([name]) => testNameMatches(name, searchQuery))
+      const match = compileQuery(searchQuery)
+      filtered = filtered.filter(([name]) => match(name))
     }
 
     // Genesis filter

--- a/ui/src/components/run-detail/TestsTable.tsx
+++ b/ui/src/components/run-detail/TestsTable.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/shared/Badge'
 import { Duration } from '@/components/shared/Duration'
 import { Pagination } from '@/components/shared/Pagination'
 import { TestName } from '@/components/shared/TestName'
-import { testNameMatches, toggleSearchTerm, TEST_FILTER_HINT } from '@/utils/eestNameFilter'
+import { testNameMatches, toggleSearchTerm } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES } from '@/pages/RunDetailPage'
 
 export type TestSortColumn = 'order' | 'name' | 'genesis' | 'time' | 'mgas' | 'passed' | 'failed'
@@ -236,12 +236,6 @@ export function TestsTable({
   const totalPages = Math.ceil(sortedTests.length / pageSize)
   const paginatedTests = sortedTests.slice((currentPage - 1) * pageSize, currentPage * pageSize)
 
-  const handleSearchInput = (value: string) => {
-    if (onSearchChange) {
-      onSearchChange(value)
-    }
-  }
-
   const handlePageSizeChange = (newSize: number) => {
     if (onPageSizeChange) {
       onPageSizeChange(newSize)
@@ -307,14 +301,6 @@ export function TestsTable({
               ))}
             </select>
           )}
-          <input
-            type="text"
-            placeholder="Search… or e.g. opcode:ORIGIN gas:90M"
-            title={TEST_FILTER_HINT}
-            value={searchQuery}
-            onChange={(e) => handleSearchInput(e.target.value)}
-            className="w-72 rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
-          />
         </div>
       </div>
 

--- a/ui/src/components/run-detail/block-logs-dashboard/BlockLogsDashboard.tsx
+++ b/ui/src/components/run-detail/block-logs-dashboard/BlockLogsDashboard.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { TabPanel } from '@headlessui/react'
 import { Blocks, CircleHelp, X, Maximize2 } from 'lucide-react'
 import type { BlockLogs, SuiteTest } from '@/api/types'
-import { FilterInput } from '@/components/shared/FilterInput'
 import { useDashboardState } from './hooks/useDashboardState'
 import { useProcessedData } from './hooks/useProcessedData'
 import { DashboardFilters } from './components/DashboardFilters'
@@ -18,7 +17,6 @@ interface BlockLogsDashboardProps {
   suiteTests?: SuiteTest[]
   onTestClick?: (testName: string) => void
   searchQuery?: string
-  onSearchChange?: (query: string) => void
   fullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }
@@ -63,7 +61,7 @@ function useFullscreen(
   return { fullscreen, setFullscreen }
 }
 
-export function BlockLogsDashboard({ blockLogs, runId, suiteTests, onTestClick, searchQuery = '', onSearchChange, fullscreen: externalFullscreen, onFullscreenChange }: BlockLogsDashboardProps) {
+export function BlockLogsDashboard({ blockLogs, runId, suiteTests, onTestClick, searchQuery = '', fullscreen: externalFullscreen, onFullscreenChange }: BlockLogsDashboardProps) {
   const isDark = useDarkMode()
   const { fullscreen, setFullscreen } = useFullscreen(externalFullscreen, onFullscreenChange)
   const { state, updateState } = useDashboardState(runId)
@@ -102,14 +100,6 @@ export function BlockLogsDashboard({ blockLogs, runId, suiteTests, onTestClick, 
         </span>
       </div>
       <div className="flex items-center gap-2">
-        {onSearchChange && (
-          <FilterInput
-            placeholder="Filter tests..."
-            value={searchQuery}
-            onValueChange={onSearchChange}
-            className="rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
-          />
-        )}
         <button
           onClick={() => setFullscreen(!fullscreen)}
           className="rounded-xs border border-gray-300 bg-white px-2 py-1 text-sm text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"

--- a/ui/src/components/run-detail/block-logs-dashboard/charts/CacheBarChart.tsx
+++ b/ui/src/components/run-detail/block-logs-dashboard/charts/CacheBarChart.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { ProcessedTestData } from '../types'
 import { CATEGORY_COLORS, CACHE_COLORS } from '../utils/colors'
+import { formatTestNameLong } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 type SortMode = 'order' | 'hitRate' | 'total'
 type CacheType = 'account' | 'storage' | 'code'
@@ -51,6 +53,7 @@ export function CacheBarChart({
   onTestClick,
 }: CacheBarChartProps) {
   const [sortMode, setSortMode] = useState<SortMode>('hitRate')
+  const { mode: nameMode } = useNameDisplayMode()
 
   const textColor = isDark ? '#e5e7eb' : '#374151'
   const subTextColor = isDark ? '#9ca3af' : '#6b7280'
@@ -93,7 +96,7 @@ export function CacheBarChart({
           const total = cache.hits + cache.misses
           return `
             <strong>Test ${testLabel}</strong><br/>
-            <span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${item.testName}</span><br/>
+            <span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${formatTestNameLong(item.testName, nameMode)}</span><br/>
             Hit Rate: ${cache.hitRate.toFixed(1)}%<br/>
             Hits: ${cache.hits.toLocaleString()}<br/>
             Misses: ${cache.misses.toLocaleString()}<br/>
@@ -246,6 +249,7 @@ export function CacheBarChart({
     tooltipBg,
     tooltipBorder,
     sortMode,
+    nameMode,
   ])
 
   const onEvents = useMemo(() => {

--- a/ui/src/components/run-detail/block-logs-dashboard/charts/ThroughputBarChart.tsx
+++ b/ui/src/components/run-detail/block-logs-dashboard/charts/ThroughputBarChart.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { ProcessedTestData, TestCategory } from '../types'
 import { ALL_CATEGORIES, CATEGORY_COLORS } from '../utils/colors'
+import { formatTestNameLong } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 type SortMode = 'order' | 'throughput'
 
@@ -16,6 +18,7 @@ interface ThroughputBarChartProps {
 export function ThroughputBarChart({ data, isDark, useLogScale, onTestClick, activeCategories }: ThroughputBarChartProps) {
   const categoriesToShow = activeCategories ?? ALL_CATEGORIES
   const [sortMode, setSortMode] = useState<SortMode>('throughput')
+  const { mode: nameMode } = useNameDisplayMode()
 
   const textColor = isDark ? '#e5e7eb' : '#374151'
   const subTextColor = isDark ? '#9ca3af' : '#6b7280'
@@ -51,7 +54,7 @@ export function ThroughputBarChart({ data, isDark, useLogScale, onTestClick, act
           const testLabel = item.testOrder === Infinity ? '-' : `#${item.testOrder}`
           return `
             <strong>Test ${testLabel}</strong><br/>
-            <span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${item.testName}</span><br/>
+            <span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${formatTestNameLong(item.testName, nameMode)}</span><br/>
             Throughput: ${item.throughput.toFixed(2)} MGas/s<br/>
             Execution: ${item.executionMs.toFixed(2)}ms<br/>
             <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${CATEGORY_COLORS[item.category]};margin-right:6px;vertical-align:middle;"></span>${item.category.charAt(0).toUpperCase() + item.category.slice(1)}
@@ -143,7 +146,7 @@ export function ThroughputBarChart({ data, isDark, useLogScale, onTestClick, act
         })),
       ],
     }
-  }, [chartData, isDark, useLogScale, sortMode, textColor, subTextColor, gridColor, tooltipBg, tooltipBorder, categoriesToShow])
+  }, [chartData, isDark, useLogScale, sortMode, textColor, subTextColor, gridColor, tooltipBg, tooltipBorder, categoriesToShow, nameMode])
 
   const onEvents = useMemo(() => {
     if (!onTestClick) return undefined

--- a/ui/src/components/run-detail/block-logs-dashboard/charts/ThroughputScatterChart.tsx
+++ b/ui/src/components/run-detail/block-logs-dashboard/charts/ThroughputScatterChart.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { ProcessedTestData, TestCategory } from '../types'
 import { ALL_CATEGORIES, CATEGORY_COLORS } from '../utils/colors'
+import { formatTestNameLong } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
 
 interface ThroughputScatterChartProps {
   data: ProcessedTestData[]
@@ -25,6 +27,7 @@ function formatGas(gas: number): string {
 }
 
 export function ThroughputScatterChart({ data, isDark, useLogScale, onTestClick, activeCategories }: ThroughputScatterChartProps) {
+  const { mode: nameMode } = useNameDisplayMode()
   const categoriesToShow = activeCategories ?? ALL_CATEGORIES
   const textColor = isDark ? '#e5e7eb' : '#374151'
   const subTextColor = isDark ? '#9ca3af' : '#6b7280'
@@ -77,7 +80,7 @@ export function ThroughputScatterChart({ data, isDark, useLogScale, onTestClick,
           const testLabel = item.testOrder === Infinity ? '-' : `#${item.testOrder}`
           return `
             <strong>Test ${testLabel}</strong><br/>
-            <span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${item.testName}</span><br/>
+            <span style="font-size: 11px; color: ${isDark ? '#9ca3af' : '#6b7280'}; word-break: break-all; display: block;">${formatTestNameLong(item.testName, nameMode)}</span><br/>
             Throughput: ${item.throughput.toFixed(2)} MGas/s<br/>
             Execution: ${item.executionMs.toFixed(2)}ms<br/>
             Gas Used: ${formatGas(item.gasUsed)}<br/>
@@ -142,7 +145,7 @@ export function ThroughputScatterChart({ data, isDark, useLogScale, onTestClick,
       ],
       series: seriesData,
     }
-  }, [data, isDark, useLogScale, textColor, subTextColor, gridColor, tooltipBg, tooltipBorder, categoriesToShow])
+  }, [data, isDark, useLogScale, textColor, subTextColor, gridColor, tooltipBg, tooltipBorder, categoriesToShow, nameMode])
 
   const onEvents = useMemo(() => {
     if (!onTestClick) return undefined

--- a/ui/src/components/run-detail/block-logs-dashboard/hooks/useProcessedData.ts
+++ b/ui/src/components/run-detail/block-logs-dashboard/hooks/useProcessedData.ts
@@ -3,7 +3,7 @@ import type { BlockLogs } from '@/api/types'
 import type { ProcessedTestData, DashboardState, DashboardStats } from '../types'
 import { parseCategory } from '../utils/categoryParser'
 import { percentile, removeOutliers, countOutliers, normalizeValue, emptyCategoryBreakdown } from '../utils/statistics'
-import { testNameMatches } from '@/utils/eestNameFilter'
+import { compileQuery } from '@/utils/eestNameFilter'
 
 export function useProcessedData(
   blockLogs: BlockLogs | null | undefined,
@@ -69,7 +69,8 @@ export function useProcessedData(
     // Apply search filter (supports the same key:value / key=value syntax
     // used elsewhere on the run-detail page).
     if (searchQuery) {
-      data = data.filter((d) => testNameMatches(d.testName, searchQuery))
+      const match = compileQuery(searchQuery)
+      data = data.filter((d) => match(d.testName))
     }
 
     // Apply throughput range filter

--- a/ui/src/components/shared/FacetPanel.tsx
+++ b/ui/src/components/shared/FacetPanel.tsx
@@ -183,7 +183,7 @@ export function FacetPanel({ testNames, query, onToggle }: FacetPanelProps) {
               onClick={() => onToggle(term)}
               title={active ? `Click to remove ${term}` : `Click to filter by ${term}`}
               className={clsx(
-                'inline-flex items-center gap-1 rounded-xs px-1.5 py-0 font-mono text-[11px]/5 ring-1 ring-inset transition-colors',
+                'inline-flex cursor-pointer items-center gap-1 rounded-xs px-1.5 py-0 font-mono text-[11px]/5 ring-1 ring-inset transition-colors',
                 active
                   ? 'bg-blue-500 text-white ring-blue-500'
                   : dimmed
@@ -224,7 +224,7 @@ export function FacetPanel({ testNames, query, onToggle }: FacetPanelProps) {
           <button
             type="button"
             onClick={() => setShowAll(!showAll)}
-            className="flex w-fit items-center gap-1 rounded-xs px-1.5 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
+            className="flex w-fit cursor-pointer items-center gap-1 rounded-xs px-1.5 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
           >
             {showAll
               ? <><ChevronUp className="size-3.5" /> Show fewer facets</>

--- a/ui/src/components/shared/FacetPanel.tsx
+++ b/ui/src/components/shared/FacetPanel.tsx
@@ -3,10 +3,10 @@ import clsx from 'clsx'
 import { ChevronDown, ChevronUp, Filter, X } from 'lucide-react'
 import { parseEESTName } from '@/utils/eestName'
 import {
+  compileQuery,
   queryWithoutDimension,
   searchQueryContains,
   splitQuery,
-  testNameMatches,
 } from '@/utils/eestNameFilter'
 
 interface FacetPanelProps {
@@ -112,10 +112,11 @@ export function FacetPanel({ testNames, query, onToggle }: FacetPanelProps) {
       // dimension, so picking another opcode value doesn't show 0 counts
       // everywhere just because a sibling opcode is selected.
       const contextQuery = queryWithoutDimension(query, def.key)
+      const matchesContext = contextQuery ? compileQuery(contextQuery) : null
       const counts = new Map<string, number>()
 
       for (const p of parsed) {
-        if (contextQuery && !testNameMatches(p.name, contextQuery)) continue
+        if (matchesContext && !matchesContext(p.name)) continue
         const vs = p.dims.get(def.key)
         if (!vs) continue
         for (const v of vs) counts.set(v, (counts.get(v) ?? 0) + 1)

--- a/ui/src/components/suite-detail/OpcodeHeatmap.tsx
+++ b/ui/src/components/suite-detail/OpcodeHeatmap.tsx
@@ -25,6 +25,8 @@ interface OpcodeHeatmapProps {
   extraColumns?: ExtraColumn[]
   searchQuery?: string
   onSearchChange?: (query: string) => void
+  /** When true, hide the internal search input (use the page-level one). */
+  hideSearchInput?: boolean
   fullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }
@@ -737,7 +739,7 @@ function HeatmapCanvas({ filteredTests, columns, maxPerColumn, isDark, maxHeight
   )
 }
 
-export function OpcodeHeatmap({ tests, onTestClick, extraColumns = [], searchQuery, onSearchChange, fullscreen: externalFullscreen, onFullscreenChange }: OpcodeHeatmapProps) {
+export function OpcodeHeatmap({ tests, onTestClick, extraColumns = [], searchQuery, onSearchChange, hideSearchInput = false, fullscreen: externalFullscreen, onFullscreenChange }: OpcodeHeatmapProps) {
   const [internalSearch, setInternalSearch] = useState('')
   const search = searchQuery ?? internalSearch
   const setSearch = onSearchChange ?? setInternalSearch
@@ -942,14 +944,16 @@ export function OpcodeHeatmap({ tests, onTestClick, extraColumns = [], searchQue
           </span>
         </h3>
         <div className="flex items-center gap-2">
-          <input
-            type="text"
-            placeholder="Filter… or e.g. opcode:ORIGIN"
-            title={TEST_FILTER_HINT}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
-          />
+          {!hideSearchInput && (
+            <input
+              type="text"
+              placeholder="Filter… or e.g. opcode:ORIGIN"
+              title={TEST_FILTER_HINT}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
+            />
+          )}
           {expanded && (
             <button
               onClick={() => setGroupStack(!groupStack)}

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -10,6 +10,7 @@ import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { FacetPanel } from '@/components/shared/FacetPanel'
+import { CompareDimensionInsights } from '@/components/compare/CompareDimensionInsights'
 import { type StepTypeOption, ALL_STEP_TYPES, DEFAULT_STEP_FILTER } from '@/pages/RunDetailPage'
 import { type CompareRun, type ChartType, CHART_TYPE_OPTIONS } from '@/components/compare/constants'
 import { MetricsComparison } from '@/components/compare/MetricsComparison'
@@ -710,6 +711,17 @@ export function CompareGroupsPage() {
             zoomRange={sharedZoom ? chartZoom : undefined}
             onZoomChange={sharedZoom ? setChartZoom : undefined}
             chartType={chartType}
+            onTestClick={setSelectedTest}
+          />
+
+          <CompareDimensionInsights
+            runs={syntheticRuns}
+            stepFilter={stepFilter}
+            baselineIdx={baselineIdx}
+            labelMode="instance-id"
+            testNameFilter={testNameFilter}
+            query={testFilter}
+            onToggle={(term) => updateSearch({ filter: toggleSearchTerm(testFilter, term) || undefined })}
             onTestClick={setSelectedTest}
           />
 

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -9,6 +9,7 @@ import { useIndex } from '@/api/hooks/useIndex'
 import { useSuite } from '@/api/hooks/useSuite'
 import { LoadingState } from '@/components/shared/Spinner'
 import { JDenticon } from '@/components/shared/JDenticon'
+import { FacetPanel } from '@/components/shared/FacetPanel'
 import { type StepTypeOption, ALL_STEP_TYPES, DEFAULT_STEP_FILTER } from '@/pages/RunDetailPage'
 import { type CompareRun, type ChartType, CHART_TYPE_OPTIONS } from '@/components/compare/constants'
 import { MetricsComparison } from '@/components/compare/MetricsComparison'
@@ -643,6 +644,12 @@ export function CompareGroupsPage() {
               </div>
             )}
           </div>
+
+          <FacetPanel
+            testNames={[...testGasMap.keys()]}
+            query={testFilter}
+            onToggle={(term) => updateSearch({ filter: toggleSearchTerm(testFilter, term) || undefined })}
+          />
 
           <MetricsComparison
             runs={syntheticRuns}

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -11,6 +11,7 @@ import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { FilterInput } from '@/components/shared/FilterInput'
+import { FacetPanel } from '@/components/shared/FacetPanel'
 import { CompareHeader } from '@/components/compare/CompareHeader'
 import { StickyRunBar } from '@/components/compare/StickyRunBar'
 import { MetricsComparison } from '@/components/compare/MetricsComparison'
@@ -448,6 +449,12 @@ export function ComparePage() {
           updateSearch({ runs: reordered.join(',') })
         }} />
       </div>
+
+      <FacetPanel
+        testNames={[...testGasMap.keys()]}
+        query={testFilter}
+        onToggle={(term) => setTestFilter(toggleSearchTerm(testFilter, term))}
+      />
 
       <MetricsComparison runs={runs} stepFilter={stepFilter} baselineIdx={baselineIdx} onBaselineChange={setBaselineIdx} labelMode={labelMode} testNameFilter={testNameFilter} />
 

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -12,6 +12,7 @@ import { ErrorState } from '@/components/shared/ErrorState'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { FilterInput } from '@/components/shared/FilterInput'
 import { FacetPanel } from '@/components/shared/FacetPanel'
+import { CompareDimensionInsights } from '@/components/compare/CompareDimensionInsights'
 import { CompareHeader } from '@/components/compare/CompareHeader'
 import { StickyRunBar } from '@/components/compare/StickyRunBar'
 import { MetricsComparison } from '@/components/compare/MetricsComparison'
@@ -469,6 +470,16 @@ export function ComparePage() {
       <BlockLogsComparison runs={runs} blockLogsPerRun={blockLogsPerRun} blockLogsLoading={blockLogsLoading} suiteTests={suite?.tests} labelMode={labelMode} testNameFilter={testNameFilter} />
 
       {allResults && <ResourceComparisonCharts runs={runs} labelMode={labelMode} testNameFilter={testNameFilter} suiteTests={suite?.tests} zoomRange={sharedZoom ? chartZoom : undefined} onZoomChange={sharedZoom ? setChartZoom : undefined} chartType={chartType} />}
+
+      <CompareDimensionInsights
+        runs={runs}
+        stepFilter={stepFilter}
+        baselineIdx={baselineIdx}
+        labelMode={labelMode}
+        testNameFilter={testNameFilter}
+        query={testFilter}
+        onToggle={(term) => setTestFilter(toggleSearchTerm(testFilter, term))}
+      />
 
       {allResults && (
         <TestComparisonTable runs={runs} suiteTests={suite?.tests} stepFilter={stepFilter} blockLogsPerRun={blockLogsPerRun} labelMode={labelMode} tableBaseline={tableBaseline} onTableBaselineChange={setTableBaseline} sortBy={tableSortBy} sortDir={tableSortDir} onSortChange={setTableSort} testNameFilter={testNameFilter} searchQuery={testFilter} onChipFilterToggle={(term) => setTestFilter(toggleSearchTerm(testFilter, term))} />

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -25,6 +25,7 @@ import { JDenticon } from '@/components/shared/JDenticon'
 import { StatusAlert } from '@/components/shared/StatusBadge'
 import { FilterInput } from '@/components/shared/FilterInput'
 import { FacetPanel } from '@/components/shared/FacetPanel'
+import { DimensionInsights } from '@/components/run-detail/DimensionInsights'
 import { TEST_FILTER_HINT, toggleSearchTerm } from '@/utils/eestNameFilter'
 import { formatTimestamp, formatDurationSeconds } from '@/utils/date'
 import { formatNumber, formatBytes } from '@/utils/format'
@@ -736,6 +737,14 @@ export function RunDetailPage() {
         <>
           <FacetPanel
             testNames={Object.keys(result.tests)}
+            query={q}
+            onToggle={(term) => handleSearchChange(toggleSearchTerm(q, term))}
+          />
+          <DimensionInsights
+            tests={result.tests}
+            stepFilter={stepFilter}
+            searchQuery={q}
+            statusFilter={status}
             query={q}
             onToggle={(term) => handleSearchChange(toggleSearchTerm(q, term))}
           />

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -736,6 +736,15 @@ export function RunDetailPage() {
 
       {result && (
         <>
+          <div className="sticky top-0 z-30 -mx-4 border-b border-gray-200 bg-white/95 px-4 py-2 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/95">
+            <FilterInput
+              placeholder="Search… or e.g. opcode:ORIGIN gas:90M"
+              title={TEST_FILTER_HINT}
+              value={q}
+              onValueChange={handleSearchChange}
+              className="w-full rounded-xs border border-gray-300 bg-white px-3 py-1.5 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
+            />
+          </div>
           <FacetPanel
             testNames={Object.keys(result.tests)}
             query={q}
@@ -786,13 +795,6 @@ export function RunDetailPage() {
                     </button>
                   )}
                 </div>
-                <FilterInput
-                  placeholder="Search… or e.g. opcode:ORIGIN gas:90M"
-                  title={TEST_FILTER_HINT}
-                  value={q}
-                  onValueChange={handleSearchChange}
-                  className="w-72 rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
-                />
               </div>
             </div>
             <div className="p-4">
@@ -872,7 +874,7 @@ export function RunDetailPage() {
                 }]}
                 onTestClick={(testIndex) => handleTestModalChange(mergedSuiteTests[testIndex - 1]?.name)}
                 searchQuery={q}
-                onSearchChange={handleSearchChange}
+                hideSearchInput
                 fullscreen={ohFs}
                 onFullscreenChange={handleOpcodeHeatmapFullscreenChange}
               />
@@ -880,7 +882,7 @@ export function RunDetailPage() {
           )}
 
           {blockLogs && Object.keys(blockLogs).length > 0 && (
-            <BlockLogsDashboard blockLogs={blockLogs} runId={runId} suiteTests={suite?.tests} onTestClick={handleTestModalChange} searchQuery={q} onSearchChange={handleSearchChange} fullscreen={blFs} onFullscreenChange={handleBlockLogsFullscreenChange} />
+            <BlockLogsDashboard blockLogs={blockLogs} runId={runId} suiteTests={suite?.tests} onTestClick={handleTestModalChange} searchQuery={q} fullscreen={blFs} onFullscreenChange={handleBlockLogsFullscreenChange} />
           )}
 
           <ResourceUsageCharts

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -736,14 +736,42 @@ export function RunDetailPage() {
 
       {result && (
         <>
-          <div className="sticky top-0 z-30 -mx-4 border-b border-gray-200 bg-white/95 px-4 py-2 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/95">
+          <div className="sticky top-0 z-30 -mx-4 flex flex-wrap items-center gap-3 border-b border-gray-200 bg-white/95 px-4 py-2 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/95">
             <FilterInput
               placeholder="Search… or e.g. opcode:ORIGIN gas:90M"
               title={TEST_FILTER_HINT}
               value={q}
               onValueChange={handleSearchChange}
-              className="w-full rounded-xs border border-gray-300 bg-white px-3 py-1.5 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
+              className="min-w-0 flex-1 rounded-xs border border-gray-300 bg-white px-3 py-1.5 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
             />
+            <div className="flex shrink-0 items-center gap-2 text-xs/5 text-gray-500 dark:text-gray-400">
+              <span>Slow threshold:</span>
+              <input
+                type="range"
+                min={MIN_THRESHOLD}
+                max={MAX_THRESHOLD}
+                value={heatmapThreshold ?? DEFAULT_THRESHOLD}
+                onChange={(e) => handleHeatmapThresholdChange(Number(e.target.value))}
+                className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-gray-200 accent-blue-500 dark:bg-gray-700"
+              />
+              <input
+                type="number"
+                min={MIN_THRESHOLD}
+                max={MAX_THRESHOLD}
+                value={heatmapThreshold ?? DEFAULT_THRESHOLD}
+                onChange={(e) => handleHeatmapThresholdChange(Number(e.target.value))}
+                className="w-16 rounded-sm border border-gray-300 bg-white px-1.5 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <span>MGas/s</span>
+              {(heatmapThreshold ?? DEFAULT_THRESHOLD) !== DEFAULT_THRESHOLD && (
+                <button
+                  onClick={() => handleHeatmapThresholdChange(DEFAULT_THRESHOLD)}
+                  className="text-xs/5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  Reset
+                </button>
+              )}
+            </div>
           </div>
           <FacetPanel
             testNames={Object.keys(result.tests)}
@@ -758,44 +786,13 @@ export function RunDetailPage() {
             query={q}
             onToggle={(term) => handleSearchChange(toggleSearchTerm(q, term))}
             threshold={heatmapThreshold}
-            onThresholdChange={handleHeatmapThresholdChange}
           />
           <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
-            <div className="flex flex-wrap items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
-              <h3 className="flex items-center gap-2 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
-                <Flame className="size-4 text-gray-400 dark:text-gray-500" />
+            <div className="flex items-center gap-2 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+              <Flame className="size-4 text-gray-400 dark:text-gray-500" />
+              <h3 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
                 Performance Heatmap
               </h3>
-              <div className="ml-auto flex flex-wrap items-center gap-3">
-                <div className="flex items-center gap-2 text-xs/5 text-gray-500 dark:text-gray-400">
-                  <span>Slow threshold:</span>
-                  <input
-                    type="range"
-                    min={MIN_THRESHOLD}
-                    max={MAX_THRESHOLD}
-                    value={heatmapThreshold ?? DEFAULT_THRESHOLD}
-                    onChange={(e) => handleHeatmapThresholdChange(Number(e.target.value))}
-                    className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-gray-200 accent-blue-500 dark:bg-gray-700"
-                  />
-                  <input
-                    type="number"
-                    min={MIN_THRESHOLD}
-                    max={MAX_THRESHOLD}
-                    value={heatmapThreshold ?? DEFAULT_THRESHOLD}
-                    onChange={(e) => handleHeatmapThresholdChange(Number(e.target.value))}
-                    className="w-16 rounded-sm border border-gray-300 bg-white px-1.5 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-                  />
-                  <span>MGas/s</span>
-                  {(heatmapThreshold ?? DEFAULT_THRESHOLD) !== DEFAULT_THRESHOLD && (
-                    <button
-                      onClick={() => handleHeatmapThresholdChange(DEFAULT_THRESHOLD)}
-                      className="text-xs/5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                    >
-                      Reset
-                    </button>
-                  )}
-                </div>
-              </div>
             </div>
             <div className="p-4">
             <TestHeatmap

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -27,6 +27,7 @@ import { FilterInput } from '@/components/shared/FilterInput'
 import { FacetPanel } from '@/components/shared/FacetPanel'
 import { DimensionInsights } from '@/components/run-detail/DimensionInsights'
 import { TEST_FILTER_HINT, toggleSearchTerm } from '@/utils/eestNameFilter'
+import { DEFAULT_THRESHOLD, MAX_THRESHOLD, MIN_THRESHOLD } from '@/utils/perfThreshold'
 import { formatTimestamp, formatDurationSeconds } from '@/utils/date'
 import { formatNumber, formatBytes } from '@/utils/format'
 import { useIndex, useLiveRuns } from '@/api/hooks/useIndex'
@@ -747,21 +748,54 @@ export function RunDetailPage() {
             statusFilter={status}
             query={q}
             onToggle={(term) => handleSearchChange(toggleSearchTerm(q, term))}
+            threshold={heatmapThreshold}
+            onThresholdChange={handleHeatmapThresholdChange}
           />
-          <div className="overflow-hidden rounded-sm bg-white p-4 shadow-xs dark:bg-gray-800">
-            <div className="mb-4 flex items-center justify-between">
+          <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
+            <div className="flex flex-wrap items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
               <h3 className="flex items-center gap-2 text-sm/6 font-medium text-gray-900 dark:text-gray-100">
                 <Flame className="size-4 text-gray-400 dark:text-gray-500" />
                 Performance Heatmap
               </h3>
-              <FilterInput
-                placeholder="Search… or e.g. opcode:ORIGIN gas:90M"
-                title={TEST_FILTER_HINT}
-                value={q}
-                onValueChange={handleSearchChange}
-                className="w-72 rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
-              />
+              <div className="ml-auto flex flex-wrap items-center gap-3">
+                <div className="flex items-center gap-2 text-xs/5 text-gray-500 dark:text-gray-400">
+                  <span>Slow threshold:</span>
+                  <input
+                    type="range"
+                    min={MIN_THRESHOLD}
+                    max={MAX_THRESHOLD}
+                    value={heatmapThreshold ?? DEFAULT_THRESHOLD}
+                    onChange={(e) => handleHeatmapThresholdChange(Number(e.target.value))}
+                    className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-gray-200 accent-blue-500 dark:bg-gray-700"
+                  />
+                  <input
+                    type="number"
+                    min={MIN_THRESHOLD}
+                    max={MAX_THRESHOLD}
+                    value={heatmapThreshold ?? DEFAULT_THRESHOLD}
+                    onChange={(e) => handleHeatmapThresholdChange(Number(e.target.value))}
+                    className="w-16 rounded-sm border border-gray-300 bg-white px-1.5 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                  />
+                  <span>MGas/s</span>
+                  {(heatmapThreshold ?? DEFAULT_THRESHOLD) !== DEFAULT_THRESHOLD && (
+                    <button
+                      onClick={() => handleHeatmapThresholdChange(DEFAULT_THRESHOLD)}
+                      className="text-xs/5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                    >
+                      Reset
+                    </button>
+                  )}
+                </div>
+                <FilterInput
+                  placeholder="Search… or e.g. opcode:ORIGIN gas:90M"
+                  title={TEST_FILTER_HINT}
+                  value={q}
+                  onValueChange={handleSearchChange}
+                  className="w-72 rounded-xs border border-gray-300 bg-white px-3 py-1 text-sm/6 placeholder-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-500"
+                />
+              </div>
             </div>
+            <div className="p-4">
             <TestHeatmap
               tests={result.tests}
               suiteTests={mergedSuiteTests ?? suite?.tests}
@@ -779,13 +813,13 @@ export function RunDetailPage() {
               onSortModeChange={handleHeatmapSortChange}
               groupMode={heatmapGroup}
               onGroupModeChange={handleHeatmapGroupChange}
-              onThresholdChange={handleHeatmapThresholdChange}
               onSearchChange={handleSearchChange}
               activeStepTab={activeStepTab}
               onActiveStepTabChange={handleStepTabChange}
               expandedExecRows={expandedExecRows}
               onExpandedExecRowsChange={handleExpandedExecRowsChange}
             />
+            </div>
           </div>
 
           {mergedSuiteTests && mergedSuiteTests.length > 0 && (

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -785,6 +785,7 @@ export function RunDetailPage() {
             statusFilter={status}
             query={q}
             onToggle={(term) => handleSearchChange(toggleSearchTerm(q, term))}
+            onTestClick={handleTestModalChange}
             threshold={heatmapThreshold}
           />
           <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">

--- a/ui/src/utils/eestName.ts
+++ b/ui/src/utils/eestName.ts
@@ -137,3 +137,23 @@ export function formatTestName(name: string, mode: 'raw' | 'decomposed'): string
   if (mode === 'raw') return name
   return parseEESTName(name).short
 }
+
+/**
+ * Same intent as `formatTestName`, but includes every decomposed field
+ * (file, fn, gas, opcode, fork, params, labels) — for chart tooltips and
+ * other contexts where we have room to show everything.
+ */
+export function formatTestNameLong(name: string, mode: 'raw' | 'decomposed'): string {
+  if (mode === 'raw') return name
+  const p = parseEESTName(name)
+  if (!p.isEEST) return name
+  const parts: string[] = []
+  if (p.file) parts.push(p.file)
+  if (p.fn) parts.push(p.fn)
+  if (p.benchmark) parts.push(p.benchmark)
+  if (p.opcode) parts.push(p.opcode)
+  if (p.fork) parts.push(`fork:${p.fork}`)
+  for (const { key, value } of p.params) parts.push(`${key}:${value}`)
+  for (const label of p.labels) parts.push(label)
+  return parts.length > 0 ? parts.join(' · ') : name
+}

--- a/ui/src/utils/eestName.ts
+++ b/ui/src/utils/eestName.ts
@@ -61,7 +61,22 @@ const IGNORE_TOKENS = new Set([
   'gas',
 ])
 
+// parseEESTName is called from multiple memos (FacetPanel, DimensionInsights,
+// TestHeatmap, …) and indirectly from testNameMatches. With ~7000 tests and
+// several dimensions, that adds up to >100k regex+split runs per filter
+// change. Cache by raw name — names are stable per session, the result is
+// pure, and total cardinality is bounded by the run/suite size.
+const parseCache = new Map<string, EESTNameParts>()
+
 export function parseEESTName(raw: string): EESTNameParts {
+  const cached = parseCache.get(raw)
+  if (cached) return cached
+  const result = parseEESTNameUncached(raw)
+  parseCache.set(raw, result)
+  return result
+}
+
+function parseEESTNameUncached(raw: string): EESTNameParts {
   const m = FILE_FN_RE.exec(raw)
   if (!m) {
     return { raw, isEEST: false, params: [], labels: [], short: raw }

--- a/ui/src/utils/eestNameFilter.ts
+++ b/ui/src/utils/eestNameFilter.ts
@@ -70,24 +70,45 @@ function parseStructuredTerm(term: string): StructuredTerm | null {
  * `fn`/`function`, `path`, `label`. Any other key hits the parsed params.
  *
  * Multiple terms are combined with AND. Whitespace separates terms.
+ *
+ * Hot-loop callers (FacetPanel, DimensionInsights, etc.) should use
+ * `compileQuery(query)` to amortise the per-call tokenization cost across
+ * thousands of test names.
  */
 export function testNameMatches(name: string, query: string): boolean {
+  return compileQuery(query)(name)
+}
+
+/**
+ * Pre-parse a query into a predicate. Saves the per-name tokenization
+ * + structured-term parsing when checking a query against many tests in
+ * a tight loop.
+ */
+export function compileQuery(query: string): (name: string) => boolean {
   const trimmed = query.trim()
-  if (!trimmed) return true
+  if (!trimmed) return () => true
 
-  const lowerName = name.toLowerCase()
-  let parsed: EESTNameParts | null = null
-  const ensureParsed = (): EESTNameParts => parsed ?? (parsed = parseEESTName(name))
-
+  const freeText: string[] = []
+  const structured: StructuredTerm[] = []
   for (const term of trimmed.split(/\s+/)) {
-    const structured = parseStructuredTerm(term)
-    if (structured) {
-      if (!matchesField(ensureParsed(), structured)) return false
-    } else {
-      if (!lowerName.includes(term.toLowerCase())) return false
-    }
+    const s = parseStructuredTerm(term)
+    if (s) structured.push(s)
+    else freeText.push(term.toLowerCase())
   }
-  return true
+
+  return (name: string) => {
+    if (freeText.length > 0) {
+      const lower = name.toLowerCase()
+      for (const t of freeText) if (!lower.includes(t)) return false
+    }
+    if (structured.length > 0) {
+      const parsed = parseEESTName(name)
+      for (const term of structured) {
+        if (!matchesField(parsed, term)) return false
+      }
+    }
+    return true
+  }
 }
 
 /** Split a query string into whitespace-separated terms. */

--- a/ui/src/utils/perfThreshold.ts
+++ b/ui/src/utils/perfThreshold.ts
@@ -1,0 +1,32 @@
+// Shared "slow threshold" model. The user picks a single MGas/s threshold
+// for the run-detail page; the Performance Heatmap, the distribution
+// histogram, and the Dimension Breakdown bars all colour against it.
+
+export const MIN_THRESHOLD = 1
+export const MAX_THRESHOLD = 1000
+export const DEFAULT_THRESHOLD = 60
+
+export const THRESHOLD_COLORS = [
+  '#22c55e', // very fast — green
+  '#84cc16', // fast — lime
+  '#eab308', // at threshold — yellow
+  '#f97316', // slow — orange
+  '#ef4444', // very slow — red
+] as const
+
+/**
+ * Map a MGas/s value to a colour, scaled relative to the threshold:
+ *   ratio >= 2     → green   (very fast)
+ *   ratio >= 1.5   → lime    (fast)
+ *   ratio >= 1     → yellow  (at threshold)
+ *   ratio >= 0.5   → orange  (slow)
+ *   ratio <  0.5   → red     (very slow)
+ */
+export function getColorByThreshold(value: number, threshold: number): string {
+  const ratio = value / threshold
+  if (ratio >= 2) return THRESHOLD_COLORS[0]
+  if (ratio >= 1.5) return THRESHOLD_COLORS[1]
+  if (ratio >= 1) return THRESHOLD_COLORS[2]
+  if (ratio >= 0.5) return THRESHOLD_COLORS[3]
+  return THRESHOLD_COLORS[4]
+}


### PR DESCRIPTION
## Summary

A bigger analytical surface on the run-detail and comparison pages, built on the decomposed-name + filter foundation.

### Dimension breakdown (run-detail)

A new collapsible-free panel sits between the FacetPanel and the Performance Heatmap.

- **Bars view** (default) — for every dimension with ≥2 distinct values (File, Test, Gas, Opcode, Fork, discovered params, Label), a row of horizontal bars per value showing mean MGas/s. Bars are colour-coded against the slow threshold (red → green) so outliers jump out. Sorted "slowest first" by default; toggle to "fastest first". Click a bar to toggle the matching `key=value` term in the page filter; active bars highlight blue.
- **Table view** — pick a dimension from a dropdown, get a sortable table with Count / Mean / P50 / P95 / P99 columns. Click a row to filter.
- **Preview pattern** mirroring the FacetPanel: File + Gas (plus any dimension with an active filter) are shown by default; "Show more dimensions (N)" reveals the rest. Once a File filter is active, Test (fn) is also surfaced in the preview as the natural next drill-down.
- **Filter row** above the controls lists every active term as a removable blue chip; header summary shows `(N dimensions, M filters)`.
- **Single-test deep link** — when a value's bucket has only one matching test, clicking it opens that test's detail modal directly instead of adding a redundant filter.

### Sticky search + threshold bar (run-detail)

- One **sticky search box** at the top of the run-detail page (with backdrop blur) replaces the per-section filter inputs in Performance Heatmap, TestsTable, BlockLogsDashboard, and OpcodeHeatmap. It drives every search-aware section via the existing `q` URL param.
- The **Slow threshold** slider/input/Reset moves to that same sticky bar — drives the heatmap colour, the distribution histogram, and the new Dimension breakdown bar colours via the shared `utils/perfThreshold.ts` model (range 1–1000, default 60). Live-run heatmap header gets the same treatment.
- Performance Heatmap and Dimension breakdown headers now share a clean border-b separator pattern.

### Faceted filtering on the comparison pages

- `<FacetPanel>` (already shared between run-detail and suite-detail) is now also rendered on `ComparePage` and `CompareGroupsPage`, above MetricsComparison. Toggling chips updates the existing testFilter URL param so every comparison section refilters.
- StickyRunBar's filter input bumped from `w-36` to `w-80` so the sticky compare-page filter isn't squeezed.

### Filter-aware analytics extension

- Block Logs Analysis filter previously did a raw substring `includes()`; switched to `testNameMatches` so structured terms (e.g. `value_bearing=True`, `gas:120M`) work there too.
- Resource Usage charts already filtered correctly; tooltips show the canonical Test # (matching the heatmap and tests table) read from a 4th element on each chart datum, with the X axis kept sequential 1..N for readability.

### Polish

- `cursor-pointer` added to every clickable element in `DimensionInsights` and `FacetPanel` so hover state telegraphs clickability.
- Settings dropdown in the header consolidates name-display mode + theme into one gear icon, replacing the standalone Sun/Moon button.
- Run-detail Performance Heatmap tooltip widened to `w-96` and clamped to the viewport so it never bleeds off the left/right edge when hovering the first/last tile.

## Test plan
- [x] Run-detail page loads with one sticky bar at top (search + threshold). Bar stays visible while scrolling; the per-section search inputs are gone.
- [x] Type `opcode:ORIGIN` (or click a chip) — heatmap, distribution, dimension bars, charts, block logs, tests table all narrow consistently.
- [x] Open Dimension breakdown — preview shows File + Gas. Click `Show more dimensions` to reveal the rest. Pick a File chip → Test row appears in the preview.
- [x] In the Dimension bars, find a value whose bucket has count=1 — clicking it opens the test detail modal (instead of adding a filter that yields the same one test).
- [x] Switch to Table view, pick a dimension, sort by P95 / P99, click a row — adds the filter.
- [x] Threshold slider/input drives bar colours and heatmap colours together; Reset returns to 60.
- [x] Compare and Compare-Groups pages show a FacetPanel above the comparison sections and toggling chips refilters MetricsComparison, charts, table, and BlockLogs.
- [x] Compare-page sticky header filter input is wide enough to actually type in.
- [x] Block Logs Analysis filters correctly with structured terms (`value_bearing=True` etc.).