### PR TITLE
feat(build): markdown summary for `benchmarkoor build`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -174,6 +174,9 @@ runs:
           ARGS+=("--config=${{ runner.temp }}/benchmarkoor-build-config-inline.yaml")
         fi
 
+        # Emit a machine-readable build summary for the markdown step below.
+        ARGS+=("--summary-json=${{ runner.temp }}/benchmarkoor-build-summary.json")
+
         # Append extra build args if provided (whitespace-split, same as run).
         if [ -n "${{ inputs.build-args }}" ]; then
           # shellcheck disable=SC2206 # intentional word-split for argv
@@ -186,6 +189,25 @@ runs:
         # them) and propagates caller env (e.g. STATE_DIR) into the build.
         echo "Running: sudo -E $BIN ${ARGS[*]}"
         sudo -E "$BIN" "${ARGS[@]}"
+
+    - name: Generate build markdown summary
+      # Runs even if the build failed so a partial summary (incl. ERR targets)
+      # still reaches the job summary. sudo because the build artifacts are
+      # root-owned (see above).
+      if: always() && (inputs.mode == 'all' || inputs.mode == 'build') && (inputs.build-config != '' || inputs.build-config-urls != '')
+      shell: bash
+      run: |
+        BIN="${{ steps.extract-binary.outputs.binary }}"
+        SUMMARY="${{ runner.temp }}/benchmarkoor-build-summary.json"
+        if [ -f "$SUMMARY" ]; then
+          sudo -E "$BIN" generate-build-markdown-summary \
+            --input="$SUMMARY" \
+            --output="${{ runner.temp }}/benchmarkoor-build-summary.md"
+          if [ -f "${{ runner.temp }}/benchmarkoor-build-summary.md" ]; then
+            cat "${{ runner.temp }}/benchmarkoor-build-summary.md" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          fi
+        fi
 
     - name: Get Job ID from GH API
       id: get-job-id
@@ -335,5 +357,6 @@ runs:
         rm -f "${{ runner.temp }}/benchmarkoor-config-inline.yaml"
         rm -f "${{ runner.temp }}/benchmarkoor-build-config-url-"*.yaml
         rm -f "${{ runner.temp }}/benchmarkoor-build-config-inline.yaml"
+        rm -f "${{ runner.temp }}/benchmarkoor-build-summary.json" "${{ runner.temp }}/benchmarkoor-build-summary.md"
         rm -f "${{ runner.temp }}/benchmarkoor-results.tar.gz"
         rm -f "${{ runner.temp }}/benchmarkoor"

--- a/cmd/benchmarkoor/build.go
+++ b/cmd/benchmarkoor/build.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -9,10 +10,12 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/builder"
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
 	"github.com/ethpandaops/benchmarkoor/pkg/docker"
+	"github.com/ethpandaops/benchmarkoor/pkg/executor"
 	"github.com/ethpandaops/benchmarkoor/pkg/podman"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -26,6 +29,7 @@ var (
 	buildSkipEESTPayloads   bool
 	buildForce              bool
 	buildRebuildOnDiff      bool
+	buildSummaryJSON        string
 )
 
 var buildCmd = &cobra.Command{
@@ -61,6 +65,8 @@ func init() {
 		"Remove each target's output_dir before building")
 	buildCmd.Flags().BoolVar(&buildRebuildOnDiff, "rebuild-on-diff", false,
 		"Rebuild a populated output_dir when its config fingerprint changed since the last build (instead of skipping)")
+	buildCmd.Flags().StringVar(&buildSummaryJSON, "summary-json", "",
+		"Write a machine-readable build summary to this path (render it with `generate-build-markdown-summary`)")
 }
 
 func runBuild(_ *cobra.Command, _ []string) error {
@@ -249,6 +255,7 @@ type buildResult struct {
 	outputDir string
 	skipped   bool
 	err       error
+	elapsed   time.Duration
 }
 
 // runBuilders selects and builds the requested targets across all builders,
@@ -274,6 +281,7 @@ func runBuilders(ctx context.Context, builders []builder.Builder) error {
 			"output_dir": sel.info.OutputDir,
 		}).Info("Building target")
 
