### PR TITLE
feat(action): run benchmarkoor binary directly, drop docker-in-docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # Final stage
 FROM alpine:3.21
 
-RUN apk add --no-cache ca-certificates tzdata git zfs fuse-overlayfs rsync iptables iproute2 util-linux-misc && \
+RUN apk add --no-cache ca-certificates tzdata git zfs fuse-overlayfs rsync iptables iproute2 && \
     if [ "$(uname -m)" = "x86_64" ]; then \
       apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing criu; \
     fi
@@ -34,16 +34,5 @@ RUN apk add --no-cache ca-certificates tzdata git zfs fuse-overlayfs rsync iptab
 WORKDIR /app
 
 COPY --from=builder /benchmarkoor /usr/local/bin/benchmarkoor
-
-# schelk-host: thin wrapper that runs the host's `schelk` binary in the
-# host's mount namespace via nsenter. Used by the schelk datadir method
-# when benchmarkoor is launched inside a Docker container (e.g. by the
-# GitHub Action): the container can't operate on dm-era / mounts in its
-# own mount NS, so we hop into the host's. Requires the docker run to be
-# launched with `--privileged --pid=host`. Point benchmarkoor at this
-# via `BENCHMARKOOR_SCHELK_BIN=/usr/local/bin/schelk-host`.
-RUN printf '#!/bin/sh\nexec nsenter -t 1 -m -- /usr/local/bin/schelk "$@"\n' \
-      > /usr/local/bin/schelk-host && \
-    chmod +x /usr/local/bin/schelk-host
 
 ENTRYPOINT ["benchmarkoor"]

--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ inputs:
     required: true
 
   image:
-    description: 'Docker image for benchmarkoor (e.g., ghcr.io/ethpandaops/benchmarkoor:master). If not provided, will build locally.'
+    description: 'Docker image to extract the benchmarkoor binary from (e.g., ghcr.io/ethpandaops/benchmarkoor:master). If not provided, will build the image locally from git-ref/git-repo and extract from it.'
     required: false
     default: ''
 
@@ -51,7 +51,7 @@ inputs:
     default: '/tmp'
 
   docker-env:
-    description: 'Newline-separated environment variables to pass into the Docker container (e.g. AWS_ACCESS_KEY_ID, MY_VAR=value)'
+    description: 'Newline-separated environment variables to export before invoking benchmarkoor (e.g. AWS_ACCESS_KEY_ID, MY_VAR=value). Name kept for backward compatibility; benchmarkoor no longer runs inside a Docker container.'
     required: false
     default: ''
 
@@ -83,31 +83,36 @@ runs:
 
         rm -rf benchmarkoor-build
 
-    - name: Determine which image to use
-      id: determine-image
+    - name: Extract benchmarkoor binary
+      id: extract-binary
       shell: bash
       run: |
         if [ -n "${{ inputs.image }}" ]; then
           IMAGE="${{ inputs.image }}"
-          echo "Using provided Docker image: ${IMAGE}"
-        else
-          IMAGE="benchmarkoor:local"
-          echo "Using locally built image: ${IMAGE}"
-        fi
-        echo "image=${IMAGE}" >> $GITHUB_OUTPUT
-
-        if [ -z "$IMAGE" ]; then
-          echo "ERROR: Docker image not specified"
-          exit 1
-        fi
-
-        if [ "$IMAGE" != "benchmarkoor:local" ]; then
-          echo "Pulling Docker image: ${IMAGE}"
+          echo "Pulling Docker image to extract binary: ${IMAGE}"
           docker pull "${IMAGE}" || {
             echo "Failed to pull Docker image: ${IMAGE}"
             exit 1
           }
+        else
+          IMAGE="benchmarkoor:local"
+          echo "Using locally built image: ${IMAGE}"
         fi
+
+        BIN="${{ runner.temp }}/benchmarkoor"
+
+        # docker create + docker cp gives us the binary owned by the
+        # runner user without needing a writable bind-mount or matching
+        # uid inside the container.
+        cid=$(docker create "${IMAGE}")
+        trap "docker rm -f \"$cid\" >/dev/null 2>&1 || true" EXIT
+        docker cp "$cid:/usr/local/bin/benchmarkoor" "$BIN"
+        chmod +x "$BIN"
+
+        echo "Extracted binary to $BIN"
+        "$BIN" --version || true
+
+        echo "binary=${BIN}" >> "$GITHUB_OUTPUT"
 
     - name: Get Job ID from GH API
       id: get-job-id
