### PR TITLE
feat(builder): rebuild datadirs/fixtures on config change (--rebuild-on-diff)

### DIFF
--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -166,7 +166,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-ref: ${{ github.event.pull_request.head.sha }}
           git-repo: ${{ github.event.pull_request.head.repo.clone_url }}
-          build-args: '--force'
+          build-args: '--rebuild-on-diff'
           build-config: |
             builder:
               state_actor:

--- a/cmd/benchmarkoor/build.go
+++ b/cmd/benchmarkoor/build.go
@@ -25,6 +25,7 @@ var (
 	buildSkipStateActor     bool
 	buildSkipEESTPayloads   bool
 	buildForce              bool
+	buildRebuildOnDiff      bool
 )
 
 var buildCmd = &cobra.Command{
@@ -58,6 +59,8 @@ func init() {
 		"Skip the builder.eest_payloads builder entirely")
 	buildCmd.Flags().BoolVar(&buildForce, "force", false,
 		"Remove each target's output_dir before building")
+	buildCmd.Flags().BoolVar(&buildRebuildOnDiff, "rebuild-on-diff", false,
+		"Rebuild a populated output_dir when its config fingerprint changed since the last build (instead of skipping)")
 }
 
 func runBuild(_ *cobra.Command, _ []string) error {
@@ -250,7 +253,7 @@ func runBuilders(ctx context.Context, builders []builder.Builder) error {
 			"output_dir": sel.info.OutputDir,
 		}).Info("Building target")
 
