### PR TITLE
fix(cpufreq,datadir): restore all CPUs and stop deleting live overlay mounts

### DIFF
--- a/pkg/cpufreq/cpufreq.go
+++ b/pkg/cpufreq/cpufreq.go
@@ -161,13 +161,14 @@ func (m *manager) Apply(ctx context.Context, cfg *Config, cpus []int) error {
 		}
 	}
 
-	// Refresh the crash-recovery state file whenever new originals were captured.
+	// Refresh the crash-recovery state file whenever new originals were
+	// captured. Write the new file before removing the previous one, so a crash
+	// or a write failure never leaves the host pinned to the benchmark settings
+	// with no state file to recover from. SaveState uses a 1-second-granularity
+	// filename, so two captures within the same second reuse the same path (an
+	// in-place overwrite); only a distinct earlier file needs removing.
 	if captured {
-		if m.stateFile != "" {
-			if err := RemoveStateFile(m.stateFile); err != nil {
-				m.log.WithError(err).Warn("Failed to remove previous CPU frequency state file")
-			}
-		}
+		previous := m.stateFile
 
 		stateFile, err := SaveState(m.cacheDir, m.originalSettings)
 		if err != nil {
@@ -175,6 +176,12 @@ func (m *manager) Apply(ctx context.Context, cfg *Config, cpus []int) error {
 		} else {
 			m.stateFile = stateFile
 			m.log.WithField("state_file", stateFile).Debug("Saved CPU frequency state")
+
+			if previous != "" && previous != stateFile {
+				if err := RemoveStateFile(previous); err != nil {
+					m.log.WithError(err).Warn("Failed to remove previous CPU frequency state file")
+				}
+			}
 		}
 	}
 
@@ -282,11 +289,14 @@ func (m *manager) restoreSettings(ctx context.Context) error {
 
 	var restoreErrs []error
 
-	// Restore turbo boost first.
+	// Restore turbo boost first. Turbo control is best-effort everywhere else
+	// (Apply and the crash-recovery RestoreFromStateFile path only log on
+	// failure), so a turbo restore failure must not be treated as fatal here:
+	// doing so would keep the recovery state forever and make Restore/Stop
+	// report an error on every call even when every CPU was restored.
 	if m.originalSettings.TurboBoost != nil {
 		if err := restoreTurboBoost(m.sysfsBasePath, m.originalSettings.TurboBoost); err != nil {
 			m.log.WithError(err).Warn("Failed to restore turbo boost")
-			restoreErrs = append(restoreErrs, fmt.Errorf("turbo boost: %w", err))
 		}
 	}
 

--- a/pkg/cpufreq/cpufreq.go
+++ b/pkg/cpufreq/cpufreq.go
@@ -2,6 +2,7 @@ package cpufreq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -131,16 +132,44 @@ func (m *manager) Apply(ctx context.Context, cfg *Config, cpus []int) error {
 
 	m.log.WithField("cpus", cpus).Debug("Applying CPU frequency settings")
 
-	// Save original settings before making changes.
+	// Capture original settings for any CPU we have not seen before, so a later
+	// Apply that targets different CPUs still records their originals. Capturing
+	// only on the first Apply would leave any CPU touched by a later call
+	// unrestorable.
 	if m.originalSettings == nil {
-		original, err := m.captureOriginalSettings(cpus)
-		if err != nil {
-			return fmt.Errorf("capturing original settings: %w", err)
-		}
-		m.originalSettings = original
+		m.originalSettings = &OriginalSettings{CPUs: make(map[int]*CPUSettings)}
+	}
 
-		// Persist state file for crash recovery.
-		stateFile, err := SaveState(m.cacheDir, original)
+	captured := false
+
+	for _, cpuID := range cpus {
+		if _, ok := m.originalSettings.CPUs[cpuID]; ok {
+			continue
+		}
+
+		m.originalSettings.CPUs[cpuID] = m.captureCPUSettings(cpuID)
+		captured = true
+	}
+
+	// Capture turbo boost state once; it is global, not per-CPU.
+	if m.originalSettings.TurboBoost == nil {
+		if turbo, err := captureTurboBoostSettings(m.sysfsBasePath); err != nil {
+			m.log.WithError(err).Debug("Turbo boost settings not available")
+		} else {
+			m.originalSettings.TurboBoost = turbo
+			captured = true
+		}
+	}
+
+	// Refresh the crash-recovery state file whenever new originals were captured.
+	if captured {
+		if m.stateFile != "" {
+			if err := RemoveStateFile(m.stateFile); err != nil {
+				m.log.WithError(err).Warn("Failed to remove previous CPU frequency state file")
+			}
+		}
+
+		stateFile, err := SaveState(m.cacheDir, m.originalSettings)
 		if err != nil {
 			m.log.WithError(err).Warn("Failed to save CPU frequency state file")
 		} else {
@@ -251,10 +280,13 @@ func (m *manager) restoreSettings(ctx context.Context) error {
 
 	m.log.Info("Restoring original CPU frequency settings")
 
+	var restoreErrs []error
+
 	// Restore turbo boost first.
 	if m.originalSettings.TurboBoost != nil {
 		if err := restoreTurboBoost(m.sysfsBasePath, m.originalSettings.TurboBoost); err != nil {
 			m.log.WithError(err).Warn("Failed to restore turbo boost")
+			restoreErrs = append(restoreErrs, fmt.Errorf("turbo boost: %w", err))
 		}
 	}
 
@@ -267,6 +299,7 @@ func (m *manager) restoreSettings(ctx context.Context) error {
 					"cpu":      cpuID,
 					"governor": settings.Governor,
 				}).WithError(err).Warn("Failed to restore governor")
+				restoreErrs = append(restoreErrs, fmt.Errorf("cpu %d governor: %w", cpuID, err))
 			}
 		}
 
@@ -277,6 +310,7 @@ func (m *manager) restoreSettings(ctx context.Context) error {
 					"cpu":     cpuID,
 					"max_khz": settings.ScalingMaxKHz,
 				}).WithError(err).Warn("Failed to restore max frequency")
+				restoreErrs = append(restoreErrs, fmt.Errorf("cpu %d max freq: %w", cpuID, err))
 			}
 		}
 		if settings.ScalingMinKHz > 0 {
@@ -285,11 +319,18 @@ func (m *manager) restoreSettings(ctx context.Context) error {
 					"cpu":     cpuID,
 					"min_khz": settings.ScalingMinKHz,
 				}).WithError(err).Warn("Failed to restore min frequency")
