### PR TITLE
feat(eest): opt-in opcode-count extraction during fill

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1685,7 +1685,7 @@ builder:
       fork: Osaka
       gas_benchmark_values: [10, 30]     # millions of gas to parametrise against
       # fixed_opcode_count: [0.5, 1, 2]  # thousands of opcodes; mutually exclusive with gas_benchmark_values
-      # extract_opcode_count: true       # record per-opcode counts in _info.metadata.opcode_count (geth filler; slow)
+      # extract_opcode_count: true       # per-opcode counts in _info.metadata.opcode_count via debug_traceBlockByHash + a custom JS tracer (slow)
       datadir_method: copy               # copy | overlayfs | fuse-overlayfs | zfs | direct | schelk
     targets:
       - name: compute-geth
@@ -1729,7 +1729,7 @@ Every field below is also available per-target; a non-nil/non-empty value on a t
 | `address_stubs_file` | string | – | **Absolute** host path to a `--address-stubs` JSON map. Mutually exclusive with `address_stubs`. |
 | `gas_benchmark_values` | int[] | – | Gas budgets in millions, e.g. `[10, 30]`; joined into `--gas-benchmark-values`. Mutually exclusive with `fixed_opcode_count`. |
 | `fixed_opcode_count` | float[] | – | Opcode counts in thousands, e.g. `[0.5, 1, 2]`; joined into `--fixed-opcode-count`. An empty list (`[]`) passes the flag bare, using the fill image's `.fixed_opcode_counts.json` default. Mutually exclusive with `gas_benchmark_values`. |
-| `extract_opcode_count` | bool | `false` | Enable `fill-stateful --extract-opcode-count`: trace each execution-phase block (`debug_traceBlockByHash` + a JS opcode tracer) and record per-opcode execution counts in each fixture's `_info.metadata.opcode_count`. Requires a JS-tracer-capable filler (**geth**) and an `eest_repo`/`eest_ref` whose `fill-stateful` carries the flag ([execution-specs#3124](https://github.com/ethereum/execution-specs/pull/3124)). Adds a full re-execution trace per block, so it is slow and opt-in. |
+| `extract_opcode_count` | bool | `false` | Enable `fill-stateful --extract-opcode-count`: after building each execution-phase block, trace it via `debug_traceBlockByHash` with a **custom JS opcode-counting tracer** and record per-opcode execution counts in each fixture's `_info.metadata.opcode_count`. The per-block re-trace with the custom tracer is what makes it **slow**, so it is opt-in. Works with any filler exposing `debug_traceBlockByHash` + JS tracer support (geth is the validated/production-ready filler). Needs an `eest_repo`/`eest_ref` whose `fill-stateful` carries the flag ([execution-specs#3124](https://github.com/ethereum/execution-specs/pull/3124)). |
 | `datadir_method` | string | `copy` | How the filler's writable copy of `source_dir` is prepared: `copy`, `overlayfs`, `fuse-overlayfs`, `zfs`, `direct`, `schelk`. Use `zfs`/`overlayfs` to avoid a full copy of a large snapshot. |
 | `max_gas_per_test` | uint64 | – | Overrides the fork's transaction gas-limit cap (`--max-gas-per-test`). |
 | `rpc_seed_key` | string | – | Pin the seed EOA for reproducible fills (`--rpc-seed-key`); otherwise one is generated and funded via CL withdrawal. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1685,6 +1685,7 @@ builder:
       fork: Osaka
       gas_benchmark_values: [10, 30]     # millions of gas to parametrise against
       # fixed_opcode_count: [0.5, 1, 2]  # thousands of opcodes; mutually exclusive with gas_benchmark_values
+      # extract_opcode_count: true       # record per-opcode counts in _info.metadata.opcode_count (geth filler; slow)
       datadir_method: copy               # copy | overlayfs | fuse-overlayfs | zfs | direct | schelk
     targets:
       - name: compute-geth