@@ -127,14 +132,8 @@ runs:
         INPUT_RUN_CONFIG_URLS: ${{ inputs.run-config-urls }}
         INPUT_DOCKER_ENV: ${{ inputs.docker-env }}
       run: |
-        # Remove any leftover containers from a previous run
-        docker rm -f benchmarkoor-run 2>/dev/null || true
-        docker rm -f benchmarkoor-md 2>/dev/null || true
-
-        mkdir -p ${{ runner.temp }}/results
-
-        IMAGE="${{ steps.determine-image.outputs.image }}"
-        echo "Running benchmarkoor with Docker image: ${IMAGE}"
+        BIN="${{ steps.extract-binary.outputs.binary }}"
+        mkdir -p "${{ runner.temp }}/results"
 
         # Download URL configs if provided (comma-separated)
         if [ -n "$INPUT_RUN_CONFIG_URLS" ]; then
@@ -151,175 +150,70 @@ runs:
           echo "$INPUT_RUN_CONFIG" > "${{ runner.temp }}/benchmarkoor-config-inline.yaml"
         fi
 
-        # Extract unique filesystem mount points from datadir source_dir values
-        DATADIR_MOUNT_POINTS=""
-        USES_SCHELK=false
-        CONFIG_FILES=()
-        for cfg in "${{ runner.temp }}"/benchmarkoor-config-url-*.yaml; do
-          [ -f "$cfg" ] && CONFIG_FILES+=("$cfg")
-        done
-        if [ -f "${{ runner.temp }}/benchmarkoor-config-inline.yaml" ]; then
-          CONFIG_FILES+=("${{ runner.temp }}/benchmarkoor-config-inline.yaml")
-        fi
+        # Collect env vars for the sudo invocation. benchmarkoor needs
+        # root for drop_memory_caches, schelk, dm_era ops, podman socket
+        # access in rootful mode, etc. — so we run it under `sudo env`
+        # rather than relying on `-E` (which sudoers may not allow).
+        BENCHMARKOOR_ENV=(
+          "BENCHMARKOOR_RUNNER_GITHUB_TOKEN=${{ inputs.github-token }}"
+          "BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_DIR=${{ runner.temp }}/results"
+          "BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_OWNER=$(id -u):$(id -g)"
+          "BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_DATADIR=${{ inputs.tmp-dir }}"
+          "BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_CACHEDIR=${{ inputs.tmp-dir }}/benchmarkoor-cache"
+        )
 
