### PR TITLE
feat(runner): fixtures_url standalone mode + GitHub artifact URL support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -457,13 +457,24 @@ tests:
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
-| `github_repo` | string | Yes | - | GitHub repository (e.g., `ethereum/execution-specs`) |
+| `github_repo` | string | Yes* | - | GitHub repository (e.g., `ethereum/execution-specs`). Required for release/artifact modes; not needed for `fixtures_url`. |
 | `github_release` | string | Yes* | - | Release tag (e.g., `test-benchmark@v0.0.9`) |
-| `fixtures_subdir` | string | No | `fixtures/blockchain_tests_engine_x` | Subdirectory within the fixtures tarball to search |
-| `fixtures_url` | string | No | Auto-generated | Override URL for fixtures tarball |
-| `genesis_url` | string | No | Auto-generated | Override URL for genesis tarball |
+| `fixtures_subdir` | string | No | `fixtures/blockchain_tests_engine_x` | Subdirectory within the extracted fixtures to search |
+| `fixtures_url` | string | No | Auto-generated | **Standalone source** (when `github_release` is unset): a release/plain `.tar.gz` URL, **or** a GitHub Actions artifact URL (`github.com/<owner>/<repo>/actions/runs/<run>/artifacts/<id>` — needs `runner.github_token`; its inner `.tar.gz` is auto-extracted). No genesis is fetched. Combine with `fixtures_subdir`. When `github_release` is set, it instead overrides the release tarball URL. |
+| `genesis_url` | string | No | Auto-generated | Override URL for genesis tarball (release mode) |
 
-*Either `github_release` or `fixtures_artifact_name` is required.
+*One of `github_release`, `fixtures_url`, or `fixtures_artifact_name` is required.
+
+**Standalone URL example** (e.g. reusing a benchmarkoor build artifact):
+
+```yaml
+tests:
+  source:
+    eest_fixtures:
+      fixtures_url: https://github.com/ethpandaops/benchmarkoor/actions/runs/28947560261/artifacts/8170387928
+      fixtures_subdir: benchmarkoor-build-artifacts/eest-payloads/geth/blockchain_tests_stateful_engine
+# runner.github_token (or BENCHMARKOOR_RUNNER_GITHUB_TOKEN) is required for artifact URLs.
+```
 
 ###### From GitHub Actions Artifacts
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -834,6 +834,14 @@ func (e *EESTFixturesSource) UseLocalTarball() bool {
 	return e.LocalFixturesTarball != "" || e.LocalGenesisTarball != ""
 }
 