-		skipped, buildErr := sel.builder.Build(ctx, sel.info.Name, builder.BuildOptions{Force: buildForce})
+		skipped, buildErr := sel.builder.Build(ctx, sel.info.Name, builder.BuildOptions{Force: buildForce, RebuildOnDiff: buildRebuildOnDiff})
 
 		results = append(results, buildResult{
 			builder:   sel.builder.Name(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1570,8 +1570,18 @@ benchmarkoor build --config build.yaml --force
 | `--skip-state-actor-build` | Skip the `builder.state_actor` builder entirely (only `eest_payloads` runs). |
 | `--skip-eest-payload-build` | Skip the `builder.eest_payloads` builder entirely (only `state_actor` runs). |
 | `--force` | Wipe each selected target's `output_dir` before building (bypasses the skip-if-populated behaviour). |
+| `--rebuild-on-diff` | Rebuild a populated `output_dir` when its config changed since the last build, instead of skipping (see below). |
 
 A target is built when it passes the global `--target` filter **and** the per-builder limit for the builder that owns it; an unset filter imposes no restriction. Any filter value that names no existing target is a hard error (typos surface immediately — the per-builder limits are checked against only that builder's target names). `--skip-*-build` removes a whole builder; a skipped builder's `--limit-*-target` is then ignored. Skipping every configured builder is an error.
+
+### Rebuild on config change (`--rebuild-on-diff`)
+
+By default a populated `output_dir` is skipped regardless of whether the config that produced it changed — you must `--force` to pick up a new fork, seed, spec, filter, etc. After every successful build benchmarkoor now records a `.benchmarkoor-build.json` sidecar in the `output_dir` holding a fingerprint of the output-affecting config. With `--rebuild-on-diff`, a populated target is rebuilt only when that fingerprint differs from the current config (the changed keys are logged); an unchanged config still skips, and a directory with no sidecar (built before this existed) is skipped until the next `--force` records a baseline.
+
+The fingerprint covers the inputs that actually change the output:
+
+- **state_actor:** client, image, target_size, seed, fork, chain_id, gas_limit, timestamp, extra_data, archive, binary_trie, group_depth, and the spec **content**.
+- **eest_payloads:** filler client + image, fork, tests, filter, marker, gas/opcode values, max gas, rpc seed key, filler extra args, datadir method, the **content** of the genesis / address-stubs / fill Dockerfile, the fork/EIP genesis overrides, and the execution-specs checkout resolved to a **commit SHA** (via `git ls-remote`, so a moving `eest_ref` that advanced is detected). It also folds in the **source snapshot's** fingerprint, so rebuilding a `state_actor` datadir cascades into rebuilding the fixtures generated from it.
 
 The command exits non-zero if any target fails; successful targets are still left in place on partial failure. A final summary lists each target with `OK ` (built), `SKIP` (output_dir already populated), or `ERR ` (failed).
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -43,4 +43,8 @@ type TargetInfo struct {
 type BuildOptions struct {
 	// Force, when true, removes OutputDir before mkdir.
 	Force bool
+	// RebuildOnDiff, when true, rebuilds a populated OutputDir if the current
+	// config fingerprint differs from the one recorded at the last build,
+	// instead of skipping. Ignored when Force is set (force always rebuilds).
+	RebuildOnDiff bool
 }

--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -146,6 +146,35 @@ func (b *EESTPayloadsBuilder) Build(ctx context.Context, name string, opts Build
 	// orchestration and streamed-client log line.
 	log := b.log.WithField("target", target.EffectiveName())
 
+	// Cascade: fold the source snapshot's fingerprint into ours so a rebuilt
+	// state-actor datadir (its config changed) also invalidates these fixtures.
+	// Best-effort — an absent/unreadable source sidecar contributes "".
+	sourceFP := ""
+	if sc, err := readBuildSidecar(target.SourceDir); err != nil {
+		log.WithError(err).Warn("Failed to read source snapshot fingerprint; ignoring for cascade")
+	} else if sc != nil {
+		sourceFP = sc.Fingerprint
+	}
+
+	// Resolve the EEST ref to a commit SHA lazily (a network round-trip) — only
+	// when a diff check or the sidecar write actually needs it.
+	var eestSHA string
+	var eestSHAResolved bool
+	resolveEESTSHA := func() (string, error) {
+		if eestSHAResolved {
+			return eestSHA, nil
+		}
+
+		sha, err := gitrepo.RemoteSHA(ctx, b.cfg.ResolveEESTRepo(), b.cfg.ResolveEESTRef())
+		if err != nil {
+			return "", err
+		}
+
+		eestSHA, eestSHAResolved = sha, true
+
+		return sha, nil
+	}
+
 	force := opts.Force || target.Force
 
 	if !force {
@@ -155,10 +184,37 @@ func (b *EESTPayloadsBuilder) Build(ctx context.Context, name string, opts Build
 		}
 
 		if populated {
-			log.Info("Skipping build: output_dir already populated " +
-				"(pass --force or set force: true on the target to rebuild)")
+			if !opts.RebuildOnDiff {
+				log.Info("Skipping build: output_dir already populated " +
+					"(pass --force, --rebuild-on-diff, or set force: true on the target to rebuild)")
 
-			return true, nil
+				return true, nil
+			}
+
+			sha, err := resolveEESTSHA()
+			if err != nil {
+				return false, fmt.Errorf("resolving EEST ref for diff check: %w", err)
+			}
+
+			inputs, err := b.eestFingerprintInputs(target, sha, sourceFP)
+			if err != nil {
+				return false, err
+			}
+
+			dec, err := decideRebuild(target.OutputDir, inputs)
+			if err != nil {
+				return false, err
+			}
+
+			if !dec.rebuild {
+				log.Infof("Skipping build: output_dir already populated (%s)", dec.reason)
+
+				return true, nil
+			}
+
+			log.WithField("changed", dec.changed).Info("Config changed since last build; rebuilding")
+
+			force = true
 		}
 	}
 
@@ -170,7 +226,102 @@ func (b *EESTPayloadsBuilder) Build(ctx context.Context, name string, opts Build
 		return false, err
 	}
 
-	return false, b.run(ctx, log, target)
+	if err := b.run(ctx, log, target); err != nil {
+		return false, err
+	}
+
+	// Record the config fingerprint for a later --rebuild-on-diff run.
+	// Best-effort; failure must not fail an otherwise-successful build.
+	if sha, err := resolveEESTSHA(); err != nil {
+		log.WithError(err).Warn("Failed to resolve EEST ref for build fingerprint; sidecar not written")
+	} else if inputs, err := b.eestFingerprintInputs(target, sha, sourceFP); err != nil {
+		log.WithError(err).Warn("Failed to compute build fingerprint; sidecar not written")
+	} else if err := writeBuildSidecar(target.OutputDir, EESTPayloadsBuilderName, inputs); err != nil {
+		log.WithError(err).Warn("Failed to write build fingerprint sidecar")
+	}
+
+	return false, nil
+}
+
+// eestFingerprintInputs builds the canonical fingerprint of an eest_payloads
+// target's output-affecting config: the fill parameters, the content hashes of
+// its input files (genesis, address stubs, fill Dockerfile), the resolved EEST
+// commit SHA, and the source snapshot's fingerprint (so a rebuilt snapshot
+// cascades into a fixtures rebuild).
+func (b *EESTPayloadsBuilder) eestFingerprintInputs(target *config.EESTPayloadTarget, eestSHA, sourceFingerprint string) (fingerprintInputs, error) {
+	genesisHash, err := sha256File(target.Genesis)
+	if err != nil {
+		return nil, err
+	}
+
+	stubsHash, err := b.addressStubsHash(target)
+	if err != nil {
+		return nil, err
+	}
+
+	fillDockerfileHash, err := b.fillDockerfileHash()
+	if err != nil {
+		return nil, err
+	}
+
+	return fingerprintInputs{
+		"filler_client":          target.FillerClient,
+		"filler_image":           target.FillerImage,
+		"filler_extra_args":      target.FillerExtraArgs,
+		"fork":                   target.Fork,
+		"tests":                  target.Tests,
+		"filter":                 target.Filter,
+		"marker":                 target.Marker,
+		"gas_benchmark_values":   target.GasBenchmarkValues,
+		"fixed_opcode_count":     target.FixedOpcodeCount,
+		"max_gas_per_test":       target.MaxGasPerTest,
+		"rpc_seed_key":           target.RPCSeedKey,
+		"datadir_method":         target.DataDirMethod,
+		"genesis_sha256":         genesisHash,
+		"genesis_fork_override":  target.GenesisForkOverride,
+		"genesis_eip_override":   target.GenesisEIPOverride,
+		"address_stubs_sha256":   stubsHash,
+		"fill_command":           b.cfg.ResolveFillCommand(),
+		"fill_image":             b.cfg.FillImage,
+		"fill_dockerfile_sha256": fillDockerfileHash,
+		"eest_repo":              b.cfg.ResolveEESTRepo(),
+		"eest_sha":               eestSHA,
+		"source_fingerprint":     sourceFingerprint,
+	}, nil
+}
+
+// addressStubsHash hashes the target's address stubs — the referenced file's
+// contents, or the inline map — returning "" when none are configured.
+func (b *EESTPayloadsBuilder) addressStubsHash(target *config.EESTPayloadTarget) (string, error) {
+	if target.AddressStubsFile != "" {
+		return sha256File(target.AddressStubsFile)
+	}
+
+	if len(target.AddressStubs) > 0 {
+		data, err := json.Marshal(target.AddressStubs)
+		if err != nil {
+			return "", fmt.Errorf("hashing address_stubs: %w", err)
+		}
+
+		return sha256Hex(data), nil
+	}
+
+	return "", nil
+}
+
+// fillDockerfileHash hashes the Dockerfile the fill image is built from (a
+// custom fill_dockerfile or the embedded default), or returns "" when a
+// pre-built fill_image is pulled instead (its identity is covered separately).
+func (b *EESTPayloadsBuilder) fillDockerfileHash() (string, error) {
+	if !b.cfg.BuildsFillImage() {
+		return "", nil
+	}
+
+	if b.cfg.FillDockerfile != "" {
+		return sha256File(b.cfg.FillDockerfile)
+	}
+
+	return sha256Hex(embeddedFillDockerfile), nil
 }
 
 // findTargetIndex returns the index of the first target whose EffectiveName

--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -177,28 +177,43 @@ func (b *EESTPayloadsBuilder) Build(ctx context.Context, name string, opts Build
 
 	force := opts.Force || target.Force
 
-	if !force {
+	// Fast path: a populated output_dir with neither --force nor
+	// --rebuild-on-diff skips before doing any fingerprint work.
+	if !force && !opts.RebuildOnDiff {
 		populated, err := isPopulated(target.OutputDir)
 		if err != nil {
 			return false, err
 		}
 
 		if populated {
-			if !opts.RebuildOnDiff {
-				log.Info("Skipping build: output_dir already populated " +
-					"(pass --force, --rebuild-on-diff, or set force: true on the target to rebuild)")
+			log.Info("Skipping build: output_dir already populated " +
+				"(pass --force, --rebuild-on-diff, or set force: true on the target to rebuild)")
 
-				return true, nil
-			}
+			return true, nil
+		}
+	}
 
-			sha, err := resolveEESTSHA()
-			if err != nil {
-				return false, fmt.Errorf("resolving EEST ref for diff check: %w", err)
-			}
+	// Compute the fingerprint up front: run() mutates target's genesis /
+	// address-stubs paths to temp files it then deletes, so the sidecar must be
+	// fingerprinted from the pre-run config (and from the same inputs the diff
+	// check used). Best-effort — a failure (e.g. a transient ls-remote) only
+	// skips the sidecar for a plain build, but is fatal for a diff check, which
+	// cannot proceed without it.
+	var inputs fingerprintInputs
+	sha, inputsErr := resolveEESTSHA()
+	if inputsErr == nil {
+		inputs, inputsErr = b.eestFingerprintInputs(target, sha, sourceFP)
+	}
 
-			inputs, err := b.eestFingerprintInputs(target, sha, sourceFP)
-			if err != nil {
-				return false, err
+	if !force && opts.RebuildOnDiff {
+		populated, err := isPopulated(target.OutputDir)
+		if err != nil {
+			return false, err
+		}
+
+		if populated {
+			if inputsErr != nil {
+				return false, fmt.Errorf("computing fingerprint for diff check: %w", inputsErr)
 			}
 
 			dec, err := decideRebuild(target.OutputDir, inputs)
@@ -230,12 +245,10 @@ func (b *EESTPayloadsBuilder) Build(ctx context.Context, name string, opts Build
 		return false, err
 	}
 
-	// Record the config fingerprint for a later --rebuild-on-diff run.
-	// Best-effort; failure must not fail an otherwise-successful build.
-	if sha, err := resolveEESTSHA(); err != nil {
-		log.WithError(err).Warn("Failed to resolve EEST ref for build fingerprint; sidecar not written")
-	} else if inputs, err := b.eestFingerprintInputs(target, sha, sourceFP); err != nil {
-		log.WithError(err).Warn("Failed to compute build fingerprint; sidecar not written")
+	// Record the config fingerprint (computed pre-run) for a later
+	// --rebuild-on-diff run. Best-effort; a failure must not fail the build.
+	if inputsErr != nil {
+		log.WithError(inputsErr).Warn("Failed to compute build fingerprint; sidecar not written")
 	} else if err := writeBuildSidecar(target.OutputDir, EESTPayloadsBuilderName, inputs); err != nil {
 		log.WithError(err).Warn("Failed to write build fingerprint sidecar")
 	}
@@ -286,7 +299,11 @@ func (b *EESTPayloadsBuilder) eestFingerprintInputs(target *config.EESTPayloadTa
 		"fill_dockerfile_sha256": fillDockerfileHash,
 		"eest_repo":              b.cfg.ResolveEESTRepo(),
 		"eest_sha":               eestSHA,
-		"source_fingerprint":     sourceFingerprint,
+		// source_dir alongside source_fingerprint: the fingerprint catches a
+		// rebuilt source snapshot, and the path catches a swap to a *different*
+		// snapshot that carries no sidecar (so contributes an empty fingerprint).
+		"source_dir":         target.SourceDir,
+		"source_fingerprint": sourceFingerprint,
 	}, nil
 }
 

--- a/pkg/builder/fingerprint.go
+++ b/pkg/builder/fingerprint.go
@@ -128,13 +128,13 @@ func changedInputKeys(old map[string]any, cur fingerprintInputs) []string {
 // current inputs matches the float64 the same value unmarshals to from a stored
 // sidecar.
 func jsonEqual(a, b any) bool {
-	ba, errA := json.Marshal(a)
-	bb, errB := json.Marshal(b)
+	aJSON, errA := json.Marshal(a)
+	bJSON, errB := json.Marshal(b)
 	if errA != nil || errB != nil {
 		return false
 	}
 
-	return string(ba) == string(bb)
+	return string(aJSON) == string(bJSON)
 }
 
 // rebuildDecision is the outcome of comparing current inputs against a

--- a/pkg/builder/fingerprint.go
+++ b/pkg/builder/fingerprint.go
@@ -1,0 +1,193 @@
+package builder
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// buildSidecarFile is the benchmarkoor-owned build-fingerprint sidecar written
+// at an output_dir root after a successful build. When --rebuild-on-diff is set,
+// the next build compares the current config fingerprint against this file to
+// decide whether the output is stale and must be rebuilt.
+const buildSidecarFile = ".benchmarkoor-build.json"
+
+// buildFingerprintSchema versions the sidecar format so a future change can
+// invalidate old sidecars deliberately.
+const buildFingerprintSchema = 1
+
+// buildSidecar records the config fingerprint of a built output_dir.
+type buildSidecar struct {
+	SchemaVersion int    `json:"schema_version"`
+	Builder       string `json:"builder"`
+	Fingerprint   string `json:"fingerprint"`
+	// Inputs is the canonical, human-readable view of what the fingerprint
+	// covers — persisted so a rebuild can report which fields changed.
+	Inputs map[string]any `json:"inputs"`
+}
+
+// fingerprintInputs is the canonical, hashable view of a build's
+// output-affecting config. Keys are stable; values are strings, numbers, bools,
+// or slices/maps thereof so the whole thing marshals to deterministic JSON
+// (encoding/json sorts map keys at every level).
+type fingerprintInputs map[string]any
+
+// hash returns the sha256 (hex) of the canonical JSON of the inputs.
+func (fi fingerprintInputs) hash() (string, error) {
+	canonical, err := json.Marshal(fi)
+	if err != nil {
+		return "", fmt.Errorf("marshalling fingerprint inputs: %w", err)
+	}
+
+	sum := sha256.Sum256(canonical)
+
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// readBuildSidecar reads the fingerprint sidecar from dir. It returns
+// (nil, nil) when the sidecar is absent — an output built before fingerprinting
+// existed, or a fresh dir — so callers can treat "no baseline" distinctly from
+// a real error.
+func readBuildSidecar(dir string) (*buildSidecar, error) {
+	data, err := os.ReadFile(filepath.Join(dir, buildSidecarFile))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("reading build sidecar: %w", err)
+	}
+
+	var sc buildSidecar
+	if err := json.Unmarshal(data, &sc); err != nil {
+		return nil, fmt.Errorf("parsing build sidecar %s: %w", buildSidecarFile, err)
+	}
+
+	return &sc, nil
+}
+
+// writeBuildSidecar writes the fingerprint sidecar into dir for builderName.
+func writeBuildSidecar(dir, builderName string, inputs fingerprintInputs) error {
+	fp, err := inputs.hash()
+	if err != nil {
+		return err
+	}
+
+	sc := buildSidecar{
+		SchemaVersion: buildFingerprintSchema,
+		Builder:       builderName,
+		Fingerprint:   fp,
+		Inputs:        inputs,
+	}
+
+	data, err := json.MarshalIndent(sc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling build sidecar: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, buildSidecarFile), append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("writing build sidecar: %w", err)
+	}
+
+	return nil
+}
+
+// changedInputKeys returns the sorted input keys that differ between a stored
+// sidecar and the current inputs — used to report what triggered a rebuild.
+func changedInputKeys(old map[string]any, cur fingerprintInputs) []string {
+	seen := make(map[string]struct{}, len(cur)+len(old))
+	for k, v := range cur {
+		ov, ok := old[k]
+		if !ok || !jsonEqual(ov, v) {
+			seen[k] = struct{}{}
+		}
+	}
+
+	for k := range old {
+		if _, ok := cur[k]; !ok {
+			seen[k] = struct{}{}
+		}
+	}
+
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+// jsonEqual compares two values by their JSON encoding, so an int in the
+// current inputs matches the float64 the same value unmarshals to from a stored
+// sidecar.
+func jsonEqual(a, b any) bool {
+	ba, errA := json.Marshal(a)
+	bb, errB := json.Marshal(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+
+	return string(ba) == string(bb)
+}
+
+// rebuildDecision is the outcome of comparing current inputs against a
+// populated output_dir's stored fingerprint under --rebuild-on-diff.
+type rebuildDecision struct {
+	rebuild bool     // true → wipe and rebuild; false → skip
+	reason  string   // why we skipped (only set when rebuild is false)
+	changed []string // input keys that changed (only set when rebuild is true)
+}
+
+// decideRebuild compares the current fingerprint inputs against the sidecar in
+// dir. An absent sidecar (no baseline) or a matching fingerprint yields skip; a
+// differing fingerprint yields rebuild with the list of changed keys.
+func decideRebuild(dir string, inputs fingerprintInputs) (rebuildDecision, error) {
+	cur, err := inputs.hash()
+	if err != nil {
+		return rebuildDecision{}, err
+	}
+
+	sidecar, err := readBuildSidecar(dir)
+	if err != nil {
+		return rebuildDecision{}, err
+	}
+
+	switch {
+	case sidecar == nil:
+		return rebuildDecision{reason: "no build fingerprint recorded (run --force to record a baseline)"}, nil
+	case sidecar.Fingerprint == cur:
+		return rebuildDecision{reason: "config unchanged"}, nil
+	default:
+		return rebuildDecision{rebuild: true, changed: changedInputKeys(sidecar.Inputs, inputs)}, nil
+	}
+}
+
+// sha256Hex returns the hex sha256 of b.
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+
+	return hex.EncodeToString(sum[:])
+}
+
+// sha256File returns the hex sha256 of the file at path, or "" when path is
+// empty. A missing file is an error (a configured input that cannot be read
+// should surface, not silently fingerprint as absent).
+func sha256File(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("hashing %s: %w", path, err)
+	}
+
+	return sha256Hex(data), nil
+}

--- a/pkg/builder/fingerprint_test.go
+++ b/pkg/builder/fingerprint_test.go
@@ -1,0 +1,176 @@
+package builder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSidecarRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	inputs := fingerprintInputs{"a": "1", "b": []string{"x", "y"}}
+
+	require.NoError(t, writeBuildSidecar(dir, "state-actor", inputs))
+
+	sc, err := readBuildSidecar(dir)
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	assert.Equal(t, "state-actor", sc.Builder)
+	assert.Equal(t, buildFingerprintSchema, sc.SchemaVersion)
+
+	want, err := inputs.hash()
+	require.NoError(t, err)
+	assert.Equal(t, want, sc.Fingerprint)
+}
+
+func TestReadBuildSidecarAbsent(t *testing.T) {
+	sc, err := readBuildSidecar(t.TempDir())
+	require.NoError(t, err)
+	assert.Nil(t, sc)
+}
+
+func TestDecideRebuild(t *testing.T) {
+	base := fingerprintInputs{"fork": "osaka", "seed": 1}
+
+	t.Run("no sidecar skips", func(t *testing.T) {
+		dec, err := decideRebuild(t.TempDir(), base)
+		require.NoError(t, err)
+		assert.False(t, dec.rebuild)
+		assert.Contains(t, dec.reason, "no build fingerprint")
+	})
+
+	t.Run("unchanged config skips", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, writeBuildSidecar(dir, "b", base))
+
+		dec, err := decideRebuild(dir, base)
+		require.NoError(t, err)
+		assert.False(t, dec.rebuild)
+		assert.Equal(t, "config unchanged", dec.reason)
+	})
+
+	t.Run("changed config rebuilds and reports keys", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, writeBuildSidecar(dir, "b", base))
+
+		dec, err := decideRebuild(dir, fingerprintInputs{"fork": "amsterdam", "seed": 1})
+		require.NoError(t, err)
+		assert.True(t, dec.rebuild)
+		assert.Equal(t, []string{"fork"}, dec.changed)
+	})
+}
+
+func TestChangedInputKeys(t *testing.T) {
+	old := map[string]any{"a": "1", "b": "2", "gone": "3"}
+	cur := fingerprintInputs{"a": "1", "b": "changed", "added": "4"}
+
+	assert.Equal(t, []string{"added", "b", "gone"}, changedInputKeys(old, cur))
+}
+
+func TestSha256File(t *testing.T) {
+	empty, err := sha256File("")
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+
+	f := filepath.Join(t.TempDir(), "x")
+	require.NoError(t, os.WriteFile(f, []byte("hello"), 0o600))
+
+	h, err := sha256File(f)
+	require.NoError(t, err)
+	assert.NotEmpty(t, h)
+
+	h2, err := sha256File(f)
+	require.NoError(t, err)
+	assert.Equal(t, h, h2, "hash of unchanged content must be stable")
+
+	_, err = sha256File(filepath.Join(t.TempDir(), "missing"))
+	require.Error(t, err)
+}
+
+func TestStateActorFingerprintInputs(t *testing.T) {
+	seed := int64(1234)
+	target := &config.StateActorTarget{Client: "geth", OutputDir: "/tmp/x", Fork: "osaka", Seed: &seed}
+
+	specFile := filepath.Join(t.TempDir(), "spec.yaml")
+	require.NoError(t, os.WriteFile(specFile, []byte("entities: []"), 0o600))
+
+	in, err := stateActorFingerprintInputs(target, "img:1", specFile)
+	require.NoError(t, err)
+
+	args, ok := in["args"].([]string)
+	require.True(t, ok)
+	for _, a := range args {
+		assert.NotContains(t, a, "--db=", "the volatile --db path must be excluded")
+	}
+	assert.NotEmpty(t, in["spec_sha256"])
+
+	h1, err := in.hash()
+	require.NoError(t, err)
+
+	// A changed fork changes the fingerprint.
+	target.Fork = "amsterdam"
+	in2, err := stateActorFingerprintInputs(target, "img:1", specFile)
+	require.NoError(t, err)
+	h2, _ := in2.hash()
+	assert.NotEqual(t, h1, h2)
+
+	// Changing only the output_dir (i.e. the --db path) does not.
+	target.Fork = "osaka"
+	target.OutputDir = "/tmp/somewhere-else"
+	in3, err := stateActorFingerprintInputs(target, "img:1", specFile)
+	require.NoError(t, err)
+	h3, _ := in3.hash()
+	assert.Equal(t, h1, h3)
+}
+
+func TestEESTFingerprintInputs(t *testing.T) {
+	b := &EESTPayloadsBuilder{cfg: &config.EESTPayloadsConfig{FillImage: "fill:1"}}
+	target := &config.EESTPayloadTarget{
+		FillerClient: "besu",
+		Fork:         "osaka",
+		Tests:        []string{"tests/benchmark/compute"},
+		Filter:       "bn128",
+	}
+
+	in, err := b.eestFingerprintInputs(target, "sha1", "srcfp1")
+	require.NoError(t, err)
+	assert.Equal(t, "srcfp1", in["source_fingerprint"])
+	assert.Equal(t, "sha1", in["eest_sha"])
+
+	h1, err := in.hash()
+	require.NoError(t, err)
+
+	cases := []struct {
+		name    string
+		sha     string
+		srcFP   string
+		mutate  func()
+		restore func()
+	}{
+		{name: "cascade: changed source fingerprint", sha: "sha1", srcFP: "srcfp2"},
+		{name: "moved EEST ref (new SHA)", sha: "sha2", srcFP: "srcfp1"},
+		{
+			name: "changed filter", sha: "sha1", srcFP: "srcfp1",
+			mutate:  func() { target.Filter = "modexp" },
+			restore: func() { target.Filter = "bn128" },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.mutate != nil {
+				tc.mutate()
+				defer tc.restore()
+			}
+
+			in2, err := b.eestFingerprintInputs(target, tc.sha, tc.srcFP)
+			require.NoError(t, err)
+			h2, _ := in2.hash()
+			assert.NotEqual(t, h1, h2)
+		})
+	}
+}

--- a/pkg/builder/fingerprint_test.go
+++ b/pkg/builder/fingerprint_test.go
@@ -127,6 +127,179 @@ func TestStateActorFingerprintInputs(t *testing.T) {
 	assert.Equal(t, h1, h3)
 }
 
+// writeTempFile writes content to a fresh temp file and returns its path.
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+
+	p := filepath.Join(t.TempDir(), "f")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+
+	return p
+}
+
+// TestStateActorFingerprint_FieldSensitivity locks fingerprint completeness:
+// mutating any output-affecting input must change the hash, so dropping a field
+// from the fingerprint fails a test.
+func TestStateActorFingerprint_FieldSensitivity(t *testing.T) {
+	seed, chain := int64(1), int64(1337)
+	gas, ts := uint64(30_000_000), uint64(1000)
+	arch, bt, gd := true, true, 5
+
+	base := func() *config.StateActorTarget {
+		return &config.StateActorTarget{
+			Client: "geth", OutputDir: "/tmp/x", Fork: "osaka", TargetSize: "256MB",
+			Seed: &seed, ChainID: &chain, GasLimit: &gas, Timestamp: &ts,
+			ExtraData: "abc", Archive: &arch, BinaryTrie: &bt, GroupDepth: &gd,
+		}
+	}
+
+	spec := writeTempFile(t, "spec: 1")
+	spec2 := writeTempFile(t, "spec: 2")
+
+	baseIn, err := stateActorFingerprintInputs(base(), "img:1", spec)
+	require.NoError(t, err)
+	baseHash, err := baseIn.hash()
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		image    string
+		specPath string
+		mut      func(*config.StateActorTarget)
+	}{
+		{name: "client", mut: func(t *config.StateActorTarget) { t.Client = "reth" }},
+		{name: "fork", mut: func(t *config.StateActorTarget) { t.Fork = "amsterdam" }},
+		{name: "target_size", mut: func(t *config.StateActorTarget) { t.TargetSize = "512MB" }},
+		{name: "seed", mut: func(t *config.StateActorTarget) { s := int64(2); t.Seed = &s }},
+		{name: "chain_id", mut: func(t *config.StateActorTarget) { c := int64(2); t.ChainID = &c }},
+		{name: "gas_limit", mut: func(t *config.StateActorTarget) { g := uint64(1); t.GasLimit = &g }},
+		{name: "timestamp", mut: func(t *config.StateActorTarget) { v := uint64(2); t.Timestamp = &v }},
+		{name: "extra_data", mut: func(t *config.StateActorTarget) { t.ExtraData = "xyz" }},
+		{name: "archive", mut: func(t *config.StateActorTarget) { f := false; t.Archive = &f }},
+		{name: "binary_trie", mut: func(t *config.StateActorTarget) { f := false; t.BinaryTrie = &f }},
+		{name: "group_depth", mut: func(t *config.StateActorTarget) { g := 9; t.GroupDepth = &g }},
+		{name: "image", image: "img:2"},
+		{name: "spec_content", specPath: spec2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tgt := base()
+			if tc.mut != nil {
+				tc.mut(tgt)
+			}
+
+			image, specPath := "img:1", spec
+			if tc.image != "" {
+				image = tc.image
+			}
+			if tc.specPath != "" {
+				specPath = tc.specPath
+			}
+
+			in, err := stateActorFingerprintInputs(tgt, image, specPath)
+			require.NoError(t, err)
+			h, err := in.hash()
+			require.NoError(t, err)
+			assert.NotEqual(t, baseHash, h, "changing %s must change the fingerprint", tc.name)
+		})
+	}
+}
+
+// TestEESTFingerprint_FieldSensitivity is the eest equivalent of the above.
+func TestEESTFingerprint_FieldSensitivity(t *testing.T) {
+	genesis1, genesis2 := writeTempFile(t, "g1"), writeTempFile(t, "g2")
+	stubs1, stubs2 := writeTempFile(t, "s1"), writeTempFile(t, "s2")
+	maxGas, foc := uint64(100), []float64{1, 2}
+
+	cfg := func() *config.EESTPayloadsConfig {
+		return &config.EESTPayloadsConfig{FillImage: "fill:1", EESTRepo: "https://example.com/a.git"}
+	}
+	base := func() *config.EESTPayloadTarget {
+		return &config.EESTPayloadTarget{
+			FillerClient: "besu", FillerImage: "f:1", Fork: "osaka",
+			Tests: []string{"a"}, Filter: "bn128", Marker: "m",
+			GasBenchmarkValues: []int{10}, FixedOpcodeCount: &foc, MaxGasPerTest: &maxGas,
+			RPCSeedKey: "0x1", DataDirMethod: "copy", FillerExtraArgs: []string{"--x"},
+			GenesisForkOverride: map[string]uint64{"amsterdam": 1},
+			Genesis:             genesis1, AddressStubsFile: stubs1, SourceDir: "/src",
+		}
+	}
+
+	b := &EESTPayloadsBuilder{cfg: cfg()}
+	baseIn, err := b.eestFingerprintInputs(base(), "sha1", "srcfp1")
+	require.NoError(t, err)
+	baseHash, err := baseIn.hash()
+	require.NoError(t, err)
+
+	// hashOf applies target/cfg/sha/srcFP overrides and returns the hash.
+	hashOf := func(t *testing.T, tgt *config.EESTPayloadTarget, c *config.EESTPayloadsConfig, sha, srcFP string) string {
+		t.Helper()
+		in, err := (&EESTPayloadsBuilder{cfg: c}).eestFingerprintInputs(tgt, sha, srcFP)
+		require.NoError(t, err)
+		h, err := in.hash()
+		require.NoError(t, err)
+
+		return h
+	}
+
+	targetCases := []struct {
+		name string
+		mut  func(*config.EESTPayloadTarget)
+	}{
+		{"filler_client", func(t *config.EESTPayloadTarget) { t.FillerClient = "geth" }},
+		{"filler_image", func(t *config.EESTPayloadTarget) { t.FillerImage = "f:2" }},
+		{"fork", func(t *config.EESTPayloadTarget) { t.Fork = "amsterdam" }},
+		{"tests", func(t *config.EESTPayloadTarget) { t.Tests = []string{"b"} }},
+		{"filter", func(t *config.EESTPayloadTarget) { t.Filter = "modexp" }},
+		{"marker", func(t *config.EESTPayloadTarget) { t.Marker = "n" }},
+		{"gas_benchmark_values", func(t *config.EESTPayloadTarget) { t.GasBenchmarkValues = []int{20} }},
+		{"fixed_opcode_count", func(t *config.EESTPayloadTarget) { f := []float64{3}; t.FixedOpcodeCount = &f }},
+		{"max_gas_per_test", func(t *config.EESTPayloadTarget) { g := uint64(200); t.MaxGasPerTest = &g }},
+		{"rpc_seed_key", func(t *config.EESTPayloadTarget) { t.RPCSeedKey = "0x2" }},
+		{"datadir_method", func(t *config.EESTPayloadTarget) { t.DataDirMethod = "overlayfs" }},
+		{"filler_extra_args", func(t *config.EESTPayloadTarget) { t.FillerExtraArgs = []string{"--y"} }},
+		{"genesis_fork_override", func(t *config.EESTPayloadTarget) { t.GenesisForkOverride = map[string]uint64{"osaka": 2} }},
+		{"genesis_content", func(t *config.EESTPayloadTarget) { t.Genesis = genesis2 }},
+		{"address_stubs_content", func(t *config.EESTPayloadTarget) { t.AddressStubsFile = stubs2 }},
+		{"source_dir", func(t *config.EESTPayloadTarget) { t.SourceDir = "/other" }},
+	}
+
+	for _, tc := range targetCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tgt := base()
+			tc.mut(tgt)
+			assert.NotEqual(t, baseHash, hashOf(t, tgt, cfg(), "sha1", "srcfp1"),
+				"changing %s must change the fingerprint", tc.name)
+		})
+	}
+
+	t.Run("eest_sha", func(t *testing.T) {
+		assert.NotEqual(t, baseHash, hashOf(t, base(), cfg(), "sha2", "srcfp1"))
+	})
+	t.Run("source_fingerprint", func(t *testing.T) {
+		assert.NotEqual(t, baseHash, hashOf(t, base(), cfg(), "sha1", "srcfp2"))
+	})
+
+	cfgCases := []struct {
+		name string
+		mut  func(*config.EESTPayloadsConfig)
+	}{
+		{"fill_image", func(c *config.EESTPayloadsConfig) { c.FillImage = "fill:2" }},
+		{"eest_repo", func(c *config.EESTPayloadsConfig) { c.EESTRepo = "https://example.com/b.git" }},
+		{"fill_command", func(c *config.EESTPayloadsConfig) { c.FillCommand = []string{"custom", "cmd"} }},
+	}
+
+	for _, tc := range cfgCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := cfg()
+			tc.mut(c)
+			assert.NotEqual(t, baseHash, hashOf(t, base(), c, "sha1", "srcfp1"),
+				"changing %s must change the fingerprint", tc.name)
+		})
+	}
+}
+
 func TestEESTFingerprintInputs(t *testing.T) {
 	b := &EESTPayloadsBuilder{cfg: &config.EESTPayloadsConfig{FillImage: "fill:1"}}
 	target := &config.EESTPayloadTarget{

--- a/pkg/builder/state_actor.go
+++ b/pkg/builder/state_actor.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
 	"github.com/ethpandaops/benchmarkoor/pkg/docker"
@@ -96,7 +97,10 @@ func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOp
 	// `--force` to state-actor.
 	force := opts.Force || target.Force
 
-	if !force {
+	// Fast path: a populated output_dir with neither --force nor
+	// --rebuild-on-diff skips without resolving the spec (the original cheap
+	// skip). Diff detection and building both need the spec, resolved below.
+	if !force && !opts.RebuildOnDiff {
 		populated, err := isPopulated(target.OutputDir)
 		if err != nil {
 			return false, err
@@ -104,20 +108,16 @@ func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOp
 
 		if populated {
 			log.Info("Skipping build: output_dir already populated " +
-				"(pass --force or set force: true on the target to rebuild)")
+				"(pass --force, --rebuild-on-diff, or set force: true on the target to rebuild)")
 
 			return true, nil
 		}
 	}
 
-	if err := prepareOutputDir(target.OutputDir, force); err != nil {
-		return false, err
-	}
-
-	// Resolve which source state-actor will see: an absolute host path to
-	// a spec file (real or temp) when this target inherits from the
-	// top-level spec/spec_file, or "" when the target opted out via its
-	// own target_size.
+	// Resolve the spec: an absolute host path to a spec file (real or temp) when
+	// this target inherits from the top-level spec/spec_file, or "" when the
+	// target opted out via its own target_size. Needed both to run the build and
+	// to fingerprint the spec content.
 	specPath, cleanupSpec, err := b.resolveSpecPath()
 	if err != nil {
 		return false, err
@@ -125,6 +125,39 @@ func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOp
 
 	if cleanupSpec != nil {
 		defer cleanupSpec()
+	}
+
+	inputs, err := stateActorFingerprintInputs(target, image, specPath)
+	if err != nil {
+		return false, err
+	}
+
+	if !force && opts.RebuildOnDiff {
+		populated, err := isPopulated(target.OutputDir)
+		if err != nil {
+			return false, err
+		}
+
+		if populated {
+			dec, err := decideRebuild(target.OutputDir, inputs)
+			if err != nil {
+				return false, err
+			}
+
+			if !dec.rebuild {
+				log.Infof("Skipping build: output_dir already populated (%s)", dec.reason)
+
+				return true, nil
+			}
+
+			log.WithField("changed", dec.changed).Info("Config changed since last build; rebuilding")
+
+			force = true
+		}
+	}
+
+	if err := prepareOutputDir(target.OutputDir, force); err != nil {
+		return false, err
 	}
 
 	mounts, err := b.buildMounts(target, specPath)
@@ -172,6 +205,13 @@ func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOp
 	if err := b.mgr.RunInitContainer(ctx, spec, stdout, stderr); err != nil {
 		return false, fmt.Errorf("running state-actor: %w (output tail: %s)",
 			err, tail.String())
+	}
+
+	// Record the config fingerprint so a later --rebuild-on-diff run can tell
+	// whether the datadir is stale. Best-effort: a failure here must not fail an
+	// otherwise-successful build.
+	if err := writeBuildSidecar(target.OutputDir, StateActorBuilderName, inputs); err != nil {
+		log.WithError(err).Warn("Failed to write build fingerprint sidecar")
 	}
 
 	log.Info("Build completed")
@@ -341,6 +381,35 @@ func buildArgs(target *config.StateActorTarget, specPath string) []string {
 	}
 
 	return args
+}
+
+// stateActorFingerprintInputs builds the canonical fingerprint of a state-actor
+// target's output-affecting config: the exact argv state-actor is invoked with
+// (minus the volatile --db path), the resolved image, and the spec content
+// hash. Deriving the args from buildArgs keeps the fingerprint in lockstep with
+// whatever actually determines the datadir.
+func stateActorFingerprintInputs(target *config.StateActorTarget, image, specPath string) (fingerprintInputs, error) {
+	raw := buildArgs(target, "")
+	args := make([]string, 0, len(raw))
+
+	for _, a := range raw {
+		if strings.HasPrefix(a, "--db=") {
+			continue
+		}
+
+		args = append(args, a)
+	}
+
+	specHash, err := sha256File(specPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return fingerprintInputs{
+		"args":        args,
+		"image":       image,
+		"spec_sha256": specHash,
+	}, nil
 }
 
 // dbPath returns the value for state-actor's --db flag. Geth requires

--- a/pkg/builder/state_actor_test.go
+++ b/pkg/builder/state_actor_test.go
@@ -204,7 +204,8 @@ func TestStateActorBuilder_PerTargetForce(t *testing.T) {
 
 	overrideEntries, err := os.ReadDir(overrideDir)
 	require.NoError(t, err)
-	assert.Empty(t, overrideEntries, "force: true should wipe the dir before running")
+	require.Len(t, overrideEntries, 1, "force: true wipes the leftover; only the build sidecar remains")
+	assert.Equal(t, buildSidecarFile, overrideEntries[0].Name())
 
 	require.Len(t, mgr.runs, 1, "only the force target should have run so far")
 
@@ -240,10 +241,12 @@ func TestStateActorBuilder_BuildForceClearsDir(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, skipped, "--force must skip the skip check")
 
-	// Force removes the directory and then re-creates it.
+	// Force removes the directory and then re-creates it; the post-build
+	// sidecar is the only thing left afterwards.
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
-	assert.Empty(t, entries, "leftover file should have been removed by --force")
+	require.Len(t, entries, 1, "force wipes the leftover; only the build sidecar remains")
+	assert.Equal(t, buildSidecarFile, entries[0].Name())
 
 	require.Len(t, mgr.runs, 1)
 	assert.Equal(t, "fallback:latest", mgr.runs[0].Image)

--- a/pkg/gitrepo/gitrepo.go
+++ b/pkg/gitrepo/gitrepo.go
@@ -96,6 +96,29 @@ func HeadSHA(ctx context.Context, repoPath string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// RemoteSHA resolves ref (a branch, tag, or commit) to a commit SHA on the
+// remote repo without cloning, via `git ls-remote`. A ref that already looks
+// like a commit hash is returned unchanged — it is pinned, and ls-remote cannot
+// look up an arbitrary commit. When a ref matches multiple entries (e.g. a
+// branch and a tag of the same name) the first is returned.
+func RemoteSHA(ctx context.Context, repo, ref string) (string, error) {
+	if looksLikeCommitHash(ref) {
+		return ref, nil
+	}
+
+	out, err := exec.CommandContext(ctx, "git", "ls-remote", repo, ref).Output()
+	if err != nil {
+		return "", fmt.Errorf("resolving %s@%s: %w", repo, ref, err)
+	}
+
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) == 0 {
+		return "", fmt.Errorf("ref %q not found in %s", ref, repo)
+	}
+
+	return fields[0], nil
+}
+
 // cloneByCommitHash initializes a repo and fetches a specific commit hash, then
 // checks it out (a commit hash cannot be passed to `git clone --branch`).
 func cloneByCommitHash(ctx context.Context, repo, version, localPath string) error {

--- a/pkg/gitrepo/gitrepo.go
+++ b/pkg/gitrepo/gitrepo.go
@@ -111,12 +111,30 @@ func RemoteSHA(ctx context.Context, repo, ref string) (string, error) {
 		return "", fmt.Errorf("resolving %s@%s: %w", repo, ref, err)
 	}
 
-	fields := strings.Fields(strings.TrimSpace(string(out)))
-	if len(fields) == 0 {
+	// ls-remote prints "<sha>\t<refname>" per line. An annotated tag yields two
+	// lines — the tag object and, suffixed "^{}", the commit it peels to; prefer
+	// the peeled commit. Otherwise the first match wins.
+	first := ""
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		if strings.HasSuffix(fields[1], "^{}") {
+			return fields[0], nil
+		}
+
+		if first == "" {
+			first = fields[0]
+		}
+	}
+
+	if first == "" {
 		return "", fmt.Errorf("ref %q not found in %s", ref, repo)
 	}
 
-	return fields[0], nil
+	return first, nil
 }
 
 // cloneByCommitHash initializes a repo and fetches a specific commit hash, then


### PR DESCRIPTION
Both builders (`state_actor`, `eest_payloads`) previously skipped whenever `output_dir` was non-empty — regardless of whether the config that produced it changed. So editing a fork/seed/spec/filter silently did nothing unless you `--force`.

## What
An **opt-in** `--rebuild-on-diff` flag. After every successful build, benchmarkoor writes a `.benchmarkoor-build.json` sidecar at the `output_dir` root holding a sha256 **fingerprint** of the output-affecting config. With the flag, a populated target is rebuilt only when its fingerprint differs from the sidecar (the changed keys are logged); unchanged → skip; a dir with no sidecar (pre-feature) → skip until the next `--force` records a baseline.

**Default behaviour is unchanged** (populated → skip). `--force` still always wipes + rebuilds.

## Fingerprint coverage
- **state_actor:** the state-actor argv (minus the volatile `--db` path), the image, and the **spec content** hash. Derived from `buildArgs`, so it auto-tracks whatever determines the datadir.
- **eest_payloads:** filler client + image, fork, tests, filter, marker, gas/opcode values, max gas, rpc seed key, filler extra args, datadir method, the **content** of genesis / address-stubs / fill Dockerfile, fork/EIP overrides, the execution-specs checkout resolved to a **commit SHA** (`git ls-remote`, so a moving `eest_ref` is detected), and the **source snapshot's fingerprint** — so rebuilding a `state_actor` datadir **cascades** into rebuilding the fixtures generated from it (builders run state_actor→eest in one invocation, so the cascade works in a single `build` too).

## Also
- New `gitrepo.RemoteSHA` (ls-remote, commit-hash passthrough).
- `ci.action.yaml`'s state-actor job now uses `--rebuild-on-diff` instead of `--force`.
- Docs: a "Rebuild on config change" section under the build flags.

## Validation
- `go build ./...` clean, golangci-lint `--new-from-rev` 0 issues, full suite green (except the pre-existing macOS-only schelk test).
- Unit tests (`fingerprint_test.go`): sidecar round-trip, the three `decideRebuild` cases, changed-key reporting, `sha256File`, and per-builder input sensitivity **including the cascade**. `RemoteSHA` verified live against execution-specs.
- **End-to-end** with `config.state-actor-eest.simple.osaka.compute.yaml` (geth) on real Docker builds:
  1. Fresh build → both sidecars written; eest `source_fingerprint` == the state-actor fingerprint.
  2. `--rebuild-on-diff`, unchanged → both **skip** ("config unchanged").
  3. eest-only change (`gas_benchmark_values`) → state-actor **skips**, eest **rebuilds** (`changed=[gas_benchmark_values]`).
  4. state-actor `seed` change → state-actor **rebuilds** (`changed=[args]`) + eest **cascade-rebuilds** (`changed=[source_fingerprint]`); new eest `source_fingerprint` == new snapshot fingerprint.
  5. changed config **without** the flag → both **skip** (opt-in confirmed).
  6. `benchmarkoor run` boots geth from a datadir carrying the sidecar → 36/36, 0 failed (sidecar is inert; it isn't swept into run results since the runner only copies `state-actor-*` files).