### PR TITLE
feat(action): add mode input to select build-only or run-only

### DIFF
--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -160,12 +160,13 @@ jobs:
             /opt/hostedtoolcache/CodeQL /usr/share/dotnet /usr/local/share/boost
           df -h /
 
-      - name: Build snapshots + fill payloads, then run (nethermind + besu)
+      - name: Build snapshots + fill payloads (nethermind + besu)
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           git-ref: ${{ github.event.pull_request.head.sha }}
           git-repo: ${{ github.event.pull_request.head.repo.clone_url }}
+          mode: build
           build-args: '--rebuild-on-diff'
           build-config: |
             builder:
@@ -221,6 +222,14 @@ jobs:
                     source_dir: /tmp/benchmarkoor/state-actor/besu
                     genesis: /tmp/benchmarkoor/state-actor/besu/besu-chainspec.json
                     output_dir: /tmp/benchmarkoor/eest-fixtures/besu
+
+      - name: Run benchmarks (nethermind + besu)
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          git-ref: ${{ github.event.pull_request.head.sha }}
+          git-repo: ${{ github.event.pull_request.head.repo.clone_url }}
+          mode: run
           run-config-urls: >-
             https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-cleanup.yaml,
             https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-clientstdout.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -10,6 +10,11 @@ inputs:
     description: 'GitHub token for API access'
     required: true
 
+  mode:
+    description: 'Which phase(s) to run: "all" (build if a build-config is set, then run — the default), "build" (build only, no run), or "run" (run only, skip build even if a build-config is set).'
+    required: false
+    default: 'all'
+
   image:
     description: 'Docker image to extract the benchmarkoor binary from (e.g., ghcr.io/ethpandaops/benchmarkoor:master). If not provided, will build the image locally from git-ref/git-repo and extract from it.'
     required: false
@@ -68,6 +73,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Validate mode
+      shell: bash
+      run: |
+        case "${{ inputs.mode }}" in
+          all|build|run) ;;
+          *) echo "Invalid mode '${{ inputs.mode }}' (expected: all, build, or run)" >&2; exit 1 ;;
+        esac
+
     - name: Verify and install dependencies
       uses: ethpandaops/benchmarkoor/.github/actions/dependencies@0ff45ea539387c901ac4a7845e2c6e6aeb9d8f25
 
@@ -126,7 +139,7 @@ runs:
 
     - name: Build Benchmarkoor artifacts
       id: build-benchmarkoor
-      if: inputs.build-config != '' || inputs.build-config-urls != ''
+      if: (inputs.mode == 'all' || inputs.mode == 'build') && (inputs.build-config != '' || inputs.build-config-urls != '')
       shell: bash
       env:
         INPUT_BUILD_CONFIG: ${{ inputs.build-config }}
@@ -176,6 +189,7 @@ runs:
 
     - name: Get Job ID from GH API
       id: get-job-id
+      if: inputs.mode == 'all' || inputs.mode == 'run'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -186,6 +200,7 @@ runs:
 
     - name: Run Benchmarkoor
       id: run-benchmarkoor
+      if: inputs.mode == 'all' || inputs.mode == 'run'
       shell: bash
       env:
         INPUT_RUN_CONFIG: ${{ inputs.run-config }}
@@ -296,7 +311,7 @@ runs:
         done
 
     - name: Create results archive
-      if: always() && inputs.upload-artifacts == 'true'
+      if: always() && inputs.upload-artifacts == 'true' && inputs.mode != 'build'
       shell: bash
       run: |
         if [ -d "${{ runner.temp }}/results" ]; then
@@ -305,7 +320,7 @@ runs:
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
-      if: always() && inputs.upload-artifacts == 'true'
+      if: always() && inputs.upload-artifacts == 'true' && inputs.mode != 'build'
       with:
         name: benchmarkoor-${{ github.run_id }}
         path: ${{ runner.temp }}/benchmarkoor-results.tar.gz


### PR DESCRIPTION
The composite `action.yaml` always ran the benchmark, with the build phase gated only on a `build-config` being present — so **run-only** was possible (omit `build-config`) but **build-only** was not.

## What
A new **`mode`** input:

| `mode` | Build phase | Run phase |
|---|---|---|
| `all` *(default)* | runs if `build-config`/`build-config-urls` set | runs |
| `build` | runs (needs a build-config) | skipped |
| `run` | skipped (even if a build-config is set) | runs |

- Build step gated on `(mode == all \|\| mode == build) && <build-config present>`.
- `Get Job ID` + `Run Benchmarkoor` gated on `mode == all \|\| mode == run`.
- Results archive/upload skip on `mode == build` (nothing to upload); markdown-summaries already self-skip when no run happened.
- New `Validate mode` step fails fast on an invalid value.

**Backward compatible:** callers that don't set `mode` default to `all` → build+run exactly as before.

## ci.action.yaml
The `state-actor` job now calls the action **twice**, exercising both modes:
1. `mode: build` — state-actor nethermind+besu snapshots → besu EEST fill (`--rebuild-on-diff`).
2. `mode: run` — replay the fixtures on nethermind + besu.

Artifacts persist across the two calls via `/tmp` on the same runner (build writes `/tmp/benchmarkoor/...`, run reads it). Tradeoff: each `uses: ./` call re-extracts the binary (Docker layer cache keeps the second image build cheap).

## Validation
`action.yaml` is valid YAML; `ci.action.yaml` passes actionlint; the config split is verified (build step carries only `build-config`, run step only `run-config`).