+// UseFixturesURL returns true when fixtures should be fetched from a standalone
+// URL — a release/plain .tar.gz download or a GitHub Actions artifact URL. When
+// github_release is also set, fixtures_url is instead a release-URL override, so
+// this is false and release mode handles it.
+func (e *EESTFixturesSource) UseFixturesURL() bool {
+	return e.FixturesURL != "" && e.GitHubRelease == ""
+}
+
 // validate checks the EEST fixtures source configuration for errors.
 // Exactly one mode must be specified: release, artifact, local_dir, or local_tarball.
 func (e *EESTFixturesSource) validate() error {
@@ -841,6 +849,7 @@ func (e *EESTFixturesSource) validate() error {
 	hasArtifacts := e.UseArtifacts()
 	hasLocalDir := e.UseLocalDir()
 	hasLocalTarball := e.UseLocalTarball()
+	hasFixturesURL := e.UseFixturesURL()
 
 	// Count active modes.
 	modeCount := 0
@@ -860,18 +869,23 @@ func (e *EESTFixturesSource) validate() error {
 		modeCount++
 	}
 
+	if hasFixturesURL {
+		modeCount++
+	}
+
 	if modeCount == 0 {
 		return fmt.Errorf(
 			"eest_fixtures: must specify one of: github_release, " +
-				"fixtures_artifact_name, local_fixtures_dir/local_genesis_dir, " +
+				"fixtures_url, fixtures_artifact_name, " +
+				"local_fixtures_dir/local_genesis_dir, " +
 				"or local_fixtures_tarball/local_genesis_tarball",
 		)
 	}
 
 	if modeCount > 1 {
 		return fmt.Errorf(
-			"eest_fixtures: cannot combine modes (release, artifact, " +
-				"local_dir, local_tarball are mutually exclusive)",
+			"eest_fixtures: cannot combine modes (release, fixtures_url, " +
+				"artifact, local_dir, local_tarball are mutually exclusive)",
 		)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4427,3 +4427,16 @@ func TestGetEESTPayloadsContainerRuntime(t *testing.T) {
 
 func u64Cfg(v uint64) *uint64 { return &v }
 func boolCfg(v bool) *bool    { return &v }
+
+func TestEESTFixturesSource_UseFixturesURL(t *testing.T) {
+	// Standalone URL mode.
+	assert.True(t, (&EESTFixturesSource{FixturesURL: "https://x/f.tar.gz"}).UseFixturesURL())
+	// With github_release set, fixtures_url is a release-URL override, not standalone.
+	assert.False(t, (&EESTFixturesSource{FixturesURL: "https://x/f.tar.gz", GitHubRelease: "v1"}).UseFixturesURL())
+	assert.False(t, (&EESTFixturesSource{}).UseFixturesURL())
+
+	// A standalone fixtures_url is a valid mode and needs no github_repo.
+	require.NoError(t, (&EESTFixturesSource{
+		FixturesURL: "https://x/f.tar.gz", FixturesSubdir: "sub",
+	}).validate())
+}

--- a/pkg/executor/eest_source.go
+++ b/pkg/executor/eest_source.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -71,6 +72,12 @@ func (s *EESTSource) Prepare(ctx context.Context) (*PreparedSource, error) {
 	// Handle local tarball mode — extract to cache.
 	if s.cfg.UseLocalTarball() {
 		return s.prepareLocalTarballs()
+	}
+
+	// Handle standalone URL mode — a release/plain .tar.gz URL or a GitHub
+	// Actions artifact URL. Downloads + extracts to cache; no genesis.
+	if s.cfg.UseFixturesURL() {
+		return s.prepareFromURL(ctx)
 	}
 
 	// Build cache path based on source type.
@@ -271,6 +278,148 @@ func (s *EESTSource) downloadArtifacts(ctx context.Context, cacheBase string) er
 	return nil
 }
 
+// prepareFromURL downloads + extracts fixtures from a standalone URL: a
+// release/plain .tar.gz URL or a GitHub Actions artifact URL. No genesis is
+// fetched (stateful-engine fixtures boot from the snapshot datadir).
+func (s *EESTSource) prepareFromURL(ctx context.Context) (*PreparedSource, error) {
+	cacheBase := filepath.Join(s.cacheDir, "eest-url", hashRepoURL(s.cfg.FixturesURL))
+	s.fixturesDir = filepath.Join(cacheBase, "fixtures")
+	s.genesisDir = filepath.Join(cacheBase, "genesis")
+
+	completeMarker := filepath.Join(cacheBase, ".complete")
+	if _, err := os.Stat(completeMarker); err == nil {
+		s.log.WithField("path", cacheBase).Info("Using cached EEST fixtures")
+
+		return s.discoverTests()
+	}
+
+	if err := os.RemoveAll(s.fixturesDir); err != nil {
+		return nil, fmt.Errorf("clearing partial fixtures cache: %w", err)
+	}
+
+	if err := s.downloadFromURL(ctx); err != nil {
+		return nil, fmt.Errorf("downloading fixtures from URL: %w", err)
+	}
+
+	if err := os.WriteFile(completeMarker, nil, 0o644); err != nil {
+		return nil, fmt.Errorf("writing cache completion marker: %w", err)
+	}
+
+	return s.discoverTests()
+}
+
+// downloadFromURL fetches fixtures from s.cfg.FixturesURL into s.fixturesDir. A
+// GitHub Actions artifact URL is downloaded via the API (needs a token) and its
+// inner .tar.gz extracted; any other URL is treated as a direct .tar.gz.
+func (s *EESTSource) downloadFromURL(ctx context.Context) error {
+	if err := os.MkdirAll(s.fixturesDir, 0o755); err != nil {
+		return fmt.Errorf("creating fixtures directory: %w", err)
+	}
+
+	url := s.cfg.FixturesURL
+
+	if owner, repo, artifactID, ok := parseGitHubArtifactURL(url); ok {
+		s.log.WithFields(logrus.Fields{
+			"owner": owner, "repo": repo, "artifact_id": artifactID,
+		}).Info("Downloading fixtures from GitHub Actions artifact URL")
+
+		if err := s.downloadArtifactZip(ctx, owner+"/"+repo, artifactID, s.fixturesDir); err != nil {
+			return fmt.Errorf("downloading artifact: %w", err)
+		}
+
+		// Build artifacts wrap the fixtures in an inner .tar.gz.
+		if err := s.extractInnerTarballs(ctx, s.fixturesDir); err != nil {
+			return fmt.Errorf("extracting inner tarballs: %w", err)
+		}
+
+		return nil
+	}
+
+	s.log.WithField("url", url).Info("Downloading fixtures tarball from URL")
+
+	if err := s.downloadAndExtractTarball(ctx, url, s.fixturesDir); err != nil {
+		return fmt.Errorf("downloading fixtures tarball: %w", err)
+	}
+
+	return nil
+}
+
+// ghArtifactURLRe matches a GitHub Actions artifact web URL, capturing owner,
+// repo, and the numeric artifact id:
+// https://github.com/<owner>/<repo>/actions/runs/<run>/artifacts/<id>
+var ghArtifactURLRe = regexp.MustCompile(
+	`^https://github\.com/([^/]+)/([^/]+)/actions/runs/\d+/artifacts/(\d+)`,
+)
+
+// parseGitHubArtifactURL returns the owner, repo, and artifact id for a GitHub
+// Actions artifact URL, or ok=false for any other URL.
+func parseGitHubArtifactURL(rawURL string) (owner, repo, artifactID string, ok bool) {
+	m := ghArtifactURLRe.FindStringSubmatch(rawURL)
+	if m == nil {
+		return "", "", "", false
+	}
+
+	return m[1], m[2], m[3], true
+}
+
+// downloadArtifactZip downloads a GitHub Actions artifact zip (apiRepo is
+// "owner/repo", artifactID is the numeric id) to targetDir and extracts it.
+// Requires a GitHub token.
+func (s *EESTSource) downloadArtifactZip(ctx context.Context, apiRepo, artifactID, targetDir string) error {
+	if s.githubToken == "" {
+		return fmt.Errorf(
+			"GitHub token is required to download a GitHub Actions artifact. " +
+				"Set runner.github_token or BENCHMARKOOR_RUNNER_GITHUB_TOKEN",
+		)
+	}
+
+	downloadURL := fmt.Sprintf(
+		"https://api.github.com/repos/%s/actions/artifacts/%s/zip",
+		apiRepo, artifactID,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating artifact download request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+s.githubToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("downloading artifact: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+
+		return fmt.Errorf("downloading artifact: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	tmpFile, err := os.CreateTemp("", "gh-artifact-*.zip")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+
+	defer func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+		return fmt.Errorf("writing artifact zip: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	return s.extractZip(tmpFile.Name(), targetDir)
+}
+
 // prepareLocalTarballs extracts local .tar.gz fixtures and genesis to a cache directory.
 func (s *EESTSource) prepareLocalTarballs() (*PreparedSource, error) {
 	// Build a cache key from the tarball paths so re-extractions can be skipped.
@@ -437,52 +586,12 @@ func (s *EESTSource) downloadGitHubArtifact(ctx context.Context, artifactName, r
 		resolvedRunID = fmt.Sprintf("%d", matched.WorkflowRun.ID)
 	}
 
-	// Download the artifact zip.
-	downloadURL := fmt.Sprintf(
-		"https://api.github.com/repos/%s/actions/artifacts/%d/zip",
-		s.cfg.GitHubRepo, matched.ID,
-	)
-
-	dlReq, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("creating artifact download request: %w", err)
+	// Download + extract the artifact zip by its resolved numeric id.
+	if err := s.downloadArtifactZip(ctx, s.cfg.GitHubRepo, fmt.Sprintf("%d", matched.ID), targetDir); err != nil {
+		return "", err
 	}
 
-	dlReq.Header.Set("Authorization", "Bearer "+s.githubToken)
-	dlReq.Header.Set("Accept", "application/vnd.github+json")
-
-	dlResp, err := http.DefaultClient.Do(dlReq)
-	if err != nil {
-		return "", fmt.Errorf("downloading artifact: %w", err)
-	}
-
-	defer func() { _ = dlResp.Body.Close() }()
-
-	if dlResp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(dlResp.Body)
-		return "", fmt.Errorf("downloading artifact: HTTP %d: %s", dlResp.StatusCode, string(body))
-	}
-
-	// Write to a temp file, then extract.
-	tmpFile, err := os.CreateTemp("", "gh-artifact-*.zip")
-	if err != nil {
-		return "", fmt.Errorf("creating temp file: %w", err)
-	}
-
-	defer func() {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-	}()
-
-	if _, err := io.Copy(tmpFile, dlResp.Body); err != nil {
-		return "", fmt.Errorf("writing artifact zip: %w", err)
-	}
-
-	if err := tmpFile.Close(); err != nil {
-		return "", fmt.Errorf("closing temp file: %w", err)
-	}
-
-	return resolvedRunID, s.extractZip(tmpFile.Name(), targetDir)
+	return resolvedRunID, nil
 }
 
 // extractZip extracts a zip archive to the target directory.

--- a/pkg/executor/eest_source_test.go
+++ b/pkg/executor/eest_source_test.go
@@ -41,3 +41,22 @@ func TestStatefulPreRunMissing(t *testing.T) {
 		})
 	}
 }
+
+func TestParseGitHubArtifactURL(t *testing.T) {
+	owner, repo, id, ok := parseGitHubArtifactURL(
+		"https://github.com/ethpandaops/benchmarkoor/actions/runs/28947560261/artifacts/8170387928",
+	)
+	assert.True(t, ok)
+	assert.Equal(t, "ethpandaops", owner)
+	assert.Equal(t, "benchmarkoor", repo)
+	assert.Equal(t, "8170387928", id)
+
+	// A plain release / tarball URL is not an artifact URL.
+	_, _, _, ok = parseGitHubArtifactURL(
+		"https://github.com/ethpandaops/benchmarkoor-tests/releases/download/untagged-x/fixtures.tar.gz",
+	)
+	assert.False(t, ok)
+
+	_, _, _, ok = parseGitHubArtifactURL("https://example.com/fixtures.tar.gz")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## What

Makes `eest_fixtures.fixtures_url` a **standalone source** (when `github_release` is unset), pointing at either:
- a **release / plain `.tar.gz` URL**, or
- a **GitHub Actions artifact URL** (`github.com/<owner>/<repo>/actions/runs/<run>/artifacts/<id>`) — downloaded via the GitHub API (needs `runner.github_token`), unzipped, and its **inner `.tar.gz` auto-extracted`.

`fixtures_subdir` points at the fixtures within; **no genesis** is fetched (stateful-engine fixtures boot from the snapshot datadir). When `github_release` *is* set, `fixtures_url` keeps its existing role as the release-URL override.

This lets you consume a **benchmarkoor build artifact** directly:

```yaml
tests:
  source:
    eest_fixtures:
      fixtures_url: https://github.com/ethpandaops/benchmarkoor/actions/runs/28947560261/artifacts/8170387928
      fixtures_subdir: benchmarkoor-build-artifacts/eest-payloads/geth/blockchain_tests_stateful_engine
# runner.github_token / BENCHMARKOOR_RUNNER_GITHUB_TOKEN required for artifact URLs
```

…and any plain tarball URL (e.g. a benchmarkoor-tests release asset) works with no token.

## How

- `config`: `UseFixturesURL()` (fixtures_url set & no github_release) as a new mode in `validate()`; no `github_repo` required for URL mode.
- `executor`: `prepareFromURL` → `downloadFromURL` auto-detects artifact-vs-plain via `parseGitHubArtifactURL`; artifact URLs reuse a new shared `downloadArtifactZip` (by owner/repo/id), plain URLs reuse `downloadAndExtractTarball`. The artifact-name mode now uses the same `downloadArtifactZip` (dedup).

## Tests / docs

- `TestParseGitHubArtifactURL` (artifact vs release vs plain) + `TestEESTFixturesSource_UseFixturesURL` (mode + validation). `go build`/`go test` green (except the pre-existing macOS-only `/proc/mounts` schelk test); golangci-lint `--new-from-rev=origin/master` 0 issues.
- `docs/configuration.md` updated: `fixtures_url` description, `github_repo` now `Yes*`, mode note, and a standalone-URL example.