### PR TITLE
feat(build-summary): surface more state-actor + eest build data

### DIFF
--- a/pkg/executor/build_markdown.go
+++ b/pkg/executor/build_markdown.go
@@ -13,6 +13,8 @@ import (
 const (
 	stateActorManifestFile = "state-actor-manifest.json"
 	eestFillResultFile     = ".benchmarkoor-fill.json"
+	buildFingerprintFile   = ".benchmarkoor-build.json"
+	pytestReportFile       = ".benchmarkoor-pytest-report.json"
 )
 
 // BuildSummary is the per-invocation result of `benchmarkoor build`, persisted
@@ -55,12 +57,33 @@ type stateActorManifest struct {
 		TotalDBSizeBytes int64  `json:"total_db_size_bytes"`
 		ElapsedMs        int64  `json:"elapsed_ms"`
 	} `json:"result"`
+	StateActor struct {
+		Version string `json:"version"`
+	} `json:"state_actor"`
 	// Benchmarkoor is the benchmarkoor-namespaced block added after generation,
 	// carrying the docker image used to produce the datadir + its sha256 digest.
 	Benchmarkoor *struct {
 		Image       string `json:"image"`
 		ImageDigest string `json:"image_digest"`
 	} `json:"benchmarkoor"`
+}
+
+// eestFingerprint mirrors the config-level fill inputs of the
+// .benchmarkoor-build.json fingerprint sidecar that we surface in the summary.
+type eestFingerprint struct {
+	Inputs struct {
+		Tests              []string `json:"tests"`
+		GasBenchmarkValues []int    `json:"gas_benchmark_values"`
+		Marker             string   `json:"marker"`
+		DataDirMethod      string   `json:"datadir_method"`
+		EESTRepo           string   `json:"eest_repo"`
+	} `json:"inputs"`
+}
+
+// pytestReport mirrors the fields of the pytest json report we surface (the
+// fill's wall-clock duration).
+type pytestReport struct {
+	Duration float64 `json:"duration"`
 }
 
 // eestFillResult mirrors the .benchmarkoor-fill.json sidecar: the eest target's
@@ -161,6 +184,26 @@ func writeStateActorSection(sb *strings.Builder, t BuildTargetSummary) {
 			writeField(sb, "Image digest", code(m.Benchmarkoor.ImageDigest))
 		}
 
