### PR TITLE
fix(runner): find EEST .meta as a sibling of the fixtures dir

### DIFF
--- a/pkg/executor/eest_source.go
+++ b/pkg/executor/eest_source.go
@@ -770,6 +770,25 @@ func (s *EESTSource) loadPreRuns(searchDir string) (map[string]*eest.StatefulPre
 }
 
 // discoverTests parses fixture files and creates test entries.
+// findMetaDir locates the EEST .meta directory (fill provenance: fixtures.ini,
+// index.json, report_fill.html) for a set of fixtures. EEST writes it as a
+// sibling of the fixtures dir, so prefer the parent of searchDir (handles
+// fixtures nested under fixtures_subdir, e.g. a benchmarkoor build artifact);
+// fall back to the fixtures-cache root for root-level tarballs/releases. Returns
+// "" when no .meta is present.
+func findMetaDir(searchDir, fixturesRoot string) string {
+	for _, dir := range []string{
+		filepath.Join(filepath.Dir(searchDir), ".meta"),
+		filepath.Join(fixturesRoot, ".meta"),
+	} {
+		if fi, err := os.Stat(dir); err == nil && fi.IsDir() {
+			return dir
+		}
+	}
+
+	return ""
+}
+
 func (s *EESTSource) discoverTests() (*PreparedSource, error) {
 	// Determine the fixtures search directory.
 	fixturesSubdir := s.cfg.FixturesSubdir
@@ -791,10 +810,9 @@ func (s *EESTSource) discoverTests() (*PreparedSource, error) {
 	}
 
 	// EEST writes a .meta directory (fixtures.ini with the fill command + python/
-	// tool versions, index.json, report_fill.html) at the root of the fixtures
+	// tool versions, index.json, report_fill.html) as a sibling of the fixtures
 	// dir. Attach it when present so each suite's output can carry the provenance.
-	metaDir := filepath.Join(s.fixturesDir, ".meta")
-	if fi, err := os.Stat(metaDir); err == nil && fi.IsDir() {
+	if metaDir := findMetaDir(searchDir, s.fixturesDir); metaDir != "" {
 		result.MetaDir = metaDir
 
 		s.log.WithField("meta_dir", metaDir).Debug("Found EEST .meta directory")

--- a/pkg/executor/eest_source_test.go
+++ b/pkg/executor/eest_source_test.go
@@ -1,11 +1,37 @@
 package executor
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/eest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestFindMetaDir(t *testing.T) {
+	// Nested fixtures (e.g. a build artifact): fixtures_subdir resolves to
+	// <root>/a/b/blockchain_tests; .meta is a sibling at <root>/a/b/.meta.
+	root := t.TempDir()
+	nested := filepath.Join(root, "a", "b")
+	require.NoError(t, os.MkdirAll(filepath.Join(nested, "blockchain_tests"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(nested, ".meta"), 0o755))
+	assert.Equal(t, filepath.Join(nested, ".meta"),
+		findMetaDir(filepath.Join(nested, "blockchain_tests"), root),
+		"prefers the .meta sibling of the resolved fixtures dir")
+
+	// Root-level fallback: .meta only at the fixtures-cache root.
+	root2 := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root2, "fixtures", "blockchain_tests"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root2, ".meta"), 0o755))
+	assert.Equal(t, filepath.Join(root2, ".meta"),
+		findMetaDir(filepath.Join(root2, "fixtures", "blockchain_tests"), root2),
+		"falls back to the fixtures-cache root")
+
+	// No .meta anywhere.
+	assert.Empty(t, findMetaDir(filepath.Join(t.TempDir(), "x"), t.TempDir()))
+}
 
 func TestStatefulPreRunMissing(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Symptom

The EEST `.meta` provenance dir (`fixtures.ini`, `index.json`, `report_fill.html`) — copied into each suite's run output as `.eest-meta` — was **not** carried through when fixtures live under a **nested `fixtures_subdir`**. Most visibly with a **benchmarkoor build artifact** consumed via `fixtures_url`:

```
benchmarkoor-build-artifacts/eest-payloads/geth/.meta                          ← here
benchmarkoor-build-artifacts/eest-payloads/geth/blockchain_tests_stateful_engine   ← fixtures_subdir
```

The lookup only checked `<fixturesDir>/.meta` (the cache root), so the nested `.meta` was missed and never reached the run output.

## Fix

`.meta` is always a **sibling of the fixtures dir**, so look there first — `filepath.Dir(searchDir)/.meta` (the dir one level up from `fixtures_subdir`) — and fall back to the fixtures-cache root (`<fixturesDir>/.meta`) for root-level tarballs/releases. Extracted into a small, unit-tested `findMetaDir(searchDir, fixturesRoot)`.

- **local_fixtures_dir**: unchanged (for a one-level subdir, `Dir(searchDir)` == `<fixturesDir>`).
- **root-level tarball / release**: unchanged (fallback).
- **nested (build artifact via `fixtures_url`)**: now found. ✅

## Tests

`TestFindMetaDir` covers the nested-sibling case, the root fallback, and no-`.meta`. `go build`/`go test` green; golangci-lint `--new-from-rev=origin/master` 0 issues.