+		start := time.Now()
 		skipped, buildErr := sel.builder.Build(ctx, sel.info.Name, builder.BuildOptions{Force: buildForce, RebuildOnDiff: buildRebuildOnDiff})
 
 		results = append(results, buildResult{
@@ -283,6 +291,7 @@ func runBuilders(ctx context.Context, builders []builder.Builder) error {
 			outputDir: sel.info.OutputDir,
 			skipped:   skipped,
 			err:       buildErr,
+			elapsed:   time.Since(start),
 		})
 
 		if buildErr != nil {
@@ -290,7 +299,61 @@ func runBuilders(ctx context.Context, builders []builder.Builder) error {
 		}
 	}
 
+	if buildSummaryJSON != "" {
+		if err := writeBuildSummaryJSON(buildSummaryJSON, results); err != nil {
+			log.WithError(err).Warn("Failed to write build summary JSON")
+		}
+	}
+
 	return summarise(results)
+}
+
+// writeBuildSummaryJSON persists the per-target build outcomes as a
+// BuildSummary that `generate-build-markdown-summary` renders to markdown.
+func writeBuildSummaryJSON(path string, results []buildResult) error {
+	targets := make([]executor.BuildTargetSummary, 0, len(results))
+
+	for _, r := range results {
+		status := "OK"
+
+		switch {
+		case r.err != nil:
+			status = "ERR"
+		case r.skipped:
+			status = "SKIP"
+		}
+
+		errMsg := ""
+		if r.err != nil {
+			errMsg = r.err.Error()
+		}
+
+		targets = append(targets, executor.BuildTargetSummary{
+			Builder:   r.builder,
+			Name:      r.name,
+			Client:    r.client,
+			OutputDir: r.outputDir,
+			Status:    status,
+			Error:     errMsg,
+			ElapsedMs: r.elapsed.Milliseconds(),
+		})
+	}
+
+	summary := executor.BuildSummary{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Targets:     targets,
+	}
+
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling build summary: %w", err)
+	}
+
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing build summary: %w", err)
+	}
+
+	return nil
 }
 
 // summarise logs the per-target outcome grouped under each builder and returns

--- a/cmd/benchmarkoor/build_markdown_summary.go
+++ b/cmd/benchmarkoor/build_markdown_summary.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/executor"
+	"github.com/spf13/cobra"
+)
+
+var generateBuildMarkdownSummaryCmd = &cobra.Command{
+	Use:   "generate-build-markdown-summary",
+	Short: "Generate a markdown summary from a benchmarkoor build",
+	Long: `Reads a build summary JSON (written by 'benchmarkoor build --summary-json') and
+produces a markdown summary of the state-actor and eest-payloads builds, enriched
+with each target's on-disk artifacts (state-actor manifest, eest fill counts).`,
+	RunE: runGenerateBuildMarkdownSummary,
+}
+
+var (
+	buildToMdInput  string
+	buildToMdOutput string
+)
+
+func init() {
+	rootCmd.AddCommand(generateBuildMarkdownSummaryCmd)
+	generateBuildMarkdownSummaryCmd.Flags().StringVar(&buildToMdInput, "input", "",
+		"Path to the build summary JSON written by `benchmarkoor build --summary-json`")
+	generateBuildMarkdownSummaryCmd.Flags().StringVar(&buildToMdOutput, "output", "",
+		"Output file path (default: build-summary.md)")
+
+	if err := generateBuildMarkdownSummaryCmd.MarkFlagRequired("input"); err != nil {
+		panic(err)
+	}
+}
+
+func runGenerateBuildMarkdownSummary(_ *cobra.Command, _ []string) error {
+	log.WithField("input", buildToMdInput).Info("Generating build markdown summary")
+
+	md, err := executor.GenerateBuildMarkdown(buildToMdInput, maxMarkdownChars)
+	if err != nil {
+		return fmt.Errorf("generating build markdown: %w", err)
+	}
+
+	output := buildToMdOutput
+	if output == "" {
+		output = "build-summary.md"
+	}
+
+	if err := os.WriteFile(output, []byte(md), 0644); err != nil {
+		return fmt.Errorf("writing output file: %w", err)
+	}
+
+	log.WithField("output", output).Info("Build markdown summary written")
+
+	return nil
+}

--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -523,7 +523,7 @@ func (b *EESTPayloadsBuilder) run(ctx context.Context, log logrus.FieldLogger, t
 		"snapshot_block": snapshotHash,
 	}).Info("Filler client ready; running fill-stateful")
 
-	return b.runFill(ctx, log, t, fillerIP, spec, jwtPath, snapshotHash, eestRepoPath)
+	return b.runFill(ctx, log, t, fillerIP, spec, jwtPath, snapshotHash, eestRepoPath, sha)
 }
 
 // waitForFillerReady blocks until the filler's RPC answers or the filler
@@ -797,13 +797,85 @@ func (b *EESTPayloadsBuilder) buildFillImage(ctx context.Context, log logrus.Fie
 	return nil
 }
 
