### PR TITLE
fix(eest): mount schelk source_dir before checkInputs stat

### DIFF
--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -233,7 +233,7 @@ func (b *EESTPayloadsBuilder) Build(ctx context.Context, name string, opts Build
 		}
 	}
 
-	if err := b.checkInputs(target); err != nil {
+	if err := b.checkInputs(ctx, target); err != nil {
 		return false, err
 	}
 
@@ -356,7 +356,21 @@ func (b *EESTPayloadsBuilder) findTargetIndex(name string) int {
 // checkInputs verifies the build-time inputs exist. Existence is checked
 // here (not at config-validation time) because a state-actor target earlier
 // in the same config may still need to produce source_dir.
-func (b *EESTPayloadsBuilder) checkInputs(t *config.EESTPayloadTarget) error {
+func (b *EESTPayloadsBuilder) checkInputs(ctx context.Context, t *config.EESTPayloadTarget) error {
+	// A source_dir under a schelk mount is only a real path once the schelk
+	// scratch is mounted — which otherwise happens later in run()→Prepare. A
+	// preceding state-actor build leaves the datadir promoted as the schelk
+	// baseline but not necessarily mounted (`schelk promote`), so mount it here
+	// before the existence checks below (source_dir and, for schelk configs, the
+	// genesis alongside it). Non-schelk source_dirs are untouched.
+	if _, isSchelk, err := datadir.SchelkDir(t.SourceDir); err != nil {
+		return fmt.Errorf("checking schelk state for source_dir %q: %w", t.SourceDir, err)
+	} else if isSchelk {
+		if err := datadir.EnsureSchelkMounted(ctx, b.log); err != nil {
+			return fmt.Errorf("ensuring schelk mount for source_dir %q: %w", t.SourceDir, err)
+		}
+	}
+
 	if info, err := os.Stat(t.SourceDir); err != nil {
 		return fmt.Errorf("source_dir %q: %w", t.SourceDir, err)
 	} else if !info.IsDir() {

--- a/pkg/builder/eest_payloads_test.go
+++ b/pkg/builder/eest_payloads_test.go
@@ -14,6 +14,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCheckInputs_NonSchelkSource(t *testing.T) {
+	// Force "no schelk configured" (absent state file) so source_dir is treated
+	// as a plain directory and the schelk mount path is not taken.
+	t.Setenv("SCHELK_STATE", filepath.Join(t.TempDir(), "absent.json"))
+
+	b := &EESTPayloadsBuilder{log: noopLogger()}
+	src := t.TempDir()
+
+	require.NoError(t, b.checkInputs(context.Background(), &config.EESTPayloadTarget{SourceDir: src}))
+
+	err := b.checkInputs(context.Background(), &config.EESTPayloadTarget{SourceDir: filepath.Join(src, "missing")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source_dir")
+}
+
 func TestEmbeddedFillDockerfile(t *testing.T) {
 	require.NotEmpty(t, embeddedFillDockerfile, "Dockerfile.eest-filler must be embedded")
 	body := string(embeddedFillDockerfile)


### PR DESCRIPTION
## Symptom
A `benchmarkoor build` that builds a state-actor datadir on a **schelk** mount and then builds eest-payloads for the same client (consuming that datadir as `source_dir`) fails immediately after the state-actor build succeeds:

```
INFO | Persisting datadir as the new schelk baseline (`schelk promote`) ... target=nethermind
INFO | Building target client=nethermind ... target=nethermind  (eest-payloads)
ERRO | Build failed error=source_dir "/schelk/state-actor/v1/nethermind": stat ...: no such file or directory
```

## Root cause
`source_dir` lives under a schelk mount, so it's only a real path once the schelk scratch is restored + mounted — which the eest-payloads builder does inside `run()`→`Prepare()`. But `checkInputs` validated `source_dir` with a plain `os.Stat` **before** that. After the state-actor build's `schelk promote`, the datadir is the schelk baseline but not mounted, so the plain stat fails.

Sequence: `state_actor.go` runs `schelk promote` after building → `eest_payloads.checkInputs` does `os.Stat(source_dir)` (not schelk-aware) → `run()`→`Prepare()` (`schelk restore`, the thing that makes the path real) only happens later.

## Fix
`checkInputs(ctx, t)` now, when `source_dir` is under a schelk mount (`datadir.SchelkDir`), calls `datadir.EnsureSchelkMounted` before the existence checks — so `source_dir` and the genesis alongside it (also under the mount for schelk configs) are visible. This is the exact helper `state_actor.Build` and the runner's schelk config-validation already use to make a schelk path available from an arbitrary state; `run()`'s `Prepare` still performs the full `restore` afterward. Non-schelk `source_dir`s are unaffected.

## Tests / validation
- New `TestCheckInputs_NonSchelkSource` (forces "no schelk configured" via `SCHELK_STATE`) confirms the added detection leaves the normal path unchanged (valid dir OK; missing → `source_dir` error).
- `go build ./...` clean; `go test ./...` green (except the pre-existing macOS-only `/proc/mounts` `TestValidateDataDirMethods_SchelkBinary`); golangci-lint `--new-from-rev=origin/master` 0 issues.

## Not covered
The live schelk path (restore/mount against a real dm-era volume) was **not** e2e'd — it needs a schelk-initialized Linux host. If, on real hardware, `schelk promote` leaves an inconsistent `is_mounted`, `EnsureSchelkMounted` will surface the clear "run `schelk full-recover`" error rather than mount; swapping `checkInputs` to a full `restore` is then a one-line change.