### PR TITLE
feat(builder): add state-actor builder and `benchmarkoor build` command

### DIFF
--- a/cmd/benchmarkoor/build.go
+++ b/cmd/benchmarkoor/build.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/builder"
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/ethpandaops/benchmarkoor/pkg/docker"
+	"github.com/ethpandaops/benchmarkoor/pkg/podman"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	buildTargetFilter []string
+	buildForce        bool
+)
+
+var buildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Build client datadirs declared in builder.state_actor.targets",
+	Long: `Materialise each datadir declared under builder.state_actor.targets
+by invoking state-actor (https://github.com/ethereum/state-actor) via the
+configured container runtime. Builds are decoupled from "benchmarkoor run":
+this command produces datadirs on disk that subsequent runs consume via
+their normal datadir.* providers.`,
+	RunE: runBuild,
+}
+
+func init() {
+	rootCmd.AddCommand(buildCmd)
+	buildCmd.Flags().StringSliceVar(&buildTargetFilter, "target", nil,
+		"Only build targets whose name matches (comma-separated or repeated)")
+	buildCmd.Flags().BoolVar(&buildForce, "force", false,
+		"Remove each target's output_dir before building")
+}
+
+func runBuild(_ *cobra.Command, _ []string) error {
+	if len(cfgFiles) == 0 {
+		return fmt.Errorf("config file is required (use --config)")
+	}
+
+	cfg, err := config.Load(cfgFiles...)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	if err := cfg.ValidateBuilder(); err != nil {
+		return fmt.Errorf("validating config: %w", err)
+	}
+
+	if cfg.Builder == nil || cfg.Builder.StateActor == nil || len(cfg.Builder.StateActor.Targets) == 0 {
+		return fmt.Errorf("builder.state_actor.targets is empty or unset; nothing to build")
+	}
+
+	targets, err := selectTargets(cfg.Builder.StateActor.Targets, buildTargetFilter)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigCh
+		log.WithField("signal", sig).Info("Received shutdown signal, cancelling build")
+		cancel()
+
+		sig = <-sigCh
+		log.WithField("signal", sig).Fatal("Received second signal, forcing exit")
+	}()
+
+	runtime := cfg.GetStateActorContainerRuntime()
+
+	var mgr docker.ContainerManager
+
+	switch runtime {
+	case "podman":
+		mgr, err = podman.NewManager(log)
+	default:
+		mgr, err = docker.NewManager(log)
+	}
+
+	if err != nil {
+		return fmt.Errorf("creating container manager: %w", err)
+	}
+
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("starting container manager: %w", err)
+	}
+
+	defer func() {
+		if err := mgr.Stop(); err != nil {
+			log.WithError(err).Warn("Failed to stop container manager")
+		}
+	}()
+
+	b := builder.NewStateActorBuilder(log, cfg.Builder.StateActor, runtime, mgr)
+
+	type result struct {
+		name      string
+		client    string
+		outputDir string
+		skipped   bool
+		err       error
+	}
+
+	results := make([]result, 0, len(targets))
+
+	for _, t := range targets {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		log.WithFields(logrus.Fields{
+			"target":     t.EffectiveName(),
+			"client":     t.Client,
+			"output_dir": t.OutputDir,
+		}).Info("Building target")
+
+		skipped, buildErr := b.Build(ctx, t.EffectiveName(), builder.BuildOptions{Force: buildForce})
+
+		results = append(results, result{
+			name:      t.EffectiveName(),
+			client:    t.Client,
+			outputDir: t.OutputDir,
+			skipped:   skipped,
+			err:       buildErr,
+		})
+
+		if buildErr != nil {
+			log.WithError(buildErr).WithField("target", t.EffectiveName()).Error("Build failed")
+		}
+	}
+
+	// Summary.
+	var failed []string
+
+	log.Info("Build summary:")
+
+	for _, r := range results {
+		var status string
+
+		switch {
+		case r.err != nil:
+			status = "ERR "
+			failed = append(failed, r.name)
+		case r.skipped:
+			status = "SKIP"
+		default:
+			status = "OK  "
+		}
+
+		log.WithFields(logrus.Fields{
+			"target":     r.name,
+			"client":     r.client,
+			"output_dir": r.outputDir,
+		}).Infof("  %s %s", status, r.name)
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("%d target(s) failed: %s",
+			len(failed), strings.Join(failed, ", "))
+	}
+
+	return nil
+}
+
+// selectTargets filters `all` by the names in `filter`, preserving the
+// order targets were declared in. An empty filter returns all targets.
+// Unmatched filter values produce an error so typos surface immediately.
+func selectTargets(all []config.StateActorTarget, filter []string) ([]config.StateActorTarget, error) {
+	if len(filter) == 0 {
+		return all, nil
+	}
+
+	wanted := make(map[string]bool, len(filter))
+	for _, f := range filter {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			wanted[f] = true
+		}
+	}
+
+	out := make([]config.StateActorTarget, 0, len(all))
+	matched := make(map[string]bool, len(wanted))
+
+	for _, t := range all {
+		name := t.EffectiveName()
+		if wanted[name] {
+			out = append(out, t)
+			matched[name] = true
+		}
+	}
+
+	var missing []string
+
+	for name := range wanted {
+		if !matched[name] {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return nil, errors.New("--target filter matched no targets: " + strings.Join(missing, ", "))
+	}
+
+	return out, nil
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -221,6 +221,52 @@ runner:
     #   #   archive: https://github.com/NethermindEth/gas-benchmarks/actions/runs/24460911828/artifacts/6456466898
     #   #   file: opcodes_tracing.json
 
+# Optional: Pre-populated client datadirs via state-actor.
+# Build with: benchmarkoor build --config config.yaml
+# Targets are decoupled from runner.instances; produced datadirs are
+# consumed by `run` through the normal datadir.method providers.
+# See https://github.com/ethereum/state-actor for spec authoring.
+# builder:
+#   state_actor:
+#     # Per-client docker images. Every active target's client needs an entry —
+#     # state-actor needs a different cgo build per EL.
+#     images:
+#       geth: ghcr.io/ethereum/state-actor:latest
+#       reth: ghcr.io/ethereum/state-actor-reth:latest
+#       besu: ghcr.io/ethereum/state-actor-besu:latest
+#       nethermind: ghcr.io/ethereum/state-actor-nethermind:latest
+#     # pull_policy: always         # always | if-not-present | never
+#     # container_runtime: docker   # defaults to runner.container_runtime, then docker
+#     # Top-level spec source — shared across every target that doesn't set its own
+#     # target_size. Pick at most one of spec (inline YAML) or spec_file (host path).
+#     # spec: |
+#     #   genesis:
+#     #     chain_id: 1337
+#     # spec_file: /etc/benchmarkoor/state-spec.yaml
+#     # Shared per-target defaults. Anything set here is used by every target
+#     # unless that target sets the same field, in which case the target wins.
+#     # config:
+#     #   target_size: 5GB    # complements top-level spec/spec_file (headroom budget)
+#     #   seed: 1
+#     #   fork: prague
+#     #   chain_id: 1337
+#     #   gas_limit: 30000000
+#     targets:
+#       - client: geth              # geth | reth | besu | nethermind
+#         output_dir: /srv/state/geth-5g
+#         target_size: 5GB          # complements any top-level spec; required if no spec is configured
+#         # force: true             # wipe output_dir before building (per-target override of the CLI --force)
+#         # seed: 42                # overrides config.seed
+#         # fork: osaka             # overrides config.fork
+#         # chain_id: 1337
+#         # gas_limit: 30000000
+#         # archive: false          # geth + reth only; set false to opt out of config.archive=true
+#         # binary_trie: false      # geth only; pair with optional group_depth (1..8)
+#       - name: reth-inherit        # optional, defaults to `client`; used by --target
+#         client: reth
+#         output_dir: /srv/state/reth-spec
+#         # inherits the top-level spec/spec_file and every field from `config`
+
 # Optional: API server for authentication and user management.
 # When configured, the UI can integrate with the API for login, admin, and role-based access.
 # Start with: benchmarkoor api --config config.yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ This document describes all configuration options for benchmarkoor. The [config.
   - [Client Instances](#client-instances)
 - [Resource Limits](#resource-limits)
 - [Post-Test RPC Calls](#post-test-rpc-calls)
+- [Builder](#builder)
 - [API Server](api.md)
 - [Examples](#examples)
 
@@ -1377,6 +1378,176 @@ runner:
           dump:
             enabled: true
             filename: trace_by_hash
+```
+
+## Builder
+
+The `builder` section configures tools that pre-populate client datadirs on disk. Today the only builder is `state-actor` (https://github.com/ethereum/state-actor), which writes per-client genesis state directly in each EL's native on-disk format — geth Pebble, reth MDBX, besu/nethermind RocksDB — bypassing the client's normal genesis-replay path.
+
+Builds are **decoupled from `benchmarkoor run`**: invoke `benchmarkoor build` to materialise datadirs, then run benchmarks against them via the regular `datadir.method: copy|zfs|schelk|…` providers. A missing datadir at `run` time is an error — it is never auto-built.
+
+### `builder.state_actor` options
+
+```yaml
+builder:
+  state_actor:
+    # Per-client images. State-actor needs cgo to write reth/besu/nethermind
+    # datadirs, so each client has its own image. Every active target's
+    # client must have an entry here.
+    images:
+      geth: ghcr.io/ethereum/state-actor:latest
+      reth: ghcr.io/ethereum/state-actor-reth:latest
+      besu: ghcr.io/ethereum/state-actor-besu:latest
+      nethermind: ghcr.io/ethereum/state-actor-nethermind:latest
+    pull_policy: always                           # always | if-not-present | never (default: always)
+    container_runtime: docker                     # docker | podman (default: inherits runner.container_runtime, then docker)
+    # spec source — top-level, shared across every target.
+    # Pick at most one of:
+    #   spec: |       # inline YAML; benchmarkoor writes it to a temp file before invoking state-actor
+    #     ...
+    #   spec_file: /etc/benchmarkoor/state-spec.yaml   # absolute host path
+    config:                                       # shared per-target defaults; targets override when set
+      seed: 1
+      fork: prague
+      chain_id: 1337
+    targets:
+      - name: geth-5g                             # optional, defaults to `client`; used by --target filter
+        client: geth
+        output_dir: /srv/state/geth-5g
+        target_size: 5GB
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `images` | map[string]string | – | Per-client docker images for state-actor. Every active target's client must have an entry; state-actor needs a different cgo build per client (reth → MDBX, besu → RocksDB JNI, nethermind → .NET RocksDB). |
+| `pull_policy` | string | `always` | One of `always`, `if-not-present`, `never`. |
+| `container_runtime` | string | runner's runtime, then `docker` | Container runtime for the build container. |
+| `spec` | string (YAML) | – | Inline state spec body (see [state-actor SPEC.md](https://github.com/ethereum/state-actor/blob/main/docs/SPEC.md)). Materialised to a temp file at build time. Mutually exclusive with `spec_file`. |
+| `spec_file` | string | – | Absolute host path to a state spec YAML. Bind-mounted read-only into the build container. Mutually exclusive with `spec`. |
+| `config` | object | – | Shared defaults for the per-target build parameters. See below. |
+| `targets` | []object | – | Required when invoking `benchmarkoor build`. See below. |
+
+The top-level `spec`/`spec_file` applies to every target. A target without its own `target_size` runs with just the spec; a target with both flags runs with both (state-actor uses the spec and treats `target_size` as a headroom budget for any further auto-fill). A target with neither `target_size` nor any spec source is a validation error.
+
+### `builder.state_actor.config` options
+
+Every field is also available per-target; a non-nil/non-empty value on a target overrides the corresponding default from `config`. Use this block to avoid repeating the same `seed`, `fork`, `chain_id`, etc. across every target.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `target_size` | string | – | Default size budget for every target (e.g. `5GB`). Targets without their own `target_size` inherit this value. Complements `spec`/`spec_file` — state-actor uses both at once, treating `target_size` as a headroom budget on top of the spec. |
+| `seed` | int64 | – | RNG seed for auto-fill. `0` = wall-clock (non-reproducible). |
+| `fork` | string | – | Hard fork at genesis, e.g. `prague`, `osaka`. |
+| `chain_id` | int64 | – | Genesis chain ID. |
+| `gas_limit` | uint64 | – | Genesis gas limit. |
+| `timestamp` | uint64 | – | Unix seconds at genesis. |
+| `extra_data` | string | – | Hex `extraData` for the genesis block. |
+| `archive` | bool | – | Archive-mode metadata. Effective value must be limited to geth/reth, regardless of where it was set. |
+| `binary_trie` | bool | – | EIP-7864 binary trie. Effective value must be limited to geth. |
+| `group_depth` | int (1..8) | – | Binary-trie serialisation unit. Requires effective `binary_trie=true`. |
+
+Applicability validation runs on the **effective** target (config defaults + per-target overrides), so `archive: true` set globally is rejected if any active target is besu/nethermind. To opt a target out of a global `archive: true`, set `archive: false` on that target.
+
+### `builder.state_actor.targets[]` options
+
+The fields below mirror `builder.state_actor.config`; any field set here overrides the corresponding default from `config`. Identifier fields (`name`, `client`, `output_dir`, `target_size`) are target-only.
+
+| Option | Type | Default | Applies to | Description |
+|---|---|---|---|---|
+| `name` | string | `client` | all | Human-readable name. Used by `--target` to filter. Must be unique across targets; defaults to the `client` field when omitted. |
+| `client` | string | – | all | One of `geth`, `reth`, `besu`, `nethermind`. State-actor does not support `erigon` or `nimbus`. |
+| `output_dir` | string | – | all | Absolute host path. If the directory already contains entries, that target is **skipped** (no error) — pass `--force` (CLI) or set `force: true` here to wipe and rebuild. For geth, state-actor writes into `<output_dir>/geth/chaindata`. |
+| `target_size` | string | from `config` | all | Advisory size budget for auto-generated state, e.g. `5GB`, `500MB` (base-1024). Required for the target when no spec is configured; when a spec is configured (top-level or default), `target_size` is optional and acts as a headroom budget that state-actor fills past the spec's projected cost. |
+| `force` | bool | `false` | all | Per-target override of the CLI `--force` flag: wipes `output_dir` before building so state-actor sees a clean directory. Useful when most targets should skip-if-built but specific ones should always rebuild. |
+| `seed` | int64 | from `config`, then `1` (state-actor) | all | RNG seed for auto-fill. `0` = wall-clock (non-reproducible). |
+| `fork` | string | from `config`, then latest supported by state-actor | all | Hard fork at genesis, e.g. `prague`, `osaka`. Run `state-actor --list-forks` for the current list. |
+| `chain_id` | int64 | from `config`, then `1337` (state-actor) | all | Genesis chain ID. |
+| `gas_limit` | uint64 | from `config`, then `30000000` (state-actor) | all | Genesis gas limit. |
+| `timestamp` | uint64 | from `config`, then `0` (state-actor) | all | Unix seconds at genesis. |
+| `extra_data` | string | from `config`, then `""` | all | Hex `extraData` for the genesis block. |
+| `archive` | bool | from `config`, then `false` | geth, reth | Archive-mode metadata. Set `false` to opt out of a global `archive: true`. Rejected (after resolution) for besu/nethermind. |
+| `binary_trie` | bool | from `config`, then `false` | geth | EIP-7864 binary trie. Set `false` to opt out of a global default. Rejected (after resolution) for non-geth. |
+| `group_depth` | int | from `config`, then `8` (state-actor) | geth + binary_trie | Binary-trie serialisation unit. Range 1..8. Requires effective `binary_trie=true`. |
+
+State-actor itself only writes the genesis block; subsequent blocks come from running a client against the produced datadir. See [state-actor RUNBOOK.md](https://github.com/ethereum/state-actor/blob/main/docs/RUNBOOK.md) for the per-client boot recipes (e.g. geth needs `--db.engine=pebble`; reth needs `--debug.skip-genesis-validation`; besu needs `--data-storage-format=BONSAI`).
+
+### Running
+
+```bash
+# Build every target declared under builder.state_actor.targets
+benchmarkoor build --config build.yaml
+
+# Build only specific targets (by name)
+benchmarkoor build --config build.yaml --target geth-5g --target reth-spec
+
+# Overwrite existing output_dir contents
+benchmarkoor build --config build.yaml --force
+```
+
+The command exits non-zero if any target fails; successful targets are still left in place on partial failure. A final summary lists each target with `OK ` (built), `SKIP` (output_dir already populated), or `ERR ` (failed). `--force` wipes each target's `output_dir` before building, bypassing the skip behaviour.
+
+### Examples
+
+Minimal — one geth datadir sized at 5 GB:
+
+```yaml
+builder:
+  state_actor:
+    images:
+      geth: ghcr.io/ethereum/state-actor:latest
+    targets:
+      - client: geth
+        output_dir: /srv/state/geth-5g
+        target_size: 5GB
+```
+
+Full — three clients sharing a top-level spec file and global defaults; geth opts out via `target_size`, reth opts out of the global archive setting:
+
+```yaml
+builder:
+  state_actor:
+    images:
+      geth: ghcr.io/ethereum/state-actor:latest
+      reth: ghcr.io/ethereum/state-actor-reth:latest
+      besu: ghcr.io/ethereum/state-actor-besu:latest
+    pull_policy: if-not-present
+    spec_file: /etc/benchmarkoor/state-spec.yaml
+    config:
+      # Applies to every target that doesn't override it.
+      seed: 42
+      fork: prague
+      chain_id: 1337
+      archive: true       # geth + reth inherit this; besu sets archive: false below
+    targets:
+      - name: geth-archive
+        client: geth
+        output_dir: /srv/state/geth-archive
+        # target_size + top-level spec: spec drives the build, target_size sets the headroom budget
+        target_size: 5GB
+        binary_trie: true
+        group_depth: 4
+      - client: reth
+        output_dir: /srv/state/reth-spec
+      - client: besu
+        output_dir: /srv/state/besu-spec
+        archive: false    # overrides config.archive=true (besu doesn't support archive)
+```
+
+Inline spec — write the YAML directly in the config:
+
+```yaml
+builder:
+  state_actor:
+    images:
+      geth: ghcr.io/ethereum/state-actor:latest
+    spec: |
+      genesis:
+        chain_id: 1337
+        gas_limit: 30000000
+      # … rest of the state spec
+    targets:
+      - client: geth
+        output_dir: /srv/state/geth-spec
 ```
 
 ## API Server

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,0 +1,46 @@
+// Package builder materialises pre-populated client datadirs declared
+// in benchmarkoor's `builder.*` config block. The only implementation
+// today wraps https://github.com/ethereum/state-actor.
+//
+// Builders are deliberately decoupled from the runner: `benchmarkoor build`
+// invokes a builder to produce datadirs on disk, and `benchmarkoor run`
+// later consumes them through the regular datadir.* providers. There is
+// no auto-build path on the run side — a missing datadir surfaces as a
+// validation error there.
+package builder
+
+import "context"
+
+// Builder materialises one pre-populated client datadir per call.
+// Implementations are safe to invoke serially across distinct targets;
+// concurrent builds against the same OutputDir are not supported.
+type Builder interface {
+	// Name returns a short identifier for the builder (e.g. "state-actor").
+	Name() string
+
+	// Targets returns the read-only summary of declared targets, in
+	// declaration order, for the build command to log and filter on.
+	Targets() []TargetInfo
+
+	// Build runs the build for the target identified by name. When the
+	// target's OutputDir already contains entries and opts.Force is
+	// false, Build is a no-op: it returns (true, nil) so the caller can
+	// surface a "skipped" status without treating it as failure.
+	// Otherwise the directory is created (wiped first when Force=true)
+	// and the build runs.
+	Build(ctx context.Context, name string, opts BuildOptions) (skipped bool, err error)
+}
+
+// TargetInfo is the read-only summary the build command uses for logging
+// and CLI-target filtering.
+type TargetInfo struct {
+	Name      string
+	Client    string
+	OutputDir string
+}
+
+// BuildOptions controls per-target build behaviour.
+type BuildOptions struct {
+	// Force, when true, removes OutputDir before mkdir.
+	Force bool
+}

--- a/pkg/builder/state_actor.go
+++ b/pkg/builder/state_actor.go
@@ -1,0 +1,468 @@
+package builder
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/ethpandaops/benchmarkoor/pkg/docker"
+	"github.com/sirupsen/logrus"
+)
+
+// StateActorBuilderName is the value of the benchmarkoor.builder label
+// set on every state-actor build container, and the value returned by
+// Name().
+const StateActorBuilderName = "state-actor"
+
+// gethDBSuffix is the path state-actor expects appended to a geth
+// datadir for the --db flag. Other clients use the datadir root as-is.
+const gethDBSuffix = "/geth/chaindata"
+
+// StateActorBuilder runs state-actor for each declared target via the
+// supplied docker/podman ContainerManager.
+type StateActorBuilder struct {
+	log     logrus.FieldLogger
+	cfg     *config.StateActorConfig
+	runtime string
+	mgr     docker.ContainerManager
+}
+
+// NewStateActorBuilder constructs a builder bound to a specific container
+// manager. The caller is expected to have Start()'d the manager and to
+// Stop() it after the last Build() call.
+func NewStateActorBuilder(
+	log logrus.FieldLogger,
+	cfg *config.StateActorConfig,
+	runtime string,
+	mgr docker.ContainerManager,
+) *StateActorBuilder {
+	return &StateActorBuilder{
+		log:     log.WithField("component", "builder.state_actor"),
+		cfg:     cfg,
+		runtime: runtime,
+		mgr:     mgr,
+	}
+}
+
+// Name implements Builder.
+func (b *StateActorBuilder) Name() string {
+	return StateActorBuilderName
+}
+
+// Targets implements Builder.
+func (b *StateActorBuilder) Targets() []TargetInfo {
+	out := make([]TargetInfo, 0, len(b.cfg.Targets))
+
+	for i := range b.cfg.Targets {
+		t := &b.cfg.Targets[i]
+		out = append(out, TargetInfo{
+			Name:      t.EffectiveName(),
+			Client:    t.Client,
+			OutputDir: t.OutputDir,
+		})
+	}
+
+	return out
+}
+
+// Build implements Builder.
+func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOptions) (bool, error) {
+	idx := b.findTargetIndex(name)
+	if idx < 0 {
+		return false, fmt.Errorf("no target named %q", name)
+	}
+
+	// Resolve so global defaults from builder.state_actor.config are
+	// merged into the per-target view exactly once, then handed to every
+	// downstream helper.
+	resolved := b.cfg.ResolveTarget(idx)
+	target := &resolved
+
+	image := b.cfg.ImageFor(target.Client)
+	if image == "" {
+		return false, fmt.Errorf("no image configured for client %q", target.Client)
+	}
+
+	log := b.log.WithFields(logrus.Fields{
+		"target":     target.EffectiveName(),
+		"client":     target.Client,
+		"output_dir": target.OutputDir,
+		"image":      image,
+	})
+
+	// The CLI `--force` flag and per-target `force: true` both bypass the
+	// skip-on-populated check, wipe the existing output_dir, and forward
+	// `--force` to state-actor.
+	force := opts.Force || target.Force
+
+	if !force {
+		populated, err := isPopulated(target.OutputDir)
+		if err != nil {
+			return false, err
+		}
+
+		if populated {
+			log.Info("Skipping build: output_dir already populated " +
+				"(pass --force or set force: true on the target to rebuild)")
+
+			return true, nil
+		}
+	}
+
+	if err := b.prepareOutputDir(target.OutputDir, force); err != nil {
+		return false, err
+	}
+
+	// Resolve which source state-actor will see: an absolute host path to
+	// a spec file (real or temp) when this target inherits from the
+	// top-level spec/spec_file, or "" when the target opted out via its
+	// own target_size.
+	specPath, cleanupSpec, err := b.resolveSpecPath()
+	if err != nil {
+		return false, err
+	}
+
+	if cleanupSpec != nil {
+		defer cleanupSpec()
+	}
+
+	mounts, err := b.buildMounts(target, specPath)
+	if err != nil {
+		return false, err
+	}
+
+	args := buildArgs(target, specPath)
+
+	if err := b.mgr.PullImage(ctx, image, b.cfg.PullPolicy); err != nil {
+		return false, fmt.Errorf("pulling image %q: %w", image, err)
+	}
+
+	suffix, err := randSuffix()
+	if err != nil {
+		return false, fmt.Errorf("generating container name suffix: %w", err)
+	}
+
+	spec := &docker.ContainerSpec{
+		Name:    fmt.Sprintf("benchmarkoor-build-state-actor-%s-%s", target.Client, suffix),
+		Image:   image,
+		Command: args,
+		Mounts:  mounts,
+		Labels: map[string]string{
+			"benchmarkoor.managed-by": "benchmarkoor",
+			"benchmarkoor.builder":    StateActorBuilderName,
+			"benchmarkoor.client":     target.Client,
+			"benchmarkoor.target":     target.EffectiveName(),
+			"benchmarkoor.output-dir": target.OutputDir,
+		},
+	}
+
+	// Capture the tail of the container's combined output so a non-zero
+	// exit yields a useful error without spamming the whole log.
+	tail := newTailBuffer(64 * 1024)
+
+	stdout := io.MultiWriter(logWriter(log, logrus.InfoLevel), tail)
+	stderr := io.MultiWriter(logWriter(log, logrus.InfoLevel), tail)
+
+	log.WithField("argv", args).Info("Running state-actor")
+
+	if err := b.mgr.RunInitContainer(ctx, spec, stdout, stderr); err != nil {
+		return false, fmt.Errorf("running state-actor: %w (output tail: %s)",
+			err, tail.String())
+	}
+
+	log.Info("Build completed")
+
+	return false, nil
+}
+
+// findTargetIndex returns the index of the first target whose
+// EffectiveName matches `name`. Returns -1 when nothing matches.
+func (b *StateActorBuilder) findTargetIndex(name string) int {
+	for i := range b.cfg.Targets {
+		if b.cfg.Targets[i].EffectiveName() == name {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// isPopulated reports whether dir exists and contains at least one
+// entry. A missing dir returns (false, nil).
+func isPopulated(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("reading output_dir %q: %w", dir, err)
+	}
+
+	return len(entries) > 0, nil
+}
+
+// prepareOutputDir ensures the target's output_dir exists. When force is
+// true the directory is removed first; the populated check that gates
+// skip-vs-build lives in Build, not here.
+func (b *StateActorBuilder) prepareOutputDir(dir string, force bool) error {
+	if force {
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("removing existing output_dir %q: %w", dir, err)
+		}
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating output_dir %q: %w", dir, err)
+	}
+
+	return nil
+}
+
+// buildMounts assembles the bind mounts state-actor needs: an identity
+// mount of the output_dir (RW) and, when a spec path is resolved, a
+// read-only mount of that file at the same path inside the container so
+// the in-container --spec arg resolves transparently.
+func (b *StateActorBuilder) buildMounts(target *config.StateActorTarget, specPath string) ([]docker.Mount, error) {
+	mounts := []docker.Mount{{
+		Source: target.OutputDir,
+		Target: target.OutputDir,
+		Type:   "bind",
+	}}
+
+	if specPath != "" {
+		mounts = append(mounts, docker.Mount{
+			Source:   specPath,
+			Target:   specPath,
+			Type:     "bind",
+			ReadOnly: true,
+		})
+	}
+
+	return mounts, nil
+}
+
+// resolveSpecPath determines the absolute host path of the spec file
+// state-actor should consume for this target. Returns "" when no spec
+// is configured (the target then runs with --target-size only). When
+// the top-level config carries inline spec YAML, it is materialised to
+// a temp file and the cleanup callback removes it. spec + target_size
+// are complementary — both flags can be passed together so state-actor
+// fills any headroom past the spec's projected cost.
+func (b *StateActorBuilder) resolveSpecPath() (string, func(), error) {
+	kind, value := b.cfg.ResolveSpec()
+	switch kind {
+	case config.StateActorSpecNone:
+		return "", nil, nil
+	case config.StateActorSpecFile:
+		abs, err := filepath.Abs(value)
+		if err != nil {
+			return "", nil, fmt.Errorf("resolving spec_file path %q: %w", value, err)
+		}
+
+		if _, err := os.Stat(abs); err != nil {
+			return "", nil, fmt.Errorf("spec_file: %w", err)
+		}
+
+		return abs, nil, nil
+	case config.StateActorSpecInline:
+		f, err := os.CreateTemp("", "benchmarkoor-state-actor-spec-*.yaml")
+		if err != nil {
+			return "", nil, fmt.Errorf("creating temp spec file: %w", err)
+		}
+
+		path := f.Name()
+
+		if _, err := f.WriteString(value); err != nil {
+			_ = f.Close()
+			_ = os.Remove(path)
+
+			return "", nil, fmt.Errorf("writing temp spec file: %w", err)
+		}
+
+		if err := f.Close(); err != nil {
+			_ = os.Remove(path)
+
+			return "", nil, fmt.Errorf("closing temp spec file: %w", err)
+		}
+
+		// Allow the container UID to read the file (we don't know what UID
+		// the state-actor image uses; 0644 is the broadest safe default).
+		if err := os.Chmod(path, 0o644); err != nil {
+			_ = os.Remove(path)
+
+			return "", nil, fmt.Errorf("chmod temp spec file: %w", err)
+		}
+
+		cleanup := func() {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				b.log.WithError(err).WithField("path", path).
+					Warn("Failed to remove temp spec file")
+			}
+		}
+
+		return path, cleanup, nil
+	}
+
+	return "", nil, fmt.Errorf("internal: unhandled spec kind %v", kind)
+}
+
+// buildArgs translates a target into the argv state-actor expects. Only
+// flags whose value differs from state-actor's default are emitted —
+// pointer fields stay nil when the user did not set them so we never
+// forward, say, `--chain-id=0` when the user wanted the default 1337.
+// specPath, when non-empty, is the host (= container) path to the
+// state-actor spec file resolved from the top-level spec/spec_file.
+//
+// The CLI `--force` and per-target `force` flags are intentionally not
+// forwarded — state-actor has no `--force` flag of its own. Wiping the
+// output_dir before the run (done in Build via prepareOutputDir) is
+// what the user-facing flag actually does.
+func buildArgs(target *config.StateActorTarget, specPath string) []string {
+	args := []string{
+		"--db=" + dbPath(target),
+		"--client=" + target.Client,
+	}
+
+	if target.TargetSize != "" {
+		args = append(args, "--target-size="+target.TargetSize)
+	}
+
+	if specPath != "" {
+		args = append(args, "--spec="+specPath)
+	}
+
+	if target.Seed != nil {
+		args = append(args, fmt.Sprintf("--seed=%d", *target.Seed))
+	}
+
+	if target.Fork != "" {
+		args = append(args, "--fork="+target.Fork)
+	}
+
+	if target.ChainID != nil {
+		args = append(args, fmt.Sprintf("--chain-id=%d", *target.ChainID))
+	}
+
+	if target.GasLimit != nil {
+		args = append(args, fmt.Sprintf("--gas-limit=%d", *target.GasLimit))
+	}
+
+	if target.Timestamp != nil {
+		args = append(args, fmt.Sprintf("--timestamp=%d", *target.Timestamp))
+	}
+
+	if target.ExtraData != "" {
+		args = append(args, "--extra-data="+target.ExtraData)
+	}
+
+	if target.Archive != nil && *target.Archive {
+		args = append(args, "--archive")
+	}
+
+	if target.BinaryTrie != nil && *target.BinaryTrie {
+		args = append(args, "--binary-trie")
+	}
+
+	if target.GroupDepth != nil {
+		args = append(args, fmt.Sprintf("--group-depth=%d", *target.GroupDepth))
+	}
+
+	return args
+}
+
+// dbPath returns the value for state-actor's --db flag. Geth requires
+// the path end at <datadir>/geth/chaindata; everything else takes the
+// datadir root directly.
+func dbPath(target *config.StateActorTarget) string {
+	if target.Client == "geth" {
+		return target.OutputDir + gethDBSuffix
+	}
+
+	return target.OutputDir
+}
+
+// randSuffix returns a 6-hex-character random string used to keep
+// concurrent build container names unique.
+func randSuffix() (string, error) {
+	var b [3]byte
+
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(b[:]), nil
+}
+
+// logWriter returns an io.Writer that forwards each line written to it
+// to the supplied logger at the given level. Used to stream container
+// stdout/stderr without writing the bytes directly to the global
+// stdout/stderr.
+func logWriter(log logrus.FieldLogger, level logrus.Level) io.Writer {
+	return &lineLogger{log: log, level: level}
+}
+
+type lineLogger struct {
+	log   logrus.FieldLogger
+	level logrus.Level
+	buf   bytes.Buffer
+}
+
+func (w *lineLogger) Write(p []byte) (int, error) {
+	w.buf.Write(p)
+
+	for {
+		i := bytes.IndexByte(w.buf.Bytes(), '\n')
+		if i < 0 {
+			break
+		}
+
+		line := w.buf.Next(i + 1)
+		msg := string(bytes.TrimRight(line, "\r\n"))
+
+		switch w.level {
+		case logrus.ErrorLevel:
+			w.log.Error(msg)
+		case logrus.WarnLevel:
+			w.log.Warn(msg)
+		case logrus.DebugLevel:
+			w.log.Debug(msg)
+		default:
+			w.log.Info(msg)
+		}
+	}
+
+	return len(p), nil
+}
+
+// tailBuffer is an io.Writer that retains at most `max` bytes of the
+// most recent input. Useful for surfacing the trailing output of a
+// failing container in the resulting error.
+type tailBuffer struct {
+	buf bytes.Buffer
+	max int
+}
+
+func newTailBuffer(maxBytes int) *tailBuffer {
+	return &tailBuffer{max: maxBytes}
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	t.buf.Write(p)
+
+	if excess := t.buf.Len() - t.max; excess > 0 {
+		t.buf.Next(excess)
+	}
+
+	return len(p), nil
+}
+
+func (t *tailBuffer) String() string {
+	return t.buf.String()
+}

--- a/pkg/builder/state_actor_test.go
+++ b/pkg/builder/state_actor_test.go
@@ -1,0 +1,580 @@
+package builder
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/ethpandaops/benchmarkoor/pkg/docker"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func i64(v int64) *int64   { return &v }
+func u64(v uint64) *uint64 { return &v }
+func iptr(v int) *int      { return &v }
+func bptr(v bool) *bool    { return &v }
+
+// allImages registers a placeholder image for every supported client so
+// tests that don't care which client runs can use a single map.
+var allImages = map[string]string{
+	"geth":       "fallback:latest",
+	"reth":       "fallback:latest",
+	"besu":       "fallback:latest",
+	"nethermind": "fallback:latest",
+}
+
+func TestBuildArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		t        config.StateActorTarget
+		specPath string
+		want     []string
+	}{
+		{
+			name: "geth_target_size",
+			t:    config.StateActorTarget{Client: "geth", OutputDir: "/srv/data", TargetSize: "5GB"},
+			want: []string{
+				"--db=/srv/data/geth/chaindata",
+				"--client=geth",
+				"--target-size=5GB",
+			},
+		},
+		{
+			name:     "reth_spec",
+			t:        config.StateActorTarget{Client: "reth", OutputDir: "/srv/r"},
+			specPath: "/etc/spec.yaml",
+			want: []string{
+				"--db=/srv/r",
+				"--client=reth",
+				"--spec=/etc/spec.yaml",
+			},
+		},
+		{
+			name: "besu_no_optional_flags",
+			t:    config.StateActorTarget{Client: "besu", OutputDir: "/srv/b", TargetSize: "1GB"},
+			want: []string{
+				"--db=/srv/b",
+				"--client=besu",
+				"--target-size=1GB",
+			},
+		},
+		{
+			name: "nethermind_full_pointers",
+			t: config.StateActorTarget{
+				Client: "nethermind", OutputDir: "/srv/n", TargetSize: "10GB",
+				Seed: i64(42), Fork: "prague", ChainID: i64(7),
+				GasLimit: u64(60_000_000), Timestamp: u64(1700000000),
+				ExtraData: "0xdeadbeef",
+			},
+			want: []string{
+				"--db=/srv/n",
+				"--client=nethermind",
+				"--target-size=10GB",
+				"--seed=42",
+				"--fork=prague",
+				"--chain-id=7",
+				"--gas-limit=60000000",
+				"--timestamp=1700000000",
+				"--extra-data=0xdeadbeef",
+			},
+		},
+		{
+			name: "geth_archive_binary_trie_group_depth",
+			t: config.StateActorTarget{
+				Client: "geth", OutputDir: "/srv/g", TargetSize: "5GB",
+				Archive: bptr(true), BinaryTrie: bptr(true), GroupDepth: iptr(4),
+			},
+			want: []string{
+				"--db=/srv/g/geth/chaindata",
+				"--client=geth",
+				"--target-size=5GB",
+				"--archive",
+				"--binary-trie",
+				"--group-depth=4",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildArgs(&tt.t, tt.specPath)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDBPath(t *testing.T) {
+	assert.Equal(t, "/data/geth/chaindata",
+		dbPath(&config.StateActorTarget{Client: "geth", OutputDir: "/data"}))
+	assert.Equal(t, "/data",
+		dbPath(&config.StateActorTarget{Client: "reth", OutputDir: "/data"}))
+	assert.Equal(t, "/data",
+		dbPath(&config.StateActorTarget{Client: "besu", OutputDir: "/data"}))
+	assert.Equal(t, "/data",
+		dbPath(&config.StateActorTarget{Client: "nethermind", OutputDir: "/data"}))
+}
+
+func TestStateActorBuilder_Targets(t *testing.T) {
+	cfg := &config.StateActorConfig{
+		Images:   allImages,
+		SpecFile: "/etc/spec.yaml",
+		Targets: []config.StateActorTarget{
+			{Client: "geth", OutputDir: "/srv/g", TargetSize: "5GB"},
+			{Name: "reth-spec", Client: "reth", OutputDir: "/srv/r"},
+		},
+	}
+
+	b := NewStateActorBuilder(logrus.New(), cfg, "docker", &fakeMgr{})
+
+	got := b.Targets()
+	require.Len(t, got, 2)
+	assert.Equal(t, TargetInfo{Name: "geth", Client: "geth", OutputDir: "/srv/g"}, got[0])
+	assert.Equal(t, TargetInfo{Name: "reth-spec", Client: "reth", OutputDir: "/srv/r"}, got[1])
+}
+
+func TestStateActorBuilder_BuildUnknownTarget(t *testing.T) {
+	cfg := &config.StateActorConfig{
+		Images:  allImages,
+		Targets: []config.StateActorTarget{{Client: "geth", OutputDir: t.TempDir(), TargetSize: "5GB"}},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", &fakeMgr{})
+
+	_, err := b.Build(context.Background(), "missing", BuildOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no target named")
+}
+
+func TestStateActorBuilder_BuildSkipsPopulatedDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "leftover"), []byte("x"), 0o644))
+
+	mgr := &fakeMgr{}
+	cfg := &config.StateActorConfig{
+		Images:  allImages,
+		Targets: []config.StateActorTarget{{Client: "geth", OutputDir: dir, TargetSize: "5GB"}},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	skipped, err := b.Build(context.Background(), "geth", BuildOptions{})
+	require.NoError(t, err)
+	assert.True(t, skipped, "Build should report skipped=true when output_dir is non-empty")
+	assert.Empty(t, mgr.runs, "no container should run when target is skipped")
+
+	// The leftover file must still be there — skip means "leave it".
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "leftover", entries[0].Name())
+}
+
+func TestStateActorBuilder_PerTargetForce(t *testing.T) {
+	// One target sets `force: true`; the other doesn't. Both have
+	// populated output_dirs and the CLI --force flag is NOT passed —
+	// only the per-target force should rebuild AND propagate --force
+	// to the state-actor argv.
+	overrideDir := t.TempDir()
+	skipDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(overrideDir, "leftover"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(skipDir, "leftover"), []byte("y"), 0o644))
+
+	mgr := &fakeMgr{}
+	cfg := &config.StateActorConfig{
+		Images: allImages,
+		Targets: []config.StateActorTarget{
+			{Name: "force-me", Client: "geth", OutputDir: overrideDir, TargetSize: "5GB", Force: true},
+			{Name: "skip-me", Client: "reth", OutputDir: skipDir, TargetSize: "5GB"},
+		},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	skipped, err := b.Build(context.Background(), "force-me", BuildOptions{})
+	require.NoError(t, err)
+	assert.False(t, skipped, "force: true target should not be skipped")
+
+	overrideEntries, err := os.ReadDir(overrideDir)
+	require.NoError(t, err)
+	assert.Empty(t, overrideEntries, "force: true should wipe the dir before running")
+
+	require.Len(t, mgr.runs, 1, "only the force target should have run so far")
+
+	for _, arg := range mgr.runs[0].Command {
+		assert.NotEqual(t, "--force", arg, "state-actor has no --force flag; we wipe the dir from benchmarkoor instead")
+	}
+
+	skipped, err = b.Build(context.Background(), "skip-me", BuildOptions{})
+	require.NoError(t, err)
+	assert.True(t, skipped, "target without force should still be skipped")
+
+	skipEntries, err := os.ReadDir(skipDir)
+	require.NoError(t, err)
+	require.Len(t, skipEntries, 1, "skipped target's leftover must remain")
+	assert.Equal(t, "leftover", skipEntries[0].Name())
+
+	require.Len(t, mgr.runs, 1, "no new container should run for the skipped target")
+}
+
+func TestStateActorBuilder_BuildForceClearsDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "leftover"), []byte("x"), 0o644))
+
+	mgr := &fakeMgr{}
+	cfg := &config.StateActorConfig{
+		Images:  allImages,
+		Targets: []config.StateActorTarget{{Client: "geth", OutputDir: dir, TargetSize: "5GB"}},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	skipped, err := b.Build(context.Background(), "geth", BuildOptions{Force: true})
+	require.NoError(t, err)
+	assert.False(t, skipped, "--force must skip the skip check")
+
+	// Force removes the directory and then re-creates it.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "leftover file should have been removed by --force")
+
+	require.Len(t, mgr.runs, 1)
+	assert.Equal(t, "fallback:latest", mgr.runs[0].Image)
+	assert.Contains(t, mgr.runs[0].Command, "--db="+dir+"/geth/chaindata")
+}
+
+func TestStateActorBuilder_BuildPullFailureSurfaced(t *testing.T) {
+	mgr := &fakeMgr{pullErr: errors.New("network down")}
+	cfg := &config.StateActorConfig{
+		Images:  allImages,
+		Targets: []config.StateActorTarget{{Client: "geth", OutputDir: t.TempDir(), TargetSize: "5GB"}},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	skipped, err := b.Build(context.Background(), "geth", BuildOptions{})
+	require.Error(t, err)
+	assert.False(t, skipped)
+	assert.Contains(t, err.Error(), "network down")
+	assert.Empty(t, mgr.runs, "container should not run when image pull fails")
+}
+
+func TestStateActorBuilder_BuildRunFailureIncludesOutputTail(t *testing.T) {
+	mgr := &fakeMgr{
+		runErr:    errors.New("exit 1"),
+		runOutput: "panic: spec failed validation",
+	}
+	cfg := &config.StateActorConfig{
+		Images:  allImages,
+		Targets: []config.StateActorTarget{{Client: "geth", OutputDir: t.TempDir(), TargetSize: "5GB"}},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	skipped, err := b.Build(context.Background(), "geth", BuildOptions{})
+	require.Error(t, err)
+	assert.False(t, skipped)
+	assert.Contains(t, err.Error(), "spec failed validation")
+}
+
+func TestStateActorBuilder_SpecFileMountAndArgs(t *testing.T) {
+	specFile := filepath.Join(t.TempDir(), "spec.yaml")
+	require.NoError(t, os.WriteFile(specFile, []byte("genesis: {}\n"), 0o644))
+
+	mgr := &fakeMgr{}
+	cfg := &config.StateActorConfig{
+		Images:   allImages,
+		SpecFile: specFile,
+		Targets: []config.StateActorTarget{{
+			Client: "reth", OutputDir: t.TempDir(),
+		}},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	_, err := b.Build(context.Background(), "reth", BuildOptions{})
+	require.NoError(t, err)
+	require.Len(t, mgr.runs, 1)
+
+	run := mgr.runs[0]
+	assert.Contains(t, run.Command, "--spec="+specFile)
+
+	// Spec must be mounted RO at the same path inside the container.
+	var found bool
+
+	for _, m := range run.Mounts {
+		if m.Source == specFile && m.Target == specFile {
+			found = true
+
+			assert.True(t, m.ReadOnly, "spec mount must be read-only")
+		}
+	}
+
+	assert.True(t, found, "spec file mount missing from container spec")
+}
+
+func TestStateActorBuilder_InlineSpecMaterialised(t *testing.T) {
+	inline := "genesis:\n  chain_id: 1337\n"
+
+	mgr := &fakeMgr{}
+	cfg := &config.StateActorConfig{
+		Images: allImages,
+		Spec:   inline,
+		Targets: []config.StateActorTarget{{
+			Client: "reth", OutputDir: t.TempDir(),
+		}},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	_, buildErr := b.Build(context.Background(), "reth", BuildOptions{})
+	require.NoError(t, buildErr)
+	require.Len(t, mgr.runs, 1)
+
+	run := mgr.runs[0]
+
+	// Find the --spec arg and the matching mount; verify the file content
+	// equals the inline YAML and that the temp file is cleaned up after
+	// the build returns.
+	var specPath string
+
+	for _, arg := range run.Command {
+		if v, ok := strings.CutPrefix(arg, "--spec="); ok {
+			specPath = v
+		}
+	}
+
+	require.NotEmpty(t, specPath, "--spec arg missing from command")
+	require.True(t, filepath.IsAbs(specPath), "spec path should be absolute, got %q", specPath)
+
+	// Cleanup runs in Build's defer, so the temp file must already be gone
+	// when the test checks. The container saw the file via the mount; we
+	// stored a recorded copy below.
+	_, err := os.Stat(specPath)
+	assert.True(t, os.IsNotExist(err), "temp spec file should be cleaned up after build, got err=%v", err)
+
+	// The mount entry should be identity (same source/target) and RO.
+	var found bool
+
+	for _, m := range run.Mounts {
+		if m.Source == specPath && m.Target == specPath {
+			found = true
+
+			assert.True(t, m.ReadOnly, "spec mount must be read-only")
+		}
+	}
+
+	assert.True(t, found, "spec mount missing from container spec")
+}
+
+func TestStateActorBuilder_GlobalTargetSizeAppliedToTarget(t *testing.T) {
+	// Global config.target_size flows into each target's argv when the
+	// target doesn't set its own. Per-target value still wins.
+	mgr := &fakeMgr{}
+	cfg := &config.StateActorConfig{
+		Images: allImages,
+		Config: &config.StateActorClientDefaults{TargetSize: "5GB"},
+		Targets: []config.StateActorTarget{
+			{Name: "geth-inherits", Client: "geth", OutputDir: t.TempDir()},
+			{Name: "reth-override", Client: "reth", OutputDir: t.TempDir(), TargetSize: "50GB"},
+		},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	_, err := b.Build(context.Background(), "geth-inherits", BuildOptions{})
+	require.NoError(t, err)
+	_, err = b.Build(context.Background(), "reth-override", BuildOptions{})
+	require.NoError(t, err)
+	require.Len(t, mgr.runs, 2)
+
+	assert.Contains(t, mgr.runs[0].Command, "--target-size=5GB", "geth should inherit global target_size")
+	assert.Contains(t, mgr.runs[1].Command, "--target-size=50GB", "reth should override with its own target_size")
+
+	for _, arg := range mgr.runs[1].Command {
+		assert.NotEqual(t, "--target-size=5GB", arg, "reth must not see the global target_size after override")
+	}
+}
+
+func TestStateActorBuilder_GlobalDefaultsAppliedToTarget(t *testing.T) {
+	// Global config sets seed/fork/chain_id/archive; target leaves them
+	// all unset, so all four should appear in the resulting argv.
+	mgr := &fakeMgr{}
+	cfg := &config.StateActorConfig{
+		Images: allImages,
+		Config: &config.StateActorClientDefaults{
+			Seed:    i64(42),
+			Fork:    "prague",
+			ChainID: i64(7),
+			Archive: bptr(true),
+		},
+		Targets: []config.StateActorTarget{{
+			Client: "reth", OutputDir: t.TempDir(), TargetSize: "5GB",
+		}},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	_, err := b.Build(context.Background(), "reth", BuildOptions{})
+	require.NoError(t, err)
+	require.Len(t, mgr.runs, 1)
+
+	got := mgr.runs[0].Command
+	assert.Contains(t, got, "--seed=42")
+	assert.Contains(t, got, "--fork=prague")
+	assert.Contains(t, got, "--chain-id=7")
+	assert.Contains(t, got, "--archive")
+}
+
+func TestStateActorBuilder_TargetOverridesGlobalDefaults(t *testing.T) {
+	// Global says fork=prague, archive=true. Target says fork=osaka and
+	// archive=false. Target must win for both.
+	mgr := &fakeMgr{}
+	cfg := &config.StateActorConfig{
+		Images: allImages,
+		Config: &config.StateActorClientDefaults{
+			Fork:    "prague",
+			Archive: bptr(true),
+		},
+		Targets: []config.StateActorTarget{{
+			Client: "geth", OutputDir: t.TempDir(), TargetSize: "5GB",
+			Fork:    "osaka",
+			Archive: bptr(false),
+		}},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	_, err := b.Build(context.Background(), "geth", BuildOptions{})
+	require.NoError(t, err)
+	require.Len(t, mgr.runs, 1)
+
+	got := mgr.runs[0].Command
+	assert.Contains(t, got, "--fork=osaka")
+
+	for _, arg := range got {
+		assert.NotEqual(t, "--archive", arg, "target Archive=false must override global Archive=true")
+		assert.NotEqual(t, "--fork=prague", arg, "target fork must override global fork")
+	}
+}
+
+func TestStateActorBuilder_SpecAndTargetSizeCoexist(t *testing.T) {
+	// spec and target_size are complementary — state-actor accepts both
+	// flags, treating target_size as a headroom budget on top of the spec.
+	mgr := &fakeMgr{}
+	cfg := &config.StateActorConfig{
+		Images: allImages,
+		Spec:   "genesis: {}\n",
+		Targets: []config.StateActorTarget{{
+			Client: "geth", OutputDir: t.TempDir(), TargetSize: "5GB",
+		}},
+	}
+
+	b := NewStateActorBuilder(noopLogger(), cfg, "docker", mgr)
+
+	_, err := b.Build(context.Background(), "geth", BuildOptions{})
+	require.NoError(t, err)
+	require.Len(t, mgr.runs, 1)
+
+	got := mgr.runs[0].Command
+	assert.Contains(t, got, "--target-size=5GB")
+
+	// The inline spec should have been materialised to a temp file, with
+	// the matching --spec arg + bind mount carrying through.
+	var hasSpecArg bool
+
+	for _, arg := range got {
+		if strings.HasPrefix(arg, "--spec=") {
+			hasSpecArg = true
+		}
+	}
+
+	assert.True(t, hasSpecArg, "--spec must also appear in argv when both spec and target_size are configured")
+	require.Len(t, mgr.runs[0].Mounts, 2, "output_dir + spec file should both be mounted")
+}
+
+// ---------------- helpers ----------------
+
+func noopLogger() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+
+	return l
+}
+
+// fakeMgr satisfies docker.ContainerManager for the methods the builder
+// touches. The rest panic with a clear message so accidental new uses
+// surface in tests instead of segfaulting.
+type fakeMgr struct {
+	pullErr   error
+	runErr    error
+	runOutput string
+	runs      []docker.ContainerSpec
+}
+
+func (m *fakeMgr) PullImage(_ context.Context, _ string, _ string) error {
+	return m.pullErr
+}
+
+func (m *fakeMgr) RunInitContainer(_ context.Context, spec *docker.ContainerSpec, stdout, _ io.Writer) error {
+	m.runs = append(m.runs, *spec)
+
+	if m.runOutput != "" {
+		_, _ = stdout.Write([]byte(m.runOutput + "\n"))
+	}
+
+	return m.runErr
+}
+
+// Unused interface methods — fail loudly if anything accidentally calls them.
+func (m *fakeMgr) Start(_ context.Context) error { panic("Start not used in builder tests") }
+func (m *fakeMgr) Stop() error                   { panic("Stop not used in builder tests") }
+func (m *fakeMgr) EnsureNetwork(_ context.Context, _ string) error {
+	panic("EnsureNetwork not used in builder tests")
+}
+func (m *fakeMgr) RemoveNetwork(_ context.Context, _ string) error {
+	panic("RemoveNetwork not used in builder tests")
+}
+func (m *fakeMgr) CreateContainer(_ context.Context, _ *docker.ContainerSpec) (string, error) {
+	panic("CreateContainer not used in builder tests")
+}
+func (m *fakeMgr) StartContainer(_ context.Context, _ string) error {
+	panic("StartContainer not used in builder tests")
+}
+func (m *fakeMgr) StopContainer(_ context.Context, _ string, _ *int) error {
+	panic("StopContainer not used in builder tests")
+}
+func (m *fakeMgr) RemoveContainer(_ context.Context, _ string) error {
+	panic("RemoveContainer not used in builder tests")
+}
+func (m *fakeMgr) StreamLogs(_ context.Context, _ string, _, _ io.Writer) error {
+	panic("StreamLogs not used in builder tests")
+}
+func (m *fakeMgr) GetImageDigest(_ context.Context, _ string) (string, error) {
+	panic("GetImageDigest not used in builder tests")
+}
+func (m *fakeMgr) GetContainerIP(_ context.Context, _, _ string) (string, error) {
+	panic("GetContainerIP not used in builder tests")
+}
+func (m *fakeMgr) CreateVolume(_ context.Context, _ string, _ map[string]string) error {
+	panic("CreateVolume not used in builder tests")
+}
+func (m *fakeMgr) RemoveVolume(_ context.Context, _ string) error {
+	panic("RemoveVolume not used in builder tests")
+}
+func (m *fakeMgr) ListContainers(_ context.Context) ([]docker.ContainerInfo, error) {
+	panic("ListContainers not used in builder tests")
+}
+func (m *fakeMgr) ListVolumes(_ context.Context) ([]docker.VolumeInfo, error) {
+	panic("ListVolumes not used in builder tests")
+}
+func (m *fakeMgr) WaitForContainerExit(_ context.Context, _ string) (<-chan docker.ContainerExitInfo, <-chan error) {
+	panic("WaitForContainerExit not used in builder tests")
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,9 +67,213 @@ const (
 
 // Config is the root configuration for benchmarkoor.
 type Config struct {
-	Global GlobalConfig `yaml:"global" mapstructure:"global"`
-	Runner RunnerConfig `yaml:"runner" mapstructure:"runner"`
-	API    *APIConfig   `yaml:"api,omitempty" mapstructure:"api"`
+	Global  GlobalConfig   `yaml:"global" mapstructure:"global"`
+	Runner  RunnerConfig   `yaml:"runner" mapstructure:"runner"`
+	API     *APIConfig     `yaml:"api,omitempty" mapstructure:"api"`
+	Builder *BuilderConfig `yaml:"builder,omitempty" mapstructure:"builder"`
+}
+
+// BuilderConfig is the top-level builder block. Today it only houses
+// state-actor; future builders (e.g. geth-import, snap-sync) plug in
+// alongside.
+type BuilderConfig struct {
+	StateActor *StateActorConfig `yaml:"state_actor,omitempty" mapstructure:"state_actor"`
+}
+
+// StateActorConfig configures how the state-actor binary is invoked via
+// docker/podman to materialise pre-populated client datadirs. See
+// https://github.com/ethereum/state-actor.
+//
+// The spec source (one of Spec/SpecFile) is shared across every target.
+// Spec carries inline YAML content; SpecFile is a host path. They are
+// mutually exclusive at the top level. Spec and target_size are
+// complementary — when both are set state-actor uses the spec and
+// treats target_size as a headroom budget for any further auto-fill.
+//
+// Config holds the per-target build parameters that can be hoisted up
+// to avoid repeating them. Any field set on a target overrides the
+// corresponding field in Config.
+type StateActorConfig struct {
+	ContainerRuntime string                    `yaml:"container_runtime,omitempty" mapstructure:"container_runtime"`
+	Images           map[string]string         `yaml:"images,omitempty" mapstructure:"images"`
+	PullPolicy       string                    `yaml:"pull_policy,omitempty" mapstructure:"pull_policy"`
+	Spec             string                    `yaml:"spec,omitempty" mapstructure:"spec"`
+	SpecFile         string                    `yaml:"spec_file,omitempty" mapstructure:"spec_file"`
+	Config           *StateActorClientDefaults `yaml:"config,omitempty" mapstructure:"config"`
+	Targets          []StateActorTarget        `yaml:"targets,omitempty" mapstructure:"targets"`
+}
+
+// StateActorClientDefaults are the per-target build parameters that may
+// be hoisted to the top level under `builder.state_actor.config`. Every
+// field is also present on StateActorTarget; a non-nil/non-empty value
+// on the target wins over the corresponding default.
+//
+// Pointer-typed fields (and pointer-typed bools) are required so that
+// "explicitly false / zero" is distinguishable from "unset" — without
+// this, a target could not opt out of a global archive=true.
+type StateActorClientDefaults struct {
+	TargetSize string  `yaml:"target_size,omitempty" mapstructure:"target_size"`
+	Seed       *int64  `yaml:"seed,omitempty" mapstructure:"seed"`
+	Fork       string  `yaml:"fork,omitempty" mapstructure:"fork"`
+	ChainID    *int64  `yaml:"chain_id,omitempty" mapstructure:"chain_id"`
+	GasLimit   *uint64 `yaml:"gas_limit,omitempty" mapstructure:"gas_limit"`
+	Timestamp  *uint64 `yaml:"timestamp,omitempty" mapstructure:"timestamp"`
+	ExtraData  string  `yaml:"extra_data,omitempty" mapstructure:"extra_data"`
+	Archive    *bool   `yaml:"archive,omitempty" mapstructure:"archive"`
+	BinaryTrie *bool   `yaml:"binary_trie,omitempty" mapstructure:"binary_trie"`
+	GroupDepth *int    `yaml:"group_depth,omitempty" mapstructure:"group_depth"`
+}
+
+// StateActorTarget is one materialised datadir. The shared per-target
+// build parameters mirror StateActorClientDefaults — see ResolveTarget
+// for the merge semantics. Name/Client/OutputDir/TargetSize are
+// intentionally not hoistable: they identify the target.
+type StateActorTarget struct {
+	Name       string  `yaml:"name,omitempty" mapstructure:"name"`
+	Client     string  `yaml:"client" mapstructure:"client"`
+	OutputDir  string  `yaml:"output_dir" mapstructure:"output_dir"`
+	TargetSize string  `yaml:"target_size,omitempty" mapstructure:"target_size"`
+	Force      bool    `yaml:"force,omitempty" mapstructure:"force"`
+	Seed       *int64  `yaml:"seed,omitempty" mapstructure:"seed"`
+	Fork       string  `yaml:"fork,omitempty" mapstructure:"fork"`
+	ChainID    *int64  `yaml:"chain_id,omitempty" mapstructure:"chain_id"`
+	GasLimit   *uint64 `yaml:"gas_limit,omitempty" mapstructure:"gas_limit"`
+	Timestamp  *uint64 `yaml:"timestamp,omitempty" mapstructure:"timestamp"`
+	ExtraData  string  `yaml:"extra_data,omitempty" mapstructure:"extra_data"`
+	Archive    *bool   `yaml:"archive,omitempty" mapstructure:"archive"`
+	BinaryTrie *bool   `yaml:"binary_trie,omitempty" mapstructure:"binary_trie"`
+	GroupDepth *int    `yaml:"group_depth,omitempty" mapstructure:"group_depth"`
+}
+
+// ResolveTarget returns a copy of the i-th target with any unset fields
+// filled in from StateActorConfig.Config. Identifier fields (Name,
+// Client, OutputDir, TargetSize) and spec sources are not touched —
+// those live exclusively on the target or the parent StateActorConfig.
+//
+// Resolution rule per field: per-target value wins when set (non-nil
+// for pointer types, non-empty for strings); otherwise the value from
+// Config is used. When Config is nil, the target is returned unchanged.
+func (s *StateActorConfig) ResolveTarget(i int) StateActorTarget {
+	t := s.Targets[i]
+	if s.Config == nil {
+		return t
+	}
+
+	g := s.Config
+
+	if t.TargetSize == "" {
+		t.TargetSize = g.TargetSize
+	}
+
+	if t.Seed == nil {
+		t.Seed = g.Seed
+	}
+
+	if t.Fork == "" {
+		t.Fork = g.Fork
+	}
+
+	if t.ChainID == nil {
+		t.ChainID = g.ChainID
+	}
+
+	if t.GasLimit == nil {
+		t.GasLimit = g.GasLimit
+	}
+
+	if t.Timestamp == nil {
+		t.Timestamp = g.Timestamp
+	}
+
+	if t.ExtraData == "" {
+		t.ExtraData = g.ExtraData
+	}
+
+	if t.Archive == nil {
+		t.Archive = g.Archive
+	}
+
+	if t.BinaryTrie == nil {
+		t.BinaryTrie = g.BinaryTrie
+	}
+
+	if t.GroupDepth == nil {
+		t.GroupDepth = g.GroupDepth
+	}
+
+	return t
+}
+
+// StateActorSpecKind classifies how the top-level spec source is provided.
+type StateActorSpecKind int
+
+const (
+	// StateActorSpecNone means no spec source is configured.
+	StateActorSpecNone StateActorSpecKind = iota
+	// StateActorSpecInline means the top-level Spec field carries the YAML body.
+	StateActorSpecInline
+	// StateActorSpecFile means the top-level SpecFile field holds a host path.
+	StateActorSpecFile
+)
+
+// ResolveSpec returns the configured spec source. Spec (inline) wins over
+// SpecFile when both are set, but validateBuilder rejects that case so
+// in practice only one is non-empty at call time.
+func (s *StateActorConfig) ResolveSpec() (StateActorSpecKind, string) {
+	if s == nil {
+		return StateActorSpecNone, ""
+	}
+
+	if s.Spec != "" {
+		return StateActorSpecInline, s.Spec
+	}
+
+	if s.SpecFile != "" {
+		return StateActorSpecFile, s.SpecFile
+	}
+
+	return StateActorSpecNone, ""
+}
+
+// EffectiveName returns the target's user-facing name. Defaults to
+// Client when Name was not set, matching the `--target` filter behaviour
+// in the build command.
+func (t *StateActorTarget) EffectiveName() string {
+	if t.Name != "" {
+		return t.Name
+	}
+
+	return t.Client
+}
+
+// ImageFor returns the docker image configured for the given client.
+// Empty string means no image is configured — validation enforces that
+// every target's client has an entry in Images.
+func (s *StateActorConfig) ImageFor(client string) string {
+	if s == nil {
+		return ""
+	}
+
+	return s.Images[client]
+}
+
+// stateActorSupportedClients lists the clients state-actor itself can
+// materialise datadirs for. Erigon and Nimbus are intentionally absent
+// (state-actor does not implement writers for them).
+var stateActorSupportedClients = map[string]struct{}{
+	"geth":       {},
+	"reth":       {},
+	"besu":       {},
+	"nethermind": {},
+}
+
+// stateActorValidPullPolicies mirrors the pull-policy vocabulary used by
+// the runner side (pkg/docker, pkg/podman).
+var stateActorValidPullPolicies = map[string]bool{
+	"":               true,
+	"always":         true,
+	"if-not-present": true,
+	"never":          true,
 }
 
 // RunnerConfig contains all run-specific configuration settings.
@@ -975,6 +1179,9 @@ func bindEnvKeys(v *viper.Viper) {
 		"api.storage.s3.secret_access_key",
 		"api.storage.s3.force_path_style",
 		"api.storage.s3.presigned_urls.expiry",
+		// Builder settings
+		"builder.state_actor.container_runtime",
+		"builder.state_actor.pull_policy",
 	}
 
 	for _, key := range keys {
@@ -1094,6 +1301,26 @@ func (c *Config) applyDefaults() {
 			// If empty, the runner will use the client's spec.DataDir() at runtime.
 		}
 	}
+
+	// Apply builder.state_actor defaults. ContainerRuntime is intentionally
+	// left empty so GetStateActorContainerRuntime can fall back to the
+	// runner's runtime at call time.
+	if c.Builder != nil && c.Builder.StateActor != nil {
+		if c.Builder.StateActor.PullPolicy == "" {
+			c.Builder.StateActor.PullPolicy = DefaultPullPolicy
+		}
+	}
+}
+
+// GetStateActorContainerRuntime returns the container runtime to use for
+// state-actor builds. Falls back to the runner's runtime when the builder
+// block does not override it.
+func (c *Config) GetStateActorContainerRuntime() string {
+	if c.Builder != nil && c.Builder.StateActor != nil && c.Builder.StateActor.ContainerRuntime != "" {
+		return c.Builder.StateActor.ContainerRuntime
+	}
+
+	return c.GetContainerRuntime()
 }
 
 // ValidateOpts controls optional validation behavior.
@@ -1293,6 +1520,11 @@ func (c *Config) Validate(opts ...ValidateOpts) error {
 		return err
 	}
 
+	// Validate builder.state_actor settings.
+	if err := c.validateBuilder(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -1314,6 +1546,156 @@ func (c *Config) validateTestFilter() error {
 
 	if _, err := regexp.Compile(expr); err != nil {
 		return fmt.Errorf("runner.benchmark.tests.filter: invalid regex %q: %w", expr, err)
+	}
+
+	return nil
+}
+
+// ValidateBuilder runs the validation rules relevant to `benchmarkoor build`:
+// the runner's container_runtime (the builder falls back to it when its
+// own container_runtime is unset) plus the builder.state_actor block
+// itself. It deliberately skips the runner-side rules (instances,
+// resource_limits, test source, rollback strategies, ...) which are
+// required only for `benchmarkoor run`.
+func (c *Config) ValidateBuilder() error {
+	if err := c.validateContainerRuntime(); err != nil {
+		return err
+	}
+
+	return c.validateBuilder()
+}
+
+// validateBuilder enforces the builder.state_actor rules: supported
+// clients, single-source-of-truth target_size XOR spec, archive/binary-trie
+// applicability, group_depth range, image resolvability, and uniqueness of
+// target names and output_dirs.
+func (c *Config) validateBuilder() error {
+	if c.Builder == nil || c.Builder.StateActor == nil {
+		return nil
+	}
+
+	sa := c.Builder.StateActor
+
+	if !validContainerRuntimes[sa.ContainerRuntime] {
+		return fmt.Errorf(
+			"builder.state_actor.container_runtime: invalid value %q "+
+				"(must be \"docker\" or \"podman\")", sa.ContainerRuntime,
+		)
+	}
+
+	if !stateActorValidPullPolicies[sa.PullPolicy] {
+		return fmt.Errorf(
+			"builder.state_actor.pull_policy: invalid value %q "+
+				"(must be \"always\", \"if-not-present\", or \"never\")",
+			sa.PullPolicy,
+		)
+	}
+
+	if sa.Spec != "" && sa.SpecFile != "" {
+		return fmt.Errorf(
+			"builder.state_actor: spec (inline YAML) and spec_file (host path) are mutually exclusive",
+		)
+	}
+
+	// spec and target_size are complementary, not mutually exclusive:
+	// when both are set state-actor uses the spec and treats target_size
+	// as a headroom budget for the auto-fill that follows.
+	specKind, _ := sa.ResolveSpec()
+
+	seenOutputs := make(map[string]int, len(sa.Targets))
+	seenNames := make(map[string]int, len(sa.Targets))
+
+	for i := range sa.Targets {
+		// Resolve the target so applicability rules (archive/binary_trie/
+		// group_depth) check the effective value — a global default in
+		// builder.state_actor.config combined with the per-target value.
+		t := sa.ResolveTarget(i)
+		prefix := fmt.Sprintf("builder.state_actor.targets[%d]", i)
+
+		if _, ok := stateActorSupportedClients[t.Client]; !ok {
+			return fmt.Errorf(
+				"%s.client: %q is not supported by state-actor "+
+					"(must be geth, reth, besu, or nethermind)",
+				prefix, t.Client,
+			)
+		}
+
+		name := t.EffectiveName()
+		if prev, dup := seenNames[name]; dup {
+			return fmt.Errorf(
+				"%s: name %q duplicates targets[%d] (set an explicit name to disambiguate)",
+				prefix, name, prev,
+			)
+		}
+
+		seenNames[name] = i
+
+		if t.OutputDir == "" {
+			return fmt.Errorf("%s.output_dir is required", prefix)
+		}
+
+		if !filepath.IsAbs(t.OutputDir) {
+			return fmt.Errorf(
+				"%s.output_dir must be an absolute path, got %q",
+				prefix, t.OutputDir,
+			)
+		}
+
+		if prev, dup := seenOutputs[t.OutputDir]; dup {
+			return fmt.Errorf(
+				"%s.output_dir %q duplicates targets[%d].output_dir",
+				prefix, t.OutputDir, prev,
+			)
+		}
+
+		seenOutputs[t.OutputDir] = i
+
+		if t.TargetSize == "" && specKind == StateActorSpecNone {
+			return fmt.Errorf(
+				"%s: no source resolved — set target_size on the target, set "+
+					"builder.state_actor.config.target_size, or set a top-level "+
+					"builder.state_actor.spec / spec_file",
+				prefix,
+			)
+		}
+
+		if t.TargetSize != "" {
+			if _, err := ParseByteSize(t.TargetSize); err != nil {
+				return fmt.Errorf("%s.target_size: %w", prefix, err)
+			}
+		}
+
+		archive := t.Archive != nil && *t.Archive
+		binaryTrie := t.BinaryTrie != nil && *t.BinaryTrie
+
+		if archive && t.Client != "geth" && t.Client != "reth" {
+			return fmt.Errorf("%s.archive: only supported for geth and reth", prefix)
+		}
+
+		if binaryTrie && t.Client != "geth" {
+			return fmt.Errorf("%s.binary_trie: only supported for geth", prefix)
+		}
+
+		if t.GroupDepth != nil {
+			if !binaryTrie {
+				return fmt.Errorf("%s.group_depth: requires binary_trie=true", prefix)
+			}
+
+			if *t.GroupDepth < 1 || *t.GroupDepth > 8 {
+				return fmt.Errorf(
+					"%s.group_depth: must be in range 1..8, got %d",
+					prefix, *t.GroupDepth,
+				)
+			}
+		}
+
+		if sa.ImageFor(t.Client) == "" {
+			return fmt.Errorf(
+				"%s: no image configured for client %q "+
+					"(set builder.state_actor.images.%s)",
+				prefix, t.Client, t.Client,
+			)
+		}
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3178,3 +3178,490 @@ func TestValidateOpcodeExtraction(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBuilder_PublicScope(t *testing.T) {
+	// `benchmarkoor build` invokes Config.ValidateBuilder(), which must
+	// not require any runner-side configuration (instances, test sources,
+	// rollback strategies, ...) — it covers only the runner's
+	// container_runtime and the builder.state_actor block.
+	dir := t.TempDir()
+
+	cfg := &Config{
+		Builder: &BuilderConfig{
+			StateActor: &StateActorConfig{
+				Images:  map[string]string{"geth": "geth:img"},
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: dir, TargetSize: "5GB"}},
+			},
+		},
+	}
+
+	require.NoError(t, cfg.ValidateBuilder())
+	require.Error(t, cfg.Validate(), "Validate() still requires runner.instances")
+}
+
+func TestValidateBuilder_PublicRejectsBadRuntime(t *testing.T) {
+	cfg := &Config{
+		Runner: RunnerConfig{ContainerRuntime: "lima"},
+		Builder: &BuilderConfig{
+			StateActor: &StateActorConfig{
+				Images:  map[string]string{"geth": "geth:img"},
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: t.TempDir(), TargetSize: "5GB"}},
+			},
+		},
+	}
+
+	err := cfg.ValidateBuilder()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "container_runtime")
+}
+
+func TestValidateBuilder(t *testing.T) {
+	t.Helper()
+
+	// Use real absolute paths so the IsAbs check passes for rows where
+	// the rule under test isn't about output_dir validity.
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	intPtr := func(v int) *int { return &v }
+	int64Ptr := func(v int64) *int64 { return &v }
+	boolPtr := func(v bool) *bool { return &v }
+
+	// allImages covers every supported client so rows that don't care
+	// about image resolution don't have to spell it out.
+	allImages := map[string]string{
+		"geth":       "ghcr.io/ethereum/state-actor:latest",
+		"reth":       "ghcr.io/ethereum/state-actor-reth:latest",
+		"besu":       "ghcr.io/ethereum/state-actor-besu:latest",
+		"nethermind": "ghcr.io/ethereum/state-actor-nethermind:latest",
+	}
+
+	// mkCfg builds a Config with just the builder block populated so the
+	// builder validation runs in isolation. The wider Validate() expects
+	// runner.instances etc., so we call validateBuilder() directly here.
+	mkCfg := func(sa *StateActorConfig) *Config {
+		return &Config{Builder: &BuilderConfig{StateActor: sa}}
+	}
+
+	tests := []struct {
+		name      string
+		sa        *StateActorConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "nil builder is fine",
+			sa:   nil,
+		},
+		{
+			name: "no targets is fine",
+			sa: &StateActorConfig{
+				Images: allImages,
+			},
+		},
+		{
+			name: "invalid container_runtime",
+			sa: &StateActorConfig{
+				ContainerRuntime: "lima",
+				Images:           allImages,
+				Targets:          []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "container_runtime",
+		},
+		{
+			name: "invalid pull_policy",
+			sa: &StateActorConfig{
+				PullPolicy: "sometimes",
+				Images:     allImages,
+				Targets:    []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "pull_policy",
+		},
+		{
+			name: "pull_policy if-not-present ok",
+			sa: &StateActorConfig{
+				PullPolicy: "if-not-present",
+				Images:     allImages,
+				Targets:    []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+		},
+		{
+			name: "unsupported client erigon",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "erigon", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "erigon",
+		},
+		{
+			name: "unsupported client nimbus",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "nimbus", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "nimbus",
+		},
+		{
+			name: "missing output_dir",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "geth", TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "output_dir is required",
+		},
+		{
+			name: "relative output_dir",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: "./relative", TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "must be an absolute path",
+		},
+		{
+			name: "duplicate output_dir",
+			sa: &StateActorConfig{
+				Images: allImages,
+				Targets: []StateActorTarget{
+					{Client: "geth", OutputDir: dirA, TargetSize: "5GB"},
+					{Name: "reth-x", Client: "reth", OutputDir: dirA, TargetSize: "5GB"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "duplicates targets[0].output_dir",
+		},
+		{
+			name: "duplicate target name",
+			sa: &StateActorConfig{
+				Images: allImages,
+				Targets: []StateActorTarget{
+					{Client: "geth", OutputDir: dirA, TargetSize: "5GB"},
+					{Client: "geth", OutputDir: dirB, TargetSize: "10GB"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "duplicates targets[0]",
+		},
+		{
+			name: "duplicate names allowed when disambiguated",
+			sa: &StateActorConfig{
+				Images: allImages,
+				Targets: []StateActorTarget{
+					{Name: "geth-5g", Client: "geth", OutputDir: dirA, TargetSize: "5GB"},
+					{Name: "geth-50g", Client: "geth", OutputDir: dirB, TargetSize: "50GB"},
+				},
+			},
+		},
+		{
+			name: "missing size and no top-level spec",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: dirA}},
+			},
+			wantErr:   true,
+			errSubstr: "no source resolved",
+		},
+		{
+			name: "global config.target_size lets targets omit size",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Config:  &StateActorClientDefaults{TargetSize: "5GB"},
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: dirA}},
+			},
+		},
+		{
+			name: "per-target target_size overrides global config.target_size",
+			sa: &StateActorConfig{
+				Images: allImages,
+				Config: &StateActorClientDefaults{TargetSize: "5GB"},
+				Targets: []StateActorTarget{{
+					Client: "geth", OutputDir: dirA, TargetSize: "50GB",
+				}},
+			},
+		},
+		{
+			name: "global config.target_size rejects invalid format",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Config:  &StateActorClientDefaults{TargetSize: "5GG"},
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: dirA}},
+			},
+			wantErr:   true,
+			errSubstr: "target_size",
+		},
+		{
+			name: "global config.target_size and spec_file can coexist (target_size = headroom budget)",
+			sa: &StateActorConfig{
+				Images:   allImages,
+				SpecFile: "/etc/spec.yaml",
+				Config:   &StateActorClientDefaults{TargetSize: "5GB"},
+				Targets:  []StateActorTarget{{Client: "geth", OutputDir: dirA}},
+			},
+		},
+		{
+			name: "per-target target_size + top-level spec_file can coexist",
+			sa: &StateActorConfig{
+				Images:   allImages,
+				SpecFile: "/etc/spec.yaml",
+				Targets:  []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+		},
+		{
+			name: "top-level spec and spec_file both set",
+			sa: &StateActorConfig{
+				Images:   allImages,
+				Spec:     "genesis: {}\n",
+				SpecFile: "/etc/spec.yaml",
+				Targets:  []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "mutually exclusive",
+		},
+		{
+			name: "top-level spec_file lets targets omit target_size",
+			sa: &StateActorConfig{
+				Images:   allImages,
+				SpecFile: "/etc/spec.yaml",
+				Targets:  []StateActorTarget{{Client: "geth", OutputDir: dirA}},
+			},
+		},
+		{
+			name: "top-level inline spec lets targets omit target_size",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Spec:    "genesis:\n  chain_id: 1337\n",
+				Targets: []StateActorTarget{{Client: "reth", OutputDir: dirA}},
+			},
+		},
+		{
+			name: "mixed: one target has target_size, other inherits top-level spec",
+			sa: &StateActorConfig{
+				Images: allImages,
+				Spec:   "genesis: {}\n",
+				Targets: []StateActorTarget{
+					{Name: "geth-5g", Client: "geth", OutputDir: dirA, TargetSize: "5GB"},
+					{Name: "reth-inherit", Client: "reth", OutputDir: dirB},
+				},
+			},
+		},
+		{
+			name: "invalid target_size",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GG"}},
+			},
+			wantErr:   true,
+			errSubstr: "target_size",
+		},
+		{
+			name: "archive on besu rejected",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "besu", OutputDir: dirA, TargetSize: "5GB", Archive: boolPtr(true)}},
+			},
+			wantErr:   true,
+			errSubstr: "archive",
+		},
+		{
+			name: "archive on reth ok",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "reth", OutputDir: dirA, TargetSize: "5GB", Archive: boolPtr(true)}},
+			},
+		},
+		{
+			name: "binary_trie on reth rejected",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "reth", OutputDir: dirA, TargetSize: "5GB", BinaryTrie: boolPtr(true)}},
+			},
+			wantErr:   true,
+			errSubstr: "binary_trie",
+		},
+		{
+			name: "binary_trie on geth ok",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GB", BinaryTrie: boolPtr(true), GroupDepth: intPtr(4)}},
+			},
+		},
+		{
+			name: "group_depth without binary_trie rejected",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GB", GroupDepth: intPtr(4)}},
+			},
+			wantErr:   true,
+			errSubstr: "binary_trie=true",
+		},
+		{
+			name: "group_depth out of range low",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GB", BinaryTrie: boolPtr(true), GroupDepth: intPtr(0)}},
+			},
+			wantErr:   true,
+			errSubstr: "1..8",
+		},
+		{
+			name: "group_depth out of range high",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GB", BinaryTrie: boolPtr(true), GroupDepth: intPtr(9)}},
+			},
+			wantErr:   true,
+			errSubstr: "1..8",
+		},
+		{
+			name: "no image configured for target's client",
+			sa: &StateActorConfig{
+				Images:  map[string]string{"geth": "geth:img"},
+				Targets: []StateActorTarget{{Client: "reth", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "no image configured",
+		},
+		{
+			name: "per-client image resolves",
+			sa: &StateActorConfig{
+				Images:  map[string]string{"besu": "besu:img"},
+				Targets: []StateActorTarget{{Client: "besu", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+		},
+		{
+			name: "spec_file passthrough ok (file existence deferred)",
+			sa: &StateActorConfig{
+				Images:   allImages,
+				SpecFile: "/nonexistent/spec.yaml",
+				Targets:  []StateActorTarget{{Client: "reth", OutputDir: dirA}},
+			},
+		},
+		{
+			name: "full pointer values pass",
+			sa: &StateActorConfig{
+				Images: allImages,
+				Targets: []StateActorTarget{{
+					Client: "geth", OutputDir: dirA, TargetSize: "5GB",
+					Seed: int64Ptr(42), Fork: "prague", ChainID: int64Ptr(1337),
+				}},
+			},
+		},
+		{
+			name: "global archive applies to besu target via resolution",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Config:  &StateActorClientDefaults{Archive: boolPtr(true)},
+				Targets: []StateActorTarget{{Client: "besu", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "archive",
+		},
+		{
+			name: "target archive=false overrides global archive=true on besu",
+			sa: &StateActorConfig{
+				Images: allImages,
+				Config: &StateActorClientDefaults{Archive: boolPtr(true)},
+				Targets: []StateActorTarget{{
+					Client: "besu", OutputDir: dirA, TargetSize: "5GB",
+					Archive: boolPtr(false),
+				}},
+			},
+		},
+		{
+			name: "global binary_trie rejected on reth",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Config:  &StateActorClientDefaults{BinaryTrie: boolPtr(true)},
+				Targets: []StateActorTarget{{Client: "reth", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "binary_trie",
+		},
+		{
+			name: "global group_depth requires effective binary_trie",
+			sa: &StateActorConfig{
+				Images:  allImages,
+				Config:  &StateActorClientDefaults{GroupDepth: intPtr(4)},
+				Targets: []StateActorTarget{{Client: "geth", OutputDir: dirA, TargetSize: "5GB"}},
+			},
+			wantErr:   true,
+			errSubstr: "binary_trie=true",
+		},
+		{
+			name: "global binary_trie + group_depth on geth ok",
+			sa: &StateActorConfig{
+				Images: allImages,
+				Config: &StateActorClientDefaults{BinaryTrie: boolPtr(true), GroupDepth: intPtr(4)},
+				Targets: []StateActorTarget{{
+					Client: "geth", OutputDir: dirA, TargetSize: "5GB",
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := mkCfg(tt.sa).validateBuilder()
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestStateActorImageFor(t *testing.T) {
+	sa := &StateActorConfig{
+		Images: map[string]string{
+			"geth": "geth-image:1",
+			"reth": "reth-image:2",
+		},
+	}
+
+	assert.Equal(t, "geth-image:1", sa.ImageFor("geth"))
+	assert.Equal(t, "reth-image:2", sa.ImageFor("reth"))
+	assert.Empty(t, sa.ImageFor("besu"))
+
+	empty := &StateActorConfig{}
+	assert.Empty(t, empty.ImageFor("geth"))
+}
+
+func TestStateActorTargetEffectiveName(t *testing.T) {
+	withName := &StateActorTarget{Name: "geth-5g", Client: "geth"}
+	assert.Equal(t, "geth-5g", withName.EffectiveName())
+
+	noName := &StateActorTarget{Client: "geth"}
+	assert.Equal(t, "geth", noName.EffectiveName())
+}
+
+func TestGetStateActorContainerRuntime(t *testing.T) {
+	t.Run("builder override wins", func(t *testing.T) {
+		cfg := &Config{
+			Runner:  RunnerConfig{ContainerRuntime: "docker"},
+			Builder: &BuilderConfig{StateActor: &StateActorConfig{ContainerRuntime: "podman"}},
+		}
+		assert.Equal(t, "podman", cfg.GetStateActorContainerRuntime())
+	})
+
+	t.Run("falls back to runner runtime", func(t *testing.T) {
+		cfg := &Config{
+			Runner:  RunnerConfig{ContainerRuntime: "podman"},
+			Builder: &BuilderConfig{StateActor: &StateActorConfig{}},
+		}
+		assert.Equal(t, "podman", cfg.GetStateActorContainerRuntime())
+	})
+
+	t.Run("no builder block defaults to runner runtime", func(t *testing.T) {
+		cfg := &Config{Runner: RunnerConfig{ContainerRuntime: "docker"}}
+		assert.Equal(t, "docker", cfg.GetStateActorContainerRuntime())
+	})
+}


### PR DESCRIPTION
## Summary

Adds a `builder.state_actor` config block and a new `benchmarkoor build` command that materialises pre-populated client datadirs by invoking [state-actor](https://github.com/ethereum/state-actor) via the configured container runtime.

Builders are deliberately **decoupled from the runner**: `build` produces datadirs on disk that subsequent `benchmarkoor run` invocations consume through the normal `datadir.*` providers. There is no auto-build path on the run side — a missing datadir surfaces as a validation error there.

state-actor writes per-client genesis state directly in each EL's native on-disk format (geth Pebble, reth MDBX, besu/nethermind RocksDB), bypassing the client's normal genesis-replay path.

## What's included

- **`pkg/builder`** — `Builder` interface + `StateActorBuilder`:
  - per-client image resolution, output-dir prep (skip-on-populated, wipe on force)
  - spec resolution: inline YAML (→ temp file), host `spec_file`, or none
  - bind-mount assembly + argv construction emitting only non-default flags
  - streamed container logs with a tail buffer for useful error context
  - geth `--db` `/geth/chaindata` suffix quirk handled
- **`cmd/benchmarkoor/build.go`** — the `build` command: `--target` filtering, `--force`, docker/podman runtime selection, signal handling, per-target build summary
- **`pkg/config`** — `StateActorConfig` / `StateActorTarget` / `StateActorClientDefaults`:
  - `ResolveTarget` merge semantics (per-target overrides hoisted defaults; pointer fields distinguish unset vs zero)
  - `ResolveSpec`, `ImageFor`, `GetStateActorContainerRuntime` (falls back to runner runtime)
  - `validateBuilder`: supported clients (geth/reth/besu/nethermind), `target_size` XOR spec source, archive/binary_trie applicability, `group_depth` 1..8 (requires binary_trie), image resolvability, name/output_dir uniqueness, abs-path enforcement
- **docs + `config.example.yaml`** — builder section

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/builder/ ./pkg/config/`
- [x] End-to-end `benchmarkoor build` against a real state-actor image (docker + podman)