@@ -1728,6 +1729,7 @@ Every field below is also available per-target; a non-nil/non-empty value on a t
 | `address_stubs_file` | string | – | **Absolute** host path to a `--address-stubs` JSON map. Mutually exclusive with `address_stubs`. |
 | `gas_benchmark_values` | int[] | – | Gas budgets in millions, e.g. `[10, 30]`; joined into `--gas-benchmark-values`. Mutually exclusive with `fixed_opcode_count`. |
 | `fixed_opcode_count` | float[] | – | Opcode counts in thousands, e.g. `[0.5, 1, 2]`; joined into `--fixed-opcode-count`. An empty list (`[]`) passes the flag bare, using the fill image's `.fixed_opcode_counts.json` default. Mutually exclusive with `gas_benchmark_values`. |
+| `extract_opcode_count` | bool | `false` | Enable `fill-stateful --extract-opcode-count`: trace each execution-phase block (`debug_traceBlockByHash` + a JS opcode tracer) and record per-opcode execution counts in each fixture's `_info.metadata.opcode_count`. Requires a JS-tracer-capable filler (**geth**) and an `eest_repo`/`eest_ref` whose `fill-stateful` carries the flag ([execution-specs#3124](https://github.com/ethereum/execution-specs/pull/3124)). Adds a full re-execution trace per block, so it is slow and opt-in. |
 | `datadir_method` | string | `copy` | How the filler's writable copy of `source_dir` is prepared: `copy`, `overlayfs`, `fuse-overlayfs`, `zfs`, `direct`, `schelk`. Use `zfs`/`overlayfs` to avoid a full copy of a large snapshot. |
 | `max_gas_per_test` | uint64 | – | Overrides the fork's transaction gas-limit cap (`--max-gas-per-test`). |
 | `rpc_seed_key` | string | – | Pin the seed EOA for reproducible fills (`--rpc-seed-key`); otherwise one is generated and funded via CL withdrawal. |
@@ -1755,7 +1757,7 @@ Identity/locator fields are target-only; the rest mirror `config` and are resolv
 | `genesis_eip_override` | object | – | Patch a parity/nethermind `genesis` at filler boot, setting `params.eip<N>TransitionTimestamp` for each listed EIP. Fields: `timestamp` (uint), `eips` ([]uint). For the nethermind filler. Requires `genesis`; mutually exclusive with `genesis_fork_override`. |
 | `output_dir` | string | – | **Absolute** host path for the generated fixtures. Skipped if already populated unless `--force` / `force: true`. Written under `<output_dir>/blockchain_tests_stateful_engine/`. |
 | `force` | bool | `false` | Per-target override of `--force`: wipe `output_dir` before filling. |
-| `filler_image`, `fork`, `tests`, `filter`, `marker`, `address_stubs`, `address_stubs_file`, `gas_benchmark_values`, `fixed_opcode_count`, `datadir_method`, `max_gas_per_test`, `rpc_seed_key`, `filler_extra_args` | — | from `config` | Mirror `config` with per-target precedence — see the `config` table above. `tests`, `fork`, and `filler_image` are required after resolution (set on the target or in `config`). |
+| `filler_image`, `fork`, `tests`, `filter`, `marker`, `address_stubs`, `address_stubs_file`, `gas_benchmark_values`, `fixed_opcode_count`, `extract_opcode_count`, `datadir_method`, `max_gas_per_test`, `rpc_seed_key`, `filler_extra_args` | — | from `config` | Mirror `config` with per-target precedence — see the `config` table above. `tests`, `fork`, and `filler_image` are required after resolution (set on the target or in `config`). |
 
 ### Replaying generated fixtures
 

--- a/examples/configuration/config.state-actor-eest.simple.osaka.compute.yaml
+++ b/examples/configuration/config.state-actor-eest.simple.osaka.compute.yaml
@@ -66,10 +66,11 @@ builder:
       fork: osaka
       gas_benchmark_values: [10]  # Millions of gas to parametrise against
       datadir_method: copy        # 1GB snapshot; copy is fine (For bigger dirs we should use zfs/overlayfs/schelk)
