### PR TITLE
feat(ui): scope Recent runs to matching labels + show run id/labels on hover

### DIFF
--- a/ui/src/components/run-detail/ClientRunsStrip.tsx
+++ b/ui/src/components/run-detail/ClientRunsStrip.tsx
@@ -42,8 +42,14 @@ const MAX_RUNS = 34
 interface TooltipData {
   run: IndexEntry
   x: number
-  y: number
+  top: number
+  bottom: number
 }
+
+// Estimated tooltip height; used to decide whether to flip below the button
+// when there isn't enough room above. Slightly overestimated so we err on the
+// side of flipping rather than clipping.
+const TOOLTIP_HEIGHT_ESTIMATE = 220
 
 interface ClientRunsStripProps {
   runs: IndexEntry[]
@@ -106,7 +112,7 @@ export function ClientRunsStrip({ runs, currentRunId, stepFilter, selectable = f
                 }}
                 onMouseEnter={(e) => {
                   const rect = e.currentTarget.getBoundingClientRect()
-                  setTooltip({ run, x: rect.left + rect.width / 2, y: rect.top })
+                  setTooltip({ run, x: rect.left + rect.width / 2, top: rect.top, bottom: rect.bottom })
                 }}
                 onMouseLeave={() => setTooltip(null)}
                 className={clsx(
@@ -154,13 +160,19 @@ export function ClientRunsStrip({ runs, currentRunId, stepFilter, selectable = f
         const stats = getIndexAggregatedStats(tooltip.run, stepFilter)
         const completed = isRunCompleted(tooltip.run)
         const mgas = calculateMGasPerSec(stats.gasUsed, stats.gasUsedDuration)
+        const labelEntries = Object.entries(tooltip.run.metadata ?? {})
+        const placeBelow = tooltip.top < TOOLTIP_HEIGHT_ESTIMATE
+        const positionStyle = placeBelow
+          ? { left: tooltip.x, top: tooltip.bottom + 8, transform: 'translate(-50%, 0)' }
+          : { left: tooltip.x, top: tooltip.top - 8, transform: 'translate(-50%, -100%)' }
         return (
           <div
             className="pointer-events-none fixed z-50 rounded-sm bg-white px-3 py-2 text-xs/5 shadow-lg ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:ring-0"
-            style={{ left: tooltip.x, top: tooltip.y - 8, transform: 'translate(-50%, -100%)' }}
+            style={positionStyle}
           >
             <div className="flex flex-col gap-1">
               <div className="font-medium">{tooltip.run.instance.client}</div>
+              <div className="font-mono text-[11px] text-gray-500 dark:text-gray-400">{tooltip.run.run_id}</div>
               <div>{formatTimestamp(tooltip.run.timestamp)}</div>
               {!completed && (
                 <div className="font-medium text-red-600 dark:text-red-400">
@@ -182,6 +194,15 @@ export function ClientRunsStrip({ runs, currentRunId, stepFilter, selectable = f
                   ({tooltip.run.tests.tests_total} total)
                 </span>
               </div>
+              {labelEntries.length > 0 && (
+                <div className="mt-1 flex flex-col gap-0.5 border-t border-gray-200 pt-1 dark:border-gray-700">
+                  {labelEntries.map(([k, v]) => (
+                    <div key={k} className="text-[11px] text-gray-500 dark:text-gray-400">
+                      <span className="font-medium">{k}:</span> {v}
+                    </div>
+                  ))}
+                </div>
+              )}
               {selectable ? (
                 <div className="text-gray-400 dark:text-gray-500">Click to select</div>
               ) : tooltip.run.run_id !== currentRunId ? (

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -213,9 +213,20 @@ export function RunDetailPage() {
   // Compute clientRuns and recentRuns before early returns to satisfy hooks rules.
   const clientRuns = useMemo(() => {
     if (!index || !config) return []
-    return index.entries.filter(
-      (r) => r.suite_hash === config.suite_hash && r.instance.client === config.instance.client,
-    )
+    const myLabels = config.metadata?.labels ?? {}
+    const myLabelKeys = Object.keys(myLabels)
+    return index.entries.filter((r) => {
+      if (r.suite_hash !== config.suite_hash) return false
+      if (r.instance.client !== config.instance.client) return false
+      // Same labels: same set of keys, same values for each key.
+      const otherLabels = r.metadata ?? {}
+      const otherKeys = Object.keys(otherLabels)
+      if (otherKeys.length !== myLabelKeys.length) return false
+      for (const k of myLabelKeys) {
+        if (otherLabels[k] !== myLabels[k]) return false
+      }
+      return true
+    })
   }, [index, config])
 
   const recentRuns = useMemo(() => {


### PR DESCRIPTION
## Summary
- Filter the **Recent** strip on the run-detail page to only show runs whose `metadata.labels` exactly match the current run (in addition to the existing `suite_hash` and client filter), so the peer set is actually comparable.
- Surface the `run_id` (mono, muted) and the full label list in the hover tooltip.
- Flip the tooltip below the strip when there isn't enough room above the viewport, so the top portion never gets clipped.

## Test plan
- [x] Open a run-detail page where multiple runs exist with different label sets — confirm only same-labelled runs appear in the Recent strip.
- [x] Open a run with no labels — confirm runs that also have no labels still appear (and labelled runs are excluded).
- [x] Hover a square in the strip — confirm `run_id` and each `key: value` label render under the existing fields.
- [x] Scroll so the strip sits near the very top of the viewport and hover — confirm the tooltip flips below the strip and isn't clipped.