+				restoreErrs = append(restoreErrs, fmt.Errorf("cpu %d min freq: %w", cpuID, err))
 			}
 		}
 	}
 
-	// Clean up state file.
+	// Keep the in-memory originals and the state file if anything failed, so a
+	// later retry or the crash-recovery path can finish restoring. Discarding
+	// them here would strand CPUs in the benchmark settings permanently.
+	if len(restoreErrs) > 0 {
+		return fmt.Errorf("failed to fully restore CPU settings: %w", errors.Join(restoreErrs...))
+	}
+
 	if m.stateFile != "" {
 		if err := RemoveStateFile(m.stateFile); err != nil {
 			m.log.WithError(err).Warn("Failed to remove state file")
@@ -325,50 +366,35 @@ func (m *manager) GetCPUInfo() ([]CPUInfo, error) {
 	return infos, nil
 }
 
-// captureOriginalSettings captures current CPU frequency settings for the given CPUs.
-func (m *manager) captureOriginalSettings(cpus []int) (*OriginalSettings, error) {
-	original := &OriginalSettings{
-		CPUs: make(map[int]*CPUSettings, len(cpus)),
-	}
+// captureCPUSettings captures the current governor and scaling frequencies for
+// a single CPU.
+func (m *manager) captureCPUSettings(cpuID int) *CPUSettings {
+	settings := &CPUSettings{}
 
-	for _, cpuID := range cpus {
-		settings := &CPUSettings{}
-
-		// Capture current governor.
-		gov, err := getGovernor(m.sysfsBasePath, cpuID)
-		if err != nil {
-			m.log.WithField("cpu", cpuID).WithError(err).Warn("Failed to get governor")
-		} else {
-			settings.Governor = gov
-		}
-
-		// Capture current scaling frequencies.
-		minKHz, err := getScalingMinFreq(m.sysfsBasePath, cpuID)
-		if err != nil {
-			m.log.WithField("cpu", cpuID).WithError(err).Warn("Failed to get scaling min freq")
-		} else {
-			settings.ScalingMinKHz = minKHz
-		}
-
-		maxKHz, err := getScalingMaxFreq(m.sysfsBasePath, cpuID)
-		if err != nil {
-			m.log.WithField("cpu", cpuID).WithError(err).Warn("Failed to get scaling max freq")
-		} else {
-			settings.ScalingMaxKHz = maxKHz
-		}
-
-		original.CPUs[cpuID] = settings
-	}
-
-	// Capture turbo boost state.
-	turboSettings, err := captureTurboBoostSettings(m.sysfsBasePath)
+	// Capture current governor.
+	gov, err := getGovernor(m.sysfsBasePath, cpuID)
 	if err != nil {
-		m.log.WithError(err).Debug("Turbo boost settings not available")
+		m.log.WithField("cpu", cpuID).WithError(err).Warn("Failed to get governor")
 	} else {
-		original.TurboBoost = turboSettings
+		settings.Governor = gov
 	}
 
-	return original, nil
+	// Capture current scaling frequencies.
+	minKHz, err := getScalingMinFreq(m.sysfsBasePath, cpuID)
+	if err != nil {
+		m.log.WithField("cpu", cpuID).WithError(err).Warn("Failed to get scaling min freq")
+	} else {
+		settings.ScalingMinKHz = minKHz
+	}
+
+	maxKHz, err := getScalingMaxFreq(m.sysfsBasePath, cpuID)
+	if err != nil {
+		m.log.WithField("cpu", cpuID).WithError(err).Warn("Failed to get scaling max freq")
+	} else {
+		settings.ScalingMaxKHz = maxKHz
+	}
+
+	return settings
 }
 
 // ParseFrequency parses a frequency string and returns the value in kHz.

--- a/pkg/cpufreq/restore_test.go
+++ b/pkg/cpufreq/restore_test.go
@@ -1,0 +1,157 @@
+package cpufreq
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func testLog() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+
+	return l
+}
+
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+
+	return err == nil
+}
+
+// buildFakeSysfs creates a writable stand-in for /sys/devices/system/cpu so the
+// real Apply/Restore exercise actual file I/O on any OS.
+func buildFakeSysfs(t *testing.T, cpus []int, governor string) string {
+	t.Helper()
+
+	base := t.TempDir()
+
+	for _, id := range cpus {
+		dir := filepath.Join(base, fmt.Sprintf("cpu%d", id), cpufreqSubdir)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		files := map[string]string{
+			scalingGovernorFile:  governor,
+			scalingMinFreqFile:   "800000",
+			scalingMaxFreqFile:   "3000000",
+			cpuinfoMinFreqFile:   "800000",
+			cpuinfoMaxFreqFile:   "3000000",
+			scalingCurFreqFile:   "1500000",
+			scalingAvailGovsFile: "performance schedutil powersave",
+		}
+
+		for name, val := range files {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(val), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	return base
+}
+
+func governorOf(t *testing.T, base string, id int) string {
+	t.Helper()
+
+	g, err := getGovernor(base, id)
+	if err != nil {
+		t.Fatalf("reading governor for cpu%d: %v", id, err)
+	}
+
+	return g
+}
+
+// Originals must be captured for every CPU touched, even across multiple Apply
+// calls with different CPU sets, so all of them are restored.
+func TestApplyCapturesCPUsAcrossCalls(t *testing.T) {
+	base := buildFakeSysfs(t, []int{0, 1, 2, 3}, "schedutil")
+	mgr := NewManager(testLog(), t.TempDir(), base)
+	ctx := context.Background()
+
+	if err := mgr.Apply(ctx, &Config{Governor: "performance"}, []int{0, 1}); err != nil {
+		t.Fatalf("Apply #1: %v", err)
+	}
+
+	if err := mgr.Apply(ctx, &Config{Governor: "performance"}, []int{2, 3}); err != nil {
+		t.Fatalf("Apply #2: %v", err)
+	}
+
+	if err := mgr.Restore(ctx); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	for _, id := range []int{0, 1, 2, 3} {
+		if g := governorOf(t, base, id); g != "schedutil" {
+			t.Fatalf("cpu%d governor = %q, want schedutil", id, g)
+		}
+	}
+}
+
+// A restore that cannot write every CPU must report the failure and keep the
+// recovery state so a later attempt can finish, rather than silently stranding
+// CPUs in the benchmark governor.
+func TestRestoreKeepsRecoveryStateOnPartialFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("requires non-root: the test blocks one write via chmod 0444")
+	}
+
+	base := buildFakeSysfs(t, []int{0, 1}, "schedutil")
+	mgr := NewManager(testLog(), t.TempDir(), base).(*manager)
+	ctx := context.Background()
+
+	if err := mgr.Apply(ctx, &Config{Governor: "performance"}, []int{0, 1}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	stateFile := mgr.stateFile
+	if stateFile == "" || !pathExists(stateFile) {
+		t.Fatalf("setup: expected a recovery state file, got %q", stateFile)
+	}
+
+	// Block cpu1's governor restore.
+	govPath1 := cpufreqPath(base, 1, scalingGovernorFile)
+	if err := os.Chmod(govPath1, 0o444); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.Restore(ctx); err == nil {
+		t.Fatal("Restore should report an error when a CPU cannot be restored")
+	}
+
+	// Recovery state is preserved for a retry.
+	if mgr.originalSettings == nil {
+		t.Fatal("originalSettings should be kept after a partial restore")
+	}
+
+	if !pathExists(stateFile) {
+		t.Fatal("state file should be kept after a partial restore")
+	}
+
+	// Unblock and retry: the restore now completes and cleans up.
+	if err := os.Chmod(govPath1, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.Restore(ctx); err != nil {
+		t.Fatalf("retry Restore: %v", err)
+	}
+
+	if g := governorOf(t, base, 1); g != "schedutil" {
+		t.Fatalf("cpu1 governor = %q after retry, want schedutil", g)
+	}
+
+	if mgr.originalSettings != nil {
+		t.Fatal("originalSettings should be cleared after a full restore")
+	}
+
+	if pathExists(stateFile) {
+		t.Fatal("state file should be removed after a full restore")
+	}
+}

--- a/pkg/datadir/cleanup.go
+++ b/pkg/datadir/cleanup.go
@@ -203,10 +203,45 @@ func isMountPoint(path string) bool {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
-		if len(fields) >= 2 && fields[1] == path {
+		if len(fields) >= 2 && unescapeMountField(fields[1]) == path {
 			return true
 		}
 	}
 
 	return false
+}
+
+// unescapeMountField decodes the octal escape sequences the kernel writes into
+// /proc/mounts (space as \040, tab as \011, newline as \012, backslash as
+// \134). Without decoding, a mount point under a path containing any of these
+// characters would never match the literal path and the still-mounted check
+// would silently fail open.
+func unescapeMountField(field string) string {
+	if !strings.ContainsRune(field, '\\') {
+		return field
+	}
+
+	var b strings.Builder
+
+	b.Grow(len(field))
+
+	for i := 0; i < len(field); i++ {
+		// A backslash followed by exactly three octal digits is an escaped byte.
+		if field[i] == '\\' && i+3 < len(field) &&
+			isOctalDigit(field[i+1]) && isOctalDigit(field[i+2]) && isOctalDigit(field[i+3]) {
+			b.WriteByte((field[i+1]-'0')<<6 | (field[i+2]-'0')<<3 | (field[i+3] - '0'))
+			i += 3
+
+			continue
+		}
+
+		b.WriteByte(field[i])
+	}
+
+	return b.String()
+}
+
+// isOctalDigit reports whether c is an octal digit (0-7).
+func isOctalDigit(c byte) bool {
+	return c >= '0' && c <= '7'
 }

--- a/pkg/datadir/cleanup.go
+++ b/pkg/datadir/cleanup.go
@@ -165,6 +165,16 @@ func CleanupOrphanedOverlayMounts(ctx context.Context, log logrus.FieldLogger, m
 			}
 		}
 
+		// Only remove the directory once the overlay is confirmed unmounted.
+		// Removing it while merged is still a live mount would make RemoveAll
+		// recurse through the mount and delete the data underneath it.
+		if overlayMountCheck(mount.MountPoint) {
+			log.WithField("mount_point", mount.MountPoint).
+				Warn("Overlay still mounted; skipping removal to avoid deleting through a live mount")
+
+			continue
+		}
+
 		// Remove the base directory.
 		if err := os.RemoveAll(mount.BaseDir); err != nil {
 			log.WithError(err).WithField("base_dir", mount.BaseDir).Warn("Failed to remove orphaned overlay directory")
@@ -174,4 +184,29 @@ func CleanupOrphanedOverlayMounts(ctx context.Context, log logrus.FieldLogger, m
 	}
 
 	return nil
+}
+
+// overlayMountCheck reports whether path is currently a mount point. It is a
+// variable so tests can simulate an overlay that is still mounted.
+var overlayMountCheck = isMountPoint
+
+// isMountPoint reports whether path appears as a mount point in /proc/mounts.
+// On systems without /proc/mounts there are no overlay mounts to worry about,
+// so it returns false.
+func isMountPoint(path string) bool {
+	file, err := os.Open("/proc/mounts")
+	if err != nil {
+		return false
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && fields[1] == path {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/datadir/cleanup_overlay_test.go
+++ b/pkg/datadir/cleanup_overlay_test.go
@@ -97,3 +97,25 @@ func testLogger() logrus.FieldLogger {
 
 	return l
 }
+
+// The kernel octal-escapes whitespace and backslashes in /proc/mounts. The
+// still-mounted gate must decode those back to the literal path it compares
+// against, otherwise it silently fails open on any temp path with a space and
+// deletes through a live mount.
+func TestUnescapeMountField(t *testing.T) {
+	cases := map[string]string{
+		"/tmp/plain/merged":              "/tmp/plain/merged",
+		`/mnt/fast\040disk/bench/merged`: "/mnt/fast disk/bench/merged",
+		`/mnt/a\011b/merged`:             "/mnt/a\tb/merged",
+		`/mnt/a\012b/merged`:             "/mnt/a\nb/merged",
+		`/mnt/back\134slash/merged`:      `/mnt/back\slash/merged`,
+		`/mnt/two\040\040spaces/merged`:  "/mnt/two  spaces/merged",
+		`/mnt/trailing\back`:             `/mnt/trailing\back`, // not a 3-octal-digit escape
+	}
+
+	for in, want := range cases {
+		if got := unescapeMountField(in); got != want {
+			t.Errorf("unescapeMountField(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/datadir/cleanup_overlay_test.go
+++ b/pkg/datadir/cleanup_overlay_test.go
@@ -1,0 +1,99 @@
+package datadir
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func pathPresent(p string) bool {
+	_, err := os.Stat(p)
+
+	return err == nil
+}
+
+func overlayFixture(t *testing.T) (base, merged, data string) {
+	t.Helper()
+
+	base, err := os.MkdirTemp(t.TempDir(), "benchmarkoor-overlay-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merged = filepath.Join(base, "merged")
+	for _, d := range []string{merged, filepath.Join(base, "upper"), filepath.Join(base, "work")} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	data = filepath.Join(merged, "underlying_data")
+	if err := os.WriteFile(data, []byte("must survive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return base, merged, data
+}
+
+// When the overlay is still mounted, the reaper must not delete the base
+// directory, since that would recurse through the live mount.
+func TestOrphanReaperSkipsRemovalWhenStillMounted(t *testing.T) {
+	base, merged, data := overlayFixture(t)
+
+	original := overlayMountCheck
+	overlayMountCheck = func(path string) bool { return path == merged }
+	t.Cleanup(func() { overlayMountCheck = original })
+
+	var buf bytes.Buffer
+	log := logrus.New()
+	log.SetOutput(&buf)
+
+	m := OrphanedOverlayMount{MountPoint: merged, BaseDir: base, Type: "overlayfs"}
+
+	if err := CleanupOrphanedOverlayMounts(context.Background(), log, []OrphanedOverlayMount{m}); err != nil {
+		t.Fatalf("reaper returned error: %v", err)
+	}
+
+	if !pathPresent(base) {
+		t.Fatal("base dir was deleted while still mounted")
+	}
+
+	if !pathPresent(data) {
+		t.Fatal("underlying data was deleted while still mounted")
+	}
+
+	if !strings.Contains(buf.String(), "still mounted") {
+		t.Fatalf("expected a skip-because-mounted log, got:\n%s", buf.String())
+	}
+}
+
+// When the overlay is not mounted, the reaper still cleans up the orphan.
+func TestOrphanReaperRemovesWhenUnmounted(t *testing.T) {
+	base, merged, _ := overlayFixture(t)
+
+	original := overlayMountCheck
+	overlayMountCheck = func(string) bool { return false }
+	t.Cleanup(func() { overlayMountCheck = original })
+
+	m := OrphanedOverlayMount{MountPoint: merged, BaseDir: base, Type: "overlayfs"}
+
+	if err := CleanupOrphanedOverlayMounts(context.Background(), testLogger(), []OrphanedOverlayMount{m}); err != nil {
+		t.Fatalf("reaper returned error: %v", err)
+	}
+
+	if pathPresent(base) {
+		t.Fatal("base dir should have been removed when not mounted")
+	}
+}
+
+func testLogger() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetOutput(bytes.NewBuffer(nil))
+
+	return l
+}


### PR DESCRIPTION
## Summary

Two host-state cleanup fixes that could leave a machine misconfigured or lose data after a run.

### cpufreq: restore every CPU, and never discard recovery on a partial restore
Original settings were captured only on the first `Apply`, so a later `Apply` targeting different CPUs never recorded their originals and those CPUs were left in the benchmark governor. Capture is now per CPU and merges across calls.

`restoreSettings` also nil'd the in-memory originals and deleted the crash-recovery state file unconditionally, even when a per-CPU restore write failed (failures were only logged). A failed restore therefore stranded CPUs in `performance` permanently with no way to recover. It now returns an error and keeps the originals and state file when anything fails, so a retry or the crash-recovery path can finish. Only a fully successful restore clears them.

### datadir: stop the orphan overlay reaper from deleting through a live mount
`CleanupOrphanedOverlayMounts` ran `os.RemoveAll(BaseDir)` even when both `umount` and `umount -l` failed. If `merged` was still a live overlay mount, that recurses through the mount and deletes the data underneath. Removal is now gated on a mount check, and the reaper skips (and logs) a base dir whose merged child is still mounted.

## Tests
- `pkg/cpufreq/restore_test.go`: capture across multiple `Apply` calls, and partial-failure keeps recovery state then succeeds on retry. Drives the real manager against a fake sysfs tree, so it runs on any OS.
- `pkg/datadir/cleanup_overlay_test.go`: reaper skips removal when still mounted, and still cleans up when unmounted.

Both packages build, `go vet` passes, and the full suites pass.