### PR TITLE
feat(action): add build-artifact-name input to disambiguate matrix legs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,9 +41,9 @@ inputs:
     default: 'false'
 
   build-artifact-name:
-    description: 'Name for the uploaded build artifact. Override to disambiguate matrix legs (artifact names must be unique within a run), e.g. append the client. Only used when upload-build-artifacts is true.'
+    description: 'Name for the uploaded build artifact. Override to disambiguate matrix legs (artifact names must be unique within a run), e.g. append the client. Leave empty for the default `benchmarkoor-build-<run_id>`. Only used when upload-build-artifacts is true.'
     required: false
-    default: 'benchmarkoor-build-${{ github.run_id }}'
+    default: ''
 
   run-config-urls:
     description: 'Comma-separated URLs for config files to download and pass via --config (merged in order)'
@@ -259,7 +259,7 @@ runs:
       uses: actions/upload-artifact@v7
       if: always() && inputs.upload-build-artifacts == 'true' && (inputs.mode == 'all' || inputs.mode == 'build') && (inputs.build-config != '' || inputs.build-config-urls != '')
       with:
-        name: ${{ inputs.build-artifact-name }}
+        name: ${{ inputs.build-artifact-name != '' && inputs.build-artifact-name || format('benchmarkoor-build-{0}', github.run_id) }}
         path: ${{ runner.temp }}/benchmarkoor-build-artifacts.tar.gz
         if-no-files-found: ignore
 

--- a/action.yaml
+++ b/action.yaml
@@ -40,6 +40,11 @@ inputs:
     required: false
     default: 'false'
 
+  build-artifact-name:
+    description: 'Name for the uploaded build artifact. Override to disambiguate matrix legs (artifact names must be unique within a run), e.g. append the client. Only used when upload-build-artifacts is true.'
+    required: false
+    default: 'benchmarkoor-build-${{ github.run_id }}'
+
   run-config-urls:
     description: 'Comma-separated URLs for config files to download and pass via --config (merged in order)'
     required: false
@@ -254,7 +259,7 @@ runs:
       uses: actions/upload-artifact@v7
       if: always() && inputs.upload-build-artifacts == 'true' && (inputs.mode == 'all' || inputs.mode == 'build') && (inputs.build-config != '' || inputs.build-config-urls != '')
       with:
-        name: benchmarkoor-build-${{ github.run_id }}
+        name: ${{ inputs.build-artifact-name }}
         path: ${{ runner.temp }}/benchmarkoor-build-artifacts.tar.gz
         if-no-files-found: ignore
 


### PR DESCRIPTION
## What

Adds an optional `build-artifact-name` action input (default `benchmarkoor-build-${{ github.run_id }}`) used as the name for the uploaded build-artifacts, when `upload-build-artifacts` is enabled.

## Why

The upload step hardcoded `benchmarkoor-build-${{ github.run_id }}`, which is identical across all legs of a matrix build. `actions/upload-artifact` requires unique artifact names within a run, so matrix builds (one client per leg) collide. Overriding the name — e.g. appending the client — lets each leg upload a distinct, individually-downloadable artifact.

## Compatibility

Backward-compatible: the default equals the previous hardcoded value, so existing callers are unaffected.

## Example

```yaml
with:
  upload-build-artifacts: "true"
  build-artifact-name: benchmarkoor-build-${{ github.run_id }}-${{ matrix.client }}
```