### PR TITLE
fix(examples): enable p2p on besu so it accepts the bootstrap FCU

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -4,3 +4,4 @@ extend-exclude = ["go.mod"]
 [default.extend-words]
 PANC = "PANC"
 ERRO = "ERRO"
+BULD = "BULD"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -945,6 +945,8 @@ When both `retry_new_payloads_syncing_state` and `retry_new_payloads_failed_stat
 
 Some clients (e.g., Erigon) may still be performing internal initialization or syncing after their RPC endpoint becomes available. The `bootstrap_fcu` option sends an `engine_forkchoiceUpdatedV3` call in a retry loop after RPC is ready, using the latest block hash from `eth_getBlockByNumber("latest")`. The client accepting the FCU with `VALID` status confirms it has finished syncing and is ready for test execution.
 
+> **Besu** accepts the bootstrap FCU on an isolated snapshot node only with `--p2p-enabled=true`: its synchronizer must run to register the post-merge head as in-sync, otherwise besu answers `SYNCING` to every FCU. Set `extra_args: [--p2p-enabled=true]` on the besu instance (`--max-peers=0` + `--discovery-enabled=false` keep it isolated, with zero real peers).
+
 **Shorthand** (uses defaults: `max_retries: 30`, `backoff: 1s`):
 
 ```yaml

--- a/examples/configuration/config.state-actor-eest.yaml
+++ b/examples/configuration/config.state-actor-eest.yaml
@@ -135,9 +135,13 @@ runner:
         - --Init.BaseDbPath=/data
     - id: besu
       client: besu
-      # Pinned: besu 26.6.1 regressed — it won't accept the bootstrap FCU on a
-      # snapshot (stays in PoS initial-sync → SYNCING). 26.6.0 works (36/36).
-      image: hyperledger/besu:26.6.0
+      # besu needs --p2p-enabled=true to accept the bootstrap FCU on a snapshot:
+      # its synchronizer must run to register the post-merge head as in-sync,
+      # otherwise besu answers SYNCING. --max-peers=0 + --discovery-enabled=false
+      # (the client defaults) keep it isolated — no real peers.
+      image: hyperledger/besu:26.6.1
+      extra_args:
+        - --p2p-enabled=true
     - id: ethrex
       client: ethrex
       # ethrex >= v16.0.0 is required: it's the first release with


### PR DESCRIPTION
## Problem

With besu in `config.state-actor-eest.yaml`, the bootstrap `engine_forkchoiceUpdatedV3` is
rejected with `SYNCING` — benchmarkoor retries then aborts before any payload runs. geth, reth,
and nethermind are unaffected.

## Root cause

besu returns `SYNCING` from `forkchoiceUpdated` while `mergeContext.isSyncing()` is true. On an
isolated snapshot node that hinges on `SyncState.reachedTerminalDifficulty`, which is set only
when besu's **synchronizer** runs (`DefaultSynchronizer`). This config passes
`--p2p-enabled=false`, which suppresses the synchronizer, so the flag is never set and besu
treats the (post-merge) snapshot head as pre-merge → `SYNCING`.

(besu ≤ 26.6.0 masked this: its `isSyncing()` also required `!isInSync()`, and `isInSync()` is
true here, so it short-circuited to `VALID`. 26.6.1 returns `SYNCING` on the unset
terminal-difficulty flag alone.)

## Fix

Enable p2p on the besu instance via `extra_args`:

```yaml
- id: besu
  image: hyperledger/besu:26.6.1
  extra_args:
    - --p2p-enabled=true
```

`--max-peers=0` + `--discovery-enabled=false` (besu client defaults) keep the node isolated — p2p
initializes but no real peers connect. Also bumps besu to the latest release (26.6.1).

## Verification

- besu **26.6.1** + `--p2p-enabled=true`: bootstrap FCU `VALID`, **36/36** (`benchmark/compute`, bn128).
- besu **26.6.0** + `--p2p-enabled=true`: **36/36** (no regression).

Also documents the requirement in `docs/configuration.md` (Bootstrap FCU section).