+const (
+	// eestFillResultFile is the sidecar written next to the fixtures recording
+	// how many tests the fill produced/failed (read by the build markdown summary).
+	eestFillResultFile = ".benchmarkoor-fill.json"
+
+	// pytestReportFile is the pytest-json-report output written under output_dir
+	// (via PYTEST_ADDOPTS --json-report); it carries the authoritative
+	// passed/failed tally. Relative to output_dir (= the fill container's /out).
+	pytestReportFile = ".benchmarkoor-pytest-report.json"
+)
+
+// recordEESTFillResult writes the .benchmarkoor-fill.json sidecar for the build
+// summary: the target's provenance plus authoritative counts from EEST's own
+// report artifacts — the generated-fixture count from .meta/index.json and the
+// failed/errored count from the pytest json report. It is written even after a
+// failed fill (fill-stateful continues through failures and still writes both the
+// fixtures and the reports), so a failed target is still fully described.
+// Best-effort: missing/unparseable reports yield zero counts rather than an error.
+func recordEESTFillResult(t *config.EESTPayloadTarget, eestSHA string) error {
+	result := struct {
+		SourceDir    string `json:"source_dir"`
+		FillerClient string `json:"filler_client"`
+		FillerImage  string `json:"filler_image"`
+		EESTSHA      string `json:"eest_sha"`
+		Fork         string `json:"fork"`
+		Filter       string `json:"filter"`
+		Filled       int    `json:"filled"`
+		Failed       int    `json:"failed"`
+	}{
+		SourceDir:    t.SourceDir,
+		FillerClient: t.FillerClient,
+		FillerImage:  t.FillerImage,
+		EESTSHA:      eestSHA,
+		Fork:         t.Fork,
+		Filter:       t.Filter,
+	}
+
+	// Generated fixtures (filled) — EEST's index.json test_count.
+	if data, err := os.ReadFile(filepath.Join(t.OutputDir, ".meta", "index.json")); err == nil {
+		var idx struct {
+			TestCount int `json:"test_count"`
+		}
+		if json.Unmarshal(data, &idx) == nil {
+			result.Filled = idx.TestCount
+		}
+	}
+
+	// Failures — pytest's json report summary (failed + errored).
+	if data, err := os.ReadFile(filepath.Join(t.OutputDir, pytestReportFile)); err == nil {
+		var rep struct {
+			Summary struct {
+				Failed int `json:"failed"`
+				Error  int `json:"error"`
+			} `json:"summary"`
+		}
+		if json.Unmarshal(data, &rep) == nil {
+			result.Failed = rep.Summary.Failed + rep.Summary.Error
+		}
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("marshalling fill result: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(t.OutputDir, eestFillResultFile), append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("writing fill result: %w", err)
+	}
+
+	return nil
+}
+
 func (b *EESTPayloadsBuilder) runFill(
 	ctx context.Context,
 	log logrus.FieldLogger,
 	t *config.EESTPayloadTarget,
 	fillerIP string,
 	spec client.Spec,
-	jwtPath, snapshotHash, eestRepoPath string,
+	jwtPath, snapshotHash, eestRepoPath, eestSHA string,
 ) error {
 	fillImage, err := b.ensureFillImage(ctx, log)
 	if err != nil {
@@ -826,9 +898,13 @@ func (b *EESTPayloadsBuilder) runFill(
 	// Run as the invoking host user so fixtures written to /out are owned by
 	// that user. The uv/pytest fill image keeps writable state under /tmp.
 	env := map[string]string{
-		"HOME":           "/tmp",
-		"UV_CACHE_DIR":   "/tmp/uv-cache",
-		"PYTEST_ADDOPTS": "-o cache_dir=/tmp/.pytest_cache",
+		"HOME":         "/tmp",
+		"UV_CACHE_DIR": "/tmp/uv-cache",
+		// Enable pytest's json report so we can read an authoritative
+		// passed/failed tally for the build summary (the json-report plugin ships
+		// in the fill image). fill-stateful continues through failures, so a
+		// partial fill still records how many tests failed.
+		"PYTEST_ADDOPTS": "-o cache_dir=/tmp/.pytest_cache --json-report --json-report-file=" + fillOutputPath + "/" + pytestReportFile,
 		// fill-stateful reads its commit hash from the /eest git checkout; as a
 		// non-root user git can refuse with "dubious ownership". Inject
 		// safe.directory=* via git's env-based config so it trusts the repo.
@@ -865,8 +941,17 @@ func (b *EESTPayloadsBuilder) runFill(
 
 	log.WithField("argv", args).Info("Running fill-stateful")
 
-	if err := b.mgr.RunInitContainer(ctx, containerSpec, out, out); err != nil {
-		return fmt.Errorf("running fill-stateful: %w (output tail: %s)", err, tail.String())
+	runErr := b.mgr.RunInitContainer(ctx, containerSpec, out, out)
+
+	// Record fill counts (from EEST's report artifacts) for the build summary —
+	// best-effort, and after a failed fill too, since fill-stateful continues
+	// through failures and still writes the reports.
+	if err := recordEESTFillResult(t, eestSHA); err != nil {
+		log.WithError(err).Warn("Failed to record fill result")
+	}
+
+	if runErr != nil {
+		return fmt.Errorf("running fill-stateful: %w (output tail: %s)", runErr, tail.String())
 	}
 
 	log.Info("Build completed")

--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -808,6 +809,27 @@ const (
 	pytestReportFile = ".benchmarkoor-pytest-report.json"
 )
 
+// dirSize returns the total size in bytes of all regular files under dir.
+func dirSize(dir string) int64 {
+	var total int64
+
+	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if d.Type().IsRegular() {
+			if info, err := d.Info(); err == nil {
+				total += info.Size()
+			}
+		}
+
+		return nil
+	})
+
+	return total
+}
+
 // recordEESTFillResult writes the .benchmarkoor-fill.json sidecar for the build
 // summary: the target's provenance plus authoritative counts from EEST's own
 // report artifacts — the generated-fixture count from .meta/index.json and the
@@ -823,6 +845,7 @@ func recordEESTFillResult(t *config.EESTPayloadTarget, eestSHA string) error {
 		EESTSHA      string `json:"eest_sha"`
 		Fork         string `json:"fork"`
 		Filter       string `json:"filter"`
+		SizeBytes    int64  `json:"size_bytes"`
 		Filled       int    `json:"filled"`
 		Failed       int    `json:"failed"`
 	}{
@@ -832,6 +855,7 @@ func recordEESTFillResult(t *config.EESTPayloadTarget, eestSHA string) error {
 		EESTSHA:      eestSHA,
 		Fork:         t.Fork,
 		Filter:       t.Filter,
+		SizeBytes:    dirSize(t.OutputDir),
 	}
 
 	// Generated fixtures (filled) — EEST's index.json test_count.

--- a/pkg/builder/eest_payloads_test.go
+++ b/pkg/builder/eest_payloads_test.go
@@ -36,6 +36,7 @@ func TestRecordEESTFillResult(t *testing.T) {
 		SourceDir    string `json:"source_dir"`
 		FillerClient string `json:"filler_client"`
 		EESTSHA      string `json:"eest_sha"`
+		SizeBytes    int64  `json:"size_bytes"`
 		Filled       int    `json:"filled"`
 		Failed       int    `json:"failed"`
 	}
@@ -45,6 +46,7 @@ func TestRecordEESTFillResult(t *testing.T) {
 	assert.Equal(t, "/src/geth", got.SourceDir)
 	assert.Equal(t, "geth", got.FillerClient)
 	assert.Equal(t, "27174ca1b2c3", got.EESTSHA)
+	assert.Positive(t, got.SizeBytes) // sums the index.json + pytest report on disk
 
 	// Missing reports → provenance still recorded, zero counts, no error.
 	empty := t.TempDir()

--- a/pkg/builder/eest_payloads_test.go
+++ b/pkg/builder/eest_payloads_test.go
@@ -14,6 +14,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRecordEESTFillResult(t *testing.T) {
+	out := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(out, ".meta"), 0o755))
+
+	// EEST's index.json gives the generated (filled) count; pytest's json report
+	// gives failed + error.
+	require.NoError(t, os.WriteFile(filepath.Join(out, ".meta", "index.json"),
+		[]byte(`{"test_count":34,"test_cases":[]}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(out, pytestReportFile),
+		[]byte(`{"summary":{"passed":34,"failed":2,"error":1,"total":37}}`), 0o600))
+
+	require.NoError(t, recordEESTFillResult(&config.EESTPayloadTarget{
+		OutputDir: out, SourceDir: "/src/geth", FillerClient: "geth", Fork: "osaka",
+	}, "27174ca1b2c3"))
+
+	data, err := os.ReadFile(filepath.Join(out, eestFillResultFile))
+	require.NoError(t, err)
+
+	var got struct {
+		SourceDir    string `json:"source_dir"`
+		FillerClient string `json:"filler_client"`
+		EESTSHA      string `json:"eest_sha"`
+		Filled       int    `json:"filled"`
+		Failed       int    `json:"failed"`
+	}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, 34, got.Filled)
+	assert.Equal(t, 3, got.Failed) // failed + error
+	assert.Equal(t, "/src/geth", got.SourceDir)
+	assert.Equal(t, "geth", got.FillerClient)
+	assert.Equal(t, "27174ca1b2c3", got.EESTSHA)
+
+	// Missing reports → provenance still recorded, zero counts, no error.
+	empty := t.TempDir()
+	require.NoError(t, recordEESTFillResult(&config.EESTPayloadTarget{OutputDir: empty, FillerClient: "besu"}, ""))
+	data, err = os.ReadFile(filepath.Join(empty, eestFillResultFile))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, 0, got.Filled)
+	assert.Equal(t, 0, got.Failed)
+	assert.Equal(t, "besu", got.FillerClient)
+}
+
 func TestCheckInputs_NonSchelkSource(t *testing.T) {
 	// Force "no schelk configured" (absent state file) so source_dir is treated
 	// as a plain directory and the schelk mount path is not taken.

--- a/pkg/executor/build_markdown.go
+++ b/pkg/executor/build_markdown.go
@@ -1,0 +1,280 @@
+package executor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Build-summary artifact filenames (written under each target's output_dir).
+const (
+	stateActorManifestFile = "state-actor-manifest.json"
+	eestFillResultFile     = ".benchmarkoor-fill.json"
+)
+
+// BuildSummary is the per-invocation result of `benchmarkoor build`, persisted
+// by the build command and rendered to markdown by GenerateBuildMarkdown.
+type BuildSummary struct {
+	GeneratedAt string               `json:"generated_at,omitempty"`
+	Targets     []BuildTargetSummary `json:"targets"`
+}
+
+// BuildTargetSummary is one builder target's outcome. It carries only the
+// in-memory build result; richer per-target detail (state-actor manifest, eest
+// provenance + fill counts) is read from the target's output_dir at render time.
+type BuildTargetSummary struct {
+	Builder   string `json:"builder"` // "state-actor" | "eest-payloads"
+	Name      string `json:"name"`
+	Client    string `json:"client"`
+	OutputDir string `json:"output_dir"`
+	Status    string `json:"status"` // "OK" | "SKIP" | "ERR"
+	Error     string `json:"error,omitempty"`
+	ElapsedMs int64  `json:"elapsed_ms"`
+}
+
+// stateActorManifest mirrors the fields of state-actor-manifest.json we render.
+// The manifest is written by the external state-actor binary; this is a partial
+// view (unused fields are ignored).
+type stateActorManifest struct {
+	Flags struct {
+		Client     string `json:"client"`
+		Fork       string `json:"fork"`
+		Seed       int64  `json:"seed"`
+		ChainID    int64  `json:"chain_id"`
+		GasLimit   int64  `json:"gas_limit"`
+		TargetSize string `json:"target_size"`
+	} `json:"flags"`
+	Result *struct {
+		StateRoot        string `json:"state_root"`
+		AccountsCreated  int64  `json:"accounts_created"`
+		ContractsCreated int64  `json:"contracts_created"`
+		StorageSlots     int64  `json:"storage_slots"`
+		TotalDBSizeBytes int64  `json:"total_db_size_bytes"`
+		ElapsedMs        int64  `json:"elapsed_ms"`
+	} `json:"result"`
+}
+
+// eestFillResult mirrors the .benchmarkoor-fill.json sidecar: the eest target's
+// provenance plus the authoritative fill counts. Written even after a failed
+// fill, so a failed target is still fully described.
+type eestFillResult struct {
+	SourceDir    string `json:"source_dir"`
+	FillerClient string `json:"filler_client"`
+	FillerImage  string `json:"filler_image"`
+	EESTSHA      string `json:"eest_sha"`
+	Fork         string `json:"fork"`
+	Filter       string `json:"filter"`
+	Filled       int    `json:"filled"`
+	Failed       int    `json:"failed"`
+}
+
+// GenerateBuildMarkdown reads a build-summary.json and renders a markdown
+// summary of the state-actor and eest-payloads builds, enriching each target
+// from its on-disk output_dir artifacts. Output is truncated to maxChars.
+func GenerateBuildMarkdown(summaryPath string, maxChars int) (string, error) {
+	data, err := os.ReadFile(summaryPath)
+	if err != nil {
+		return "", fmt.Errorf("reading build summary %s: %w", summaryPath, err)
+	}
+
+	var summary BuildSummary
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return "", fmt.Errorf("parsing build summary %s: %w", summaryPath, err)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## 🛠️ Build Summary\n\n")
+
+	if summary.GeneratedAt != "" {
+		fmt.Fprintf(&sb, "_Generated at %s_\n\n", summary.GeneratedAt)
+	}
+
+	if len(summary.Targets) == 0 {
+		sb.WriteString("_No build targets._\n")
+	}
+
+	for _, t := range summary.Targets {
+		writeTargetSection(&sb, t)
+	}
+
+	out := sb.String()
+	if len(out) > maxChars {
+		out = out[:maxChars] + "\n\n_… truncated._\n"
+	}
+
+	return out, nil
+}
+
+// writeTargetSection renders one build target as its own section with a
+// Field | Value table (matching the run markdown generator's style).
+func writeTargetSection(sb *strings.Builder, t BuildTargetSummary) {
+	fmt.Fprintf(sb, "### %s %s — %s\n\n", statusEmoji(t.Status), t.Name, t.Builder)
+
+	sb.WriteString("| Field | Value |\n")
+	sb.WriteString("|---|---|\n")
+
+	writeField(sb, "Status", statusLabel(t.Status))
+
+	switch t.Builder {
+	case "eest-payloads":
+		writeEESTSection(sb, t)
+	default:
+		writeStateActorSection(sb, t)
+	}
+
+	sb.WriteString("\n")
+
+	if t.Status == "ERR" && t.Error != "" {
+		fmt.Fprintf(sb, "> ❌ %s\n\n", t.Error)
+	}
+}
+
+func writeStateActorSection(sb *strings.Builder, t BuildTargetSummary) {
+	writeField(sb, "Client", orDash(t.Client))
+
+	if m := readStateActorManifest(t.OutputDir); m != nil {
+		writeField(sb, "Fork", orDash(m.Flags.Fork))
+
+		if m.Result != nil {
+			writeField(sb, "State root", code(shortHash(m.Result.StateRoot)))
+			writeField(sb, "Accounts created", formatInt(m.Result.AccountsCreated))
+			writeField(sb, "Contracts created", formatInt(m.Result.ContractsCreated))
+			writeField(sb, "Storage slots", formatInt(m.Result.StorageSlots))
+			writeField(sb, "DB size", formatBytes(m.Result.TotalDBSizeBytes))
+		}
+	}
+
+	writeField(sb, "Elapsed", formatDurationNs(t.ElapsedMs*1_000_000))
+}
+
+func writeEESTSection(sb *strings.Builder, t BuildTargetSummary) {
+	if fill := readEESTFillResult(t.OutputDir); fill != nil {
+		writeField(sb, "Source", orDash(fill.SourceDir))
+		writeField(sb, "Filler", orDash(fill.FillerClient))
+		writeField(sb, "Filler image", code(fill.FillerImage))
+		writeField(sb, "EEST commit", code(shortSHA(fill.EESTSHA)))
+		writeField(sb, "Fork", orDash(fill.Fork))
+		writeField(sb, "Filter", orDash(fill.Filter))
+		writeField(sb, "Filled", formatInt(int64(fill.Filled)))
+		writeField(sb, "Failed", formatInt(int64(fill.Failed)))
+	}
+
+	writeField(sb, "Elapsed", formatDurationNs(t.ElapsedMs*1_000_000))
+}
+
+func writeField(sb *strings.Builder, label, value string) {
+	fmt.Fprintf(sb, "| %s | %s |\n", label, value)
+}
+
+func statusEmoji(status string) string {
+	switch status {
+	case "OK":
+		return "✅"
+	case "SKIP":
+		return "⏭️"
+	case "ERR":
+		return "❌"
+	default:
+		return "•"
+	}
+}
+
+func statusLabel(status string) string {
+	switch status {
+	case "OK":
+		return "OK"
+	case "SKIP":
+		return "Skipped (unchanged)"
+	case "ERR":
+		return "Failed"
+	default:
+		return orDash(status)
+	}
+}
+
+// code wraps s in inline-code backticks, or renders a dash when empty.
+func code(s string) string {
+	if s == "" || s == "-" {
+		return "-"
+	}
+
+	return "`" + s + "`"
+}
+
+// formatInt renders n with thousands separators (1351914 → "1,351,914").
+func formatInt(n int64) string {
+	s := strconv.FormatInt(n, 10)
+
+	sign := ""
+	if strings.HasPrefix(s, "-") {
+		sign, s = "-", s[1:]
+	}
+
+	var out []byte
+	for i := 0; i < len(s); i++ {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+
+		out = append(out, s[i])
+	}
+
+	return sign + string(out)
+}
+
+// shortSHA abbreviates a git commit hash to its first 10 chars.
+func shortSHA(s string) string {
+	if len(s) <= 10 {
+		return orDash(s)
+	}
+
+	return s[:10]
+}
+
+func readStateActorManifest(outputDir string) *stateActorManifest {
+	data, err := os.ReadFile(filepath.Join(outputDir, stateActorManifestFile))
+	if err != nil {
+		return nil
+	}
+
+	var m stateActorManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil
+	}
+
+	return &m
+}
+
+func readEESTFillResult(outputDir string) *eestFillResult {
+	data, err := os.ReadFile(filepath.Join(outputDir, eestFillResultFile))
+	if err != nil {
+		return nil
+	}
+
+	var r eestFillResult
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil
+	}
+
+	return &r
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+
+	return s
+}
+
+// shortHash abbreviates a 0x hash to first-10…last-6 for table display.
+func shortHash(h string) string {
+	if len(h) <= 20 {
+		return orDash(h)
+	}
+
+	return h[:10] + "…" + h[len(h)-6:]
+}

--- a/pkg/executor/build_markdown.go
+++ b/pkg/executor/build_markdown.go
@@ -67,6 +67,7 @@ type eestFillResult struct {
 	EESTSHA      string `json:"eest_sha"`
 	Fork         string `json:"fork"`
 	Filter       string `json:"filter"`
+	SizeBytes    int64  `json:"size_bytes"`
 	Filled       int    `json:"filled"`
 	Failed       int    `json:"failed"`
 }
@@ -160,6 +161,7 @@ func writeEESTSection(sb *strings.Builder, t BuildTargetSummary) {
 		writeField(sb, "Filter", orDash(fill.Filter))
 		writeField(sb, "Filled", formatInt(int64(fill.Filled)))
 		writeField(sb, "Failed", formatInt(int64(fill.Failed)))
+		writeField(sb, "Fixtures size", formatBytes(fill.SizeBytes))
 	}
 
 	writeField(sb, "Elapsed", formatDurationNs(t.ElapsedMs*1_000_000))

--- a/pkg/executor/build_markdown_test.go
+++ b/pkg/executor/build_markdown_test.go
@@ -34,7 +34,7 @@ func TestGenerateBuildMarkdown(t *testing.T) {
 		`"accounts_created":301540,"contracts_created":5248,"storage_slots":1351914,"total_db_size_bytes":526000000,"elapsed_ms":4348}}`
 	require.NoError(t, os.WriteFile(filepath.Join(saDir, stateActorManifestFile), []byte(manifest), 0o600))
 
-	fill := `{"source_dir":"/schelk/state-actor/v1/nethermind","filler_client":"geth","filler_image":"ethpandaops/geth:master","eest_sha":"27174ca1b2c3deadbeef","fork":"osaka","filter":"bn128","filled":36,"failed":0}`
+	fill := `{"source_dir":"/schelk/state-actor/v1/nethermind","filler_client":"geth","filler_image":"ethpandaops/geth:master","eest_sha":"27174ca1b2c3deadbeef","fork":"osaka","filter":"bn128","size_bytes":78643200,"filled":36,"failed":0}`
 	require.NoError(t, os.WriteFile(filepath.Join(eestDir, eestFillResultFile), []byte(fill), 0o600))
 
 	p := writeBuildSummary(t, dir, BuildSummary{
@@ -62,6 +62,7 @@ func TestGenerateBuildMarkdown(t *testing.T) {
 	assert.Contains(t, md, "| EEST commit | `27174ca1b2` |")
 	assert.Contains(t, md, "| Filled | 36 |")
 	assert.Contains(t, md, "| Failed | 0 |")
+	assert.Contains(t, md, "| Fixtures size | 75.0 MiB |")
 }
 
 func TestGenerateBuildMarkdown_ErrTargetShowsError(t *testing.T) {

--- a/pkg/executor/build_markdown_test.go
+++ b/pkg/executor/build_markdown_test.go
@@ -1,0 +1,81 @@
+package executor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeBuildSummary(t *testing.T, dir string, summary BuildSummary) string {
+	t.Helper()
+
+	data, err := json.Marshal(summary)
+	require.NoError(t, err)
+
+	p := filepath.Join(dir, "build-summary.json")
+	require.NoError(t, os.WriteFile(p, data, 0o600))
+
+	return p
+}
+
+func TestGenerateBuildMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	saDir := filepath.Join(dir, "sa")
+	eestDir := filepath.Join(dir, "eest")
+	require.NoError(t, os.MkdirAll(saDir, 0o755))
+	require.NoError(t, os.MkdirAll(eestDir, 0o755))
+
+	manifest := `{"flags":{"client":"nethermind","fork":"osaka","seed":1234,"chain_id":1337,"gas_limit":300000000,"target_size":"256MB"},` +
+		`"result":{"state_root":"0x120a6b331ed0fa9bec93ce22ab765a057b4e7c707d0fd97388fcd4316ed65498",` +
+		`"accounts_created":301540,"contracts_created":5248,"storage_slots":1351914,"total_db_size_bytes":526000000,"elapsed_ms":4348}}`
+	require.NoError(t, os.WriteFile(filepath.Join(saDir, stateActorManifestFile), []byte(manifest), 0o600))
+
+	fill := `{"source_dir":"/schelk/state-actor/v1/nethermind","filler_client":"geth","filler_image":"ethpandaops/geth:master","eest_sha":"27174ca1b2c3deadbeef","fork":"osaka","filter":"bn128","filled":36,"failed":0}`
+	require.NoError(t, os.WriteFile(filepath.Join(eestDir, eestFillResultFile), []byte(fill), 0o600))
+
+	p := writeBuildSummary(t, dir, BuildSummary{
+		GeneratedAt: "2026-07-06T00:00:00Z",
+		Targets: []BuildTargetSummary{
+			{Builder: "state-actor", Name: "nethermind", Client: "nethermind", OutputDir: saDir, Status: "OK", ElapsedMs: 4348},
+			{Builder: "eest-payloads", Name: "payload-generator-geth", Client: "geth", OutputDir: eestDir, Status: "OK", ElapsedMs: 30000},
+		},
+	})
+
+	md, err := GenerateBuildMarkdown(p, 65000)
+	require.NoError(t, err)
+
+	// per-target sections, each a Field | Value table
+	assert.Contains(t, md, "### ✅ nethermind — state-actor")
+	assert.Contains(t, md, "### ✅ payload-generator-geth — eest-payloads")
+	assert.Contains(t, md, "| Field | Value |")
+	// state-actor manifest enrichment (counts use thousands separators)
+	assert.Contains(t, md, "| Accounts created | 301,540 |")
+	assert.Contains(t, md, "| Storage slots | 1,351,914 |")
+	assert.Contains(t, md, "0x120a6b33") // short state root prefix
+	// eest provenance + fill counts + newly added filler image / EEST commit
+	assert.Contains(t, md, "| Source | /schelk/state-actor/v1/nethermind |")
+	assert.Contains(t, md, "| Filler image | `ethpandaops/geth:master` |")
+	assert.Contains(t, md, "| EEST commit | `27174ca1b2` |")
+	assert.Contains(t, md, "| Filled | 36 |")
+	assert.Contains(t, md, "| Failed | 0 |")
+}
+
+func TestGenerateBuildMarkdown_ErrTargetShowsError(t *testing.T) {
+	dir := t.TempDir()
+
+	p := writeBuildSummary(t, dir, BuildSummary{
+		Targets: []BuildTargetSummary{
+			{Builder: "eest-payloads", Name: "besu", OutputDir: filepath.Join(dir, "nope"), Status: "ERR", Error: "fill failed"},
+		},
+	})
+
+	md, err := GenerateBuildMarkdown(p, 65000)
+	require.NoError(t, err)
+	assert.Contains(t, md, "### ❌ besu — eest-payloads")
+	assert.Contains(t, md, "| Status | Failed |")
+	assert.Contains(t, md, "> ❌ fill failed")
+}


### PR DESCRIPTION
## What

Adds a build-side markdown summary, mirroring the existing run summary, and surfaces it in the composite action's GitHub **job summary**. Each build target (state-actor + eest-payloads) gets its own section as a `Field | Value` table.

## How

- **`benchmarkoor build --summary-json <path>`** persists a per-target `BuildSummary` (builder, name, client, output_dir, status OK/SKIP/ERR, elapsed).
- **New `generate-build-markdown-summary --input <json> [--output <md>]`** renders it via `executor.GenerateBuildMarkdown`, enriching each target from its on-disk artifacts:
  - **state-actor** — from `state-actor-manifest.json`: fork, state root, accounts/contracts/storage counts, DB size.
  - **eest-payloads** — provenance (source snapshot, filler client + image, EEST commit, fork, filter) + authoritative **filled/failed** counts.
- **eest counts are read from EEST's own report artifacts**, not stdout: `filled` from `.meta/index.json` `test_count`, `failed` from pytest's `--json-report` summary (`failed + error`), enabled via `PYTEST_ADDOPTS`. The `.benchmarkoor-fill.json` sidecar is written **even after a failed fill** — fill-stateful continues through failures and still writes the reports — so a failed target is fully described.
- **`action.yaml`**: the build step writes `--summary-json`, and a new "Generate build markdown summary" step appends the rendered markdown to `$GITHUB_STEP_SUMMARY`. Gated on `mode == all || mode == build`, runs on `always()` so a failed build still publishes its summary.

## Example output

### ✅ geth — state-actor
| Field | Value |
|---|---|
| Status | OK |
| Client | geth |
| Fork | osaka |
| State root | `0x120a6b33…d65498` |
| Accounts created | 301,540 |
| Contracts created | 5,248 |
| Storage slots | 1,351,914 |
| DB size | 502.4 MiB |
| Elapsed | 4s |

### ❌ payload-generator-geth — eest-payloads
| Field | Value |
|---|---|
| Status | Failed |
| Source | /schelk/state-actor/v1/geth |
| Filler | geth |
| Filler image | `ethpandaops/geth:master` |
| EEST commit | `27174ca1b2` |
| Fork | osaka |
| Filled | 1,103 |
| Failed | 10 |
| Elapsed | 7m 0s |

> ❌ running fill-stateful: init container exited with code 1 (10 tests failed)

## Validation

- Real geth build validated end-to-end: `--json-report` produces the pytest report; a broadened fill (all `compute` tests) yielded **1,103 filled / 10 failed** — counts read correctly from `index.json` + the pytest report, and the failed target renders full provenance.
- Unit tests: `recordEESTFillResult` (index.json + pytest report → sidecar) and `GenerateBuildMarkdown` (section rendering, OK + ERR).
- `go build`/`go test` green (except the pre-existing macOS-only `/proc/mounts` `TestValidateDataDirMethods_SchelkBinary`); golangci-lint `--new-from-rev=origin/master` 0 issues; `action.yaml` valid.