### PR TITLE
fix: increase client settle time before ZFS snapshot to 20s

### DIFF
--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -104,10 +104,12 @@ func (r *runner) runTestsWithContainerStrategy(
 			)
 		}
 
-		// Brief settle time so the client finishes any in-flight
-		// initialisation before we send SIGTERM.
-		log.Info("Waiting 2s for client to settle before stop")
-		time.Sleep(2 * time.Second)
+		// Settle time so the client finishes any in-flight
+		// initialisation and flushes its DB before we send SIGTERM.
+		// Too short here (e.g. reth/MDBX) snapshots a dirty datadir,
+		// which makes the client come up in "syncing" on restart.
+		log.Info("Waiting 20s for client to settle before stop")
+		time.Sleep(20 * time.Second)
 
 		// Stop the initial container so writes are flushed to disk.
 		// Use the default 60s SIGTERM grace period so the client has


### PR DESCRIPTION
## Summary

The `container-recreate` strategy waits after pre-run steps before sending SIGTERM to stop the initial container and snapshot its datadir. That wait was hardcoded to **2s**, which is too short for reth (MDBX) to finish flushing its in-flight state to disk.

The result: the ZFS snapshot captures a **dirty datadir**, so on every per-test restart the client comes up in **`syncing`** state — `engine_forkchoiceUpdated`/`engine_newPayload` return `SYNCING` instead of `VALID`, benchmarkoor retries 10× and gives up, and **no gas is ever measured** (`mgas_s: {}`). Observed on a reth `bal-full` run: 0 completed tests, ~10h ETA of pure retry-looping.

## Change

Bump the settle from `2s` → `20s` in `pkg/runner/strategy_container.go`, giving the client time to flush before the (already graceful, 60s) stop that precedes the snapshot.