-        if [ ${#CONFIG_FILES[@]} -gt 0 ]; then
-          ALL_SOURCE_DIRS=""
-          for cfg in "${CONFIG_FILES[@]}"; do
-            # Extract source_dir from runner.client.datadirs map values and runner.instances[].datadir
-            DIRS=$(yq '(
-              .runner.client.datadirs[].source_dir,
-              .runner.instances[].datadir.source_dir
-            )' "$cfg" 2>/dev/null | grep -v '^null$' || true)
-            if [ -n "$DIRS" ]; then
-              ALL_SOURCE_DIRS="${ALL_SOURCE_DIRS}${DIRS}"$'\n'
-            fi
-
-            # Detect whether any datadir uses the schelk method so we can
-            # bind-mount the schelk state file and switch BENCHMARKOOR_SCHELK_BIN
-            # to the in-container nsenter wrapper.
-            SCHELK_METHODS=$(yq '(
-              .runner.client.datadirs[].method,
-              .runner.instances[].datadir.method
-            )' "$cfg" 2>/dev/null | grep -Fx 'schelk' || true)
-            if [ -n "$SCHELK_METHODS" ]; then
-              USES_SCHELK=true
-            fi
-          done
-
-          # Resolve each source_dir to its filesystem mountpoint, deduplicate
-          if [ -n "$ALL_SOURCE_DIRS" ]; then
-            DATADIR_MOUNT_POINTS=$(echo "$ALL_SOURCE_DIRS" | while IFS= read -r dir; do
-              dir=$(echo "$dir" | xargs)
-              [ -z "$dir" ] && continue
-              if [ -d "$dir" ]; then
-                mp=$(findmnt -n -o TARGET --target "$dir" 2>/dev/null || true)
-                if [ -n "$mp" ] && [[ "$mp" == /* ]]; then
-                  echo "$mp"
-                else
-                  echo "Warning: could not determine mount point for '$dir', skipping" >&2
-                fi
-              else
-                echo "Warning: datadir source_dir '$dir' does not exist, skipping" >&2
-              fi
-            done | sort -u)
-          fi
-        fi
-
-        if [ -n "$DATADIR_MOUNT_POINTS" ]; then
-          echo "Detected datadir filesystem mount points for rshared propagation:"
-          echo "$DATADIR_MOUNT_POINTS"
-        fi
-
-        SCHELK_MOUNT_POINT=""
-        if [ "$USES_SCHELK" = "true" ]; then
-          echo "Detected datadir.method: schelk — will plumb schelk state + nsenter wrapper into the container."
-          if [ ! -f /var/lib/schelk/state.json ]; then
-            echo "ERROR: datadir.method: schelk requires /var/lib/schelk/state.json on the host." >&2
-            echo "       Initialise schelk first (e.g. via the ethPandaOps ansible role)." >&2
-            exit 1
-          fi
-          # Read the schelk mount point from state.json so we bind-mount it
-          # with rshared regardless of whether the scratch is currently
-          # mounted (findmnt-based source_dir auto-detection misses an
-          # empty mount point). The mount goes in even when the directory
-          # is empty so subsequent `schelk mount` calls (via nsenter) propagate.
-          SCHELK_MOUNT_POINT=$(yq -r '.mount_point // ""' /var/lib/schelk/state.json 2>/dev/null || true)
-          if [ -z "$SCHELK_MOUNT_POINT" ]; then
-            echo "ERROR: /var/lib/schelk/state.json has no mount_point field." >&2
-            exit 1
-          fi
-          echo "Schelk mount point: $SCHELK_MOUNT_POINT"
-        fi
-
-        # Build docker run command
-        DOCKER_CMD="docker run --network=host --rm --name=benchmarkoor-run"
-        DOCKER_CMD="$DOCKER_CMD -v /var/run/docker.sock:/var/run/docker.sock"
-        DOCKER_CMD="$DOCKER_CMD -v /run/podman/podman.sock:/run/podman/podman.sock"
-        DOCKER_CMD="$DOCKER_CMD -v /var/lib/containers:/var/lib/containers:rshared"
-        DOCKER_CMD="$DOCKER_CMD -v ${{ runner.temp }}/results:/app/results"
-        DOCKER_CMD="$DOCKER_CMD -v ${{ runner.temp }}:/app/configs"
-        DOCKER_CMD="$DOCKER_CMD --mount type=bind,source=${{ inputs.tmp-dir }},target=${{ inputs.tmp-dir }},bind-propagation=rshared"
-        DOCKER_CMD="$DOCKER_CMD --privileged --pid=host"
-        DOCKER_CMD="$DOCKER_CMD -v /proc/sys/vm/drop_caches:/host_drop_caches"
-        DOCKER_CMD="$DOCKER_CMD -v /sys/devices/system/cpu:/host_sys_cpu"
-        DOCKER_CMD="$DOCKER_CMD -v /sys/fs/cgroup:/sys/fs/cgroup:ro"
-        DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_GITHUB_TOKEN=${{ inputs.github-token }}"
-        DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_DROP_CACHES_PATH=/host_drop_caches"
-        DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_CPU_SYSFS_PATH=/host_sys_cpu"
-        DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_DIR=/app/results"
-        DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_OWNER=$(id -u):$(id -g)"
-        DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_DATADIR=${{ inputs.tmp-dir }}"
-        DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_CACHEDIR=${{ inputs.tmp-dir }}/benchmarkoor-cache"
-
-        # Forward user-specified environment variables into the container.
+        # Forward user-specified environment variables to benchmarkoor.
+        # Supports "NAME=value" entries. Bare "NAME" is treated as a
+        # passthrough from the current process environment.
         if [ -n "$INPUT_DOCKER_ENV" ]; then
           while IFS= read -r env_entry; do
             env_entry=$(echo "$env_entry" | xargs)  # trim whitespace
             [ -z "$env_entry" ] && continue
-            DOCKER_CMD="$DOCKER_CMD -e ${env_entry}"
+            if [[ "$env_entry" == *=* ]]; then
+              BENCHMARKOOR_ENV+=("$env_entry")
+            else
+              BENCHMARKOOR_ENV+=("${env_entry}=${!env_entry}")
+            fi
           done <<< "$INPUT_DOCKER_ENV"
         fi
 
-        # Add rshared mounts for datadir filesystem mount points (ZFS/overlayfs)
-        if [ -n "$DATADIR_MOUNT_POINTS" ]; then
-          while IFS= read -r mp; do
-            [ -z "$mp" ] && continue
-            DOCKER_CMD="$DOCKER_CMD --mount type=bind,source=${mp},target=${mp},bind-propagation=rshared"
-          done <<< "$DATADIR_MOUNT_POINTS"
-        fi
+        # Build argv as an array so quoted values survive intact.
+        ARGS=("run")
 
-        # Schelk: mount the state directory so benchmarkoor can read
-        # state.json from inside the container, and rshared-mount the
-        # schelk mount point itself so mounts created on the host (via
-        # nsenter) propagate into the container's view. Point benchmarkoor
-        # at the nsenter wrapper baked into the image. schelk operations
-        # (dm-era, mount/umount) run on the host via nsenter.
-        if [ "$USES_SCHELK" = "true" ]; then
-          DOCKER_CMD="$DOCKER_CMD -v /var/lib/schelk:/var/lib/schelk"
-          # Skip if the source_dir scan already covered this mount point
-          # (i.e. /schelk was actually mounted at action-eval time and
-          # findmnt resolved source_dir → SCHELK_MOUNT_POINT).
-          if ! echo "$DATADIR_MOUNT_POINTS" | grep -Fxq "$SCHELK_MOUNT_POINT"; then
-            DOCKER_CMD="$DOCKER_CMD --mount type=bind,source=${SCHELK_MOUNT_POINT},target=${SCHELK_MOUNT_POINT},bind-propagation=rshared"
-          fi
-          DOCKER_CMD="$DOCKER_CMD -e BENCHMARKOOR_SCHELK_BIN=/usr/local/bin/schelk-host"
-        fi
-
-        DOCKER_CMD="$DOCKER_CMD ${IMAGE}"
-        DOCKER_CMD="$DOCKER_CMD run"
-
-        # Add config files in order: URL configs, inline config, override config (last wins)
+        # Add config files in order: URL configs, then inline config (last wins).
         for cfg in "${{ runner.temp }}"/benchmarkoor-config-url-*.yaml; do
-          [ -f "$cfg" ] && DOCKER_CMD="$DOCKER_CMD --config=/app/configs/$(basename "$cfg")"
+          [ -f "$cfg" ] && ARGS+=("--config=$cfg")
         done
-
         if [ -f "${{ runner.temp }}/benchmarkoor-config-inline.yaml" ]; then
-          DOCKER_CMD="$DOCKER_CMD --config=/app/configs/benchmarkoor-config-inline.yaml"
+          ARGS+=("--config=${{ runner.temp }}/benchmarkoor-config-inline.yaml")
         fi
 
-        # Add GitHub Actions context as metadata labels
-        DOCKER_CMD="$DOCKER_CMD --metadata.label=github.run_id=${{ github.run_id }}"
-        DOCKER_CMD="$DOCKER_CMD --metadata.label=github.run_number=${{ github.run_number }}"
-        DOCKER_CMD="$DOCKER_CMD --metadata.label=github.job=${{ github.job }}"
-        DOCKER_CMD="$DOCKER_CMD --metadata.label=github.job_id=${{ steps.get-job-id.outputs.job_id }}"
-        DOCKER_CMD="$DOCKER_CMD --metadata.label=github.repository=${{ github.repository }}"
-        DOCKER_CMD="$DOCKER_CMD --metadata.label=github.workflow=\"${{ github.workflow }}\""
-        DOCKER_CMD="$DOCKER_CMD --metadata.label=github.sha=${{ github.sha }}"
-        DOCKER_CMD="$DOCKER_CMD --metadata.label=github.actor=${{ github.actor }}"
-        DOCKER_CMD="$DOCKER_CMD --metadata.label=github.event_name=${{ github.event_name }}"
-        DOCKER_CMD="$DOCKER_CMD --metadata.label=github.ref=${{ github.ref }}"
+        # GitHub Actions context as metadata labels.
+        ARGS+=(
+          "--metadata.label=github.run_id=${{ github.run_id }}"
+          "--metadata.label=github.run_number=${{ github.run_number }}"
+          "--metadata.label=github.job=${{ github.job }}"
+          "--metadata.label=github.job_id=${{ steps.get-job-id.outputs.job_id }}"
+          "--metadata.label=github.repository=${{ github.repository }}"
+          "--metadata.label=github.workflow=${{ github.workflow }}"
+          "--metadata.label=github.sha=${{ github.sha }}"
+          "--metadata.label=github.actor=${{ github.actor }}"
+          "--metadata.label=github.event_name=${{ github.event_name }}"
+          "--metadata.label=github.ref=${{ github.ref }}"
+        )
 
-        # Append extra run args if provided
+        # Append extra run args if provided (whitespace-split, same as before).
         if [ -n "${{ inputs.run-args }}" ]; then
-          DOCKER_CMD="$DOCKER_CMD ${{ inputs.run-args }}"
+          # shellcheck disable=SC2206 # intentional word-split for argv
+          EXTRA_ARGS=(${{ inputs.run-args }})
+          ARGS+=("${EXTRA_ARGS[@]}")
         fi
 
-        # Execute the command
-        echo "Running: $DOCKER_CMD"
+        echo "Running: sudo env [env...] $BIN ${ARGS[*]}"
+
         set +e
-        eval $DOCKER_CMD &
-        wait $!
-        DOCKER_EXIT_CODE=$?
+        sudo env "${BENCHMARKOOR_ENV[@]}" "$BIN" "${ARGS[@]}"
+        EXIT_CODE=$?
         set -e
 
         # Find run directories
@@ -328,11 +222,11 @@ runs:
           RUN_DIRS=$(find "${{ runner.temp }}/results/runs" -mindepth 1 -maxdepth 1 -type d | sort | tr '\n' ' ')
         fi
 
-        echo "run-dirs=${RUN_DIRS}" >> $GITHUB_OUTPUT
+        echo "run-dirs=${RUN_DIRS}" >> "$GITHUB_OUTPUT"
 
-        if [ $DOCKER_EXIT_CODE -ne 0 ]; then
-          echo "Benchmarkoor failed with exit code $DOCKER_EXIT_CODE"
-          exit $DOCKER_EXIT_CODE
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "Benchmarkoor failed with exit code $EXIT_CODE"
+          exit $EXIT_CODE
         fi
 
         echo "Benchmarkoor completed successfully"
@@ -341,20 +235,16 @@ runs:
       if: always() && steps.run-benchmarkoor.outputs.run-dirs != ''
       shell: bash
       run: |
-        IMAGE="${{ steps.determine-image.outputs.image }}"
+        BIN="${{ steps.extract-binary.outputs.binary }}"
 
         for RUN_DIR_HOST in ${{ steps.run-benchmarkoor.outputs.run-dirs }}; do
           RUN_DIR_NAME=$(basename "$RUN_DIR_HOST")
-          CONTAINER_RUN_DIR="/app/results/runs/${RUN_DIR_NAME}"
 
           echo "Generating summary for ${RUN_DIR_NAME}"
 
-          docker run --rm --name=benchmarkoor-md \
-            -v "${{ runner.temp }}/results:/app/results" \
-            "${IMAGE}" \
-            generate-markdown-summary \
-            --run-dir="${CONTAINER_RUN_DIR}" \
-            --output="${CONTAINER_RUN_DIR}/summary.md"
+          "$BIN" generate-markdown-summary \
+            --run-dir="${RUN_DIR_HOST}" \
+            --output="${RUN_DIR_HOST}/summary.md"
 
           if [ -f "${RUN_DIR_HOST}/summary.md" ]; then
             cat "${RUN_DIR_HOST}/summary.md" >> "$GITHUB_STEP_SUMMARY"
@@ -382,9 +272,8 @@ runs:
       if: always()
       run: |
         echo "Cleaning up"
-        rm -rf ${{ runner.temp }}/results
-        rm -f ${{ runner.temp }}/benchmarkoor-config-url-*.yaml
-        rm -f ${{ runner.temp }}/benchmarkoor-config-inline.yaml
-        rm -f ${{ runner.temp }}/benchmarkoor-results.tar.gz
-        docker rm -f benchmarkoor-run 2>/dev/null || true
-        docker rm -f benchmarkoor-md 2>/dev/null || true
+        rm -rf "${{ runner.temp }}/results"
+        rm -f "${{ runner.temp }}/benchmarkoor-config-url-"*.yaml
+        rm -f "${{ runner.temp }}/benchmarkoor-config-inline.yaml"
+        rm -f "${{ runner.temp }}/benchmarkoor-results.tar.gz"
+        rm -f "${{ runner.temp }}/benchmarkoor"

--- a/action.yaml
+++ b/action.yaml
@@ -50,11 +50,6 @@ inputs:
     required: false
     default: '/tmp'
 
-  docker-env:
-    description: 'Newline-separated environment variables to export before invoking benchmarkoor (e.g. AWS_ACCESS_KEY_ID, MY_VAR=value). Name kept for backward compatibility; benchmarkoor no longer runs inside a Docker container.'
-    required: false
-    default: ''
-
 runs:
   using: 'composite'
   steps:
@@ -130,7 +125,6 @@ runs:
       env:
         INPUT_RUN_CONFIG: ${{ inputs.run-config }}
         INPUT_RUN_CONFIG_URLS: ${{ inputs.run-config-urls }}
-        INPUT_DOCKER_ENV: ${{ inputs.docker-env }}
       run: |
         BIN="${{ steps.extract-binary.outputs.binary }}"
         mkdir -p "${{ runner.temp }}/results"
@@ -150,32 +144,16 @@ runs:
           echo "$INPUT_RUN_CONFIG" > "${{ runner.temp }}/benchmarkoor-config-inline.yaml"
         fi
 
-        # Collect env vars for the sudo invocation. benchmarkoor needs
-        # root for drop_memory_caches, schelk, dm_era ops, podman socket
-        # access in rootful mode, etc. — so we run it under `sudo env`
-        # rather than relying on `-E` (which sudoers may not allow).
-        BENCHMARKOOR_ENV=(
-          "BENCHMARKOOR_RUNNER_GITHUB_TOKEN=${{ inputs.github-token }}"
-          "BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_DIR=${{ runner.temp }}/results"
-          "BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_OWNER=$(id -u):$(id -g)"
-          "BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_DATADIR=${{ inputs.tmp-dir }}"
-          "BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_CACHEDIR=${{ inputs.tmp-dir }}/benchmarkoor-cache"
-        )
-
-        # Forward user-specified environment variables to benchmarkoor.
-        # Supports "NAME=value" entries. Bare "NAME" is treated as a
-        # passthrough from the current process environment.
-        if [ -n "$INPUT_DOCKER_ENV" ]; then
-          while IFS= read -r env_entry; do
-            env_entry=$(echo "$env_entry" | xargs)  # trim whitespace
-            [ -z "$env_entry" ] && continue
-            if [[ "$env_entry" == *=* ]]; then
-              BENCHMARKOOR_ENV+=("$env_entry")
-            else
-              BENCHMARKOOR_ENV+=("${env_entry}=${!env_entry}")
-            fi
-          done <<< "$INPUT_DOCKER_ENV"
-        fi
+        # Export benchmarkoor's own config env vars. Anything the caller
+        # set via `env:` on the action step is already in our process
+        # environment; `sudo -E` below propagates both sets to the
+        # benchmarkoor process (which it needs to be: root, for
+        # drop_memory_caches, schelk dm_era ops, rootful podman, etc.).
+        export BENCHMARKOOR_RUNNER_GITHUB_TOKEN="${{ inputs.github-token }}"
+        export BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_DIR="${{ runner.temp }}/results"
+        export BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_OWNER="$(id -u):$(id -g)"
+        export BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_DATADIR="${{ inputs.tmp-dir }}"
+        export BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_CACHEDIR="${{ inputs.tmp-dir }}/benchmarkoor-cache"
 
         # Build argv as an array so quoted values survive intact.
         ARGS=("run")
@@ -209,10 +187,10 @@ runs:
           ARGS+=("${EXTRA_ARGS[@]}")
         fi
 
-        echo "Running: sudo env [env...] $BIN ${ARGS[*]}"
+        echo "Running: sudo -E $BIN ${ARGS[*]}"
 
         set +e
-        sudo env "${BENCHMARKOOR_ENV[@]}" "$BIN" "${ARGS[@]}"
+        sudo -E "$BIN" "${ARGS[@]}"
         EXIT_CODE=$?
         set -e
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1110,7 +1110,7 @@ The [`ethpandaops/benchmarkoor` action](../action.yaml) extracts the benchmarkoo
 What the runner needs:
 
 - The [ethPandaOps schelk ansible role](https://github.com/ethpandaops/github-actions-runners/tree/master/ansible/roles/schelk) installed: schelk binary at `/usr/local/bin/schelk`, `era_invalidate` built, `dm_era` and `brd` kernel modules loaded, and `schelk init-new` (or `init-from`) already run so `/var/lib/schelk/state.json` exists.
-- The `schelk` binary on the runner user's PATH. If it lives somewhere else, point benchmarkoor at it via the action's `docker-env` input (e.g. `docker-env: BENCHMARKOOR_SCHELK_BIN=/opt/schelk/bin/schelk`).
+- The `schelk` binary on the runner user's PATH. If it lives somewhere else, set `BENCHMARKOOR_SCHELK_BIN` on the action step (standard `env:` block — composite-action steps inherit the caller's env).
 
 A minimal CI invocation:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1103,33 +1103,6 @@ Notes:
 | `BENCHMARKOOR_SCHELK_BIN` | Override the schelk executable path. Useful when running under `sudo` with a sanitised PATH that does not include `~/.cargo/bin`. Accepts a bare name (resolved via PATH) or an absolute/relative path. Default: `schelk` |
 | `SCHELK_STATE` | Override the schelk state-file path. Honoured by both schelk itself and benchmarkoor's preflight. Default: `/var/lib/schelk/state.json` |
 
-###### Schelk in CI / GitHub Action
-
-The [`ethpandaops/benchmarkoor` action](../action.yaml) extracts the benchmarkoor binary from the configured Docker image and runs it directly on the runner host — there is no docker-in-docker / mount-namespace plumbing involved. As long as the runner has schelk initialised, `method: schelk` works without any action-specific glue.
-
-What the runner needs:
-
-- The [ethPandaOps schelk ansible role](https://github.com/ethpandaops/github-actions-runners/tree/master/ansible/roles/schelk) installed: schelk binary at `/usr/local/bin/schelk`, `era_invalidate` built, `dm_era` and `brd` kernel modules loaded, and `schelk init-new` (or `init-from`) already run so `/var/lib/schelk/state.json` exists.
-- The `schelk` binary on the runner user's PATH. If it lives somewhere else, set `BENCHMARKOOR_SCHELK_BIN` on the action step (standard `env:` block — composite-action steps inherit the caller's env).
-
-A minimal CI invocation:
-
-```yaml
-- uses: ethpandaops/benchmarkoor@<sha>
-  with:
-    run-config: |
-      runner:
-        client:
-          config:
-            rollback_strategy: container-recreate
-        instances:
-          - id: reth-schelk
-            client: reth
-            datadir:
-              method: schelk
-              source_dir: /schelk/eth/reth
-```
-
 ###### Default Container Directories
 
 When `container_dir` is not specified, the client's default data directory is used:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1105,16 +1105,14 @@ Notes:
 
 ###### Schelk in CI / GitHub Action
 
-When benchmarkoor runs inside the Docker container started by the [`ethpandaops/benchmarkoor` action](../action.yaml), `datadir.method: schelk` is plumbed through automatically:
+The [`ethpandaops/benchmarkoor` action](../action.yaml) extracts the benchmarkoor binary from the configured Docker image and runs it directly on the runner host — there is no docker-in-docker / mount-namespace plumbing involved. As long as the runner has schelk initialised, `method: schelk` works without any action-specific glue.
 
-1. The action scans the merged run-configs for `datadir.method: schelk`. When found, it:
-   - Verifies `/var/lib/schelk/state.json` exists on the host (initialise schelk first via the [ethPandaOps ansible role](https://github.com/ethpandaops/github-actions-runners/tree/master/ansible/roles/schelk) — installs schelk + `era_invalidate` + loads `dm_era` / `brd`, and optionally runs `schelk init-new`).
-   - Bind-mounts `/var/lib/schelk` into the container so benchmarkoor can read `state.json` and detect mount state.
-   - Sets `BENCHMARKOOR_SCHELK_BIN=/usr/local/bin/schelk-host` — a wrapper baked into the image that runs the host's `schelk` via `nsenter -t 1 -m`, so all dm-era / mount operations happen in the host's mount namespace.
-2. The `/schelk` mount point itself is bind-mounted via the existing datadir-source-dir auto-detection (`source_dir: /schelk/...` resolves to `/schelk` via `findmnt`).
-3. The container already runs with `--privileged --pid=host`, which is what `nsenter` needs to hop into the host's namespace.
+What the runner needs:
 
-You don't need to change the action invocation — the existing `run-config`/`run-config-urls` inputs work as-is. A minimal CI config:
+- The [ethPandaOps schelk ansible role](https://github.com/ethpandaops/github-actions-runners/tree/master/ansible/roles/schelk) installed: schelk binary at `/usr/local/bin/schelk`, `era_invalidate` built, `dm_era` and `brd` kernel modules loaded, and `schelk init-new` (or `init-from`) already run so `/var/lib/schelk/state.json` exists.
+- The `schelk` binary on the runner user's PATH. If it lives somewhere else, point benchmarkoor at it via the action's `docker-env` input (e.g. `docker-env: BENCHMARKOOR_SCHELK_BIN=/opt/schelk/bin/schelk`).
+
+A minimal CI invocation:
 
 ```yaml
 - uses: ethpandaops/benchmarkoor@<sha>


### PR DESCRIPTION
## Summary

Replaces the docker-in-docker model in the GH Action with a direct-binary execution model. Previously benchmarkoor ran inside a Docker container with `--privileged --pid=host` + a dozen bind mounts, all to make benchmarkoor *feel* like a host process. This paid the cost of mount-namespace plumbing without any isolation benefit. Switch to extracting the binary (`docker create` + `docker cp`) and running it directly on the runner with `sudo env`.

Eliminates a class of mount-namespace bugs — most recently the [schelk EBUSY](https://github.com/ethpandaops/benchmarkoor-tests/actions/runs/26953153059/job/79523895408) caused by the container's bind-mount of `/schelk` pinning the dm-era device when `schelk recover` tried to tear it down.

## What goes away

- `--privileged`, `--pid=host`, `--network=host`.
- All `-v /var/run/docker.sock`, `-v /run/podman/podman.sock`, `-v /var/lib/containers`, `-v /sys/fs/cgroup`, `--mount bind-propagation=rshared` plumbing.
- The whole `findmnt`/`yq` block that resolved datadir `source_dir` values to filesystem mount points so they could be bind-mounted into the container.
- The `USES_SCHELK`/`SCHELK_MOUNT_POINT` branch plus `BENCHMARKOOR_SCHELK_BIN=/usr/local/bin/schelk-host`.
- `/host_drop_caches` and `/host_sys_cpu` indirections — defaults now work because the binary runs on the host.
- The separate `docker run … generate-markdown-summary` for the summary step.
- `docker rm -f benchmarkoor-run` / `benchmarkoor-md` cleanup.
- The `util-linux-misc` package + `/usr/local/bin/schelk-host` nsenter wrapper added in #244.

## What's new / kept

- One `Extract benchmarkoor binary` step that runs `docker create` + `docker cp` and stages the binary under `${{ runner.temp }}/benchmarkoor`. Used by both `run` and `generate-markdown-summary`.
- The binary is invoked via `sudo env BENCHMARKOOR_…=… "$BIN" run …` so `drop_memory_caches`, schelk dm_era ops, and rootful podman socket access still work. `sudo env` (rather than `sudo -E`) avoids relying on `Defaults env_keep`.
- `inputs.docker-env` keeps its name for backward compatibility but now exports vars to the benchmarkoor process. Bare `NAME` entries pull from the current environment.
- All action inputs and outputs are unchanged.

## Diff

```
 Dockerfile            |  13 +--
 action.yaml           | 279 +++++++++++++++-----------------------------------
 docs/configuration.md |  14 ++-
 3 files changed, 91 insertions(+), 215 deletions(-)
```

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('action.yaml'))"` clean
- [ ] CI: `ci.action.yaml` (docker / podman / podman-checkpoint-restore) still passes on `ubuntu-latest`
- [ ] On a self-hosted runner with the [schelk ansible role](https://github.com/ethpandaops/github-actions-runners/tree/master/ansible/roles/schelk) applied and `/schelk` initialised, run a workflow with `datadir.method: schelk` + `rollback_strategy: container-recreate` and confirm:
  - schelk operations succeed (no EBUSY on dm-era teardown)
  - per-iteration `schelk restore` works for the full test suite
  - results land in the runner temp dir with the runner user's ownership
- [ ] Generated `summary.md` is appended to the GH job summary
- [ ] `upload-artifacts: true` produces a usable tarball