### PR TITLE
feat: per-test engine_newPayload transaction counts

### DIFF
--- a/pkg/executor/suite.go
+++ b/pkg/executor/suite.go
@@ -90,6 +90,11 @@ type SuiteTest struct {
 	// {raw, bal, snappy} arrays (one element per engine_newPayload* line in
 	// step order). Steps with no newPayload activity are omitted.
 	PayloadSizes *PayloadSizes `json:"payload_sizes,omitempty"`
+
+	// Engine newPayload transaction counts per step — one element per
+	// engine_newPayload* line in step order, equal to len(payload.transactions).
+	// Steps with no newPayload activity are omitted.
+	TxCounts *TxCounts `json:"tx_counts,omitempty"`
 }
 
 // ComputeSuiteHash computes a hash of all test file contents.
@@ -250,30 +255,46 @@ func CreateSuiteOutput(
 				{StepKindCleanup, test.Cleanup},
 			}
 			var ps PayloadSizes
+			var tc TxCounts
 			anyData := false
+			anyTxData := false
 			for _, s := range steps {
 				if s.file == nil {
 					continue
 				}
 				lines := stepLinesForTest(psLog, s.file)
 				buckets := ComputePayloadSizeBuckets(psLog, test.Name, lines)
-				if !buckets.HasData() {
-					continue
+				if buckets.HasData() {
+					b := buckets
+					switch s.kind {
+					case StepKindSetup:
+						ps.Setup = &b
+					case StepKindTest:
+						ps.Test = &b
+					case StepKindCleanup:
+						ps.Cleanup = &b
+					}
+					anyData = true
 				}
-				b := buckets
-				switch s.kind {
-				case StepKindSetup:
-					ps.Setup = &b
-				case StepKindTest:
-					ps.Test = &b
-				case StepKindCleanup:
-					ps.Cleanup = &b
+				if counts := ComputeTxCountsForStep(lines); len(counts) > 0 {
+					switch s.kind {
+					case StepKindSetup:
+						tc.Setup = counts
+					case StepKindTest:
+						tc.Test = counts
+					case StepKindCleanup:
+						tc.Cleanup = counts
+					}
+					anyTxData = true
 				}
-				anyData = true
 			}
 			if anyData {
 				p := ps
 				suiteTest.PayloadSizes = &p
+			}
+			if anyTxData {
+				t := tc
+				suiteTest.TxCounts = &t
 			}
 
 			info.Tests = append(info.Tests, suiteTest)
@@ -296,7 +317,7 @@ func CreateSuiteOutput(
 				// Merge opcode data from prepared tests into existing entries.
 				mergeOpcodeData(existing.Tests, prepared)
 
-				MergePayloadSizes(log, existing.Tests, func(testName string, step StepKind) []string {
+				lineProvider := func(testName string, step StepKind) []string {
 					reqPath := filepath.Join(suiteDir, testName, string(step)+".request")
 					data, err := os.ReadFile(reqPath)
 					if err != nil {
@@ -308,7 +329,10 @@ func CreateSuiteOutput(
 						return nil
 					}
 					return splitNonEmptyLines(string(data))
-				})
+				}
+
+				MergePayloadSizes(log, existing.Tests, lineProvider)
+				MergeTxCounts(log, existing.Tests, lineProvider)
 
 				info.Tests = existing.Tests
 			}

--- a/pkg/executor/tx_counts.go
+++ b/pkg/executor/tx_counts.go
@@ -1,0 +1,108 @@
+package executor
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// TxCounts is the per-test container persisted under "tx_counts" in
+// summary.json. Each step that actually contains engine_newPayload*
+// lines gets a populated array — one element per newPayload in step
+// order, holding the transaction count for that block. Steps with no
+// newPayload activity are omitted entirely.
+//
+// JSON shape:
+//
+//	"tx_counts": {
+//	  "setup":   [tx_count_block_1, tx_count_block_2, ...],
+//	  "test":    [tx_count_block_1, ...],
+//	  "cleanup": [tx_count_block_1, ...]
+//	}
+type TxCounts struct {
+	Setup   []uint64 `json:"setup,omitempty"`
+	Test    []uint64 `json:"test,omitempty"`
+	Cleanup []uint64 `json:"cleanup,omitempty"`
+}
+
+// HasData returns true if any step carries at least one block.
+func (t *TxCounts) HasData() bool {
+	if t == nil {
+		return false
+	}
+
+	return len(t.Setup) > 0 || len(t.Test) > 0 || len(t.Cleanup) > 0
+}
+
+// ComputeTxCountsForStep returns the transaction count for each
+// engine_newPayloadV* line in the given step lines, in step order.
+// Lines that fail to parse are skipped silently — the function mirrors
+// ComputePayloadSizeBuckets, which is the source-of-truth path.
+func ComputeTxCountsForStep(lines []string) []uint64 {
+	nps := ExtractNewPayloadLines(lines)
+
+	out := make([]uint64, 0, len(nps))
+	for _, np := range nps {
+		if np.Payload == nil {
+			continue
+		}
+
+		out = append(out, uint64(len(np.Payload.Transactions)))
+	}
+
+	return out
+}
+
+// MergeTxCounts attaches a TxCounts container to tests that don't
+// already carry one. The lineProvider callback returns the JSON-RPC
+// lines for a given (test, step) pair — callers can fetch from disk
+// or from memory as appropriate. Returning nil/empty for a step skips
+// that step.
+//
+// Tests that already carry any tx-count data are left alone (idempotent
+// re-run).
+func MergeTxCounts(
+	log logrus.FieldLogger,
+	tests []SuiteTest,
+	lineProvider func(testName string, step StepKind) []string,
+) {
+	for i := range tests {
+		t := &tests[i]
+		if t.TxCounts.HasData() {
+			continue
+		}
+
+		var (
+			merged  TxCounts
+			anyData bool
+		)
+
+		for _, step := range []StepKind{StepKindSetup, StepKindTest, StepKindCleanup} {
+			lines := lineProvider(t.Name, step)
+			if len(lines) == 0 {
+				continue
+			}
+
+			counts := ComputeTxCountsForStep(lines)
+			if len(counts) == 0 {
+				continue
+			}
+
+			switch step {
+			case StepKindSetup:
+				merged.Setup = counts
+			case StepKindTest:
+				merged.Test = counts
+			case StepKindCleanup:
+				merged.Cleanup = counts
+			}
+
+			anyData = true
+		}
+
+		if anyData {
+			m := merged
+			t.TxCounts = &m
+		}
+	}
+
+	_ = log // signature parity with MergePayloadSizes; not used today.
+}

--- a/pkg/executor/tx_counts_test.go
+++ b/pkg/executor/tx_counts_test.go
@@ -1,0 +1,143 @@
+package executor
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/eest"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newPayloadWithTxCount builds an engine_newPayloadV3 line carrying the
+// given number of fake transaction hex strings, so the only thing the
+// tx-count computation can see is the slice length.
+func newPayloadWithTxCount(t *testing.T, txCount int) string {
+	t.Helper()
+
+	txs := make([]string, txCount)
+	for i := range txs {
+		txs[i] = "0xdeadbeef"
+	}
+
+	ep := eest.ExecutionPayload{
+		ParentHash:    "0x" + hexN("11", 32),
+		FeeRecipient:  "0x" + hexN("22", 20),
+		StateRoot:     "0x" + hexN("33", 32),
+		ReceiptsRoot:  "0x" + hexN("44", 32),
+		LogsBloom:     "0x" + hexN("00", 256),
+		PrevRandao:    "0x" + hexN("55", 32),
+		BlockNumber:   "0x10",
+		GasLimit:      "0x1000000",
+		GasUsed:       "0x800000",
+		Timestamp:     "0x65000000",
+		ExtraData:     "0x",
+		BaseFeePerGas: "0x7",
+		BlockHash:     "0x" + hexN("66", 32),
+		Transactions:  txs,
+		Withdrawals:   []*eest.Withdrawal{},
+	}
+
+	epJSON, err := json.Marshal(ep)
+	require.NoError(t, err)
+
+	return fmt.Sprintf(`{"jsonrpc":"2.0","method":"engine_newPayloadV3","params":[%s],"id":1}`, epJSON)
+}
+
+func TestComputeTxCountsForStep_MultipleBlocks(t *testing.T) {
+	lines := []string{
+		newPayloadWithTxCount(t, 3),
+		newPayloadWithTxCount(t, 7),
+		newPayloadWithTxCount(t, 0),
+	}
+
+	got := ComputeTxCountsForStep(lines)
+	assert.Equal(t, []uint64{3, 7, 0}, got)
+}
+
+func TestComputeTxCountsForStep_NoNewPayloadLines(t *testing.T) {
+	got := ComputeTxCountsForStep([]string{
+		`{"jsonrpc":"2.0","method":"engine_forkchoiceUpdatedV3","params":[],"id":1}`,
+	})
+	assert.Empty(t, got)
+}
+
+func TestComputeTxCountsForStep_NoLines(t *testing.T) {
+	got := ComputeTxCountsForStep(nil)
+	assert.Empty(t, got)
+}
+
+func TestMergeTxCounts_FillsMissing(t *testing.T) {
+	existing := []SuiteTest{
+		{Name: "test_a"},
+		{Name: "test_b"},
+	}
+
+	lineProvider := func(name string, step StepKind) []string {
+		if step != StepKindTest {
+			return nil
+		}
+
+		switch name {
+		case "test_a":
+			return []string{newPayloadWithTxCount(t, 5)}
+		default:
+			return nil
+		}
+	}
+
+	MergeTxCounts(logrus.New(), existing, lineProvider)
+
+	require.NotNil(t, existing[0].TxCounts)
+	assert.Equal(t, []uint64{5}, existing[0].TxCounts.Test)
+	assert.Nil(t, existing[1].TxCounts)
+}
+
+func TestMergeTxCounts_SkipsAlreadyPopulated(t *testing.T) {
+	preExisting := &TxCounts{Test: []uint64{999}}
+	existing := []SuiteTest{{Name: "test_a", TxCounts: preExisting}}
+
+	called := false
+	lineProvider := func(string, StepKind) []string {
+		called = true
+
+		return []string{newPayloadWithTxCount(t, 3)}
+	}
+
+	MergeTxCounts(logrus.New(), existing, lineProvider)
+	assert.False(t, called, "should not invoke provider for already-populated entries")
+	assert.Equal(t, []uint64{999}, existing[0].TxCounts.Test)
+}
+
+func TestMergeTxCounts_PerStep(t *testing.T) {
+	existing := []SuiteTest{{Name: "test_a"}}
+
+	lineProvider := func(_ string, step StepKind) []string {
+		switch step {
+		case StepKindSetup:
+			return []string{newPayloadWithTxCount(t, 1)}
+		case StepKindTest:
+			return []string{newPayloadWithTxCount(t, 2), newPayloadWithTxCount(t, 4)}
+		default:
+			return nil
+		}
+	}
+
+	MergeTxCounts(logrus.New(), existing, lineProvider)
+
+	require.NotNil(t, existing[0].TxCounts)
+	assert.Equal(t, []uint64{1}, existing[0].TxCounts.Setup)
+	assert.Equal(t, []uint64{2, 4}, existing[0].TxCounts.Test)
+	assert.Nil(t, existing[0].TxCounts.Cleanup)
+}
+
+func TestTxCounts_HasData(t *testing.T) {
+	var nilCounts *TxCounts
+	assert.False(t, nilCounts.HasData())
+	assert.False(t, (&TxCounts{}).HasData())
+	assert.True(t, (&TxCounts{Setup: []uint64{0}}).HasData())
+	assert.True(t, (&TxCounts{Test: []uint64{42}}).HasData())
+	assert.True(t, (&TxCounts{Cleanup: []uint64{1, 2, 3}}).HasData())
+}

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -468,6 +468,12 @@ export interface SuiteTest {
    * `bal[i]`, `snappy[i]` describe the i-th newPayload in step order.
    */
   payload_sizes?: PayloadSizes
+  /**
+   * Per-newPayload transaction counts (len of payload.transactions) for
+   * each step that contains engine_newPayload* calls. Steps with no
+   * newPayload activity are omitted.
+   */
+  tx_counts?: TxCounts
 }
 
 /**
@@ -496,6 +502,17 @@ export interface PayloadSizes {
   setup?: PayloadSizeBuckets
   test?: PayloadSizeBuckets
   cleanup?: PayloadSizeBuckets
+}
+
+/**
+ * Per-newPayload transaction counts for a single test, broken down by
+ * step. Each array has one element per engine_newPayload* line in step
+ * order, holding the transaction count for that block.
+ */
+export interface TxCounts {
+  setup?: number[]
+  test?: number[]
+  cleanup?: number[]
 }
 
 export interface SourceInfo {

--- a/ui/src/components/run-detail/ExecutionsList.tsx
+++ b/ui/src/components/run-detail/ExecutionsList.tsx
@@ -69,6 +69,12 @@ interface ExecutionsListProps {
   stepType: StepType
   expandedRows?: Set<number>
   onExpandedRowsChange?: (rows: Set<number>) => void
+  /**
+   * Per-newPayload transaction counts for the active step (typically
+   * suiteTest.tx_counts[stepType]). Indexed by newPayload order, not by
+   * row position — non-newPayload methods consume no slot.
+   */
+  txCounts?: number[]
 }
 
 function parseMethod(request: string): string {
@@ -117,6 +123,8 @@ interface ExecutionRowProps {
   status?: number // 0=success, 1=fail
   mgasPerSec?: number
   gasUsed?: number
+  /** Transaction count for this row when the method is engine_newPayloadV*. */
+  txCount?: number
   /** File viewer link for the response file at this line. */
   responseViewerUrl?: string
   /** File viewer link for the request file at this line. */
@@ -144,7 +152,7 @@ function StatusIndicator({ status }: { status?: number }) {
 
 const MAX_LAZY_LINE_SIZE = 1_000_000 // 1MB — lazy-load lines up to this size
 
-function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo, response, responseSize, time, status, mgasPerSec, gasUsed, responseViewerUrl, requestViewerUrl, expanded: expandedProp, onExpandedChange }: ExecutionRowProps & { expanded?: boolean; onExpandedChange?: (index: number, expanded: boolean) => void }) {
+function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo, response, responseSize, time, status, mgasPerSec, gasUsed, txCount, responseViewerUrl, requestViewerUrl, expanded: expandedProp, onExpandedChange }: ExecutionRowProps & { expanded?: boolean; onExpandedChange?: (index: number, expanded: boolean) => void }) {
   const [expandedLocal, setExpandedLocal] = useState(false)
   const expanded = expandedProp ?? expandedLocal
   const setExpanded = (v: boolean) => {
@@ -200,6 +208,14 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
           {method ?? (requestSize === undefined
             ? <span className="inline-block size-3 animate-spin rounded-full border border-gray-300 border-t-gray-600" />
             : '-')}
+          {txCount !== undefined && (
+            <span
+              className="ml-2 inline-block rounded-xs bg-violet-100 px-1.5 py-0.5 font-sans text-xs/5 font-medium text-violet-700 dark:bg-violet-900/40 dark:text-violet-300"
+              title={`${txCount.toLocaleString()} transaction${txCount === 1 ? '' : 's'} in this engine_newPayload`}
+            >
+              {txCount.toLocaleString()} tx{txCount === 1 ? '' : 's'}
+            </span>
+          )}
         </span>
         <span className="w-44 shrink-0 text-right text-sm/6 font-medium text-blue-600 dark:text-blue-400">
           {mgasPerSec !== undefined ? (
@@ -323,7 +339,7 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
 
 const EXECUTIONS_PAGE_SIZE = 100
 
-export function ExecutionsList({ runId, suiteHash, testName, stepType, expandedRows, onExpandedRowsChange }: ExecutionsListProps) {
+export function ExecutionsList({ runId, suiteHash, testName, stepType, expandedRows, onExpandedRowsChange, txCounts }: ExecutionsListProps) {
   const { data: requests, isLoading: requestsLoading, error: requestsError } = useTestRequests(suiteHash, testName, stepType)
   const { data: responses, error: responsesError } = useTestResponses(runId, testName, stepType)
   const { data: resultDetails, isLoading: detailsLoading, error: detailsError } = useTestResultDetails(runId, testName, stepType)
@@ -380,6 +396,29 @@ export function ExecutionsList({ runId, suiteHash, testName, stepType, expandedR
   const startIdx = (page - 1) * EXECUTIONS_PAGE_SIZE
   const endIdx = Math.min(startIdx + EXECUTIONS_PAGE_SIZE, executionCount)
 
+  // Map row index → tx count. tx_counts is indexed by newPayload order,
+  // not row position, so we walk all rows up to endIdx once to assign
+  // each newPayload row its slot. Returns a Map keyed by absolute row
+  // index (not page-relative).
+  const txCountByRow = (() => {
+    if (!txCounts || txCounts.length === 0) return new Map<number, number>()
+    const out = new Map<number, number>()
+    let nextNp = 0
+    const rowMethod = (i: number): string | undefined => {
+      const req = safeRequests?.[i]
+      if (req) return parseMethod(req)
+      return requestSummaries?.[i]?.head.match(/"method"\s*:\s*"([^"]+)"/)?.[1]
+    }
+    for (let i = 0; i < executionCount; i++) {
+      const m = rowMethod(i)
+      if (m && m.startsWith('engine_newPayloadV')) {
+        if (nextNp < txCounts.length) out.set(i, txCounts[nextNp])
+        nextNp++
+      }
+    }
+    return out
+  })()
+
   return (
     <div className="mt-4 max-w-full overflow-hidden">
       <div className="mb-2 flex items-center justify-between">
@@ -416,6 +455,7 @@ export function ExecutionsList({ runId, suiteHash, testName, stepType, expandedR
               status={safeDetails?.status[index]}
               mgasPerSec={safeDetails?.mgas_s[String(index)]}
               gasUsed={safeDetails?.gas_used[String(index)]}
+              txCount={txCountByRow.get(index)}
               responseViewerUrl={!safeResponses?.[index] && responseSummaries?.[index] && responseSummaries[index].size > 1_000_000
                 ? `/runs/${runId}/fileviewer?file=${encodeURIComponent(`${testName}/${stepType}.response`)}&lines=${index + 1}`
                 : undefined}

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -980,6 +980,7 @@ export function TestHeatmap({
                 ].filter(s => s.step)
 
                 const activeStep = steps.find(s => s.key === activeStepTab) ?? steps[0]
+                const matchingSuiteTest = suiteTests?.find((t) => t.name === selectedTest)
 
                 return (
                   <div className="flex flex-col gap-4">
@@ -1034,6 +1035,7 @@ export function TestHeatmap({
                           stepType={activeStep.key}
                           expandedRows={expandedExecRows}
                           onExpandedRowsChange={onExpandedExecRowsChange}
+                          txCounts={matchingSuiteTest?.tx_counts?.[activeStep.key]}
                         />
                       </div>
                     )}

--- a/ui/src/components/suite-detail/TestFilesList.tsx
+++ b/ui/src/components/suite-detail/TestFilesList.tsx
@@ -421,6 +421,65 @@ function PayloadSizesContent({ test }: { test: SuiteTest }) {
   )
 }
 
+// Per-step transaction-count breakdown for the test-details modal.
+// One table row per engine_newPayload in each populated step, plus a
+// totals row when there's more than one block.
+function TxCountsContent({ test }: { test: SuiteTest }) {
+  const tc = test.tx_counts
+  if (!tc) return null
+  const steps: { label: string; counts: number[] }[] = []
+  if (tc.setup?.length) steps.push({ label: 'Setup', counts: tc.setup })
+  if (tc.test?.length) steps.push({ label: 'Test', counts: tc.test })
+  if (tc.cleanup?.length) steps.push({ label: 'Cleanup', counts: tc.cleanup })
+  if (steps.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <Badge variant="default">Transaction Counts</Badge>
+        <span className="text-xs/5 text-gray-500 dark:text-gray-400">per engine_newPayload</span>
+      </div>
+      <div className="flex flex-col gap-4">
+        {steps.map(({ label, counts }) => {
+          const total = counts.reduce((a, b) => a + b, 0)
+          return (
+            <div key={label} className="overflow-x-auto rounded-sm border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+              <div className="border-b border-gray-200 px-4 py-2 text-sm/6 font-medium text-gray-700 dark:border-gray-700 dark:text-gray-200">
+                {label} step
+                <span className="ml-2 text-xs/5 font-normal text-gray-500 dark:text-gray-400">
+                  {counts.length} newPayload{counts.length === 1 ? '' : 's'} · {total.toLocaleString()} tx{total === 1 ? '' : 's'} total
+                </span>
+              </div>
+              <table className="min-w-full">
+                <thead className="bg-gray-50/50 text-left text-xs/5 font-medium uppercase tracking-wider text-gray-500 dark:bg-gray-800/50 dark:text-gray-400">
+                  <tr>
+                    <th className="w-12 px-3 py-2">#</th>
+                    <th className="px-3 py-2 text-right">Transactions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {counts.map((n, i) => (
+                    <tr key={i} className="border-t border-gray-200 dark:border-gray-700">
+                      <td className="px-3 py-1.5 font-mono text-xs/5 text-gray-500 dark:text-gray-400">#{i + 1}</td>
+                      <td className="px-3 py-1.5 text-right font-mono text-sm/6 text-gray-900 dark:text-gray-100">{n.toLocaleString()}</td>
+                    </tr>
+                  ))}
+                  {counts.length > 1 && (
+                    <tr className="border-t-2 border-gray-300 bg-gray-50/50 dark:border-gray-600 dark:bg-gray-800/50">
+                      <td className="px-3 py-1.5 text-xs/5 font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Total</td>
+                      <td className="px-3 py-1.5 text-right font-mono text-sm/6 font-semibold text-gray-900 dark:text-gray-100">{total.toLocaleString()}</td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 // Component for displaying test steps content (for tests with setup/test/cleanup)
 function TestStepsContent({ suiteHash, test, opcodeSort, onOpcodeSortChange }: { suiteHash: string; test: SuiteTest; opcodeSort: OpcodeSortMode; onOpcodeSortChange: (sort: OpcodeSortMode) => void }) {
   const steps = [
@@ -430,10 +489,12 @@ function TestStepsContent({ suiteHash, test, opcodeSort, onOpcodeSortChange }: {
   ].filter((s) => s.file) as { key: string; label: string; file: SuiteFile }[]
 
   const hasPayloadSizes = !!test.payload_sizes
+  const hasTxCounts = !!(test.tx_counts?.setup?.length || test.tx_counts?.test?.length || test.tx_counts?.cleanup?.length)
   const hasInfo =
     !!test.eest?.info ||
     (test.opcode_count && Object.keys(test.opcode_count).length > 0) ||
-    hasPayloadSizes
+    hasPayloadSizes ||
+    hasTxCounts
   if (steps.length === 0 && !hasInfo) {
     return <div className="p-4 text-sm/6 text-gray-500">No step files available</div>
   }
@@ -447,6 +508,7 @@ function TestStepsContent({ suiteHash, test, opcodeSort, onOpcodeSortChange }: {
       </div>
       <EESTInfoContent test={test} opcodeSort={opcodeSort} onOpcodeSortChange={onOpcodeSortChange} />
       <PayloadSizesContent test={test} />
+      <TxCountsContent test={test} />
       {steps.map(({ key, label, file }) => (
         <div key={key} className="flex min-w-0 flex-col gap-2">
           <div className="flex items-center gap-2">

--- a/ui/src/components/suite-detail/TxCountsSection.tsx
+++ b/ui/src/components/suite-detail/TxCountsSection.tsx
@@ -1,0 +1,268 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import clsx from 'clsx'
+import { ListOrdered } from 'lucide-react'
+import ReactECharts from 'echarts-for-react'
+import type { SuiteTest } from '@/api/types'
+import { compileQuery } from '@/utils/eestNameFilter'
+import { formatTestNameLong } from '@/utils/eestName'
+import { useNameDisplayMode } from '@/hooks/useNameDisplayMode'
+
+// Reactive dark-mode detector — mirrors PayloadSizesSection so the
+// chart's tooltip theming flips with the rest of the page.
+function useDarkMode() {
+  const [isDark, setIsDark] = useState(() =>
+    typeof document !== 'undefined' && document.documentElement.classList.contains('dark'),
+  )
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains('dark'))
+    })
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+  return isDark
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => {
+    switch (c) {
+      case '&': return '&amp;'
+      case '<': return '&lt;'
+      case '>': return '&gt;'
+      case '"': return '&quot;'
+      default: return '&#39;'
+    }
+  })
+}
+
+type ChartOrder = 'index' | 'count'
+
+interface TxCountsSectionProps {
+  tests: SuiteTest[]
+  /** Called when a bar is clicked, with the 1-based test index. */
+  onTestClick?: (index: number) => void
+  /**
+   * External search query that filters which tests appear in the chart.
+   * Controlled by the parent so the same query also drives the tests
+   * table and other sections on the suite-details page.
+   */
+  searchQuery?: string
+  order?: ChartOrder
+  onOrderChange?: (order: ChartOrder) => void
+}
+
+interface TxRow {
+  index: number // 1-based position in the suite, matches the # column in the tests table.
+  name: string
+  total: number // sum of tx counts across all newPayloads in the test step.
+  blocks: number // number of newPayloads in the test step.
+}
+
+function sumArray(xs: number[] | undefined): number {
+  if (!xs) return 0
+  let total = 0
+  for (const v of xs) total += v
+  return total
+}
+
+// Rolls up the per-newPayload tx counts from the `test` step into a
+// single number per test. The full per-block / per-step breakdown lives
+// on the test-details modal; this section is the at-a-glance bar chart.
+function toRow(t: SuiteTest, index: number): TxRow | null {
+  const testStep = t.tx_counts?.test
+  if (!testStep || testStep.length === 0) return null
+  const total = sumArray(testStep)
+  return { index, name: t.name, total, blocks: testStep.length }
+}
+
+export function TxCountsSection({
+  tests,
+  onTestClick,
+  searchQuery = '',
+  order: orderProp,
+  onOrderChange,
+}: TxCountsSectionProps) {
+  const [localOrder, setLocalOrder] = useState<ChartOrder>('index')
+  const order = orderProp ?? localOrder
+  const setOrder = (next: ChartOrder) => {
+    if (onOrderChange) onOrderChange(next)
+    else setLocalOrder(next)
+  }
+  const isDark = useDarkMode()
+  const { mode: nameMode } = useNameDisplayMode()
+  const chartRef = useRef<ReactECharts | null>(null)
+
+  const rows = useMemo(() => {
+    const all: TxRow[] = []
+    for (let i = 0; i < tests.length; i++) {
+      const row = toRow(tests[i], i + 1)
+      if (row) all.push(row)
+    }
+    return all
+  }, [tests])
+
+  const compiled = useMemo(() => compileQuery(searchQuery), [searchQuery])
+  const filtered = useMemo(() => {
+    if (!searchQuery.trim()) return rows
+    return rows.filter((r) => compiled(r.name))
+  }, [rows, compiled, searchQuery])
+
+  const ordered = useMemo(
+    () => order === 'count' ? [...filtered].sort((a, b) => b.total - a.total) : filtered,
+    [filtered, order],
+  )
+
+  const categories = useMemo(() => ordered.map((r) => String(r.index)), [ordered])
+  const indexToRow = useMemo(
+    () => new Map(ordered.map((r) => [String(r.index), r])),
+    [ordered],
+  )
+
+  // Click-anywhere-in-a-column → open the test modal (same pattern as
+  // PayloadSizesSection, since ECharts' built-in click misses gaps).
+  useEffect(() => {
+    if (!onTestClick) return
+    const inst = chartRef.current?.getEchartsInstance()
+    if (!inst) return
+    const zr = inst.getZr()
+    const handler = (event: { offsetX: number; offsetY: number }) => {
+      const pixel: [number, number] = [event.offsetX, event.offsetY]
+      if (!inst.containPixel('grid', pixel)) return
+      const raw = inst.convertFromPixel({ xAxisIndex: 0 }, event.offsetX) as number
+      if (typeof raw !== 'number' || !Number.isFinite(raw)) return
+      const i = Math.round(raw)
+      if (i < 0 || i >= categories.length) return
+      const idx = parseInt(categories[i], 10)
+      if (Number.isFinite(idx) && idx > 0) onTestClick(idx)
+    }
+    zr.on('click', handler)
+    return () => zr.off('click', handler)
+  }, [onTestClick, categories])
+
+  if (rows.length === 0) return null
+
+  const maxTotal = Math.max(...rows.map((r) => r.total))
+
+  return (
+    <>
+      <div className="flex w-full items-center gap-2 border-b border-gray-200 px-4 py-3 text-sm/6 font-medium text-gray-900 dark:border-gray-700 dark:text-gray-100">
+        <ListOrdered className="size-4 text-gray-400 dark:text-gray-500" />
+        Transaction Counts
+        <span className="text-xs/5 text-gray-500 dark:text-gray-400">
+          · {rows.length} tests · max {maxTotal.toLocaleString()} txs
+        </span>
+      </div>
+      <div className="p-4">
+        <div className="mb-3 flex items-center justify-end gap-2">
+          {searchQuery.trim() && (
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {filtered.length} of {rows.length} matching
+            </span>
+          )}
+          <div className="flex shrink-0 items-center gap-1 rounded-sm border border-gray-300 bg-white p-0.5 text-xs/5 dark:border-gray-600 dark:bg-gray-800">
+            <span className="px-1 text-gray-500 dark:text-gray-400">Order:</span>
+            {([
+              { value: 'index', label: 'Test #' },
+              { value: 'count', label: 'Tx count' },
+            ] as const).map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setOrder(opt.value)}
+                className={clsx(
+                  'cursor-pointer rounded-xs px-2 py-1 font-medium transition-colors',
+                  order === opt.value
+                    ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                    : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700',
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <ReactECharts
+          ref={chartRef}
+          option={(() => {
+            const textColor = isDark ? '#ffffff' : '#374151'
+            const mutedTextColor = isDark ? '#9ca3af' : '#6b7280'
+            const axisLineColor = isDark ? '#4b5563' : '#d1d5db'
+            const splitLineColor = isDark ? '#374151' : '#e5e7eb'
+            return {
+              backgroundColor: 'transparent',
+              textStyle: { color: textColor },
+              grid: { left: 70, right: 24, top: 16, bottom: 55, containLabel: false },
+              tooltip: {
+                trigger: 'axis',
+                axisPointer: { type: 'shadow' },
+                backgroundColor: isDark ? '#1f2937' : '#ffffff',
+                borderColor: isDark ? '#374151' : '#e5e7eb',
+                textStyle: { color: textColor },
+                confine: true,
+                extraCssText: 'max-width: 300px; white-space: normal;',
+                formatter: (params: Array<{ color: string; data: number; name: string }>) => {
+                  if (!params.length) return ''
+                  const idx = params[0].name ?? ''
+                  const row = indexToRow.get(idx)
+                  const rawName = row?.name ?? ''
+                  const decomposedSafe = escapeHtml(formatTestNameLong(rawName, nameMode))
+                  let content = `<strong>Test #${escapeHtml(idx)}</strong>`
+                  content += `<br/><span style="font-size:11px;color:${mutedTextColor};word-break:break-all;display:block;">${decomposedSafe}</span><br/>`
+                  content += `<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${params[0].color};margin-right:6px;"></span>`
+                  content += `Transactions: ${params[0].data.toLocaleString()}`
+                  if (row) {
+                    content += `<br/><span style="font-size:11px;color:${mutedTextColor};">${row.blocks} block${row.blocks === 1 ? '' : 's'}</span>`
+                  }
+                  return content
+                },
+              },
+              xAxis: {
+                type: 'category',
+                data: categories,
+                axisLabel: {
+                  color: textColor,
+                  fontSize: 10,
+                  formatter: (v: string) => `#${v}`,
+                },
+                axisLine: { lineStyle: { color: axisLineColor } },
+                axisTick: { lineStyle: { color: axisLineColor } },
+              },
+              yAxis: {
+                type: 'value',
+                axisLabel: { color: textColor, formatter: (v: number) => v.toLocaleString() },
+                axisLine: { show: true, lineStyle: { color: axisLineColor } },
+                splitLine: { lineStyle: { color: splitLineColor } },
+              },
+              dataZoom: [
+                {
+                  type: 'slider',
+                  xAxisIndex: 0,
+                  start: 0,
+                  end: 100,
+                  height: 14,
+                  bottom: 30,
+                  borderColor: axisLineColor,
+                  fillerColor: isDark ? 'rgba(139, 92, 246, 0.3)' : 'rgba(139, 92, 246, 0.1)',
+                  backgroundColor: isDark ? '#374151' : '#f3f4f6',
+                  textStyle: { color: textColor },
+                },
+                { type: 'inside', xAxisIndex: 0, start: 0, end: 100 },
+              ],
+              series: [
+                {
+                  name: 'Transactions',
+                  type: 'bar',
+                  itemStyle: { color: '#8b5cf6' },
+                  data: ordered.map((r) => r.total),
+                },
+              ],
+            }
+          })()}
+          style={{ height: 320 }}
+          notMerge
+        />
+      </div>
+    </>
+  )
+}

--- a/ui/src/pages/SuiteDetailPage.tsx
+++ b/ui/src/pages/SuiteDetailPage.tsx
@@ -21,6 +21,7 @@ import { FilterInput } from '@/components/shared/FilterInput'
 import { toggleSearchTerm, TEST_FILTER_HINT } from '@/utils/eestNameFilter'
 import { OpcodeHeatmap } from '@/components/suite-detail/OpcodeHeatmap'
 import { PayloadSizesSection } from '@/components/suite-detail/PayloadSizesSection'
+import { TxCountsSection } from '@/components/suite-detail/TxCountsSection'
 import { RunsTable } from '@/components/runs/RunsTable'
 import { sortIndexEntries, type SortColumn, type SortDirection } from '@/components/runs/sortEntries'
 import { RunFilters, type TestStatusFilter } from '@/components/runs/RunFilters'
@@ -1492,6 +1493,15 @@ export function SuiteDetailPage() {
                   onOrderChange={handlePsOrderChange}
                   encoding={psEncoding}
                   onEncodingChange={handlePsEncodingChange}
+                />
+              </div>
+            )}
+            {suite.tests?.some((t) => !!t.tx_counts?.test?.length) && (
+              <div className="overflow-hidden rounded-sm border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+                <TxCountsSection
+                  tests={suite.tests ?? []}
+                  onTestClick={handleDetailChange}
+                  searchQuery={q ?? ''}
                 />
               </div>
             )}


### PR DESCRIPTION
## Summary

Mirrors the per-test payload-sizes feature for transaction counts. For each test, walks `engine_newPayloadV*` lines in setup/test/cleanup and records `len(payload.transactions)` per block. Arrays land in `summary.json` under `tx_counts`:

```json
"tx_counts": {
  "setup":   [0],
  "test":    [42, 7, 0],
  "cleanup": [1]
}
```

### UI surfaces

- **Suite-detail · Transaction Counts chart** — new bar chart below the payload-sizes section. One bar per test = sum of `test`-step tx counts. Order-by-index / order-by-count toggle. Click anywhere in a column opens the test modal.
- **Suite-detail · test modal** — per-step table with one row per `engine_newPayload` block and a totals row, alongside the existing `PayloadSizesContent` table.
- **Run-detail · Executions list** — inline `N txs` badge next to the method name on every `engine_newPayload*` row. Row index → newPayload index is computed by counting newPayload methods in step order, so the badge stays aligned even when `engine_forkchoiceUpdated` (or other calls) are interleaved.

### Backend

- `pkg/executor/tx_counts.go` — `TxCounts` (setup/test/cleanup, each `[]uint64`), `ComputeTxCountsForStep`, `MergeTxCounts` (idempotent re-run backfill).
- `SuiteTest` gains a `TxCounts *TxCounts` field next to `PayloadSizes`.
- `CreateSuiteOutput` populates `tx_counts` from the same newPayload line scan; existing-suite path also calls `MergeTxCounts` so older suites get backfilled.

## Test plan

- [x] `go test ./pkg/executor` (compute multi-block, no-newPayload steps, merge fills missing, idempotent re-merge, per-step splitting, `HasData`)
- [x] `npx tsc --noEmit` and `npx eslint` clean on changed files
- [ ] Open a suite with the new code and confirm the "Transaction Counts" chart renders with reasonable values
- [ ] Open a test's modal and verify the per-step tx-count table matches the chart total
- [ ] Open a test's run-detail modal and confirm `N txs` badges appear only on `engine_newPayloadV*` rows and that the count for the i-th newPayload matches `tx_counts.test[i]`