### PR TITLE
feat(action): plumb datadir.method=schelk through the GH Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # Final stage
 FROM alpine:3.21
 
-RUN apk add --no-cache ca-certificates tzdata git zfs fuse-overlayfs rsync iptables iproute2 && \
+RUN apk add --no-cache ca-certificates tzdata git zfs fuse-overlayfs rsync iptables iproute2 util-linux-misc && \
     if [ "$(uname -m)" = "x86_64" ]; then \
       apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing criu; \
     fi
@@ -34,5 +34,16 @@ RUN apk add --no-cache ca-certificates tzdata git zfs fuse-overlayfs rsync iptab
 WORKDIR /app
 
 COPY --from=builder /benchmarkoor /usr/local/bin/benchmarkoor
+
+# schelk-host: thin wrapper that runs the host's `schelk` binary in the
+# host's mount namespace via nsenter. Used by the schelk datadir method
+# when benchmarkoor is launched inside a Docker container (e.g. by the
+# GitHub Action): the container can't operate on dm-era / mounts in its
+# own mount NS, so we hop into the host's. Requires the docker run to be
+# launched with `--privileged --pid=host`. Point benchmarkoor at this
+# via `BENCHMARKOOR_SCHELK_BIN=/usr/local/bin/schelk-host`.
+RUN printf '#!/bin/sh\nexec nsenter -t 1 -m -- /usr/local/bin/schelk "$@"\n' \
+      > /usr/local/bin/schelk-host && \
+    chmod +x /usr/local/bin/schelk-host
 
 ENTRYPOINT ["benchmarkoor"]

--- a/action.yaml
+++ b/action.yaml
@@ -153,6 +153,7 @@ runs:
 
         # Extract unique filesystem mount points from datadir source_dir values
         DATADIR_MOUNT_POINTS=""
+        USES_SCHELK=false
         CONFIG_FILES=()
         for cfg in "${{ runner.temp }}"/benchmarkoor-config-url-*.yaml; do
           [ -f "$cfg" ] && CONFIG_FILES+=("$cfg")
@@ -171,6 +172,17 @@ runs:
             )' "$cfg" 2>/dev/null | grep -v '^null$' || true)
             if [ -n "$DIRS" ]; then
               ALL_SOURCE_DIRS="${ALL_SOURCE_DIRS}${DIRS}"$'\n'
+            fi
+
+            # Detect whether any datadir uses the schelk method so we can
+            # bind-mount the schelk state file and switch BENCHMARKOOR_SCHELK_BIN
+            # to the in-container nsenter wrapper.
+            SCHELK_METHODS=$(yq '(
+              .runner.client.datadirs[].method,
+              .runner.instances[].datadir.method
+            )' "$cfg" 2>/dev/null | grep -Fx 'schelk' || true)
+            if [ -n "$SCHELK_METHODS" ]; then
+              USES_SCHELK=true
             fi
           done
 
@@ -196,6 +208,27 @@ runs:
         if [ -n "$DATADIR_MOUNT_POINTS" ]; then
           echo "Detected datadir filesystem mount points for rshared propagation:"
           echo "$DATADIR_MOUNT_POINTS"
+        fi
+
+        SCHELK_MOUNT_POINT=""
+        if [ "$USES_SCHELK" = "true" ]; then
+          echo "Detected datadir.method: schelk — will plumb schelk state + nsenter wrapper into the container."
+          if [ ! -f /var/lib/schelk/state.json ]; then
+            echo "ERROR: datadir.method: schelk requires /var/lib/schelk/state.json on the host." >&2
+            echo "       Initialise schelk first (e.g. via the ethPandaOps ansible role)." >&2
+            exit 1
+          fi
+          # Read the schelk mount point from state.json so we bind-mount it
+          # with rshared regardless of whether the scratch is currently
+          # mounted (findmnt-based source_dir auto-detection misses an
+          # empty mount point). The mount goes in even when the directory
+          # is empty so subsequent `schelk mount` calls (via nsenter) propagate.
+          SCHELK_MOUNT_POINT=$(yq -r '.mount_point // ""' /var/lib/schelk/state.json 2>/dev/null || true)
+          if [ -z "$SCHELK_MOUNT_POINT" ]; then
+            echo "ERROR: /var/lib/schelk/state.json has no mount_point field." >&2
+            exit 1
+          fi
+          echo "Schelk mount point: $SCHELK_MOUNT_POINT"
         fi
 
         # Build docker run command
@@ -233,6 +266,23 @@ runs:
             [ -z "$mp" ] && continue
             DOCKER_CMD="$DOCKER_CMD --mount type=bind,source=${mp},target=${mp},bind-propagation=rshared"
           done <<< "$DATADIR_MOUNT_POINTS"
+        fi
+
+        # Schelk: mount the state directory so benchmarkoor can read
+        # state.json from inside the container, and rshared-mount the
+        # schelk mount point itself so mounts created on the host (via
+        # nsenter) propagate into the container's view. Point benchmarkoor
+        # at the nsenter wrapper baked into the image. schelk operations
+        # (dm-era, mount/umount) run on the host via nsenter.
+        if [ "$USES_SCHELK" = "true" ]; then
+          DOCKER_CMD="$DOCKER_CMD -v /var/lib/schelk:/var/lib/schelk"
+          # Skip if the source_dir scan already covered this mount point
+          # (i.e. /schelk was actually mounted at action-eval time and
+          # findmnt resolved source_dir → SCHELK_MOUNT_POINT).
+          if ! echo "$DATADIR_MOUNT_POINTS" | grep -Fxq "$SCHELK_MOUNT_POINT"; then
+            DOCKER_CMD="$DOCKER_CMD --mount type=bind,source=${SCHELK_MOUNT_POINT},target=${SCHELK_MOUNT_POINT},bind-propagation=rshared"
+          fi
+          DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_SCHELK_BIN=/usr/local/bin/schelk-host"
         fi
 
         DOCKER_CMD="$DOCKER_CMD ${IMAGE}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1103,6 +1103,35 @@ Notes:
 | `BENCHMARKOOR_SCHELK_BIN` | Override the schelk executable path. Useful when running under `sudo` with a sanitised PATH that does not include `~/.cargo/bin`. Accepts a bare name (resolved via PATH) or an absolute/relative path. Default: `schelk` |
 | `SCHELK_STATE` | Override the schelk state-file path. Honoured by both schelk itself and benchmarkoor's preflight. Default: `/var/lib/schelk/state.json` |
 
