### PR TITLE
chore: fixing CI for PRs from forks

### DIFF
--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -20,10 +20,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-ref: ${{ github.event.pull_request.head.sha }}
+          git-repo: ${{ github.event.pull_request.head.repo.clone_url }}
           #run-args: '--log-level=debug'
           run-config-urls: >-
-            https://raw.githubusercontent.com/ethpandaops/benchmarkoor/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-cleanup.yaml,
-            https://raw.githubusercontent.com/ethpandaops/benchmarkoor/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-clientstdout.yaml
+            https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-cleanup.yaml,
+            https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-clientstdout.yaml
           run-config: |
             runner:
               benchmark:
@@ -62,10 +63,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-ref: ${{ github.event.pull_request.head.sha }}
+          git-repo: ${{ github.event.pull_request.head.repo.clone_url }}
           #run-args: '--log-level=debug'
           run-config-urls: >-
-            https://raw.githubusercontent.com/ethpandaops/benchmarkoor/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-cleanup.yaml,
-            https://raw.githubusercontent.com/ethpandaops/benchmarkoor/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-clientstdout.yaml
+            https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-cleanup.yaml,
+            https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-clientstdout.yaml
           run-config: |
             runner:
               container_runtime: podman
@@ -102,10 +104,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-ref: ${{ github.event.pull_request.head.sha }}
+          git-repo: ${{ github.event.pull_request.head.repo.clone_url }}
           #run-args: '--log-level=debug'
           run-config-urls: >-
-            https://raw.githubusercontent.com/ethpandaops/benchmarkoor/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-cleanup.yaml,
-            https://raw.githubusercontent.com/ethpandaops/benchmarkoor/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-clientstdout.yaml
+            https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-cleanup.yaml,
+            https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-clientstdout.yaml
           run-config: |
             runner:
               container_runtime: podman

--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,11 @@ inputs:
     required: false
     default: ''
 
+  git-repo:
+    description: 'Git repository URL to clone for building the image. Only used when image is not provided. Defaults to ethpandaops/benchmarkoor.'
+    required: false
+    default: 'https://github.com/ethpandaops/benchmarkoor.git'
+
   upload-artifacts:
     description: 'Whether to upload run results as GitHub artifacts'
     required: false
@@ -65,8 +70,10 @@ runs:
           GIT_REF="master"
         fi
 
-        echo "Cloning https://github.com/ethpandaops/benchmarkoor.git at ref $GIT_REF"
-        git clone https://github.com/ethpandaops/benchmarkoor.git benchmarkoor-build
+        GIT_REPO="${{ inputs.git-repo }}"
+
+        echo "Cloning ${GIT_REPO} at ref $GIT_REF"
+        git clone "${GIT_REPO}" benchmarkoor-build
         cd benchmarkoor-build
         git checkout "$GIT_REF"
 


### PR DESCRIPTION
## Summary
Cherry-picked from the second commit of #182 (`4439298`, by @fselmo). Adds a `git-repo` input to the composite action so CI workflows triggered by PRs from forks clone the fork's HEAD instead of always cloning `ethpandaops/benchmarkoor`. The workflow wires `github.event.pull_request.head.repo.clone_url` into that input and uses `head.repo.full_name` in the `run-config-urls` so the runtime config files are also fetched from the fork.

## Test plan
- [ ] Open a PR from a fork against this branch and confirm the CI action clones the fork (the workflow log should show `Cloning https://github.com/<fork-owner>/benchmarkoor.git at ref <sha>`).
- [ ] Verify the `run-config-urls` resolve to `raw.githubusercontent.com/<fork-owner>/benchmarkoor/<sha>/...` rather than the canonical repo path.
- [ ] PRs from branches inside `ethpandaops/benchmarkoor` should continue to clone the canonical repo unchanged.