+		if m.StateActor.Version != "" {
+			writeField(sb, "State-actor version", code(m.StateActor.Version))
+		}
+
+		if m.Flags.TargetSize != "" {
+			writeField(sb, "Target size", m.Flags.TargetSize)
+		}
+
+		if m.Flags.GasLimit != 0 {
+			writeField(sb, "Gas limit", formatInt(m.Flags.GasLimit))
+		}
+
+		if m.Flags.Seed != 0 {
+			writeField(sb, "Seed", formatInt(m.Flags.Seed))
+		}
+
+		if m.Flags.ChainID != 0 {
+			writeField(sb, "Chain ID", formatInt(m.Flags.ChainID))
+		}
+
 		if m.Result != nil {
 			writeField(sb, "State root", code(shortHash(m.Result.StateRoot)))
 			writeField(sb, "Accounts created", formatInt(m.Result.AccountsCreated))
@@ -174,16 +217,55 @@ func writeStateActorSection(sb *strings.Builder, t BuildTargetSummary) {
 }
 
 func writeEESTSection(sb *strings.Builder, t BuildTargetSummary) {
-	if fill := readEESTFillResult(t.OutputDir); fill != nil {
+	fill := readEESTFillResult(t.OutputDir)
+	fp := readEESTFingerprint(t.OutputDir)
+	rep := readPytestReport(t.OutputDir)
+
+	if fill != nil {
 		writeField(sb, "Source", orDash(fill.SourceDir))
 		writeField(sb, "Filler", orDash(fill.FillerClient))
 		writeField(sb, "Filler image", code(fill.FillerImage))
+	}
+
+	if fp != nil && fp.Inputs.EESTRepo != "" {
+		writeField(sb, "EEST repo", fp.Inputs.EESTRepo)
+	}
+
+	if fill != nil {
 		writeField(sb, "EEST commit", code(shortSHA(fill.EESTSHA)))
 		writeField(sb, "Fork", orDash(fill.Fork))
+	}
+
+	if fp != nil && len(fp.Inputs.Tests) > 0 {
+		writeField(sb, "Tests", code(strings.Join(fp.Inputs.Tests, ", ")))
+	}
+
+	if fill != nil {
 		writeField(sb, "Filter", orDash(fill.Filter))
+	}
+
+	if fp != nil {
+		if fp.Inputs.Marker != "" {
+			writeField(sb, "Marker", code(fp.Inputs.Marker))
+		}
+
+		if len(fp.Inputs.GasBenchmarkValues) > 0 {
+			writeField(sb, "Gas values", joinInts(fp.Inputs.GasBenchmarkValues))
+		}
+
+		if fp.Inputs.DataDirMethod != "" {
+			writeField(sb, "Datadir method", fp.Inputs.DataDirMethod)
+		}
+	}
+
+	if fill != nil {
 		writeField(sb, "Filled", formatInt(int64(fill.Filled)))
 		writeField(sb, "Failed", formatInt(int64(fill.Failed)))
 		writeField(sb, "Fixtures size", formatBytes(fill.SizeBytes))
+	}
+
+	if rep != nil && rep.Duration > 0 {
+		writeField(sb, "Fill duration", formatDurationNs(int64(rep.Duration*1e9)))
 	}
 
 	writeField(sb, "Elapsed", formatDurationNs(t.ElapsedMs*1_000_000))
@@ -284,6 +366,44 @@ func readEESTFillResult(outputDir string) *eestFillResult {
 	}
 
 	return &r
+}
+
+func readEESTFingerprint(outputDir string) *eestFingerprint {
+	data, err := os.ReadFile(filepath.Join(outputDir, buildFingerprintFile))
+	if err != nil {
+		return nil
+	}
+
+	var fp eestFingerprint
+	if err := json.Unmarshal(data, &fp); err != nil {
+		return nil
+	}
+
+	return &fp
+}
+
+func readPytestReport(outputDir string) *pytestReport {
+	data, err := os.ReadFile(filepath.Join(outputDir, pytestReportFile))
+	if err != nil {
+		return nil
+	}
+
+	var r pytestReport
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil
+	}
+
+	return &r
+}
+
+// joinInts renders an int slice as a comma-separated string ("200, 300").
+func joinInts(vals []int) string {
+	parts := make([]string, len(vals))
+	for i, v := range vals {
+		parts[i] = strconv.Itoa(v)
+	}
+
+	return strings.Join(parts, ", ")
 }
 
 func orDash(s string) string {

--- a/pkg/executor/build_markdown_test.go
+++ b/pkg/executor/build_markdown_test.go
@@ -30,6 +30,7 @@ func TestGenerateBuildMarkdown(t *testing.T) {
 	require.NoError(t, os.MkdirAll(eestDir, 0o755))
 
 	manifest := `{"flags":{"client":"nethermind","fork":"osaka","seed":1234,"chain_id":1337,"gas_limit":300000000,"target_size":"256MB"},` +
+		`"state_actor":{"version":"50e3475"},` +
 		`"benchmarkoor":{"image":"ethpandaops/nethermind:master","image_digest":"sha256:abc123def456"},` +
 		`"result":{"state_root":"0x120a6b331ed0fa9bec93ce22ab765a057b4e7c707d0fd97388fcd4316ed65498",` +
 		`"accounts_created":301540,"contracts_created":5248,"storage_slots":1351914,"total_db_size_bytes":526000000,"elapsed_ms":4348}}`
@@ -37,6 +38,10 @@ func TestGenerateBuildMarkdown(t *testing.T) {
 
 	fill := `{"source_dir":"/schelk/state-actor/v1/nethermind","filler_client":"geth","filler_image":"ethpandaops/geth:master","eest_sha":"27174ca1b2c3deadbeef","fork":"osaka","filter":"bn128","size_bytes":78643200,"filled":36,"failed":0}`
 	require.NoError(t, os.WriteFile(filepath.Join(eestDir, eestFillResultFile), []byte(fill), 0o600))
+
+	fingerprint := `{"inputs":{"tests":["tests/benchmark/compute"],"gas_benchmark_values":[200,300],"marker":"repricing","datadir_method":"schelk","eest_repo":"https://github.com/ethereum/execution-specs.git"}}`
+	require.NoError(t, os.WriteFile(filepath.Join(eestDir, buildFingerprintFile), []byte(fingerprint), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(eestDir, pytestReportFile), []byte(`{"duration":2215.6}`), 0o600))
 
 	p := writeBuildSummary(t, dir, BuildSummary{
 		GeneratedAt: "2026-07-06T00:00:00Z",
@@ -60,6 +65,12 @@ func TestGenerateBuildMarkdown(t *testing.T) {
 	// docker image + digest recorded into the manifest
 	assert.Contains(t, md, "| Docker image | `ethpandaops/nethermind:master` |")
 	assert.Contains(t, md, "| Image digest | `sha256:abc123def456` |")
+	// state-actor: version + build params from the manifest
+	assert.Contains(t, md, "| State-actor version | `50e3475` |")
+	assert.Contains(t, md, "| Target size | 256MB |")
+	assert.Contains(t, md, "| Gas limit | 300,000,000 |")
+	assert.Contains(t, md, "| Seed | 1,234 |")
+	assert.Contains(t, md, "| Chain ID | 1,337 |")
 	// eest provenance + fill counts + newly added filler image / EEST commit
 	assert.Contains(t, md, "| Source | /schelk/state-actor/v1/nethermind |")
 	assert.Contains(t, md, "| Filler image | `ethpandaops/geth:master` |")
@@ -67,6 +78,13 @@ func TestGenerateBuildMarkdown(t *testing.T) {
 	assert.Contains(t, md, "| Filled | 36 |")
 	assert.Contains(t, md, "| Failed | 0 |")
 	assert.Contains(t, md, "| Fixtures size | 75.0 MiB |")
+	// eest: config inputs (fingerprint sidecar) + fill duration (pytest report)
+	assert.Contains(t, md, "| EEST repo | https://github.com/ethereum/execution-specs.git |")
+	assert.Contains(t, md, "| Tests | `tests/benchmark/compute` |")
+	assert.Contains(t, md, "| Marker | `repricing` |")
+	assert.Contains(t, md, "| Gas values | 200, 300 |")
+	assert.Contains(t, md, "| Datadir method | schelk |")
+	assert.Contains(t, md, "| Fill duration | 36m 55s |")
 }
 
 func TestGenerateBuildMarkdown_ErrTargetShowsError(t *testing.T) {


### PR DESCRIPTION
## What

Adds more fields to the build markdown summary (the GitHub-Action job summary), pulled from artifacts already written to each target's `output_dir` — no new data collection.

**state-actor** (from `state-actor-manifest.json`):
- State-actor tool version, Target size, Gas limit, Seed, Chain ID.

**eest-payloads** (from `.benchmarkoor-build.json` inputs + `.benchmarkoor-pytest-report.json`):
- EEST repo, Tests, Marker, Gas values, Datadir method, and **Fill duration** (the pytest wall-clock).

Missing/unset fields are omitted (e.g. no `Marker` row when unset; `rpc_seed_key` is deliberately never shown).

## Example (from a real bloatnet/repricing artifact)

### ✅ nethermind — state-actor
| Field | Value |
|---|---|
| … | … |
| State-actor version | `50e3475` |
| Target size | 200GB |
| Gas limit | 1,000,000,000 |
| Seed | 42 |
| Chain ID | 1,337 |
| Accounts created | 241,232,397 |
| DB size | 246.3 GiB |

### ✅ payload-generator-nethermind — eest-payloads
| Field | Value |
|---|---|
| … | … |
| Tests | `tests/benchmark/stateful/bloatnet` |
| Marker | `repricing` |
| Gas values | 200, 300 |
| Datadir method | schelk |
| Filled | 266 |
| Fixtures size | 616.8 MiB |
| Fill duration | 36m 55s |

## How

`GenerateBuildMarkdown` reads two more per-eest-target sidecars at render time — `.benchmarkoor-build.json` (config inputs) and `.benchmarkoor-pytest-report.json` (duration) — plus a couple more manifest fields for state-actor. All best-effort: an absent file just drops those rows.

Verified by rendering against a real downloaded build artifact; `go test` + golangci-lint (`--new-from-rev=origin/master`) green.