### PR TITLE
perf(api): cache the /index response and stop re-parsing run JSON

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -44,6 +44,12 @@ type server struct {
 	httpServer     *http.Server
 	wg             sync.WaitGroup
 	done           chan struct{}
+
+	// indexCache holds the marshaled /index response keyed by the runs-table
+	// generation, so repeated polls don't rebuild it. See handleIndex.
+	indexCacheMu   sync.Mutex
+	indexCacheGen  uint64
+	indexCacheBody []byte
 }
 
 // NewServer creates a new API server.

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -29,6 +29,14 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	}
 }
 
+// writeRawJSON writes an already-marshaled JSON body with a 200 status. Used
+// for responses that are built and cached ahead of time.
+func writeRawJSON(w http.ResponseWriter, body []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
 // --- Public handlers ---
 
 // handleHealth returns server health status.

--- a/pkg/api/handlers_index.go
+++ b/pkg/api/handlers_index.go
@@ -13,10 +13,54 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// emptyJSONObject is spliced in for runs that have no (or malformed) steps
+// JSON, preserving the historical behaviour where "steps" is always present.
+var emptyJSONObject = json.RawMessage("{}")
+
+// indexResponse is the /index payload. Field order mirrors the historical
+// shape (discovery_path first, then the executor.IndexEntry fields).
+type indexResponse struct {
+	Generated int64        `json:"generated"`
+	Entries   []indexEntry `json:"entries"`
+}
+
+type indexEntry struct {
+	DiscoveryPath     string                  `json:"discovery_path"`
+	RunID             string                  `json:"run_id"`
+	Timestamp         int64                   `json:"timestamp"`
+	TimestampEnd      int64                   `json:"timestamp_end,omitempty"`
+	SuiteHash         string                  `json:"suite_hash,omitempty"`
+	Instance          *executor.IndexInstance `json:"instance"`
+	Tests             indexTestStats          `json:"tests"`
+	Status            string                  `json:"status,omitempty"`
+	TerminationReason string                  `json:"termination_reason,omitempty"`
+	Metadata          json.RawMessage         `json:"metadata,omitempty"`
+}
+
+type indexTestStats struct {
+	TestsTotal  int             `json:"tests_total"`
+	TestsPassed int             `json:"tests_passed"`
+	TestsFailed int             `json:"tests_failed"`
+	Steps       json.RawMessage `json:"steps"`
+}
+
 // handleIndex returns the aggregated index of all benchmark runs from all
 // discovery paths. The response shape matches executor.Index with an
 // additional "discovery_path" field on each entry.
+//
+// The full payload is O(number of runs) and the UI polls it periodically, so
+// the marshaled body is cached and keyed by the store's runs generation: while
+// no run is upserted or deleted the response is served straight from the cache
+// without touching the database.
 func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	gen := s.indexStore.RunsGeneration()
+
+	if body := s.cachedIndex(gen); body != nil {
+		writeRawJSON(w, body)
+
+		return
+	}
+
 	runs, err := s.indexStore.ListAllRuns(r.Context())
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError,
@@ -25,26 +69,27 @@ func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	type indexEntryWithDP struct {
-		DiscoveryPath string `json:"discovery_path"`
-		*executor.IndexEntry
-	}
-
-	entries := make([]indexEntryWithDP, 0, len(runs))
+	// ListAllRuns already orders by timestamp descending, so no re-sort here.
+	entries := make([]indexEntry, 0, len(runs))
 
 	for i := range runs {
 		run := &runs[i]
 
-		// Unmarshal steps JSON back to the struct.
-		var steps *executor.IndexStepsStats
-		if run.StepsJSON != "" {
-			var s executor.IndexStepsStats
-			if json.Unmarshal([]byte(run.StepsJSON), &s) == nil {
-				steps = &s
-			}
+		// Splice the stored steps/metadata JSON straight through instead of
+		// unmarshaling then re-marshaling. Malformed blobs fall back to the
+		// historical defaults ("{}" for steps, omitted for metadata).
+		steps := json.RawMessage(run.StepsJSON)
+		if len(steps) == 0 || !json.Valid(steps) {
+			steps = emptyJSONObject
 		}
 
-		entry := &executor.IndexEntry{
+		var metadata json.RawMessage
+		if run.MetadataJSON != "" && json.Valid([]byte(run.MetadataJSON)) {
+			metadata = json.RawMessage(run.MetadataJSON)
+		}
+
+		entries = append(entries, indexEntry{
+			DiscoveryPath:     run.DiscoveryPath,
 			RunID:             run.RunID,
 			Timestamp:         run.Timestamp,
 			TimestampEnd:      run.TimestampEnd,
@@ -57,40 +102,56 @@ func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
 				Image:            run.Image,
 				RollbackStrategy: run.RollbackStrategy,
 			},
-			Tests: &executor.IndexTestStats{
+			Tests: indexTestStats{
 				TestsTotal:  run.TestsTotal,
 				TestsPassed: run.TestsPassed,
 				TestsFailed: run.TestsFailed,
 				Steps:       steps,
 			},
-		}
-
-		if entry.Tests.Steps == nil {
-			entry.Tests.Steps = &executor.IndexStepsStats{}
-		}
-
-		if run.MetadataJSON != "" {
-			var m map[string]string
-			if json.Unmarshal([]byte(run.MetadataJSON), &m) == nil {
-				entry.Metadata = m
-			}
-		}
-
-		entries = append(entries, indexEntryWithDP{
-			DiscoveryPath: run.DiscoveryPath,
-			IndexEntry:    entry,
+			Metadata: metadata,
 		})
 	}
 
-	// Sort by timestamp descending.
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Timestamp > entries[j].Timestamp
+	body, err := json.Marshal(indexResponse{
+		Generated: time.Now().Unix(),
+		Entries:   entries,
 	})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError,
+			errorResponse{"encoding index: " + err.Error()})
 
-	writeJSON(w, http.StatusOK, map[string]any{
-		"generated": time.Now().Unix(),
-		"entries":   entries,
-	})
+		return
+	}
+
+	s.storeCachedIndex(gen, body)
+	writeRawJSON(w, body)
+}
+
+// cachedIndex returns the cached marshaled index body if it was built for the
+// given runs generation, otherwise nil.
+func (s *server) cachedIndex(gen uint64) []byte {
+	s.indexCacheMu.Lock()
+	defer s.indexCacheMu.Unlock()
+
+	if s.indexCacheBody != nil && s.indexCacheGen == gen {
+		return s.indexCacheBody
+	}
+
+	return nil
+}
+
+// storeCachedIndex records a freshly built index body for the given
+// generation. A build is only allowed to replace the cache if its generation
+// is at least as fresh, so a slow build for an older generation can't clobber
+// a newer cached body.
+func (s *server) storeCachedIndex(gen uint64, body []byte) {
+	s.indexCacheMu.Lock()
+	defer s.indexCacheMu.Unlock()
+
+	if s.indexCacheBody == nil || gen >= s.indexCacheGen {
+		s.indexCacheGen = gen
+		s.indexCacheBody = body
+	}
 }
 
 // handleSuiteStats returns suite statistics for a given suite hash.

--- a/pkg/api/handlers_index_test.go
+++ b/pkg/api/handlers_index_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/api/indexstore"
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+)
+
+func newIndexTestServer(t *testing.T) *server {
+	t.Helper()
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	st := indexstore.NewStore(log, &config.APIDatabaseConfig{
+		Driver: "sqlite",
+		SQLite: config.SQLiteDatabaseConfig{Path: ":memory:"},
+	})
+	require.NoError(t, st.Start(context.Background()))
+	t.Cleanup(func() { _ = st.Stop() })
+
+	return &server{log: log, indexStore: st}
+}
+
+func getIndex(t *testing.T, s *server) (*httptest.ResponseRecorder, indexResponse) {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/index", nil)
+	s.handleIndex(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp indexResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	return rec, resp
+}
+
+// TestHandleIndex_SplicesAndCaches covers the RawMessage splicing, the
+// generation-keyed cache, and cache invalidation on a new run.
+func TestHandleIndex_SplicesAndCaches(t *testing.T) {
+	s := newIndexTestServer(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.indexStore.UpsertRun(ctx, &indexstore.Run{
+		DiscoveryPath: "dp/one",
+		RunID:         "run-1",
+		Timestamp:     100,
+		Status:        "completed",
+		Client:        "geth",
+		TestsTotal:    3,
+		TestsPassed:   2,
+		TestsFailed:   1,
+		StepsJSON:     `{"import":{"count":2}}`,
+		MetadataJSON:  `{"env":"ci"}`,
+	}))
+
+	rec1, resp1 := getIndex(t, s)
+	require.Len(t, resp1.Entries, 1)
+
+	e := resp1.Entries[0]
+	assert.Equal(t, "dp/one", e.DiscoveryPath)
+	assert.Equal(t, "run-1", e.RunID)
+	assert.Equal(t, "geth", e.Instance.Client)
+	assert.Equal(t, 3, e.Tests.TestsTotal)
+	// The stored JSON blobs are spliced through verbatim.
+	assert.JSONEq(t, `{"import":{"count":2}}`, string(e.Tests.Steps))
+	assert.JSONEq(t, `{"env":"ci"}`, string(e.Metadata))
+
+	// The build populated the cache for the current generation.
+	gen := s.indexStore.RunsGeneration()
+	require.NotNil(t, s.indexCacheBody)
+	assert.Equal(t, gen, s.indexCacheGen)
+
+	// A second request with no intervening writes is served from cache and
+	// returns byte-for-byte identical output.
+	rec2, _ := getIndex(t, s)
+	assert.Equal(t, rec1.Body.Bytes(), rec2.Body.Bytes())
+
+	// A new run bumps the generation and invalidates the cache.
+	require.NoError(t, s.indexStore.UpsertRun(ctx, &indexstore.Run{
+		DiscoveryPath: "dp/two",
+		RunID:         "run-2",
+		Timestamp:     200,
+	}))
+	assert.Greater(t, s.indexStore.RunsGeneration(), gen)
+
+	_, resp3 := getIndex(t, s)
+	require.Len(t, resp3.Entries, 2)
+	// run-2 has the newer timestamp; the store returns rows timestamp DESC and
+	// the handler no longer re-sorts, so it must come first.
+	assert.Equal(t, "run-2", resp3.Entries[0].RunID)
+}
+
+// TestHandleIndex_MissingBlobs verifies the historical defaults: absent steps
+// JSON becomes "{}" and absent metadata is omitted.
+func TestHandleIndex_MissingBlobs(t *testing.T) {
+	s := newIndexTestServer(t)
+
+	require.NoError(t, s.indexStore.UpsertRun(context.Background(), &indexstore.Run{
+		DiscoveryPath: "dp",
+		RunID:         "r",
+		Timestamp:     1,
+	}))
+
+	_, resp := getIndex(t, s)
+	require.Len(t, resp.Entries, 1)
+	assert.JSONEq(t, `{}`, string(resp.Entries[0].Tests.Steps))
+	assert.Nil(t, resp.Entries[0].Metadata)
+}

--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/api/gormlogger"
@@ -49,6 +50,11 @@ type Store interface {
 
 	ListAllRuns(ctx context.Context) ([]Run, error)
 
+	// RunsGeneration returns a monotonic counter that is bumped on every
+	// mutation of the runs table. Callers can use it as a cheap cache key to
+	// detect whether the runs list has changed since a prior read.
+	RunsGeneration() uint64
+
 	GetRunByRunID(ctx context.Context, runID string) (*Run, error)
 	DeleteRun(ctx context.Context, runID string) error
 	DeleteRunCascade(ctx context.Context, runID string) error
@@ -84,6 +90,10 @@ type store struct {
 	cfg    *config.APIDatabaseConfig
 	db     *gorm.DB // write-only connection (single conn for SQLite)
 	readDB *gorm.DB // read-only connection pool (concurrent readers)
+
+	// runsGen is bumped on every runs-table mutation so readers can cheaply
+	// detect staleness. See RunsGeneration.
+	runsGen atomic.Uint64
 }
 
 // NewStore creates a new index Store backed by the configured database driver.
@@ -268,6 +278,8 @@ func (s *store) UpsertRun(ctx context.Context, run *Run) error {
 		return fmt.Errorf("upserting run: %w", err)
 	}
 
+	s.runsGen.Add(1)
+
 	return nil
 }
 
@@ -430,6 +442,11 @@ func (s *store) ListAllRuns(ctx context.Context) ([]Run, error) {
 	return runs, nil
 }
 
+// RunsGeneration returns the current runs-table generation counter.
+func (s *store) RunsGeneration() uint64 {
+	return s.runsGen.Load()
+}
+
 // GetRunByRunID returns a single run by its run ID.
 func (s *store) GetRunByRunID(
 	ctx context.Context, runID string,
@@ -454,6 +471,8 @@ func (s *store) DeleteRun(
 		return fmt.Errorf("deleting run: %w", err)
 	}
 
+	s.runsGen.Add(1)
+
 	return nil
 }
 
@@ -470,7 +489,7 @@ func (s *store) DeleteRunCascade(
 		return fmt.Errorf("looking up run: %w", err)
 	}
 
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("run_id = ?", runID).
 			Delete(&TestStat{}).Error; err != nil {
 			return fmt.Errorf("deleting test stats: %w", err)
@@ -504,7 +523,13 @@ func (s *store) DeleteRunCascade(
 		}
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	s.runsGen.Add(1)
+
+	return nil
 }
 
 // DeleteOrphanedSuite deletes a suite if no runs reference it anymore.

--- a/pkg/api/indexstore/indexstore_test.go
+++ b/pkg/api/indexstore/indexstore_test.go
@@ -118,6 +118,40 @@ func TestStore_UpsertRunIdempotent(t *testing.T) {
 	assert.Equal(t, 10, runs[0].TestsTotal)
 }
 
+func TestStore_RunsGeneration(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	// Starts at zero and every runs-table mutation bumps it.
+	assert.Equal(t, uint64(0), s.RunsGeneration())
+
+	run := &indexstore.Run{
+		DiscoveryPath: "dp/gen",
+		RunID:         "run-gen",
+		Timestamp:     time.Now().Unix(),
+		Status:        "completed",
+		Client:        "geth",
+	}
+	require.NoError(t, s.UpsertRun(ctx, run))
+	afterInsert := s.RunsGeneration()
+	assert.Greater(t, afterInsert, uint64(0))
+
+	// An idempotent upsert still counts as a mutation.
+	require.NoError(t, s.UpsertRun(ctx, run))
+	afterUpsert := s.RunsGeneration()
+	assert.Greater(t, afterUpsert, afterInsert)
+
+	// Cascade delete bumps it too.
+	require.NoError(t, s.DeleteRunCascade(ctx, "run-gen"))
+	assert.Greater(t, s.RunsGeneration(), afterUpsert)
+
+	// A read does not.
+	before := s.RunsGeneration()
+	_, err := s.ListAllRuns(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, before, s.RunsGeneration())
+}
+
 func TestStore_ListRunIDs(t *testing.T) {
 	s := setupTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Problem

On a prod instance with 20k+ runs, `GET /api/v1/index` takes **5-6s** — and the UI (`useIndex`) polls it **every 30s** from every open tab. Each request rebuilt the whole index from scratch:

1. `ListAllRuns` = `SELECT * FROM runs ORDER BY timestamp DESC` — all 20k rows including the two big `TEXT` blobs (`steps_json`, `metadata_json`).
2. **~40k `json.Unmarshal`** — steps + metadata parsed for every run.
3. A **redundant Go re-sort** by timestamp (SQL already ordered it).
4. A full **`json.Marshal`** of 20k entries.

gzip is already on (`chimw.Compress(5)`), so compression wasn't the gap — the per-request rebuild was.

## Changes

**1. Cache the serialized response, keyed by a runs generation counter.** The store keeps an atomic counter bumped on every runs-table mutation (`UpsertRun` / `DeleteRun` / `DeleteRunCascade`), exposed via `RunsGeneration()`. The handler caches the marshaled body against that generation: while no run changes, requests are served straight from cache without touching the DB. A new or deleted run bumps the generation and invalidates the cache immediately (no TTL staleness).

**2. Splice stored JSON through with `json.RawMessage`.** `steps_json`/`metadata_json` are already JSON — they were unmarshaled to structs then re-marshaled. Now they're passed through verbatim, eliminating the ~40k parses and the re-marshal on the cold rebuild. Malformed blobs keep the historical fallbacks (`{}` for steps, omitted metadata).

**3. Drop the redundant Go sort.** `ListAllRuns` already returns rows `timestamp DESC`.

Response shape is unchanged.

## Result

Steady-state `/index` goes from a full rebuild on every poll to serving cached bytes; the cold/first rebuild after a change is itself cheaper (no double JSON round-trip, no re-sort).

## Notes / scope

- The generation counter is in-process. All writes in this deployment flow through the one embedded store instance (indexer + ingest), so it captures every mutation. A multi-writer-process Postgres setup would need a DB-derived key instead — out of scope here.
- Longer-term, the payload is still O(runs) and the client parses it each poll; server-side pagination or a `?since=` delta is the scalable follow-up, but it needs UI changes across several pages (Runs/Suites/Compare/LiveRunDetail all consume the full index).

## Tests

- `TestStore_RunsGeneration` — counter starts at 0, bumps on upsert/idempotent-upsert/cascade-delete, not on reads.
- `TestHandleIndex_SplicesAndCaches` — RawMessage splicing, byte-identical cache hit, invalidation on a new run, and DESC ordering without the re-sort.
- `TestHandleIndex_MissingBlobs` — `{}` steps fallback + omitted metadata.

Full `pkg/api/...` suite passes (incl. `-race`); golangci-lint `--new-from-rev=origin/master` clean.