### PR TITLE
feat(datadir): add schelk method for volume restores

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -485,6 +485,21 @@ runner:
     #     #                    Requires: root access OR ZFS delegations configured:
     #     #                      zfs allow -u <user> clone,create,destroy,mount,snapshot <dataset>
     #     #                    The dataset is auto-detected from the source_dir mount point.
+    #     #   direct         - bind-mount source_dir directly into the container with no copy or snapshot.
+    #     #                    Changes persist after the run. Intended for inspection / resume workflows,
+    #     #                    not normal benchmarking.
+    #     #   schelk         - use a schelk-managed scratch volume (https://github.com/tempoxyz/schelk)
+    #     #                    restored from a virgin baseline between iterations via dm-era.
+    #     #                    Requires: `schelk` binary on PATH (override with BENCHMARKOOR_SCHELK_BIN)
+    #     #                    Requires: schelk already initialised via `schelk init-new` / `init-from`
+    #     #                    Requires: root access
+    #     #                    `source_dir` must be the schelk mount point or a subdirectory of it.
+    #     #                    Pairs naturally with rollback_strategy: container-recreate so each
+    #     #                    iteration starts from a clean baseline. Not compatible with
+    #     #                    rollback_strategy: container-checkpoint-restore (that requires ZFS).
+    #     #                    Optional env var BENCHMARKOOR_SCHELK_BIN overrides the binary path
+    #     #                    (useful under sudo with a sanitised PATH); SCHELK_STATE overrides the
+    #     #                    schelk state-file path (default /var/lib/schelk/state.json).
     #     method: copy
     #   reth:
     #     source_dir: ./data/snapshots/reth
@@ -495,6 +510,10 @@ runner:
     #   #   source_dir: /tank/benchmarkoor/nethermind-snapshot  # Must be on ZFS
     #   #   container_dir: /nethermind/data
     #   #   method: zfs  # near-instant via ZFS clones
+    #   # Example: schelk-backed data directory
+    #   # reth:
+    #   #   source_dir: /schelk/eth/reth  # Must be under the schelk mount point
+    #   #   method: schelk
 
   instances:
     - id: geth-latest

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1049,6 +1049,8 @@ runner:
 | `overlayfs` | Linux overlayfs for near-instant setup | Root access |
 | `fuse-overlayfs` | FUSE-based overlayfs | `fuse-overlayfs` package; `user_allow_other` in `/etc/fuse.conf` if Docker runs as root. **Warning:** ~3x slower than native overlayfs |
 | `zfs` | ZFS snapshots and clones for copy-on-write setup | Source directory on ZFS filesystem; root access or ZFS delegations configured |
