### PR TITLE
fix: expose debug/admin http.api namespaces for ethrex by default

### DIFF
--- a/pkg/client/ethrex.go
+++ b/pkg/client/ethrex.go
@@ -28,6 +28,9 @@ func (s *ethrexSpec) DefaultCommand() []string {
 		// "Public" JSON-RPC API
 		"--http.addr=0.0.0.0",
 		"--http.port=8545",
+		// Match geth's exposed namespaces; ethrex defaults to eth,net,web3
+		// only, so debug_/admin_ calls would otherwise be unavailable.
+		"--http.api=eth,net,web3,debug,admin",
 		// Engine API. authrpc.addr defaults to 127.0.0.1, must override
 		// so the runner can reach it from outside the container.
 		"--authrpc.addr=0.0.0.0",


### PR DESCRIPTION
## Summary

ethrex's `DefaultCommand` doesn't set `--http.api`, so it falls back to ethrex's built-in default of `eth,net,web3`. geth's `DefaultCommand` already hardcodes `--http.api=admin,debug,web3,eth,net`, so `debug_*` (e.g. `debug_traceBlockByNumber`, used by tracing/compute tests) and `admin_*` calls are unavailable for ethrex but available for geth.

This adds `--http.api=eth,net,web3,debug,admin` to ethrex's `DefaultCommand` for parity.

The `engine` namespace is always served on the authrpc port and cannot be set via `--http.api` (ethrex rejects it there), so it's intentionally omitted.

## Test plan
- `go build ./pkg/client/` passes; `gofmt` clean.