### PR TITLE
feat(build): upload build artifacts + record state-actor image/digest

### DIFF
--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -168,6 +168,7 @@ jobs:
           git-repo: ${{ github.event.pull_request.head.repo.clone_url }}
           mode: build
           build-args: '--rebuild-on-diff'
+          upload-build-artifacts: 'true'
           build-config: |
             builder:
               state_actor:

--- a/action.yaml
+++ b/action.yaml
@@ -251,7 +251,7 @@ runs:
         tar -czf "${{ runner.temp }}/benchmarkoor-build-artifacts.tar.gz" -C "${{ runner.temp }}" benchmarkoor-build-artifacts
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always() && inputs.upload-build-artifacts == 'true' && (inputs.mode == 'all' || inputs.mode == 'build') && (inputs.build-config != '' || inputs.build-config-urls != '')
       with:
         name: benchmarkoor-build-${{ github.run_id }}
@@ -390,7 +390,7 @@ runs:
         fi
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always() && inputs.upload-artifacts == 'true' && inputs.mode != 'build'
       with:
         name: benchmarkoor-${{ github.run_id }}

--- a/action.yaml
+++ b/action.yaml
@@ -235,7 +235,9 @@ runs:
 
         while IFS=$'\t' read -r builder name outdir; do
           [ -d "$outdir" ] || continue
-          dest="$STAGING/${name}"
+          # Group by builder (state-actor/<target>, eest-payloads/<target>) so a
+          # state-actor and eest target of the same name don't collide.
+          dest="$STAGING/${builder}/${name}"
           mkdir -p "$dest"
           if [ "$builder" = "eest-payloads" ]; then
             sudo cp -a "$outdir/." "$dest/"

--- a/action.yaml
+++ b/action.yaml
@@ -35,6 +35,11 @@ inputs:
     required: false
     default: 'false'
 
+  upload-build-artifacts:
+    description: 'Whether to upload build artifacts as a GitHub artifact: each state-actor target''s metadata JSON (not the datadir) and each eest-payloads target''s full fixtures directory.'
+    required: false
+    default: 'false'
+
   run-config-urls:
     description: 'Comma-separated URLs for config files to download and pass via --config (merged in order)'
     required: false
@@ -209,6 +214,48 @@ runs:
           fi
         fi
 
+    - name: Archive build artifacts
+      # Collect each built target's artifacts (discovered from build-summary.json):
+      # eest-payloads → the full fixtures directory; state-actor → only the
+      # state-actor-* metadata files, NOT the multi-GB datadir. sudo because the
+      # build artifacts are root-owned; chown the staging copy so the upload (and
+      # tar) can read it. Runs on build modes, even on failure (partial artifacts).
+      if: always() && inputs.upload-build-artifacts == 'true' && (inputs.mode == 'all' || inputs.mode == 'build') && (inputs.build-config != '' || inputs.build-config-urls != '')
+      shell: bash
+      run: |
+        SUMMARY="${{ runner.temp }}/benchmarkoor-build-summary.json"
+        STAGING="${{ runner.temp }}/benchmarkoor-build-artifacts"
+        if [ ! -f "$SUMMARY" ]; then
+          echo "No build summary at $SUMMARY; nothing to archive"
+          exit 0
+        fi
+
+        sudo rm -rf "$STAGING"
+        mkdir -p "$STAGING"
+
+        while IFS=$'\t' read -r builder name outdir; do
+          [ -d "$outdir" ] || continue
+          dest="$STAGING/${name}"
+          mkdir -p "$dest"
+          if [ "$builder" = "eest-payloads" ]; then
+            sudo cp -a "$outdir/." "$dest/"
+          else
+            # state-actor: metadata files only (find runs as root to read the datadir).
+            sudo find "$outdir" -maxdepth 1 -name 'state-actor-*' -exec cp -a {} "$dest/" \;
+          fi
+        done < <(jq -r '.targets[] | [.builder, .name, .output_dir] | @tsv' "$SUMMARY")
+
+        sudo chown -R "$(id -u):$(id -g)" "$STAGING"
+        tar -czf "${{ runner.temp }}/benchmarkoor-build-artifacts.tar.gz" -C "${{ runner.temp }}" benchmarkoor-build-artifacts
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      if: always() && inputs.upload-build-artifacts == 'true' && (inputs.mode == 'all' || inputs.mode == 'build') && (inputs.build-config != '' || inputs.build-config-urls != '')
+      with:
+        name: benchmarkoor-build-${{ github.run_id }}
+        path: ${{ runner.temp }}/benchmarkoor-build-artifacts.tar.gz
+        if-no-files-found: ignore
+
     - name: Get Job ID from GH API
       id: get-job-id
       if: inputs.mode == 'all' || inputs.mode == 'run'
