### PR TITLE
feat(runner): make genesis artifact optional in eest_fixtures artifact mode

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -824,6 +824,14 @@ func (e *EESTFixturesSource) UseArtifacts() bool {
 	return e.FixturesArtifactName != "" || e.GenesisArtifactName != ""
 }
 
+// HasGenesisArtifact reports whether a genesis artifact is explicitly configured.
+// Genesis is optional in artifact mode — stateful-engine fixtures boot from a
+// pre-populated snapshot datadir (runner.client.datadirs) and carry no genesis —
+// so it is only resolved/downloaded when a name or run ID is set.
+func (e *EESTFixturesSource) HasGenesisArtifact() bool {
+	return e.GenesisArtifactName != "" || e.GenesisArtifactRunID != ""
+}
+
 // UseLocalDir returns true if the source is configured to use local directories.
 func (e *EESTFixturesSource) UseLocalDir() bool {
 	return e.LocalFixturesDir != "" || e.LocalGenesisDir != ""

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4425,5 +4425,14 @@ func TestGetEESTPayloadsContainerRuntime(t *testing.T) {
 	})
 }
 
+func TestEESTFixturesSource_HasGenesisArtifact(t *testing.T) {
+	// Fixtures-only artifact → genesis is optional (not fetched).
+	assert.False(t, (&EESTFixturesSource{FixturesArtifactName: "f"}).HasGenesisArtifact())
+	assert.False(t, (&EESTFixturesSource{}).HasGenesisArtifact())
+	// Explicitly configured genesis → fetched.
+	assert.True(t, (&EESTFixturesSource{GenesisArtifactName: "benchmark_genesis"}).HasGenesisArtifact())
+	assert.True(t, (&EESTFixturesSource{GenesisArtifactRunID: "123"}).HasGenesisArtifact())
+}
+
 func u64Cfg(v uint64) *uint64 { return &v }
 func boolCfg(v bool) *bool    { return &v }

--- a/pkg/executor/eest_source.go
+++ b/pkg/executor/eest_source.go
@@ -106,22 +106,27 @@ func (s *EESTSource) Prepare(ctx context.Context) (*PreparedSource, error) {
 			s.log.WithField("run_id", runID).Info("Resolved latest fixtures artifact run ID")
 		}
 
-		genesisArtifact := s.cfg.GenesisArtifactName
-		if genesisArtifact == "" {
-			genesisArtifact = "benchmark_genesis"
-		}
-
-		if s.cfg.GenesisArtifactRunID != "" {
-			s.resolvedGenesisRunID = s.cfg.GenesisArtifactRunID
-		} else {
-			runID, err := s.resolveArtifactRunID(ctx, genesisArtifact)
-			if err != nil {
-				return nil, fmt.Errorf("resolving genesis artifact run ID: %w", err)
+		// Genesis is optional: only resolve it when explicitly configured. This
+		// lets a fixtures-only artifact (e.g. a benchmarkoor build artifact) be
+		// used without a paired genesis artifact.
+		if s.cfg.HasGenesisArtifact() {
+			genesisArtifact := s.cfg.GenesisArtifactName
+			if genesisArtifact == "" {
+				genesisArtifact = "benchmark_genesis"
 			}
 
-			s.resolvedGenesisRunID = runID
+			if s.cfg.GenesisArtifactRunID != "" {
+				s.resolvedGenesisRunID = s.cfg.GenesisArtifactRunID
+			} else {
+				runID, err := s.resolveArtifactRunID(ctx, genesisArtifact)
+				if err != nil {
+					return nil, fmt.Errorf("resolving genesis artifact run ID: %w", err)
+				}
 
-			s.log.WithField("run_id", runID).Info("Resolved latest genesis artifact run ID")
+				s.resolvedGenesisRunID = runID
+
+				s.log.WithField("run_id", runID).Info("Resolved latest genesis artifact run ID")
+			}
 		}
 
 		artifactKey := fmt.Sprintf("%s-%s", fixturesArtifact, s.resolvedFixturesRunID)
@@ -247,7 +252,14 @@ func (s *EESTSource) downloadArtifacts(ctx context.Context, cacheBase string) er
 		return fmt.Errorf("extracting fixtures tarballs: %w", err)
 	}
 
-	// Download genesis artifact.
+	// Download genesis artifact — only when explicitly configured (optional for
+	// stateful-engine fixtures, which boot from the snapshot datadir).
+	if !s.cfg.HasGenesisArtifact() {
+		s.log.Debug("No genesis artifact configured; skipping genesis download")
+
+		return nil
+	}
+
 	genesisArtifact := s.cfg.GenesisArtifactName
 	if genesisArtifact == "" {
 		genesisArtifact = "benchmark_genesis"


### PR DESCRIPTION
## What

In `eest_fixtures` **artifact mode**, benchmarkoor always resolved + downloaded a paired *genesis* artifact (defaulting to `benchmark_genesis`) — unconditionally. So a **fixtures-only** artifact (e.g. a benchmarkoor build artifact, which bundles state-actor + eest-payloads but has no separate genesis artifact) failed on the genesis lookup, even though stateful-engine fixtures need no genesis (they boot from the snapshot datadir — as `local_genesis_dir` already treats as optional).

## Change

Only resolve/download the genesis artifact when it's **explicitly configured** (`genesis_artifact_name` or `genesis_artifact_run_id` set), via a new `EESTFixturesSource.HasGenesisArtifact()` helper. The per-test genesis lookup already `os.Stat`s and degrades gracefully when absent, and config validation already permits a fixtures-only artifact (`valid eest_fixtures with artifacts` test) — this just makes the *fetch* match the validation.

## Result

You can now point `fixtures_artifact_name` at any fixtures artifact without a paired genesis:

```yaml
eest_fixtures:
  github_repo: ethpandaops/benchmarkoor
  fixtures_artifact_name: benchmarkoor-build-28947560261
  fixtures_artifact_run_id: "28947560261"
  fixtures_subdir: benchmarkoor-build-artifacts/eest-payloads/geth/blockchain_tests_stateful_engine
```

## Tests

`TestEESTFixturesSource_HasGenesisArtifact` + existing validation/executor tests pass; golangci-lint `--new-from-rev=origin/master` 0 issues. (The pre-existing macOS-only `/proc/mounts` schelk test is unrelated.)