### PR TITLE
fix(build-summary): mount schelk before rendering so a skipped state-actor shows its data

### DIFF
--- a/cmd/benchmarkoor/build_markdown_summary.go
+++ b/cmd/benchmarkoor/build_markdown_summary.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
+	"github.com/ethpandaops/benchmarkoor/pkg/datadir"
 	"github.com/ethpandaops/benchmarkoor/pkg/executor"
 	"github.com/spf13/cobra"
 )
@@ -37,6 +39,12 @@ func init() {
 func runGenerateBuildMarkdownSummary(_ *cobra.Command, _ []string) error {
 	log.WithField("input", buildToMdInput).Info("Generating build markdown summary")
 
+	// The summary renders each target from its on-disk output_dir (state-actor
+	// manifest, eest fill sidecar). A state-actor datadir promoted onto a schelk
+	// mount may be unmounted by now, so its manifest would read as missing and
+	// the (skipped) target would show no data. Mount it first.
+	ensureSchelkForBuildSummary(context.Background(), buildToMdInput)
+
 	md, err := executor.GenerateBuildMarkdown(buildToMdInput, maxMarkdownChars)
 	if err != nil {
 		return fmt.Errorf("generating build markdown: %w", err)
@@ -54,4 +62,25 @@ func runGenerateBuildMarkdownSummary(_ *cobra.Command, _ []string) error {
 	log.WithField("output", output).Info("Build markdown summary written")
 
 	return nil
+}
+
+// ensureSchelkForBuildSummary mounts the schelk scratch when any build target's
+// output_dir lives under a schelk mount, so the renderer can read its on-disk
+// artifacts (e.g. a state-actor manifest). Best-effort — a non-schelk host or an
+// unreadable summary is a no-op; one schelk volume covers every schelk output_dir.
+func ensureSchelkForBuildSummary(ctx context.Context, summaryPath string) {
+	summary, err := executor.ReadBuildSummary(summaryPath)
+	if err != nil {
+		return
+	}
+
+	for _, t := range summary.Targets {
+		if _, isSchelk, err := datadir.SchelkDir(t.OutputDir); err == nil && isSchelk {
+			if err := datadir.EnsureSchelkMounted(ctx, log); err != nil {
+				log.WithError(err).Warn("Failed to ensure schelk mount for build summary")
+			}
+
+			return
+		}
+	}
 }

--- a/pkg/executor/build_markdown.go
+++ b/pkg/executor/build_markdown.go
@@ -78,18 +78,29 @@ type eestFillResult struct {
 	Failed       int    `json:"failed"`
 }
 
-// GenerateBuildMarkdown reads a build-summary.json and renders a markdown
-// summary of the state-actor and eest-payloads builds, enriching each target
-// from its on-disk output_dir artifacts. Output is truncated to maxChars.
-func GenerateBuildMarkdown(summaryPath string, maxChars int) (string, error) {
-	data, err := os.ReadFile(summaryPath)
+// ReadBuildSummary parses a build-summary.json written by
+// `benchmarkoor build --summary-json`.
+func ReadBuildSummary(path string) (*BuildSummary, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("reading build summary %s: %w", summaryPath, err)
+		return nil, fmt.Errorf("reading build summary %s: %w", path, err)
 	}
 
 	var summary BuildSummary
 	if err := json.Unmarshal(data, &summary); err != nil {
-		return "", fmt.Errorf("parsing build summary %s: %w", summaryPath, err)
+		return nil, fmt.Errorf("parsing build summary %s: %w", path, err)
+	}
+
+	return &summary, nil
+}
+
+// GenerateBuildMarkdown reads a build-summary.json and renders a markdown
+// summary of the state-actor and eest-payloads builds, enriching each target
+// from its on-disk output_dir artifacts. Output is truncated to maxChars.
+func GenerateBuildMarkdown(summaryPath string, maxChars int) (string, error) {
+	summary, err := ReadBuildSummary(summaryPath)
+	if err != nil {
+		return "", err
 	}
 
 	var sb strings.Builder


### PR DESCRIPTION
## Symptom

In the GitHub Action's build summary, a **skipped** state-actor target shows only `Status: Skipped`, `Client`, and `Elapsed` — no fork, state root, docker image, account/contract/storage counts, or DB size. The eest-payloads section on the same run shows full data.

## Root cause

The build markdown summary is rendered by a **separate** `generate-build-markdown-summary` step that reads each target's on-disk `output_dir` (state-actor `state-actor-manifest.json`, eest `.benchmarkoor-fill.json`). The state-actor `output_dir` lives under a **schelk** mount (`/schelk/state-actor/v1/nethermind`); a promoted state-actor datadir is left **unmounted** (`schelk promote`). So when the render step runs after the build, the manifest reads as *missing* → the renderer shows nothing beyond the fields already in `build-summary.json` (status/client/elapsed).

The eest section is fine because its fill sidecar isn't under schelk.

## Fix

`generate-build-markdown-summary` now ensures the schelk scratch is mounted before rendering, when any target's `output_dir` is under a schelk mount:

- New exported `executor.ReadBuildSummary(path)` (also used by `GenerateBuildMarkdown` now).
- The cmd reads the summary, and if any `output_dir` is schelk-backed, calls `datadir.EnsureSchelkMounted` once (one volume covers all). Best-effort — a non-schelk host or unreadable summary is a no-op; a mount failure logs a warning and renders what it can (no regression).

The render step already runs with `sudo -E` in the action, so it can mount.

The executor stays free of a `datadir` dependency — the schelk-ensure lives in the cmd layer.

## Tests / validation

- Existing executor + cmd tests pass (`GenerateBuildMarkdown` refactored onto `ReadBuildSummary`); `go build`/`go test` green; golangci-lint `--new-from-rev=origin/master` 0 issues.
- The live schelk path can't be exercised here (needs a schelk-initialised Linux host); worth confirming on a `benchmarkoor-tests` re-run.