-      # extract_opcode_count: true  # trace each block (debug_traceBlockByHash + JS tracer) and
-      #                             # record per-opcode counts in _info.metadata.opcode_count.
-      #                             # Needs a JS-tracer-capable filler (geth) and an eest_repo/ref
-      #                             # carrying fill-stateful's --extract-opcode-count. Slow; opt-in.
+      # extract_opcode_count: true  # record per-opcode counts in each fixture's _info.metadata.opcode_count.
+      #                             # Traces each block via debug_traceBlockByHash with a custom JS tracer
+      #                             # (the per-block re-trace is what makes it slow; opt-in). Works with any
+      #                             # filler exposing debug_traceBlockByHash + JS tracer support (geth is
+      #                             # the validated one), and an eest_repo/ref carrying --extract-opcode-count.
       # Every target fills the same compute subset, so hoist tests + filter here.
       tests:
         - tests/benchmark/compute   # pytest paths inside the fill image

--- a/examples/configuration/config.state-actor-eest.simple.osaka.compute.yaml
+++ b/examples/configuration/config.state-actor-eest.simple.osaka.compute.yaml
@@ -66,6 +66,10 @@ builder:
       fork: osaka
       gas_benchmark_values: [10]  # Millions of gas to parametrise against
       datadir_method: copy        # 1GB snapshot; copy is fine (For bigger dirs we should use zfs/overlayfs/schelk)
+      # extract_opcode_count: true  # trace each block (debug_traceBlockByHash + JS tracer) and
+      #                             # record per-opcode counts in _info.metadata.opcode_count.
+      #                             # Needs a JS-tracer-capable filler (geth) and an eest_repo/ref
+      #                             # carrying fill-stateful's --extract-opcode-count. Slow; opt-in.
       # Every target fills the same compute subset, so hoist tests + filter here.
       tests:
         - tests/benchmark/compute   # pytest paths inside the fill image

--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -1227,9 +1227,10 @@ func buildFillArgs(
 		}
 	}
 
-	// --extract-opcode-count traces each execution-phase block and records
-	// per-opcode counts in the fixture's _info.metadata.opcode_count. Needs a
-	// filler client with the debug namespace + JS tracer support (e.g. geth).
+	// --extract-opcode-count traces each execution-phase block via
+	// debug_traceBlockByHash with a custom JS tracer and records per-opcode
+	// counts in the fixture's _info.metadata.opcode_count. Works with any filler
+	// exposing debug_traceBlockByHash + JS tracer support (geth is validated).
 	if t.ExtractOpcodeCount != nil && *t.ExtractOpcodeCount {
 		args = append(args, "--extract-opcode-count")
 	}

--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -1227,6 +1227,13 @@ func buildFillArgs(
 		}
 	}
 
+	// --extract-opcode-count traces each execution-phase block and records
+	// per-opcode counts in the fixture's _info.metadata.opcode_count. Needs a
+	// filler client with the debug namespace + JS tracer support (e.g. geth).
+	if t.ExtractOpcodeCount != nil && *t.ExtractOpcodeCount {
+		args = append(args, "--extract-opcode-count")
+	}
+
 	if t.MaxGasPerTest != nil {
 		args = append(args, fmt.Sprintf("--max-gas-per-test=%d", *t.MaxGasPerTest))
 	}

--- a/pkg/builder/eest_payloads_test.go
+++ b/pkg/builder/eest_payloads_test.go
@@ -111,6 +111,8 @@ func TestResolveFillDockerfile(t *testing.T) {
 	})
 }
 
