### PR TITLE
fix(client): persist reth blocks during ZFS snapshot prep so the head isn't lost

### DIFF
--- a/pkg/client/besu.go
+++ b/pkg/client/besu.go
@@ -103,3 +103,8 @@ func (s *besuSpec) RPCRollbackSpec() *RPCRollbackSpec {
 func (s *besuSpec) DefaultConfigFiles() map[string]string {
 	return nil
 }
+
+// SnapshotPrepareArgs returns nil; Besu needs no snapshot-only args.
+func (s *besuSpec) SnapshotPrepareArgs() []string {
+	return nil
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -88,6 +88,9 @@ type Spec interface {
 	// Keys are target paths inside the container, values are file contents.
 	// Returns nil if no config files are needed.
 	DefaultConfigFiles() map[string]string
+
+	// SnapshotPrepareArgs returns args for the ZFS snapshot-prep container only (not per-test measurement); nil if none.
+	SnapshotPrepareArgs() []string
 }
 
 // Registry manages client specifications.

--- a/pkg/client/erigon.go
+++ b/pkg/client/erigon.go
@@ -109,3 +109,8 @@ func (s *erigonSpec) RPCRollbackSpec() *RPCRollbackSpec {
 func (s *erigonSpec) DefaultConfigFiles() map[string]string {
 	return nil
 }
+
+// SnapshotPrepareArgs returns nil; Erigon needs no snapshot-only args.
+func (s *erigonSpec) SnapshotPrepareArgs() []string {
+	return nil
+}

--- a/pkg/client/ethrex.go
+++ b/pkg/client/ethrex.go
@@ -89,3 +89,8 @@ func (s *ethrexSpec) RPCRollbackSpec() *RPCRollbackSpec {
 func (s *ethrexSpec) DefaultConfigFiles() map[string]string {
 	return nil
 }
+
+// SnapshotPrepareArgs returns nil; Ethrex needs no snapshot-only args.
+func (s *ethrexSpec) SnapshotPrepareArgs() []string {
+	return nil
+}

--- a/pkg/client/geth.go
+++ b/pkg/client/geth.go
@@ -108,3 +108,8 @@ IdleTimeout = 120000000000 # 120s
 `,
 	}
 }
+
+// SnapshotPrepareArgs returns nil; Geth needs no snapshot-only args.
+func (s *gethSpec) SnapshotPrepareArgs() []string {
+	return nil
+}

--- a/pkg/client/nethermind.go
+++ b/pkg/client/nethermind.go
@@ -101,3 +101,8 @@ func (s *nethermindSpec) RPCRollbackSpec() *RPCRollbackSpec {
 func (s *nethermindSpec) DefaultConfigFiles() map[string]string {
 	return nil
 }
+
+// SnapshotPrepareArgs returns nil; Nethermind needs no snapshot-only args.
+func (s *nethermindSpec) SnapshotPrepareArgs() []string {
+	return nil
+}

--- a/pkg/client/nimbus.go
+++ b/pkg/client/nimbus.go
@@ -88,3 +88,8 @@ func (s *nimbusSpec) RPCRollbackSpec() *RPCRollbackSpec {
 func (s *nimbusSpec) DefaultConfigFiles() map[string]string {
 	return nil
 }
+
+// SnapshotPrepareArgs returns nil; Nimbus needs no snapshot-only args.
+func (s *nimbusSpec) SnapshotPrepareArgs() []string {
+	return nil
+}

--- a/pkg/client/reth.go
+++ b/pkg/client/reth.go
@@ -90,3 +90,11 @@ func (s *rethSpec) RPCRollbackSpec() *RPCRollbackSpec {
 func (s *rethSpec) DefaultConfigFiles() map[string]string {
 	return nil
 }
+
+// SnapshotPrepareArgs makes reth persist every block during snapshot prep so the pre-run head reaches disk (else the snapshot lags a block and tests hang SYNCING).
+func (s *rethSpec) SnapshotPrepareArgs() []string {
+	return []string{
+		"--engine.persistence-threshold=0",
+		"--engine.memory-block-buffer-target=0",
+	}
+}

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -699,8 +699,25 @@ func (r *runner) runContainerLifecycle(
 	params.DataDirCfg = datadirCfg
 	params.UseDataDir = useDataDir
 
+	// Apply client-specific snapshot-prepare args to the initial (pre-run/snapshot) container only, scoped to ZFS container-recreate; per-test containers clone params.ContainerSpec and keep the base command.
+	createSpec := containerSpec
+
+	if prepareArgs := spec.SnapshotPrepareArgs(); len(prepareArgs) > 0 &&
+		r.cfg.FullConfig != nil &&
+		r.cfg.FullConfig.GetRollbackStrategy(instance) ==
+			config.RollbackStrategyContainerRecreate &&
+		datadirCfg != nil && datadirCfg.Method == "zfs" {
+		prepareSpec := *containerSpec
+		prepareSpec.Command = append(append([]string{}, cmd...), prepareArgs...)
+		createSpec = &prepareSpec
+
+		log.WithField("args", prepareArgs).Info(
+			"Applying snapshot-prepare args to initial (pre-run) container",
+		)
+	}
+
 	// Create container.
-	containerID, err := r.containerMgr.CreateContainer(ctx, containerSpec)
+	containerID, err := r.containerMgr.CreateContainer(ctx, createSpec)
 	if err != nil {
 		return fmt.Errorf("creating container: %w", err)
 	}


### PR DESCRIPTION
## Problem

`reth-bal-*` stateful suites fail **every test** — reth boots fine but is stuck in permanent `SYNCING`. After each per-test ZFS rollback, reth comes up **one block behind** the chain head, so the test's first `newPayload` references a parent reth never has. With no peers to backfill it stays `SYNCING`, exhausts the 10 retries, and `forkchoiceUpdatedV3` returns `SYNCING` instead of `VALID` → every test fails.

Only suites whose pre-run ends on a **heavy block** hit this. Here the fixture base `24407728` is the funding block (**15k withdrawals → trie-heavy**); light suites are unaffected.

## Root cause (verified against reth `bal-devnet-7` @ `d9d028b` + the run-`9a2b9b5e` prepare logs)

reth keeps recent canonical blocks in its in-memory engine tree and only flushes to MDBX once they are `persistence_threshold` (default **2**) deep — `should_persist()` fires only when `canonical_head − last_persisted > threshold` (`crates/engine/tree/src/tree/mod.rs:2066`). Confirmed from the logs: pre-run reached canonical head **24407728** (`0xfad0a7f2…`) but the snapshot persisted only **24407727** (`0x97f16c5f…`).

Two compounding reasons the head never lands on disk:
1. **The 20s settle doesn't help.** With `threshold=2`, `should_persist` never fires while the canonical-vs-persisted gap is ≤2, so reth has no reason to flush during the settle (a longer settle was already tried — no effect).
2. **The shutdown flush is cut off.** The only flush attempt is at graceful shutdown (`persist_until_complete` → `PersistTarget::Head`), which recomputes the state root from the DB — heavy for a 15k-withdrawal block — and is bounded by reth's **5s** `graceful_shutdown_timeout` (`crates/cli/runner/src/lib.rs:197`, not CLI-configurable). On slow ZFS (reth's own log warns about ZFS+MDBX) it doesn't finish; the observed stop took ~5.7s. Light suites flush in time → no gap.

Because reth is forced onto the container-recreate + ZFS strategy (RPC rollback disabled in `dc2d25d`, `RPCRollbackSpec()` returns nil), every test rolls back to that block-short snapshot.

## Fix — scoped to snapshot creation only

Add a `client.Spec.SnapshotPrepareArgs()` hook (mirrors the existing `RPCRollbackSpec()`/`DefaultConfigFiles()` nil-returning pattern). reth returns `--engine.persistence-threshold=0` (+ `--engine.memory-block-buffer-target=0`); all other clients return `nil`. In `runContainerLifecycle`, these args are applied **only to the initial container that runs pre-run and is snapshotted**, scoped to the `container-recreate` + `zfs` case. Per-test recreated containers clone `params.ContainerSpec` (base command), so they keep reth's **default** persistence.

Effect: reth persists each block as it becomes canonical during pre-run, so the heavy trie write lands inside the **20s settle window** instead of the **5s shutdown box**, and the snapshot captures the true head **24407728**.

### Why scoped, not global

An earlier version put the flag in reth's `DefaultCommand` (global). That also changes reth's persistence during the **measured** per-test runs — extra MDBX commits on ZFS that perturb the `newPayload`/`forkchoiceUpdated` timings the tool reports, and make reth non-default vs geth/besu. Per-test correctness doesn't need it (each test force-kills + rolls back, discarding persisted state), so the change belongs at snapshot creation only.

## Verification

- `go build`/`go vet`/`gofmt` clean on `pkg/client` and `pkg/runner`.
- Root cause confirmed by block-hash tracing in the run-`9a2b9b5e` prepare logs (canonical `24407728` reached; only `24407727` snapshotted).
- reth source semantics confirmed at `d9d028b` (the exact build in the logs).
- `--engine.persistence-threshold=0`/`--engine.memory-block-buffer-target=0` accepted by `ethpandaops/reth:bal-devnet-7`.

## Deploy note

No manual snapshot surgery: the `benchmarkoor-ready` snapshot is rebuilt by the prepare phase each run, so the first run with the new binary produces a correct snapshot.

## Follow-up (not in this PR)

reth's graceful-shutdown flush being capped at a 5s timeout it can't meet for heavy blocks on ZFS is arguably a reth-side robustness gap; worth a separate upstream note.