### PR TITLE
feat(state-actor): log datadir size periodically during build

### DIFF
--- a/pkg/builder/progress.go
+++ b/pkg/builder/progress.go
@@ -1,0 +1,68 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// datadirProgressInterval is how often the datadir-size progress line is logged
+// during a build.
+const datadirProgressInterval = 30 * time.Second
+
+// logDatadirProgress periodically logs the size of dir until the returned stop
+// func is called, giving visible progress during a long build even when the
+// underlying tool (e.g. state-actor) logs nothing itself. The stop func cancels
+// the ticker and blocks until the logging goroutine has exited.
+func logDatadirProgress(ctx context.Context, log logrus.FieldLogger, dir string, interval time.Duration) (stop func()) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				log.WithField("datadir_size", humanizeBytes(dirSize(dir))).
+					Info("Building datadir (size growing)")
+			}
+		}
+	}()
+
+	return func() {
+		cancel()
+		wg.Wait()
+	}
+}
+
+// humanizeBytes renders a byte count as a human-readable KiB/MiB/GiB string.
+func humanizeBytes(b int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+
+	switch {
+	case b >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(b)/float64(gib))
+	case b >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(b)/float64(mib))
+	case b >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(b)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/pkg/builder/progress.go
+++ b/pkg/builder/progress.go
@@ -11,7 +11,7 @@ import (
 
 // datadirProgressInterval is how often the datadir-size progress line is logged
 // during a build.
-const datadirProgressInterval = 30 * time.Second
+const datadirProgressInterval = 5 * time.Minute
 
 // logDatadirProgress periodically logs the size of dir until the returned stop
 // func is called, giving visible progress during a long build even when the

--- a/pkg/builder/progress_test.go
+++ b/pkg/builder/progress_test.go
@@ -1,0 +1,53 @@
+package builder
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHumanizeBytes(t *testing.T) {
+	tests := []struct {
+		bytes int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{2048, "2.0 KiB"},
+		{5 * 1024 * 1024, "5.0 MiB"},
+		{3 * 1024 * 1024 * 1024, "3.0 GiB"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, humanizeBytes(tt.bytes))
+	}
+}
+
+func TestLogDatadirProgress(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "chaindata"), make([]byte, 4096), 0o644))
+
+	logger, hook := test.NewNullLogger()
+
+	stop := logDatadirProgress(context.Background(), logger, dir, 5*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return len(hook.AllEntries()) > 0
+	}, 2*time.Second, 5*time.Millisecond, "should log at least one progress line")
+
+	stop() // must return promptly, not hang
+
+	entries := hook.AllEntries()
+	require.NotEmpty(t, entries)
+	assert.Contains(t, entries[0].Message, "datadir")
+
+	size, ok := entries[0].Data["datadir_size"].(string)
+	require.True(t, ok, "progress line carries a datadir_size string field")
+	assert.Contains(t, size, "KiB", "4096 bytes should render as KiB")
+}

--- a/pkg/builder/state_actor.go
+++ b/pkg/builder/state_actor.go
@@ -225,9 +225,16 @@ func (b *StateActorBuilder) Build(ctx context.Context, name string, opts BuildOp
 
 	log.WithFields(logrus.Fields{"image": image, "argv": args}).Info("Running state-actor")
 
-	if err := b.mgr.RunInitContainer(ctx, spec, stdout, stderr); err != nil {
+	// state-actor can run for a long time and may log nothing; periodically log
+	// the growing datadir size so the build shows progress.
+	stopProgress := logDatadirProgress(ctx, log, target.OutputDir, datadirProgressInterval)
+
+	runErr := b.mgr.RunInitContainer(ctx, spec, stdout, stderr)
+	stopProgress()
+
+	if runErr != nil {
 		return false, fmt.Errorf("running state-actor: %w (output tail: %s)",
-			err, tail.String())
+			runErr, tail.String())
 	}
 
 	// Record the docker image (name + resolved sha256 digest) into the manifest


### PR DESCRIPTION
## What

When building a `state_actor` datadir, periodically log the growing target datadir size so the build shows progress. state-actor can run for a long time and may log nothing itself, which makes a running build look stalled — this gives a visible heartbeat.

## How

- `pkg/builder/progress.go`: `logDatadirProgress(ctx, log, dir, interval)` starts a ticker goroutine that logs `dir`'s size every `interval` and returns a `stop` func. The goroutine is cancelled + waited on (`context.WithCancel` + `sync.WaitGroup`) when `stop` is called, so there's no leak. Plus a small `humanizeBytes` (KiB/MiB/GiB) helper.
- `pkg/builder/state_actor.go`: wraps the `RunInitContainer` call — start progress, run, stop.
- Interval is a **5-minute** constant (`datadirProgressInterval`).

The datadir walk reuses the existing `dirSize`; state-actor datadirs are a handful of large SST/LDB files, so the walk is cheap.

## Example output

```
INFO | Running state-actor ...
INFO | Building datadir (size growing) datadir_size=239.7 MiB target=geth
INFO | Building datadir (size growing) datadir_size=594.8 MiB target=geth
INFO | Build completed target=geth
```

(validated with a shortened interval to observe the lines; the committed default is 5m.)

## Tests

- `TestHumanizeBytes` (formatting) and `TestLogDatadirProgress` (short interval → logs a `datadir_size` line and `stop()` returns without hanging), passing under `-race`.
- `go build`/`go test` green; golangci-lint `--new-from-rev=origin/master` 0 issues.