### PR TITLE
fix(build): backfill benchmarkoor metadata for skipped targets

### DIFF
--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -190,6 +190,8 @@ func (b *EESTPayloadsBuilder) Build(ctx context.Context, name string, opts Build
 			log.Info("Skipping build: output_dir already populated " +
 				"(pass --force, --rebuild-on-diff, or set force: true on the target to rebuild)")
 
+			b.backfillFillSidecarIfMissing(log, target)
+
 			return true, nil
 		}
 	}
@@ -224,6 +226,8 @@ func (b *EESTPayloadsBuilder) Build(ctx context.Context, name string, opts Build
 
 			if !dec.rebuild {
 				log.Infof("Skipping build: output_dir already populated (%s)", dec.reason)
+
+				b.backfillFillSidecarIfMissing(log, target)
 
 				return true, nil
 			}
@@ -828,6 +832,40 @@ func dirSize(dir string) int64 {
 	})
 
 	return total
+}
+
+// backfillFillSidecarIfMissing writes the fill result sidecar for a skipped
+// target when it's absent — e.g. fixtures produced by an older benchmarkoor or
+// restored from a baseline — so the build summary still shows the target's data
+// instead of just "skipped". Best-effort; an existing sidecar is left untouched.
+func (b *EESTPayloadsBuilder) backfillFillSidecarIfMissing(log logrus.FieldLogger, t *config.EESTPayloadTarget) {
+	if _, err := os.Stat(filepath.Join(t.OutputDir, eestFillResultFile)); err == nil {
+		return
+	}
+
+	if err := recordEESTFillResult(t, eestSHAFromFingerprint(t.OutputDir)); err != nil {
+		log.WithError(err).Warn("Failed to backfill fill result sidecar on skip")
+	}
+}
+
+// eestSHAFromFingerprint recovers the EEST commit recorded in the build
+// fingerprint sidecar, if present ("" when absent/unparseable).
+func eestSHAFromFingerprint(outputDir string) string {
+	data, err := os.ReadFile(filepath.Join(outputDir, buildSidecarFile))
+	if err != nil {
+		return ""
+	}
+
+	var sidecar struct {
+		Inputs struct {
+			EESTSHA string `json:"eest_sha"`
+		} `json:"inputs"`
+	}
+	if json.Unmarshal(data, &sidecar) != nil {
+		return ""
+	}
+
+	return sidecar.Inputs.EESTSHA
 }
 
 // recordEESTFillResult writes the .benchmarkoor-fill.json sidecar for the build

--- a/pkg/builder/eest_payloads_test.go
+++ b/pkg/builder/eest_payloads_test.go
@@ -347,10 +347,11 @@ func TestEESTPayloadsBuilder_BuildSkipsPopulatedDir(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, skipped, "Build should report skipped=true when output_dir is non-empty")
 
-	entries, err := os.ReadDir(dir)
-	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	assert.Equal(t, "leftover", entries[0].Name())
+	// The original content is preserved, and the skip backfills the fill-result
+	// sidecar (it was missing) so the build summary can still show this target's
+	// data instead of just "skipped".
+	assert.FileExists(t, filepath.Join(dir, "leftover"))
+	assert.FileExists(t, filepath.Join(dir, eestFillResultFile))
 }
 
 func TestMaterializeAddressStubs(t *testing.T) {

--- a/pkg/builder/state_actor.go
+++ b/pkg/builder/state_actor.go
@@ -129,6 +129,8 @@ func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOp
 			log.Info("Skipping build: output_dir already populated " +
 				"(pass --force, --rebuild-on-diff, or set force: true on the target to rebuild)")
 
+			b.backfillManifestImageIfMissing(ctx, log, target.OutputDir, image)
+
 			return true, nil
 		}
 	}
@@ -165,6 +167,8 @@ func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOp
 
 			if !dec.rebuild {
 				log.Infof("Skipping build: output_dir already populated (%s)", dec.reason)
+
+				b.backfillManifestImageIfMissing(ctx, log, target.OutputDir, image)
 
 				return true, nil
 			}
@@ -261,6 +265,28 @@ func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOp
 // stateActorManifestFile is the metadata JSON the external state-actor binary
 // writes into each datadir.
 const stateActorManifestFile = "state-actor-manifest.json"
+
+// backfillManifestImageIfMissing records the docker image into a skipped
+// target's manifest when the benchmarkoor block is absent — a datadir built by
+// an older benchmarkoor or restored from a baseline — so the build summary
+// shows the image even on skip. Best-effort; an existing block is left as-is.
+func (b *StateActorBuilder) backfillManifestImageIfMissing(ctx context.Context, log logrus.FieldLogger, outputDir, image string) {
+	data, err := os.ReadFile(filepath.Join(outputDir, stateActorManifestFile))
+	if err != nil {
+		return
+	}
+
+	var probe struct {
+		Benchmarkoor json.RawMessage `json:"benchmarkoor"`
+	}
+	if json.Unmarshal(data, &probe) == nil && len(probe.Benchmarkoor) > 0 {
+		return
+	}
+
+	if err := b.recordManifestImage(ctx, log, outputDir, image); err != nil {
+		log.WithError(err).Warn("Failed to backfill docker image in manifest on skip")
+	}
+}
 
 // recordManifestImage augments the state-actor manifest with the docker image
 // used to produce the datadir and its resolved sha256 digest, under a


### PR DESCRIPTION
## Symptom

When a build target is **skipped**, the markdown build summary shows only `Status: Skipped` (+ `Elapsed`) with none of the target's data — most visibly the entire eest-payloads section is empty, and state-actor is missing Docker image / digest:

| Field | Value |
|---|---|
| Status | Skipped (unchanged) |
| Elapsed | 516ms |

## Root cause

benchmarkoor's own metadata — the eest `.benchmarkoor-fill.json` sidecar and the state-actor manifest's `benchmarkoor` image block — is only written when a build **actually runs**. A target whose output was produced by an **older benchmarkoor** (before those features) or **restored from a baseline** never got them, and a skip returns before the code that writes them. The renderer then finds nothing to show.

(state-actor stats still show on skip because the manifest is written by the external state-actor tool; only benchmarkoor-authored data was missing.)

## Fix

On skip, backfill the benchmarkoor metadata from the on-disk artifacts + target config when it's missing (best-effort; existing metadata is left untouched):

- **eest** — (re)write `.benchmarkoor-fill.json`: provenance from the target config, `filled` from `.meta/index.json`, size from the fixtures dir, and the EEST commit recovered from the fingerprint sidecar (`.benchmarkoor-build.json`) when present.
- **state-actor** — augment the manifest with the docker image + resolved sha256 digest.

## Validation

Simulated the exact scenario — stripped the `benchmarkoor` block from a manifest and deleted the eest fill sidecar, then ran a skip build. Both sections came back fully populated:

- state-actor: `Docker image` + `Image digest` restored.
- eest: `Source`, `Filler`, `Filler image`, `EEST commit` (recovered from the fingerprint sidecar), `Fork`, `Filter`, `Filled 36`, `Failed 0`, `Fixtures size` — all shown.

Updated `TestEESTPayloadsBuilder_BuildSkipsPopulatedDir` to assert the skip now backfills the sidecar. `go build`/`go test` green (except the pre-existing macOS-only `/proc/mounts` `TestValidateDataDirMethods_SchelkBinary`); golangci-lint `--new-from-rev=origin/master` 0 issues.