@@ -359,4 +406,5 @@ runs:
         rm -f "${{ runner.temp }}/benchmarkoor-build-config-inline.yaml"
         rm -f "${{ runner.temp }}/benchmarkoor-build-summary.json" "${{ runner.temp }}/benchmarkoor-build-summary.md"
         rm -f "${{ runner.temp }}/benchmarkoor-results.tar.gz"
+        sudo rm -rf "${{ runner.temp }}/benchmarkoor-build-artifacts" "${{ runner.temp }}/benchmarkoor-build-artifacts.tar.gz"
         rm -f "${{ runner.temp }}/benchmarkoor"

--- a/pkg/builder/state_actor.go
+++ b/pkg/builder/state_actor.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -225,6 +226,13 @@ func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOp
 			err, tail.String())
 	}
 
+	// Record the docker image (name + resolved sha256 digest) into the manifest
+	// so it travels with the state-actor metadata and surfaces in the build
+	// summary. Best-effort: a failure here must not fail an otherwise-good build.
+	if err := b.recordManifestImage(ctx, log, target.OutputDir, image); err != nil {
+		log.WithError(err).Warn("Failed to record docker image in state-actor manifest")
+	}
+
 	// Record the config fingerprint so a later --rebuild-on-diff run can tell
 	// whether the datadir is stale. Best-effort: a failure here must not fail an
 	// otherwise-successful build.
@@ -248,6 +256,51 @@ func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOp
 	log.Info("Build completed")
 
 	return false, nil
+}
+
+// stateActorManifestFile is the metadata JSON the external state-actor binary
+// writes into each datadir.
+const stateActorManifestFile = "state-actor-manifest.json"
+
+// recordManifestImage augments the state-actor manifest with the docker image
+// used to produce the datadir and its resolved sha256 digest, under a
+// benchmarkoor-namespaced key, so the image travels with the state-actor
+// metadata (and surfaces in the build summary).
+func (b *StateActorBuilder) recordManifestImage(ctx context.Context, log logrus.FieldLogger, outputDir, image string) error {
+	digest, err := b.mgr.GetImageDigest(ctx, image)
+	if err != nil {
+		log.WithError(err).Debug("Could not resolve state-actor image digest")
+
+		digest = ""
+	}
+
+	path := filepath.Join(outputDir, stateActorManifestFile)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading manifest: %w", err)
+	}
+
+	var manifest map[string]any
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("parsing manifest: %w", err)
+	}
+
+	manifest["benchmarkoor"] = map[string]any{
+		"image":        image,
+		"image_digest": digest,
+	}
+
+	out, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling manifest: %w", err)
+	}
+
+	if err := os.WriteFile(path, append(out, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing manifest: %w", err)
+	}
+
+	return nil
 }
 
 // findTargetIndex returns the index of the first target whose

--- a/pkg/builder/state_actor_test.go
+++ b/pkg/builder/state_actor_test.go
@@ -503,6 +503,23 @@ func TestStateActorBuilder_SpecAndTargetSizeCoexist(t *testing.T) {
 	require.Len(t, mgr.runs[0].Mounts, 2, "output_dir + spec file should both be mounted")
 }
 
+func TestRecordManifestImage(t *testing.T) {
+	out := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(out, stateActorManifestFile),
+		[]byte(`{"schema_version":1,"flags":{"client":"geth"}}`), 0o600))
+
+	b := &StateActorBuilder{mgr: &fakeMgr{}, log: noopLogger()}
+	require.NoError(t, b.recordManifestImage(context.Background(), noopLogger(), out, "ethpandaops/geth:master"))
+
+	got, err := os.ReadFile(filepath.Join(out, stateActorManifestFile))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(got), `"benchmarkoor"`)
+	assert.Contains(t, string(got), `"image": "ethpandaops/geth:master"`)
+	assert.Contains(t, string(got), `"image_digest": "sha256:`)
+	assert.Contains(t, string(got), `"client": "geth"`) // existing fields preserved
+}
+
 // ---------------- helpers ----------------
 
 func noopLogger() logrus.FieldLogger {
@@ -564,7 +581,7 @@ func (m *fakeMgr) StreamLogs(_ context.Context, _ string, _, _ io.Writer) error 
 	panic("StreamLogs not used in builder tests")
 }
 func (m *fakeMgr) GetImageDigest(_ context.Context, _ string) (string, error) {
-	panic("GetImageDigest not used in builder tests")
+	return "sha256:0000000000000000000000000000000000000000000000000000000000000000", nil
 }
 func (m *fakeMgr) GetContainerIP(_ context.Context, _, _ string) (string, error) {
 	panic("GetContainerIP not used in builder tests")

--- a/pkg/executor/build_markdown.go
+++ b/pkg/executor/build_markdown.go
@@ -55,6 +55,12 @@ type stateActorManifest struct {
 		TotalDBSizeBytes int64  `json:"total_db_size_bytes"`
 		ElapsedMs        int64  `json:"elapsed_ms"`
 	} `json:"result"`
+	// Benchmarkoor is the benchmarkoor-namespaced block added after generation,
+	// carrying the docker image used to produce the datadir + its sha256 digest.
+	Benchmarkoor *struct {
+		Image       string `json:"image"`
+		ImageDigest string `json:"image_digest"`
+	} `json:"benchmarkoor"`
 }
 
 // eestFillResult mirrors the .benchmarkoor-fill.json sidecar: the eest target's
