### PR TITLE
fix: ethrex block-log parser to capture exec/merkle/store phase timings

### DIFF
--- a/pkg/blocklog/ethrex.go
+++ b/pkg/blocklog/ethrex.go
@@ -18,18 +18,52 @@ import (
 // it in the header. benchmarkoor's collector can only associate a log with a
 // test when block.hash is present, so a hash-less build parses but never
 // matches.
-//
-// Note: ethrex follows this header with separate "|- validate/exec/merkle/store"
-// lines. Those are distinct log lines, so the collector (which matches one
-// payload per line) cannot fold them into this payload; only the header fields
-// are captured.
 var ethrexLogPattern = regexp.MustCompile(
 	`\[METRIC\] BLOCK (\d+)(?:\s+(0x[0-9a-fA-F]+))? \| ` +
 		`([0-9.]+) Ggas/s \| ([0-9.]+) ms \| (\d+) txs \| ([0-9.]+) Mgas \((\d+)%\)`,
 )
 
+// ethrexPhasePattern matches the per-phase breakdown lines that follow the
+// header, e.g. (after ANSI stripping):
+//
+//	|- exec:      450.00 ms  (80%) << BOTTLENECK
+//	|- merkle:     12.34 ms  (20%)  [concurrent: 1.2 ms, drain: 12.3 ms, ...]
+//	|- store:       0.82 ms  ( 4%)
+//
+// validate and warmer lines share the shape but have no destination column, so
+// only exec/merkle/store are mapped.
+var ethrexPhasePattern = regexp.MustCompile(
+	`\|-\s*(exec|merkle|store):\s*([0-9.]+)\s*ms`,
+)
+
 // ethrexParser parses metrics from ethrex block execution throughput logs.
-type ethrexParser struct{}
+//
+// ethrex prints one header line followed by separate phase lines per block, so
+// the parser is stateful: it buffers the header and folds in the phase timings,
+// emitting one complete payload. Because benchmarkoor registers a block hash
+// *before* the engine_newPayload RPC, the first payload emitted for a hash is
+// the one stored — so it must already be complete. It is emitted on the `store`
+// line (the last mapped phase); a block that never reaches `store` (e.g. a
+// header-only build) is flushed when the next header arrives.
+type ethrexParser struct {
+	pending *ethrexBlock
+}
+
+type ethrexBlock struct {
+	number      int64
+	hash        string
+	gasUsedMgas float64
+	txCount     int64
+	totalMs     float64
+	mgasPerSec  float64
+	execMs      float64
+	merkleMs    float64
+	storeMs     float64
+	haveExec    bool
+	haveMerkle  bool
+	haveStore   bool
+	emitted     bool
+}
 
 // NewEthrexParser creates a new ethrex log parser.
 func NewEthrexParser() Parser {
@@ -39,36 +73,87 @@ func NewEthrexParser() Parser {
 // Ensure interface compliance.
 var _ Parser = (*ethrexParser)(nil)
 
-// ParseLine extracts metrics from an ethrex per-block metric header and returns
-// them as a nested JSON structure matching the shape used by the other client
-// parsers ({ "block": { "hash": ... }, ... }).
+// ParseLine extracts metrics from ethrex per-block metric logs and returns them
+// as a nested JSON structure matching the shape used by the other client
+// parsers ({ "block": {...}, "timing": {...}, "throughput": {...} }).
 func (p *ethrexParser) ParseLine(line string) (json.RawMessage, bool) {
 	// Strip ANSI escape codes — ethrex colorizes stdout logs when on a TTY.
 	line = ansiPattern.ReplaceAllString(line, "")
 
-	matches := ethrexLogPattern.FindStringSubmatch(line)
-	if matches == nil {
+	if m := ethrexLogPattern.FindStringSubmatch(line); m != nil {
+		// New block header. Flush the previous block if it never reached its
+		// `store` line (header-only build, or a missing phase) so it isn't lost.
+		var flushed json.RawMessage
+		var flush bool
+		if p.pending != nil && !p.pending.emitted {
+			flushed, flush = p.pending.payload()
+		}
+		p.pending = &ethrexBlock{
+			number:      parseInt(m[1]),
+			hash:        m[2],
+			mgasPerSec:  parseFloat(m[3]) * 1000.0, // Ggas/s -> Mgas/s
+			totalMs:     parseFloat(m[4]),
+			txCount:     parseInt(m[5]),
+			gasUsedMgas: parseFloat(m[6]),
+		}
+		if flush {
+			return flushed, true
+		}
+
 		return nil, false
 	}
 
-	block := map[string]any{
-		"number":        parseInt(matches[1]),
-		"gas_used_mgas": parseFloat(matches[6]),
-		"gas_used_pct":  parseInt(matches[7]),
-		"tx_count":      parseInt(matches[5]),
+	if p.pending != nil {
+		if m := ethrexPhasePattern.FindStringSubmatch(line); m != nil {
+			ms := parseFloat(m[2])
+			switch m[1] {
+			case "exec":
+				p.pending.execMs, p.pending.haveExec = ms, true
+			case "merkle":
+				p.pending.merkleMs, p.pending.haveMerkle = ms, true
+			case "store":
+				p.pending.storeMs, p.pending.haveStore = ms, true
+				// `store` is the last mapped phase: the record is complete.
+				p.pending.emitted = true
+
+				return p.pending.payload()
+			}
+		}
 	}
-	// matches[2] (hash) is only present on builds that log it; the collector
-	// needs block.hash to associate the log with a test.
-	if matches[2] != "" {
-		block["hash"] = matches[2]
+
+	return nil, false
+}
+
+// payload renders the buffered block as the nested JSON the indexer expects.
+func (b *ethrexBlock) payload() (json.RawMessage, bool) {
+	block := map[string]any{
+		"number":   b.number,
+		"gas_used": int64(b.gasUsedMgas*1e6 + 0.5), // header only carries Mgas
+		"tx_count": b.txCount,
+	}
+	// hash is only present on builds that log it; the collector needs it to
+	// associate the log with a test.
+	if b.hash != "" {
+		block["hash"] = b.hash
+	}
+
+	timing := map[string]any{"total_ms": b.totalMs}
+	if b.haveExec {
+		timing["execution_ms"] = b.execMs
+	}
+	if b.haveMerkle {
+		timing["state_hash_ms"] = b.merkleMs // ethrex "merkle" == state hashing
+	}
+	if b.haveStore {
+		timing["commit_ms"] = b.storeMs // ethrex "store" == commit
 	}
 
 	result := map[string]any{
 		"level":      "info",
 		"msg":        "Block execution throughput",
 		"block":      block,
-		"timing":     map[string]any{"total_ms": parseFloat(matches[4])},
-		"throughput": map[string]any{"ggas_per_sec": parseFloat(matches[3])},
+		"timing":     timing,
+		"throughput": map[string]any{"mgas_per_sec": b.mgasPerSec},
 	}
 
 	data, err := json.Marshal(result)

--- a/pkg/blocklog/ethrex_test.go
+++ b/pkg/blocklog/ethrex_test.go
@@ -8,135 +8,126 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEthrexParser_ParseLine(t *testing.T) {
-	parser := NewEthrexParser()
+// feed runs every line through the parser and returns the emitted payloads, in
+// order, decoded to maps.
+func feed(t *testing.T, p Parser, lines []string) []map[string]any {
+	t.Helper()
 
-	tests := []struct {
-		name   string
-		line   string
-		wantOK bool
-		// checkJSON is called when wantOK is true to verify the parsed output.
-		checkJSON func(t *testing.T, data map[string]any)
-	}{
-		{
-			name:   "pipeline header with hash",
-			line:   `2026-05-27T14:00:00.123456Z  INFO [METRIC] BLOCK 24358000 0xc957abc123 | 1.234 Ggas/s | 567.00 ms | 150 txs | 700 Mgas (93%)`,
-			wantOK: true,
-			checkJSON: func(t *testing.T, data map[string]any) {
-				t.Helper()
-
-				assert.Equal(t, "info", data["level"])
-				assert.Equal(t, "Block execution throughput", data["msg"])
-
-				block := data["block"].(map[string]any)
-				assert.Equal(t, float64(24358000), block["number"])
-				assert.Equal(t, "0xc957abc123", block["hash"])
-				assert.Equal(t, float64(700), block["gas_used_mgas"])
-				assert.Equal(t, float64(93), block["gas_used_pct"])
-				assert.Equal(t, float64(150), block["tx_count"])
-
-				throughput := data["throughput"].(map[string]any)
-				assert.Equal(t, 1.234, throughput["ggas_per_sec"])
-
-				timing := data["timing"].(map[string]any)
-				assert.Equal(t, float64(567), timing["total_ms"])
-			},
-		},
-		{
-			name:   "current ethrex header without hash still parses (but lacks block.hash)",
-			line:   `2026-05-27T14:00:00.123456Z  INFO [METRIC] BLOCK 24358000 | 1.234 Ggas/s | 567.00 ms | 150 txs | 700 Mgas (93%)`,
-			wantOK: true,
-			checkJSON: func(t *testing.T, data map[string]any) {
-				t.Helper()
-
-				block := data["block"].(map[string]any)
-				assert.Equal(t, float64(24358000), block["number"])
-				_, hasHash := block["hash"]
-				assert.False(t, hasHash, "no hash should be set when the log omits it")
-			},
-		},
-		{
-			name:   "zero-gas block",
-			line:   `2026-05-27T14:00:00.123456Z  INFO [METRIC] BLOCK 100 0xdeadbeef | 0.000 Ggas/s | 12.00 ms | 0 txs | 0 Mgas (0%)`,
-			wantOK: true,
-			checkJSON: func(t *testing.T, data map[string]any) {
-				t.Helper()
-
-				block := data["block"].(map[string]any)
-				assert.Equal(t, float64(100), block["number"])
-				assert.Equal(t, "0xdeadbeef", block["hash"])
-				assert.Equal(t, float64(0), block["tx_count"])
-
-				timing := data["timing"].(map[string]any)
-				assert.Equal(t, float64(12), timing["total_ms"])
-			},
-		},
-		{
-			name:   "header with ANSI escape codes",
-			line:   "\x1b[2m2026-05-27T14:00:00.123456Z\x1b[0m \x1b[32m INFO\x1b[0m [METRIC] BLOCK 24358001 0x9f566dc9f8beb533 | 2.500 Ggas/s | 400.00 ms | 200 txs | 1000 Mgas (50%)",
-			wantOK: true,
-			checkJSON: func(t *testing.T, data map[string]any) {
-				t.Helper()
-
-				block := data["block"].(map[string]any)
-				assert.Equal(t, float64(24358001), block["number"])
-				assert.Equal(t, "0x9f566dc9f8beb533", block["hash"])
-				assert.Equal(t, float64(1000), block["gas_used_mgas"])
-
-				throughput := data["throughput"].(map[string]any)
-				assert.Equal(t, 2.5, throughput["ggas_per_sec"])
-			},
-		},
-		{
-			name:   "phase sub-line is not the header",
-			line:   `2026-05-27T14:00:00.123456Z  INFO   |- exec:     450.00 ms  (80%) << BOTTLENECK`,
-			wantOK: false,
-		},
-		{
-			name:   "non-pipeline import throughput line is not matched",
-			line:   `2026-05-27T14:00:00.123456Z  INFO [METRIC] BLOCK EXECUTION THROUGHPUT (24358000): 1.234 Ggas/s TIME SPENT: 567 ms. Gas Used: 0.700 (93%), #Txs: 150.`,
-			wantOK: false,
-		},
-		{
-			name:   "block building throughput is not block execution",
-			line:   `2026-05-27T14:00:00.123456Z  INFO [METRIC] BLOCK BUILDING THROUGHPUT: 1.234 Gigagas/s TIME SPENT: 567 msecs`,
-			wantOK: false,
-		},
-		{
-			name:   "unrelated ethrex info log",
-			line:   `2026-05-27T14:00:00.123456Z  INFO Initiating blockchain with levm`,
-			wantOK: false,
-		},
-		{
-			name:   "empty line",
-			line:   "",
-			wantOK: false,
-		},
-		{
-			name:   "random text",
-			line:   "some random log output that does not match",
-			wantOK: false,
-		},
+	var out []map[string]any
+	for _, line := range lines {
+		if payload, ok := p.ParseLine(line); ok {
+			require.NotNil(t, payload)
+			var m map[string]any
+			require.NoError(t, json.Unmarshal(payload, &m))
+			out = append(out, m)
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, ok := parser.ParseLine(tt.line)
+	return out
+}
 
-			assert.Equal(t, tt.wantOK, ok)
+// A full per-block report: header followed by the phase breakdown lines.
+var fullBlock = []string{
+	`2026-06-11T04:49:18.910Z  INFO [METRIC] BLOCK 24358000 0xc957abc123 | 1.234 Ggas/s | 567.00 ms | 150 txs | 700 Mgas (93%)`,
+	`2026-06-11T04:49:18.910Z  INFO   |- validate:   1.50 ms  ( 0%)`,
+	`2026-06-11T04:49:18.910Z  INFO   |- exec:     450.00 ms  (79%) << BOTTLENECK`,
+	`2026-06-11T04:49:18.910Z  INFO   |- merkle:    12.34 ms  ( 2%)  [concurrent: 1.20 ms, drain: 12.34 ms, overlap: 9%, queue: 0, start_delay: 1.10 ms]`,
+	`2026-06-11T04:49:18.910Z  INFO   |- store:      0.82 ms  ( 0%)`,
+	"2026-06-11T04:49:18.910Z  INFO   `- warmer:    3.00 ms         [finished: 3.00 ms before exec]",
+}
 
-			if tt.wantOK {
-				require.NotNil(t, result)
+func TestEthrexParser_FullBlock(t *testing.T) {
+	out := feed(t, NewEthrexParser(), fullBlock)
+	require.Len(t, out, 1, "exactly one complete payload, emitted on the store line")
 
-				var parsed map[string]any
-				err := json.Unmarshal(result, &parsed)
-				require.NoError(t, err)
+	data := out[0]
+	assert.Equal(t, "info", data["level"])
+	assert.Equal(t, "Block execution throughput", data["msg"])
 
-				tt.checkJSON(t, parsed)
-			} else {
-				assert.Nil(t, result)
-			}
-		})
+	block := data["block"].(map[string]any)
+	assert.Equal(t, float64(24358000), block["number"])
+	assert.Equal(t, "0xc957abc123", block["hash"])
+	assert.Equal(t, float64(150), block["tx_count"])
+	assert.Equal(t, float64(700_000_000), block["gas_used"], "700 Mgas -> absolute gas")
+
+	timing := data["timing"].(map[string]any)
+	assert.Equal(t, float64(567), timing["total_ms"])
+	assert.Equal(t, float64(450), timing["execution_ms"], "exec")
+	assert.Equal(t, 12.34, timing["state_hash_ms"], "merkle -> state_hash_ms")
+	assert.Equal(t, 0.82, timing["commit_ms"], "store -> commit_ms")
+
+	throughput := data["throughput"].(map[string]any)
+	assert.InDelta(t, 1234.0, throughput["mgas_per_sec"], 0.001, "1.234 Ggas/s -> 1234 Mgas/s")
+}
+
+func TestEthrexParser_EmitsOnStoreNotHeader(t *testing.T) {
+	p := NewEthrexParser()
+	// Header alone must not emit — the runner stores the first payload per hash,
+	// so it must be the complete one (emitted on the store line).
+	_, ok := p.ParseLine(fullBlock[0])
+	assert.False(t, ok, "header line should not emit on its own")
+}
+
+func TestEthrexParser_HeaderOnlyFlushedOnNextHeader(t *testing.T) {
+	// A build that logs only headers (no phase lines): each header flushes the
+	// previous block so its total_ms/throughput are still captured.
+	lines := []string{
+		`INFO [METRIC] BLOCK 100 0xaaa | 1.000 Ggas/s | 10.00 ms | 5 txs | 50 Mgas (50%)`,
+		`INFO [METRIC] BLOCK 101 0xbbb | 2.000 Ggas/s | 20.00 ms | 6 txs | 60 Mgas (50%)`,
+	}
+	out := feed(t, NewEthrexParser(), lines)
+	require.Len(t, out, 1, "first block flushed when the second header arrives")
+
+	block := out[0]["block"].(map[string]any)
+	assert.Equal(t, float64(100), block["number"])
+	assert.Equal(t, "0xaaa", block["hash"])
+
+	timing := out[0]["timing"].(map[string]any)
+	assert.Equal(t, float64(10), timing["total_ms"])
+	_, hasMerkle := timing["state_hash_ms"]
+	assert.False(t, hasMerkle, "header-only block has no phase timings")
+}
+
+func TestEthrexParser_HeaderWithoutHash(t *testing.T) {
+	lines := append([]string{
+		`INFO [METRIC] BLOCK 24358000 | 1.234 Ggas/s | 567.00 ms | 150 txs | 700 Mgas (93%)`,
+	}, fullBlock[1:]...)
+	out := feed(t, NewEthrexParser(), lines)
+	require.Len(t, out, 1)
+
+	block := out[0]["block"].(map[string]any)
+	_, hasHash := block["hash"]
+	assert.False(t, hasHash, "no hash should be set when the log omits it")
+}
+
+func TestEthrexParser_ANSIStripped(t *testing.T) {
+	lines := []string{
+		"\x1b[2m2026-06-11T04:49:18Z\x1b[0m \x1b[32m INFO\x1b[0m [METRIC] BLOCK 24358001 0x9f56 | 2.500 Ggas/s | 400.00 ms | 200 txs | 1000 Mgas (50%)",
+		"\x1b[32m INFO\x1b[0m   |- exec:     100.00 ms  (25%)",
+		"\x1b[32m INFO\x1b[0m   |- store:      5.00 ms  ( 1%)",
+	}
+	out := feed(t, NewEthrexParser(), lines)
+	require.Len(t, out, 1)
+
+	block := out[0]["block"].(map[string]any)
+	assert.Equal(t, float64(24358001), block["number"])
+	assert.Equal(t, "0x9f56", block["hash"])
+	timing := out[0]["timing"].(map[string]any)
+	assert.Equal(t, float64(100), timing["execution_ms"])
+}
+
+func TestEthrexParser_NonMatchingLines(t *testing.T) {
+	p := NewEthrexParser()
+	for _, line := range []string{
+		"",
+		"some random log output",
+		`INFO Initiating blockchain with levm`,
+		`INFO [METRIC] BLOCK BUILDING THROUGHPUT: 1.234 Gigagas/s TIME SPENT: 567 msecs`,
+		// phase line with no pending header must not emit
+		`INFO   |- exec:     450.00 ms  (80%) << BOTTLENECK`,
+	} {
+		_, ok := p.ParseLine(line)
+		assert.False(t, ok, "line should not emit: %q", line)
 	}
 }
 


### PR DESCRIPTION
The ethrex parser from #240 only read the `[METRIC] BLOCK` header line, so `timing_execution_ms`, `timing_state_hash_ms` (merkle) and `timing_commit_ms` (store) all stayed 0 in `test_stats_block_logs`. `throughput_mgas_per_sec` and `block_gas_used` were also 0, because the header values were emitted under keys the indexer does not read (`ggas_per_sec`, `gas_used_mgas`).

ethrex prints the phase breakdown (`|- exec/merkle/store`) on separate lines after the header, so this makes the parser stateful: it buffers the header, folds in those phase lines, and emits one complete payload on the `store` line. It has to emit there rather than on the header because the runner calls `RegisterBlockHash` before the `engine_newPayload` RPC, so the collector keeps the first payload it sees for a hash, and that payload needs to already be complete. Builds that only log the header (no phase lines) still work: the block is flushed when the next header arrives.

Field mapping: exec to `timing.execution_ms`, merkle to `timing.state_hash_ms`, store to `timing.commit_ms`. The header Ggas/s becomes `throughput.mgas_per_sec` and Mgas becomes `block.gas_used`.

`go test ./pkg/blocklog/...` passes. Also checked the regexes against a real 52MB container.log: 72028 block headers, each with matching exec/merkle/store lines, one complete record emitted per block.