+| `direct` | Bind-mount `source_dir` directly into the container with no copy/snapshot. **Changes persist after the run.** Intended for inspection / resume workflows, not normal benchmarking | None |
+| `schelk` | Use a [schelk](https://github.com/tempoxyz/schelk)-managed scratch volume restored from a virgin baseline between iterations | `schelk` binary on PATH (or `BENCHMARKOOR_SCHELK_BIN`); schelk initialised via `schelk init-new` / `init-from`; root access |
 
 ###### ZFS Setup
 
@@ -1058,6 +1060,48 @@ zfs allow -u <user> clone,create,destroy,mount,snapshot <dataset>
 ```
 
 The dataset is auto-detected from the source directory mount point.
+
+###### Schelk Setup
+
+[schelk](https://github.com/tempoxyz/schelk) keeps a pristine virgin block device and a scratch block device, using `dm-era` on a ramdisk to track which blocks changed during a run so the scratch can be surgically restored from virgin between iterations. It pairs well with `rollback_strategy: container-recreate`, which gives schelk a clean baseline at the start of every test.
+
+Before configuring benchmarkoor, initialise schelk on the host (see [schelk's SKILL.md](https://github.com/tempoxyz/schelk/blob/master/docs/SKILL.md)):
+
+```bash
+sudo schelk init-from \
+  --virgin /dev/<virgin>  --scratch /dev/<scratch> \
+  --ramdisk /dev/ram0 --mount-point /schelk --fstype ext4
+```
+
+Then point `source_dir` at the path inside the schelk mount that holds your client's datadir:
+
+```yaml
+runner:
+  client:
+    config:
+      rollback_strategy: container-recreate
+  instances:
+    - id: reth-schelk
+      client: reth
+      datadir:
+        method: schelk
+        source_dir: /schelk/eth/reth   # subpath under the schelk mount
+```
+
+What benchmarkoor does at runtime:
+- **Config validation** verifies `schelk` is on PATH, reads `/var/lib/schelk/state.json` to learn the mount point, and runs `schelk mount` if the scratch isn't currently mounted. If state says mounted but `/proc/mounts` disagrees (a crash artefact), benchmarkoor surfaces a clear error pointing at `schelk full-recover`.
+- **Per container lifecycle**, `Prepare` runs `schelk restore` (recover + mount) so each iteration starts from the virgin baseline. `Cleanup` runs `schelk recover` to unmount and restore baseline.
+- **Graceful shutdown**: schelk commands run in their own process group, so a SIGTERM to benchmarkoor does not propagate to schelk. An in-flight schelk command is given up to 60 seconds to finish before being killed, so a recover mid-flight is not interrupted.
+
+Notes:
+- `rollback_strategy: container-checkpoint-restore` is **not** compatible with `method: schelk` (it requires `method: zfs`).
+- All operational schelk commands require root.
+- `source_dir` must be the schelk mount point or a subdirectory of it.
+
+| Environment Variable | Description |
+|----------------------|-------------|
+| `BENCHMARKOOR_SCHELK_BIN` | Override the schelk executable path. Useful when running under `sudo` with a sanitised PATH that does not include `~/.cargo/bin`. Accepts a bare name (resolved via PATH) or an absolute/relative path. Default: `schelk` |
+| `SCHELK_STATE` | Override the schelk state-file path. Honoured by both schelk itself and benchmarkoor's preflight. Default: `/var/lib/schelk/state.json` |
 
 ###### Default Container Directories
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/ethpandaops/benchmarkoor/pkg/cpufreq"
+	"github.com/ethpandaops/benchmarkoor/pkg/datadir"
 	"github.com/mitchellh/mapstructure"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/spf13/viper"
@@ -735,6 +738,18 @@ func (d *DataDirConfig) Validate(prefix string) error {
 		return fmt.Errorf("%s: source_dir is required", prefix)
 	}
 
+	validMethods := map[string]bool{"": true, "copy": true, "overlayfs": true, "fuse-overlayfs": true, "zfs": true, "direct": true, "schelk": true}
+	if !validMethods[d.Method] {
+		return fmt.Errorf("%s: invalid method %q, must be: copy, overlayfs, fuse-overlayfs, zfs, direct, schelk", prefix, d.Method)
+	}
+
+	// For method=schelk, source_dir lives under a schelk-managed mount
+	// that may not be mounted yet at config load time. validateDataDirMethods
+	// performs the mount and re-checks existence afterwards.
+	if d.Method == "schelk" {
+		return nil
+	}
+
 	info, err := os.Stat(d.SourceDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -746,11 +761,6 @@ func (d *DataDirConfig) Validate(prefix string) error {
 
 	if !info.IsDir() {
 		return fmt.Errorf("%s: source_dir %q is not a directory", prefix, d.SourceDir)
-	}
-
-	validMethods := map[string]bool{"": true, "copy": true, "overlayfs": true, "fuse-overlayfs": true, "zfs": true, "direct": true}
-	if !validMethods[d.Method] {
-		return fmt.Errorf("%s: invalid method %q, must be: copy, overlayfs, fuse-overlayfs, zfs, direct", prefix, d.Method)
 	}
 
 	return nil
@@ -1205,6 +1215,11 @@ func (c *Config) Validate(opts ...ValidateOpts) error {
 
 	// Validate rollback_strategy settings.
 	if err := c.validateRollbackStrategy(opt); err != nil {
+		return err
+	}
+
+	// Validate per-method datadir requirements (binary availability, etc.).
+	if err := c.validateDataDirMethods(opt); err != nil {
 		return err
 	}
 
@@ -1939,6 +1954,109 @@ func (c *Config) validateRollbackStrategy(opt ValidateOpts) error {
 					instance.ID, opts.TmpfsMaxSize, err,
 				)
 			}
+		}
+	}
+
+	return nil
+}
+
+// validateDataDirMethods runs per-method preflight for active instances.
+// For method=schelk: verifies the binary is on PATH, ensures the schelk
+// scratch volume is mounted (calling `schelk mount` if not), and then
+// verifies each instance's source_dir exists under the schelk mount
+// point. This shifts the existence check out of DataDirConfig.Validate
+// for schelk since the path only materialises after mount.
+func (c *Config) validateDataDirMethods(opt ValidateOpts) error {
+	type schelkInstance struct {
+		id, sourceDir string
+	}
+
+	var schelkInstances []schelkInstance
+
+	for _, instance := range c.Runner.Instances {
+		if !opt.isInstanceActive(instance.ID) {
+			continue
+		}
+
+		dd := c.resolveDataDir(&instance)
+		if dd != nil && dd.Method == "schelk" {
+			schelkInstances = append(schelkInstances, schelkInstance{
+				id:        instance.ID,
+				sourceDir: dd.SourceDir,
+			})
+		}
+	}
+
+	if len(schelkInstances) == 0 {
+		return nil
+	}
+
+	bin := datadir.SchelkBinary()
+
+	if _, err := exec.LookPath(bin); err != nil {
+		return fmt.Errorf(
+			"datadir.method \"schelk\" requires the `%s` binary on PATH "+
+				"(override with %s): %w",
+			bin, datadir.SchelkBinaryEnv, err,
+		)
+	}
+
+	state, err := datadir.ReadSchelkState(datadir.SchelkStatePath())
+	if err != nil {
+		return fmt.Errorf("datadir.method \"schelk\": %w", err)
+	}
+
+	if state.MountPoint == "" {
+		return fmt.Errorf("datadir.method \"schelk\": schelk state has no mount_point — run `schelk init-new` or `schelk init-from` first")
+	}
+
+	mountedActual, err := datadir.IsMountedAt(state.MountPoint)
+	if err != nil {
+		return fmt.Errorf("datadir.method \"schelk\": checking mount status: %w", err)
+	}
+
+	switch {
+	case state.IsMounted && !mountedActual:
+		// schelk state says mounted but the kernel disagrees — typically
+		// a crash or interrupted recover left dm-era and state out of sync.
+		// schelk mount will refuse ("Volume is already mounted") and only
+		// `schelk full-recover` can re-establish a consistent baseline.
+		return fmt.Errorf(
+			"datadir.method \"schelk\": state at %q says is_mounted=true but %q is not in /proc/mounts "+
+				"(inconsistent, likely from a prior crash) — run `%s full-recover` to reset, then retry",
+			datadir.SchelkStatePath(), state.MountPoint, bin,
+		)
+	case !state.IsMounted && !mountedActual:
+		// Use datadir.RunSchelk so a SIGTERM during validation does not
+		// kill the in-flight `schelk mount` mid-operation.
+		output, runErr := datadir.RunSchelk(context.Background(), nil, "mount", "-y")
+		if runErr != nil {
+			return fmt.Errorf(
+				"datadir.method \"schelk\": `%s mount` failed: %w (output: %s)",
+				bin, runErr, strings.TrimSpace(string(output)),
+			)
+		}
+	}
+	// state.IsMounted && mountedActual: nothing to do — Prepare will run
+	//   schelk restore to re-establish baseline at run start.
+	// !state.IsMounted && mountedActual: unusual but harmless; let Prepare
+	//   handle it via restore.
+
+	for _, si := range schelkInstances {
+		info, statErr := os.Stat(si.sourceDir)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				return fmt.Errorf(
+					"instance %q datadir: source_dir %q does not exist under schelk mount %q",
+					si.id, si.sourceDir, state.MountPoint,
+				)
+			}
+
+			return fmt.Errorf("instance %q datadir: checking source_dir: %w", si.id, statErr)
+		}
+
+		if !info.IsDir() {
+			return fmt.Errorf("instance %q datadir: source_dir %q is not a directory", si.id, si.sourceDir)
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -2029,6 +2030,31 @@ func TestValidateRollbackStrategy_CheckpointRestore(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "checkpoint-restore rejects schelk datadir",
+			cfg: Config{
+				Runner: RunnerConfig{
+					ContainerRuntime: "podman",
+					Client: ClientConfig{
+						Config: ClientDefaults{
+							RollbackStrategy: RollbackStrategyCheckpointRestore,
+						},
+					},
+					Instances: []ClientInstance{
+						{
+							ID:     "test",
+							Client: "geth",
+							DataDir: &DataDirConfig{
+								SourceDir: validDir,
+								Method:    "schelk",
+							},
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "with datadir requires datadir.method: \"zfs\"",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2260,6 +2286,209 @@ func TestValidate_WithValidateOpts(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestValidateDataDirMethods_SchelkBinary(t *testing.T) {
+	validDir := t.TempDir()
+
+	mkCfg := func(method, sourceDir string) Config {
+		return Config{
+			Runner: RunnerConfig{
+				Instances: []ClientInstance{
+					{
+						ID:     "test",
+						Client: "geth",
+						DataDir: &DataDirConfig{
+							SourceDir: sourceDir,
+							Method:    method,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// stageSchelkState writes a fake schelk state file with the given mount
+	// point and is_mounted flag, then points SCHELK_STATE at it. For
+	// "happy path" tests, pass mountPoint="/" and isMounted=true so the
+	// /proc/mounts check matches state without running `schelk mount`.
+	stageSchelkState := func(t *testing.T, mountPoint string, isMounted bool) {
+		t.Helper()
+
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "state.json")
+		body := fmt.Sprintf(`{"mount_point":%q,"is_mounted":%t}`, mountPoint, isMounted)
+		require.NoError(t, os.WriteFile(statePath, []byte(body), 0o600))
+		t.Setenv("SCHELK_STATE", statePath)
+	}
+
+	// stageSchelkBin installs a no-op `schelk` shim on PATH so the binary
+	// preflight passes and any `schelk mount` invocation succeeds without
+	// touching the kernel.
+	stageSchelkBin := func(t *testing.T, name string) string {
+		t.Helper()
+
+		binDir := t.TempDir()
+		fake := filepath.Join(binDir, name)
+		require.NoError(t, os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+		t.Setenv("PATH", binDir)
+
+		return fake
+	}
+
+	t.Run("non-schelk methods don't probe PATH", func(t *testing.T) {
+		// Hide PATH so any LookPath call would fail; copy must still validate.
+		t.Setenv("PATH", "")
+
+		cfg := mkCfg("copy", validDir)
+		require.NoError(t, cfg.validateDataDirMethods(ValidateOpts{}))
+	})
+
+	t.Run("schelk method requires `schelk` on PATH", func(t *testing.T) {
+		t.Setenv("PATH", "")
+
+		cfg := mkCfg("schelk", validDir)
+		err := cfg.validateDataDirMethods(ValidateOpts{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires the `schelk` binary on PATH")
+	})
+
+	t.Run("inactive instance with schelk is skipped", func(t *testing.T) {
+		t.Setenv("PATH", "")
+
+		cfg := mkCfg("schelk", validDir)
+		opts := ValidateOpts{ActiveInstanceIDs: map[string]struct{}{"other": {}}}
+		require.NoError(t, cfg.validateDataDirMethods(opts))
+	})
+
+	t.Run("schelk method passes when binary and state are present", func(t *testing.T) {
+		stageSchelkBin(t, "schelk")
+		stageSchelkState(t, "/", true)
+
+		cfg := mkCfg("schelk", validDir)
+		require.NoError(t, cfg.validateDataDirMethods(ValidateOpts{}))
+	})
+
+	t.Run("missing schelk state file is reported clearly", func(t *testing.T) {
+		stageSchelkBin(t, "schelk")
+		// Point SCHELK_STATE at a path that doesn't exist.
+		t.Setenv("SCHELK_STATE", filepath.Join(t.TempDir(), "missing.json"))
+
+		cfg := mkCfg("schelk", validDir)
+		err := cfg.validateDataDirMethods(ValidateOpts{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "schelk state file")
+		assert.Contains(t, err.Error(), "init-new")
+	})
+
+	t.Run("source_dir under mount that doesn't exist fails clearly", func(t *testing.T) {
+		stageSchelkBin(t, "schelk")
+		stageSchelkState(t, "/", true)
+
+		cfg := mkCfg("schelk", "/this/path/should/not/exist/in/tests")
+		err := cfg.validateDataDirMethods(ValidateOpts{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not exist under schelk mount")
+	})
+
+	t.Run("BENCHMARKOOR_SCHELK_BIN overrides the binary name", func(t *testing.T) {
+		stageSchelkBin(t, "schelk-custom")
+		t.Setenv("BENCHMARKOOR_SCHELK_BIN", "schelk-custom")
+		stageSchelkState(t, "/", true)
+
+		cfg := mkCfg("schelk", validDir)
+		require.NoError(t, cfg.validateDataDirMethods(ValidateOpts{}))
+	})
+
+	t.Run("BENCHMARKOOR_SCHELK_BIN absolute path bypasses PATH lookup", func(t *testing.T) {
+		fake := stageSchelkBin(t, "schelk-abs")
+		t.Setenv("PATH", "")
+		t.Setenv("BENCHMARKOOR_SCHELK_BIN", fake)
+		stageSchelkState(t, "/", true)
+
+		cfg := mkCfg("schelk", validDir)
+		require.NoError(t, cfg.validateDataDirMethods(ValidateOpts{}))
+	})
+
+	t.Run("BENCHMARKOOR_SCHELK_BIN error message names the override", func(t *testing.T) {
+		t.Setenv("PATH", "")
+		t.Setenv("BENCHMARKOOR_SCHELK_BIN", "missing-schelk-binary")
+
+		cfg := mkCfg("schelk", validDir)
+		err := cfg.validateDataDirMethods(ValidateOpts{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing-schelk-binary")
+		assert.Contains(t, err.Error(), "BENCHMARKOOR_SCHELK_BIN")
+	})
+
+	t.Run("state inconsistency points user at full-recover", func(t *testing.T) {
+		stageSchelkBin(t, "schelk")
+		// State says mounted at a path that isn't in /proc/mounts.
+		stageSchelkState(t, filepath.Join(t.TempDir(), "fake-mount-point"), true)
+
+		cfg := mkCfg("schelk", validDir)
+		err := cfg.validateDataDirMethods(ValidateOpts{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "inconsistent")
+		assert.Contains(t, err.Error(), "full-recover")
+	})
+
+	t.Run("not-mounted state triggers schelk mount call", func(t *testing.T) {
+		// Use a shim that records the args it was called with so we can
+		// confirm we called `schelk mount -y` exactly once.
+		binDir := t.TempDir()
+		logFile := filepath.Join(binDir, "calls.log")
+		fake := filepath.Join(binDir, "schelk")
+		script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\nexit 0\n", logFile)
+		require.NoError(t, os.WriteFile(fake, []byte(script), 0o755))
+		t.Setenv("PATH", binDir)
+
+		// State says unmounted at a path that isn't in /proc/mounts.
+		stageSchelkState(t, filepath.Join(t.TempDir(), "not-mounted-anywhere"), false)
+
+		cfg := mkCfg("schelk", validDir)
+		require.NoError(t, cfg.validateDataDirMethods(ValidateOpts{}))
+
+		logged, err := os.ReadFile(logFile)
+		require.NoError(t, err)
+		assert.Equal(t, "mount -y\n", string(logged))
+	})
+}
+
+func TestDataDirConfig_Validate_Methods(t *testing.T) {
+	validDir := t.TempDir()
+
+	tests := []struct {
+		name      string
+		method    string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "empty defaults ok", method: "", wantErr: false},
+		{name: "copy", method: "copy", wantErr: false},
+		{name: "overlayfs", method: "overlayfs", wantErr: false},
+		{name: "fuse-overlayfs", method: "fuse-overlayfs", wantErr: false},
+		{name: "zfs", method: "zfs", wantErr: false},
+		{name: "direct", method: "direct", wantErr: false},
+		{name: "schelk", method: "schelk", wantErr: false},
+		{name: "unknown rejected", method: "bogus", wantErr: true, errSubstr: "invalid method"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dd := &DataDirConfig{SourceDir: validDir, Method: tt.method}
+			err := dd.Validate("dd")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/datadir/provider.go
+++ b/pkg/datadir/provider.go
@@ -27,7 +27,7 @@ type PreparedDir struct {
 }
 
 // NewProvider creates a new Provider based on the method.
-// Supported methods: "copy" (default), "overlayfs", "fuse-overlayfs", "zfs", "direct".
+// Supported methods: "copy" (default), "overlayfs", "fuse-overlayfs", "zfs", "direct", "schelk".
 func NewProvider(log logrus.FieldLogger, method string) (Provider, error) {
 	switch method {
 	case "", "copy":
@@ -40,6 +40,8 @@ func NewProvider(log logrus.FieldLogger, method string) (Provider, error) {
 		return NewZFSProvider(log), nil
 	case "direct":
 		return NewDirectProvider(log), nil
+	case "schelk":
+		return NewSchelkProvider(log), nil
 	default:
 		return nil, fmt.Errorf("unknown datadir method: %q", method)
 	}

--- a/pkg/datadir/schelk.go
+++ b/pkg/datadir/schelk.go
@@ -1,0 +1,308 @@
+package datadir
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DefaultSchelkStatePath is the default schelk state file location.
+const DefaultSchelkStatePath = "/var/lib/schelk/state.json"
+
+// SchelkBinaryEnv overrides the schelk executable used by the provider
+// and by config preflight. Useful when running under sudo with a
+// sanitized PATH that does not include ~/.cargo/bin or wherever
+// `schelk` is installed.
+const SchelkBinaryEnv = "BENCHMARKOOR_SCHELK_BIN"
+
+// DefaultSchelkBinary is the binary name used when SchelkBinaryEnv is unset.
+const DefaultSchelkBinary = "schelk"
+
+// SchelkGracePeriod is the wall-clock budget granted to an in-flight
+// schelk command after the caller context is cancelled (typically by
+// SIGTERM). Killing schelk mid-recover/restore leaves dm-era and
+// state.json out of sync — usually only recoverable via
+// `schelk full-recover` — so we wait for it to finish naturally rather
+// than yanking it.
+//
+// var (not const) so tests can shorten it.
+var SchelkGracePeriod = 60 * time.Second
+
+// SchelkBinary returns the schelk executable path: SchelkBinaryEnv if
+// set, otherwise the unqualified binary name (resolved via PATH).
+func SchelkBinary() string {
+	if p := os.Getenv(SchelkBinaryEnv); p != "" {
+		return p
+	}
+
+	return DefaultSchelkBinary
+}
+
+// RunSchelk invokes the schelk binary with the given args. Schelk is
+// launched in its own process group (Setpgid) so a SIGTERM delivered
+// to benchmarkoor's group is not propagated, and the parent ctx is
+// only used to start a SchelkGracePeriod countdown — schelk is allowed
+// to finish for up to SchelkGracePeriod after ctx is cancelled before
+// it is killed. log may be nil.
+//
+// Returns combined stdout+stderr and the exec error (if any).
+func RunSchelk(ctx context.Context, log logrus.FieldLogger, args ...string) ([]byte, error) {
+	return runSchelkWithGrace(ctx, log, SchelkGracePeriod, args...)
+}
+
+func runSchelkWithGrace(
+	ctx context.Context,
+	log logrus.FieldLogger,
+	grace time.Duration,
+	args ...string,
+) ([]byte, error) {
+	bin := SchelkBinary()
+
+	//nolint:gosec // bin resolves to a controlled binary name or env override.
+	cmd := exec.Command(bin, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	var buf bytes.Buffer
+
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting `%s %s`: %w", bin, strings.Join(args, " "), err)
+	}
+
+	waitErrCh := make(chan error, 1)
+	go func() { waitErrCh <- cmd.Wait() }()
+
+	select {
+	case waitErr := <-waitErrCh:
+		return buf.Bytes(), waitErr
+	case <-ctx.Done():
+		if log != nil {
+			log.WithFields(logrus.Fields{
+				"args":  args,
+				"grace": grace,
+			}).Warn("Context cancelled; waiting for schelk to finish before killing")
+		}
+	}
+
+	select {
+	case waitErr := <-waitErrCh:
+		return buf.Bytes(), waitErr
+	case <-time.After(grace):
+		// schelk is the leader of its own process group (Setpgid above),
+		// so signal the entire group to also bring down any child it
+		// forked (e.g. dmsetup, rsync). Without this, cmd.Wait() blocks
+		// on the stdout pipe held open by grandchildren.
+		if killErr := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); killErr != nil && log != nil {
+			log.WithError(killErr).Warn("Failed to kill schelk process group after grace period")
+		}
+
+		<-waitErrCh
+
+		return buf.Bytes(), fmt.Errorf(
+			"`%s %s` did not complete within %s after shutdown signal",
+			bin, strings.Join(args, " "), grace,
+		)
+	}
+}
+
+// SchelkProvider implements Provider by binding to a schelk-managed mount.
+//
+// schelk maintains a single scratch mount at a fixed mount point, restored
+// from a pristine virgin baseline via `schelk recover`. Unlike the ZFS or
+// copy providers, Prepare does not produce an isolated clone per call —
+// instead it verifies that the schelk scratch volume is mounted (mounting
+// it if necessary) and returns the configured source_dir, which must live
+// under the schelk mount point. Cleanup runs `schelk recover` to restore
+// the scratch volume to baseline.
+//
+// Pairing with rollback_strategy:
+//   - container-recreate: Prepare/Cleanup runs per iteration, so recover
+//     happens between every test.
+//   - none / rpc-debug-setHead: Prepare/Cleanup runs once per container
+//     lifecycle, so recover happens at end of run.
+type SchelkProvider interface {
+	Provider
+}
+
+// NewSchelkProvider creates a new schelk-backed datadir provider.
+func NewSchelkProvider(log logrus.FieldLogger) SchelkProvider {
+	return &schelkProvider{
+		log: log.WithField("component", "datadir-schelk"),
+	}
+}
+
+// SchelkState mirrors the fields we care about from the schelk state file
+// (see /var/lib/schelk/state.json). schelk owns the schema; we only
+// inspect mount_point to validate the source path.
+type SchelkState struct {
+	MountPoint string `json:"mount_point"`
+	IsMounted  bool   `json:"is_mounted"`
+}
+
+type schelkProvider struct {
+	log logrus.FieldLogger
+}
+
+// Ensure interface compliance.
+var _ SchelkProvider = (*schelkProvider)(nil)
+
+// Prepare guarantees the schelk scratch volume is at the virgin baseline
+// and mounted before returning. It always runs `schelk restore` (recover
+// + mount) so a prior dirty or inconsistent state from a crashed run
+// cannot leak into this benchmark. cfg.SourceDir must be the schelk
+// mount point or a subdirectory of it.
+func (p *schelkProvider) Prepare(ctx context.Context, cfg *ProviderConfig) (*PreparedDir, error) {
+	state, err := ReadSchelkState(SchelkStatePath())
+	if err != nil {
+		return nil, fmt.Errorf("reading schelk state: %w", err)
+	}
+
+	if state.MountPoint == "" {
+		return nil, fmt.Errorf("schelk state has no mount_point — run `schelk init-new` or `schelk init-from` first")
+	}
+
+	sourceAbs, err := filepath.Abs(cfg.SourceDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving source_dir: %w", err)
+	}
+
+	if !pathIsUnderMountpoint(sourceAbs, state.MountPoint) {
+		return nil, fmt.Errorf(
+			"source_dir %q is not under schelk mount point %q",
+			sourceAbs, state.MountPoint,
+		)
+	}
+
+	p.log.WithFields(logrus.Fields{
+		"mount_point": state.MountPoint,
+		"instance_id": cfg.InstanceID,
+	}).Info("Running `schelk restore` to ensure baseline + mounted")
+
+	// `restore` = recover (surgical block restore from virgin) + mount.
+	// Idempotent and fast when already at baseline. If the state is
+	// inconsistent (e.g. post-crash), schelk will surface the error and
+	// the user must run `schelk full-recover` once before retrying.
+	if err := p.runSchelk(ctx, "restore", "-y"); err != nil {
+		return nil, fmt.Errorf("schelk restore: %w", err)
+	}
+
+	// Sanity-check the mount actually appeared. Cheap insurance against
+	// silent schelk-side regressions.
+	mounted, err := IsMountedAt(state.MountPoint)
+	if err != nil {
+		return nil, fmt.Errorf("checking mount status: %w", err)
+	}
+
+	if !mounted {
+		return nil, fmt.Errorf(
+			"schelk restore reported success but %q is not mounted",
+			state.MountPoint,
+		)
+	}
+
+	p.log.WithFields(logrus.Fields{
+		"mount_point": state.MountPoint,
+		"source_dir":  sourceAbs,
+		"instance_id": cfg.InstanceID,
+	}).Info("schelk datadir ready")
+
+	return &PreparedDir{
+		MountPath: sourceAbs,
+		Cleanup: func() error {
+			return p.cleanup(state.MountPoint)
+		},
+	}, nil
+}
+
+// cleanup runs `schelk recover` to restore the scratch volume to the
+// virgin baseline. Uses background context so cleanup completes even
+// when the caller's context has been cancelled.
+func (p *schelkProvider) cleanup(mountPoint string) error {
+	p.log.WithField("mount_point", mountPoint).Info("Running `schelk recover` to restore baseline")
+
+	if err := p.runSchelk(context.Background(), "recover", "-y"); err != nil {
+		return fmt.Errorf("schelk recover: %w", err)
+	}
+
+	return nil
+}
+
+// runSchelk invokes the schelk binary with the given args, isolating
+// it from benchmarkoor's process group and giving it up to
+// SchelkGracePeriod to finish after ctx is cancelled.
+func (p *schelkProvider) runSchelk(ctx context.Context, args ...string) error {
+	output, err := RunSchelk(ctx, p.log, args...)
+	if err != nil {
+		return fmt.Errorf("`%s %s` failed: %w (output: %s)",
+			SchelkBinary(), strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+
+	p.log.WithFields(logrus.Fields{
+		"args":   args,
+		"output": strings.TrimSpace(string(output)),
+	}).Debug("schelk command succeeded")
+
+	return nil
+}
+
+// SchelkStatePath returns the state-file path, honouring SCHELK_STATE
+// to match schelk's own behaviour.
+func SchelkStatePath() string {
+	if p := os.Getenv("SCHELK_STATE"); p != "" {
+		return p
+	}
+
+	return DefaultSchelkStatePath
+}
+
+// ReadSchelkState reads and decodes the schelk JSON state file.
+func ReadSchelkState(path string) (*SchelkState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("schelk state file %q not found — run `schelk init-new` or `schelk init-from` first", path)
+		}
+
+		return nil, fmt.Errorf("reading %q: %w", path, err)
+	}
+
+	var s SchelkState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parsing %q: %w", path, err)
+	}
+
+	return &s, nil
+}
+
+// IsMountedAt reports whether the given mount point appears as a mount
+// in /proc/mounts. The schelk state's is_mounted flag is unreliable
+// after a crash, so we consult the kernel directly.
+func IsMountedAt(mountPoint string) (bool, error) {
+	file, err := os.Open("/proc/mounts")
+	if err != nil {
+		return false, fmt.Errorf("opening /proc/mounts: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && fields[1] == mountPoint {
+			return true, nil
+		}
+	}
+
+	return false, scanner.Err()
+}

--- a/pkg/datadir/schelk_test.go
+++ b/pkg/datadir/schelk_test.go
@@ -1,0 +1,77 @@
+package datadir
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// installFakeSchelk writes a shell shim that runs the given body and
+// wires PATH + BENCHMARKOOR_SCHELK_BIN so RunSchelk picks it up. The
+// shim's PATH keeps the original system PATH appended so shell
+// builtins like `sleep` remain available inside the shim.
+func installFakeSchelk(t *testing.T, body string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "schelk")
+	script := fmt.Sprintf("#!/bin/sh\n%s\n", body)
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BENCHMARKOOR_SCHELK_BIN", binPath)
+}
+
+func TestRunSchelk_HappyPath(t *testing.T) {
+	installFakeSchelk(t, "echo hello\nexit 0")
+
+	output, err := RunSchelk(context.Background(), nil, "anyarg")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "hello")
+}
+
+func TestRunSchelk_NonZeroExitSurfacesOutput(t *testing.T) {
+	installFakeSchelk(t, "echo boom >&2\nexit 7")
+
+	output, err := RunSchelk(context.Background(), nil, "arg")
+	require.Error(t, err)
+	assert.Contains(t, string(output), "boom")
+}
+
+func TestRunSchelk_FinishesWithinGraceAfterCancel(t *testing.T) {
+	// Shim sleeps 200ms then exits cleanly. ctx is cancelled immediately,
+	// but the 2s grace window must let schelk finish naturally — so
+	// RunSchelk should return success, not a kill error.
+	installFakeSchelk(t, "sleep 0.2\necho done\nexit 0")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	output, err := runSchelkWithGrace(ctx, nil, 2*time.Second, "arg")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "done")
+}
+
+func TestRunSchelk_KilledWhenGraceExpires(t *testing.T) {
+	// Shim ignores SIGTERM and sleeps longer than the 100ms grace, so
+	// only SIGKILL after grace expiry can stop it. The call should
+	// return shortly after the grace window with a "did not complete"
+	// error — not block for the full sleep.
+	installFakeSchelk(t, "trap '' TERM\nsleep 5\nexit 0")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := runSchelkWithGrace(ctx, nil, 100*time.Millisecond, "arg")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not complete within")
+	assert.Less(t, elapsed, 2*time.Second, "should return shortly after grace window")
+}


### PR DESCRIPTION
## Summary

Adds a new `datadir.method: schelk` that bind-mounts a path under a [schelk](https://github.com/tempoxyz/schelk)-managed scratch volume into the client container. schelk uses `dm-era` on a ramdisk to surgically restore the scratch volume from a virgin baseline between iterations, so each test starts from a clean state without copying the full datadir.

- **Config preflight** verifies `schelk` is on PATH (honouring `BENCHMARKOOR_SCHELK_BIN`), reads `/var/lib/schelk/state.json` (honouring `SCHELK_STATE`), and runs `schelk mount` if the scratch isn't mounted. State-vs-`/proc/mounts` inconsistency (post-crash) is detected and the user is pointed at `schelk full-recover`.
- **Runtime**: `Prepare` runs `schelk restore` so each lifecycle starts at baseline; `Cleanup` runs `schelk recover`. Pairs naturally with `rollback_strategy: container-recreate` for per-test rollback. `container-checkpoint-restore` + schelk is rejected (that still requires ZFS).
- **Graceful shutdown**: schelk is launched in its own process group with `Setpgid`, so SIGTERM to benchmarkoor does not propagate. An in-flight schelk command gets up to `SchelkGracePeriod` (60s) to finish before the process group is SIGKILL'd, so a mid-flight `recover` is not interrupted.
- **Docs**: `docs/configuration.md` and `config.example.yaml` cover the new method, the env-var overrides, and the recommended pairing with `container-recreate`.

Example:

```yaml
runner:
  client:
    config:
      rollback_strategy: container-recreate
  instances:
    - id: reth-schelk
      client: reth
      datadir:
        method: schelk
        source_dir: /schelk/eth/reth   # subpath under the schelk mount
```

## Test plan

- [x] `go test ./pkg/config ./pkg/datadir` (config validation, schelk method acceptance, preflight, state-inconsistency, env-var overrides, grace-period kill path)
- [x] `golangci-lint run --new-from-rev=origin/master` clean
- [x] End-to-end run with `method: schelk` + `rollback_strategy: container-recreate` against a real reth datadir
- [x] Verify SIGTERM during a `schelk recover` waits for it to finish (not killed)
- [x] Verify state-inconsistency error surfaces the `schelk full-recover` suggestion as expected