+###### Schelk in CI / GitHub Action
+
+When benchmarkoor runs inside the Docker container started by the [`ethpandaops/benchmarkoor` action](../action.yaml), `datadir.method: schelk` is plumbed through automatically:
+
+1. The action scans the merged run-configs for `datadir.method: schelk`. When found, it:
+   - Verifies `/var/lib/schelk/state.json` exists on the host (initialise schelk first via the [ethPandaOps ansible role](https://github.com/ethpandaops/github-actions-runners/tree/master/ansible/roles/schelk) — installs schelk + `era_invalidate` + loads `dm_era` / `brd`, and optionally runs `schelk init-new`).
+   - Bind-mounts `/var/lib/schelk` into the container so benchmarkoor can read `state.json` and detect mount state.
+   - Sets `BENCHMARKOOR_SCHELK_BIN=/usr/local/bin/schelk-host` — a wrapper baked into the image that runs the host's `schelk` via `nsenter -t 1 -m`, so all dm-era / mount operations happen in the host's mount namespace.
+2. The `/schelk` mount point itself is bind-mounted via the existing datadir-source-dir auto-detection (`source_dir: /schelk/...` resolves to `/schelk` via `findmnt`).
+3. The container already runs with `--privileged --pid=host`, which is what `nsenter` needs to hop into the host's namespace.
+
+You don't need to change the action invocation — the existing `run-config`/`run-config-urls` inputs work as-is. A minimal CI config:
+
+```yaml
+- uses: ethpandaops/benchmarkoor@<sha>
+  with:
+    run-config: |
+      runner:
+        client:
+          config:
+            rollback_strategy: container-recreate
+        instances:
+          - id: reth-schelk
+            client: reth
+            datadir:
+              method: schelk
+              source_dir: /schelk/eth/reth
+```
+
 ###### Default Container Directories
 
 When `container_dir` is not specified, the client's default data directory is used:


### PR DESCRIPTION
## Summary

Makes `datadir.method: schelk` work when benchmarkoor is launched from inside the Docker container the [`ethpandaops/benchmarkoor` action](../action.yaml) builds. dm-era and mount/umount can't operate in the container's mount namespace, so:

- **Dockerfile** — install `util-linux-misc` (for `nsenter`) and bake `/usr/local/bin/schelk-host`:

  ```sh
  #!/bin/sh
  exec nsenter -t 1 -m -- /usr/local/bin/schelk "$@"
  ```

  With the existing `--privileged --pid=host`, this hops into the host's mount namespace before exec'ing the host's schelk.

- **action.yaml** — scans the merged run-configs for `datadir.method: schelk`. When detected:
  - Requires `/var/lib/schelk/state.json` on the host (fail-fast, points at the ansible role).
  - Reads `mount_point` from `state.json`.
  - Bind-mounts `/var/lib/schelk` into the container (state.json reads + writes).
  - `rshared` bind-mounts the schelk mount point so future host-side mounts propagate (deduped against the existing source_dir scanner so we don't try to mount the same target twice).
  - Sets `BENCHMARKOOR_SCHELK_BIN=/usr/local/bin/schelk-host` so the provider + preflight call schelk via the wrapper.

- **docs/configuration.md** — new "Schelk in CI / GitHub Action" subsection describing the automatic plumbing, the host prerequisite, and a minimal action example.

### Call chain at runtime

```
GH Action runner (host, schelk installed via ansible)
└── benchmarkoor docker container (--privileged --pid=host)
    └── benchmarkoor go process
        └── RunSchelk()  →  exec("/usr/local/bin/schelk-host", ...)
            └── nsenter -t 1 -m --  →  drops into host's mount NS
                └── /usr/local/bin/schelk (host)
                    └── dmsetup / mount / etc on host
```

No changes needed in the Go code: `BENCHMARKOOR_SCHELK_BIN` and the state-file read are already namespace-agnostic.

### Host prerequisites

Handled by the [`schelk` ansible role](https://github.com/ethpandaops/github-actions-runners/tree/master/ansible/roles/schelk):
- schelk binary at `/usr/local/bin/schelk`
- kernel modules `dm_era` + `brd` loaded
- `era_invalidate` available
- `schelk init-new` (or `init-from`) already run → `state.json` present

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('action.yaml'))"` — action.yaml stays valid YAML
- [ ] Build the Docker image locally and confirm `/usr/local/bin/schelk-host` is present and executable, and `nsenter --version` runs inside the container
- [ ] On a host with schelk already initialised and mounted, invoke the action with a `datadir.method: schelk` config and confirm:
  - the action logs "Detected datadir.method: schelk" and "Schelk mount point: …"
  - benchmarkoor's preflight reads state.json and validates source_dir
  - per-iteration `schelk restore` runs and the container sees the freshly-mounted scratch
- [ ] On a host where schelk hasn't been initialised, confirm the action fails fast with the "requires /var/lib/schelk/state.json" error pointing at the ansible role