+func boolPtr(b bool) *bool { return &b }
+
 func TestBuildFillArgs(t *testing.T) {
 	spec := client.NewGethSpec()
 	prefix := []string{"uv", "run", "fill-stateful"}
@@ -140,8 +142,28 @@ func TestBuildFillArgs(t *testing.T) {
 			},
 			wantAbsent: []string{
 				"--clean", "--gas-benchmark-values", "--fixed-opcode-count", "--max-gas-per-test",
-				"--rpc-seed-key", "--address-stubs", "-k",
+				"--rpc-seed-key", "--address-stubs", "-k", "--extract-opcode-count",
 			},
+		},
+		{
+			name: "extract opcode count enabled",
+			target: &config.EESTPayloadTarget{
+				FillerClient:       "geth",
+				Fork:               "Osaka",
+				ExtractOpcodeCount: boolPtr(true),
+				Tests:              []string{"tests/benchmark/compute"},
+			},
+			wantContain: []string{"--extract-opcode-count"},
+		},
+		{
+			name: "extract opcode count disabled",
+			target: &config.EESTPayloadTarget{
+				FillerClient:       "geth",
+				Fork:               "Osaka",
+				ExtractOpcodeCount: boolPtr(false),
+				Tests:              []string{"tests/benchmark/compute"},
+			},
+			wantAbsent: []string{"--extract-opcode-count"},
 		},
 		{
 			name: "fixed opcode count values",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -461,12 +461,13 @@ type EESTPayloadTarget struct {
 	AddressStubs       map[string]map[string]string `yaml:"address_stubs,omitempty" mapstructure:"address_stubs"`
 	GasBenchmarkValues []int                        `yaml:"gas_benchmark_values,omitempty" mapstructure:"gas_benchmark_values"`
 	FixedOpcodeCount   *[]float64                   `yaml:"fixed_opcode_count,omitempty" mapstructure:"fixed_opcode_count"`
-	// ExtractOpcodeCount enables fill-stateful's --extract-opcode-count: each
-	// execution-phase block is traced (debug_traceBlockByHash + a JS opcode
-	// tracer) and per-opcode execution counts are recorded in the fixture's
-	// _info.metadata.opcode_count. Requires a filler client with the debug
-	// namespace + JS tracer support (e.g. geth). Slow (a re-execution trace per
-	// block); opt-in.
+	// ExtractOpcodeCount enables fill-stateful's --extract-opcode-count: after
+	// building each execution-phase block it is traced via debug_traceBlockByHash
+	// with a custom JS opcode-counting tracer, recording per-opcode execution
+	// counts in the fixture's _info.metadata.opcode_count. The per-block re-trace
+	// with the custom tracer is what makes it slow, so it's opt-in. Works with any
+	// filler exposing debug_traceBlockByHash + JS tracer support (geth is the
+	// validated one).
 	ExtractOpcodeCount *bool    `yaml:"extract_opcode_count,omitempty" mapstructure:"extract_opcode_count"`
 	DataDirMethod      string   `yaml:"datadir_method,omitempty" mapstructure:"datadir_method"`
 	MaxGasPerTest      *uint64  `yaml:"max_gas_per_test,omitempty" mapstructure:"max_gas_per_test"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -408,6 +408,7 @@ type EESTPayloadDefaults struct {
 	AddressStubs       map[string]map[string]string `yaml:"address_stubs,omitempty" mapstructure:"address_stubs"`
 	GasBenchmarkValues []int                        `yaml:"gas_benchmark_values,omitempty" mapstructure:"gas_benchmark_values"`
 	FixedOpcodeCount   *[]float64                   `yaml:"fixed_opcode_count,omitempty" mapstructure:"fixed_opcode_count"`
+	ExtractOpcodeCount *bool                        `yaml:"extract_opcode_count,omitempty" mapstructure:"extract_opcode_count"`
 	DataDirMethod      string                       `yaml:"datadir_method,omitempty" mapstructure:"datadir_method"`
 	MaxGasPerTest      *uint64                      `yaml:"max_gas_per_test,omitempty" mapstructure:"max_gas_per_test"`
 	RPCSeedKey         string                       `yaml:"rpc_seed_key,omitempty" mapstructure:"rpc_seed_key"`
@@ -460,10 +461,17 @@ type EESTPayloadTarget struct {
 	AddressStubs       map[string]map[string]string `yaml:"address_stubs,omitempty" mapstructure:"address_stubs"`
 	GasBenchmarkValues []int                        `yaml:"gas_benchmark_values,omitempty" mapstructure:"gas_benchmark_values"`
 	FixedOpcodeCount   *[]float64                   `yaml:"fixed_opcode_count,omitempty" mapstructure:"fixed_opcode_count"`
-	DataDirMethod      string                       `yaml:"datadir_method,omitempty" mapstructure:"datadir_method"`
-	MaxGasPerTest      *uint64                      `yaml:"max_gas_per_test,omitempty" mapstructure:"max_gas_per_test"`
-	RPCSeedKey         string                       `yaml:"rpc_seed_key,omitempty" mapstructure:"rpc_seed_key"`
-	FillerExtraArgs    []string                     `yaml:"filler_extra_args,omitempty" mapstructure:"filler_extra_args"`
+	// ExtractOpcodeCount enables fill-stateful's --extract-opcode-count: each
+	// execution-phase block is traced (debug_traceBlockByHash + a JS opcode
+	// tracer) and per-opcode execution counts are recorded in the fixture's
+	// _info.metadata.opcode_count. Requires a filler client with the debug
+	// namespace + JS tracer support (e.g. geth). Slow (a re-execution trace per
+	// block); opt-in.
+	ExtractOpcodeCount *bool    `yaml:"extract_opcode_count,omitempty" mapstructure:"extract_opcode_count"`
+	DataDirMethod      string   `yaml:"datadir_method,omitempty" mapstructure:"datadir_method"`
+	MaxGasPerTest      *uint64  `yaml:"max_gas_per_test,omitempty" mapstructure:"max_gas_per_test"`
+	RPCSeedKey         string   `yaml:"rpc_seed_key,omitempty" mapstructure:"rpc_seed_key"`
+	FillerExtraArgs    []string `yaml:"filler_extra_args,omitempty" mapstructure:"filler_extra_args"`
 }
 
 // ResolveTarget returns a copy of the i-th target with any unset hoistable
@@ -512,6 +520,10 @@ func (e *EESTPayloadsConfig) ResolveTarget(i int) EESTPayloadTarget {
 
 	if t.FixedOpcodeCount == nil {
 		t.FixedOpcodeCount = g.FixedOpcodeCount
+	}
+
+	if t.ExtractOpcodeCount == nil {
+		t.ExtractOpcodeCount = g.ExtractOpcodeCount
 	}
 
 	if t.DataDirMethod == "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4329,14 +4329,15 @@ func TestEESTPayloadsResolveTarget(t *testing.T) {
 			DataDirMethod:      "zfs",
 			MaxGasPerTest:      u64Cfg(45000000),
 			RPCSeedKey:         "0xseed",
+			ExtractOpcodeCount: boolCfg(true),
 			FillerExtraArgs:    []string{"--verbosity=3"},
 		},
 		Targets: []EESTPayloadTarget{
 			// Inherits everything from config.
 			{Name: "inherit", FillerClient: "geth", SourceDir: "/s", OutputDir: "/o"},
-			// Overrides fork and gas values.
+			// Overrides fork, gas values, and opts out of opcode extraction.
 			{Name: "override", FillerClient: "geth", SourceDir: "/s2", OutputDir: "/o2",
-				Fork: "Prague", GasBenchmarkValues: []int{60}},
+				Fork: "Prague", GasBenchmarkValues: []int{60}, ExtractOpcodeCount: boolCfg(false)},
 		},
 	}
 
@@ -4351,11 +4352,15 @@ func TestEESTPayloadsResolveTarget(t *testing.T) {
 	assert.Equal(t, "zfs", inherit.DataDirMethod)
 	require.NotNil(t, inherit.MaxGasPerTest)
 	assert.Equal(t, uint64(45000000), *inherit.MaxGasPerTest)
+	require.NotNil(t, inherit.ExtractOpcodeCount)
+	assert.True(t, *inherit.ExtractOpcodeCount, "inherits extract_opcode_count when unset")
 	assert.Equal(t, []string{"--verbosity=3"}, inherit.FillerExtraArgs)
 
 	override := ep.ResolveTarget(1)
 	assert.Equal(t, "Prague", override.Fork, "per-target fork wins")
 	assert.Equal(t, []int{60}, override.GasBenchmarkValues, "per-target gas values win")
+	require.NotNil(t, override.ExtractOpcodeCount)
+	assert.False(t, *override.ExtractOpcodeCount, "per-target extract_opcode_count=false wins over default")
 	assert.Equal(t, "ethpandaops/geth:master", override.FillerImage, "still inherits unset fields")
 	assert.Equal(t, "not erc20", override.Filter, "inherits filter when unset")
 }
@@ -4421,3 +4426,4 @@ func TestGetEESTPayloadsContainerRuntime(t *testing.T) {
 }
 
 func u64Cfg(v uint64) *uint64 { return &v }
+func boolCfg(v bool) *bool    { return &v }


### PR DESCRIPTION
## What

Adds an opt-in `extract_opcode_count` option to eest-payloads targets. When enabled, benchmarkoor passes `--extract-opcode-count` to `fill-stateful`, which traces each execution-phase block (`debug_traceBlockByHash` + a JS opcode-counting tracer) and records per-opcode execution counts in each fixture's `_info.metadata.opcode_count`.

## Depends on

**https://github.com/ethereum/execution-specs/pull/3124** — the `fill-stateful --extract-opcode-count` flag lives there. This benchmarkoor change is just the passthrough; it's **inert unless enabled**, and only functions when `eest_repo`/`eest_ref` point at a `fill-stateful` that carries the flag (i.e. once #3124 lands, or a fork/branch with it).

## Changes

- `pkg/config`: `extract_opcode_count` (`*bool`) on `EESTPayloadTarget` + `EESTPayloadDefaults`, hoistable to `config:` and inherited via `ResolveTarget`.
- `pkg/builder`: `buildFillArgs` appends `--extract-opcode-count` when enabled.
- Example config: a commented note documenting the option + its requirements.
- Tests: `buildFillArgs` cases (enabled/disabled/absent-by-default) and `ResolveTarget` inheritance/override coverage.

## Requirements / caveats

- Filler must support the `debug` namespace + JS tracers — **geth** works (besu/nethermind/reth/ethrex don't expose geth-style JS tracers).
- **Slow**: a full re-execution trace per block. Opt-in for that reason.

## Validation

Ran a real geth build against a branch carrying #3124 (`skylenet/execution-specs @ opcode-filing`), filling the bn128 compute subset. The fill argv included `--extract-opcode-count`, the build succeeded, and **all 36 filled tests** got a non-empty `opcode_count`. Confirmed against the written fixture on disk, e.g.:

```
tests/benchmark/compute/precompile/test_alt_bn128.py::test_bn128_pairings_amortized[fork_Osaka-...-value_10M]
  _info.metadata.opcode_count = {
    "CALLDATASIZE":11,"PUSH1":42,"CALLDATACOPY":1,"JUMPDEST":1,"GAS":10,"STATICCALL":10,"POP":9
  }
```

(Values are sensible: the BN128 pairing work runs inside the precompile, invoked via `STATICCALL` to `0x08` — counted 10× — so the traced EVM opcodes are the calling harness.)

`go build`/`go test` green (except the pre-existing macOS-only `/proc/mounts` `TestValidateDataDirMethods_SchelkBinary`); golangci-lint `--new-from-rev=origin/master` 0 issues.