@@ -138,6 +144,11 @@ func writeStateActorSection(sb *strings.Builder, t BuildTargetSummary) {
 
 	if m := readStateActorManifest(t.OutputDir); m != nil {
 		writeField(sb, "Fork", orDash(m.Flags.Fork))
+
+		if m.Benchmarkoor != nil {
+			writeField(sb, "Docker image", code(m.Benchmarkoor.Image))
+			writeField(sb, "Image digest", code(m.Benchmarkoor.ImageDigest))
+		}
 
 		if m.Result != nil {
 			writeField(sb, "State root", code(shortHash(m.Result.StateRoot)))

--- a/pkg/executor/build_markdown_test.go
+++ b/pkg/executor/build_markdown_test.go
@@ -30,6 +30,7 @@ func TestGenerateBuildMarkdown(t *testing.T) {
 	require.NoError(t, os.MkdirAll(eestDir, 0o755))
 
 	manifest := `{"flags":{"client":"nethermind","fork":"osaka","seed":1234,"chain_id":1337,"gas_limit":300000000,"target_size":"256MB"},` +
+		`"benchmarkoor":{"image":"ethpandaops/nethermind:master","image_digest":"sha256:abc123def456"},` +
 		`"result":{"state_root":"0x120a6b331ed0fa9bec93ce22ab765a057b4e7c707d0fd97388fcd4316ed65498",` +
 		`"accounts_created":301540,"contracts_created":5248,"storage_slots":1351914,"total_db_size_bytes":526000000,"elapsed_ms":4348}}`
 	require.NoError(t, os.WriteFile(filepath.Join(saDir, stateActorManifestFile), []byte(manifest), 0o600))
@@ -56,6 +57,9 @@ func TestGenerateBuildMarkdown(t *testing.T) {
 	assert.Contains(t, md, "| Accounts created | 301,540 |")
 	assert.Contains(t, md, "| Storage slots | 1,351,914 |")
 	assert.Contains(t, md, "0x120a6b33") // short state root prefix
+	// docker image + digest recorded into the manifest
+	assert.Contains(t, md, "| Docker image | `ethpandaops/nethermind:master` |")
+	assert.Contains(t, md, "| Image digest | `sha256:abc123def456` |")
 	// eest provenance + fill counts + newly added filler image / EEST commit
 	assert.Contains(t, md, "| Source | /schelk/state-actor/v1/nethermind |")
 	assert.Contains(t, md, "| Filler image | `ethpandaops/geth:master` |")


### PR DESCRIPTION
Builds on the build markdown summary (#264). Two related additions.

## 1. Optional upload of build artifacts (`action.yaml`)

New `upload-build-artifacts` input (default `false`). When enabled, an "Archive build artifacts" step reads `build-summary.json` to discover each target's `output_dir` and stages:
- **eest-payloads** targets → the full fixtures directory.
- **state-actor** targets → only the `state-actor-*` metadata files (**not** the multi-GB datadir).

The staged copy is chowned to the runner, tarred, and uploaded as `benchmarkoor-build-<run_id>`. Gated on build modes, runs on failure too (partial artifacts), and cleaned up at the end.

The selective collection was validated locally: a fake state-actor datadir blob (`nodes.db`) is excluded while its `state-actor-manifest.json` + spec are kept; the eest fixtures dir is taken whole.

## 2. Record state-actor docker image + digest

After a state-actor build, its manifest JSON is augmented with a `benchmarkoor`-namespaced block carrying the docker image used and its resolved sha256 digest (via the existing `GetImageDigest`):

```json
"benchmarkoor": {
  "image": "ghcr.io/ethereum/state-actor:main",
  "image_digest": "sha256:d93e9c0099ea5f4553b0293a443e0469a0b39f9e1a38ddc02e00212f50127f29"
}
```

This travels with the state-actor metadata (so it's included in the uploaded artifacts) and surfaces in the build markdown summary:

| Field | Value |
|---|---|
| Docker image | `ghcr.io/ethereum/state-actor:main` |
| Image digest | `sha256:d93e9c00…` |

Best-effort — a failure to resolve/record the image never fails the build.

## Validation

- Real state-actor geth build: manifest gets the `benchmarkoor` block with the resolved digest; summary renders Docker image + Image digest.
- Unit tests: `recordManifestImage` (manifest augmentation preserves existing fields) and the renderer (`GenerateBuildMarkdown` shows image/digest).
- `go build`/`go test` green (except the pre-existing macOS-only `/proc/mounts` `TestValidateDataDirMethods_SchelkBinary`); golangci-lint `--new-from-rev=origin/master` 0 issues; `action.yaml` valid.