### PR TITLE
fix(ui): open S3-hosted files via redirect instead of the JSON envelope

### DIFF
--- a/ui/src/components/run-detail/FilesPanel.tsx
+++ b/ui/src/components/run-detail/FilesPanel.tsx
@@ -7,7 +7,7 @@ import { FolderOpen, Folder, Check, Copy, Download, List, ChevronDown, ChevronRi
 import type { PostTestRPCCallConfig, TestEntry } from '@/api/types'
 import { fetchHead, type HeadResult } from '@/api/client'
 import { formatBytes } from '@/utils/format'
-import { getDataUrl, isS3Mode, loadRuntimeConfig, toAbsoluteUrl } from '@/config/runtime'
+import { getNavigableDataUrl, loadRuntimeConfig, toAbsoluteUrl } from '@/config/runtime'
 import { useAuth } from '@/hooks/useAuth'
 import { Modal } from '@/components/shared/Modal'
 
@@ -589,25 +589,20 @@ export function FilesPanel({ runId, tests, postTestRPCCalls, showDownloadList, d
 
   const downloadListText = useMemo(() => {
     if (!runtimeConfig || downloadEntries.length === 0) return ''
-    const s3 = isS3Mode(runtimeConfig)
     const needsAuth = requiresAuth && runtimeConfig.api?.baseUrl
 
     if (downloadFormat === 'urls') {
-      return downloadEntries.map((e) => {
-        let url = getDataUrl(e.path, runtimeConfig)
-        if (s3) url += `${url.includes('?') ? '&' : '?'}redirect=true`
-        return toAbsoluteUrl(url)
-      }).join('\n')
+      return downloadEntries.map((e) =>
+        toAbsoluteUrl(getNavigableDataUrl(e.path, runtimeConfig)),
+      ).join('\n')
     }
 
     // Build curl script with progress.
     const authFlag = needsAuth ? ' -H "Authorization: Bearer $BENCHMARKOOR_API_KEY"' : ''
     const total = downloadEntries.length
-    const urls = downloadEntries.map((e) => {
-      let url = getDataUrl(e.path, runtimeConfig)
-      if (s3) url += `${url.includes('?') ? '&' : '?'}redirect=true`
-      return `  '${toAbsoluteUrl(url)}' '${e.outputPath}'`
-    })
+    const urls = downloadEntries.map(
+      (e) => `  '${toAbsoluteUrl(getNavigableDataUrl(e.path, runtimeConfig))}' '${e.outputPath}'`,
+    )
 
     const lines: string[] = []
 

--- a/ui/src/components/run-detail/StateActorConfiguration.tsx
+++ b/ui/src/components/run-detail/StateActorConfiguration.tsx
@@ -10,7 +10,7 @@ import { fetchText } from '@/api/client'
 import type { StateActorManifest } from '@/api/types'
 import { Badge } from '@/components/shared/Badge'
 import { Card } from '@/components/shared/Card'
-import { getDataUrl, loadRuntimeConfig } from '@/config/runtime'
+import { getNavigableDataUrl, loadRuntimeConfig } from '@/config/runtime'
 import { formatBytes, formatNumber } from '@/utils/format'
 
 interface StateActorConfigurationProps {
@@ -77,7 +77,9 @@ function RawFile({ runId, name }: { runId: string; name: string }) {
   })
 
   const text = file?.data ?? ''
-  const url = config ? getDataUrl(`runs/${runId}/.state-actor/${name}`, config) : undefined
+  const url = config
+    ? getNavigableDataUrl(`runs/${runId}/.state-actor/${name}`, config)
+    : undefined
 
   return (
     <div className="overflow-hidden rounded-xs border border-gray-200 dark:border-gray-700">

--- a/ui/src/components/suite-detail/EESTMetadata.tsx
+++ b/ui/src/components/suite-detail/EESTMetadata.tsx
@@ -5,7 +5,7 @@ import { ExternalLink } from 'lucide-react'
 
 import { fetchText } from '@/api/client'
 import { Card } from '@/components/shared/Card'
-import { getDataUrl, loadRuntimeConfig } from '@/config/runtime'
+import { getNavigableDataUrl, loadRuntimeConfig } from '@/config/runtime'
 
 interface EESTMetadataProps {
   suiteHash: string
@@ -76,10 +76,10 @@ export function EESTMetadata({ suiteHash }: EESTMetadataProps) {
   }
 
   const reportUrl = config
-    ? getDataUrl(`suites/${suiteHash}/.eest-meta/report_fill.html`, config)
+    ? getNavigableDataUrl(`suites/${suiteHash}/.eest-meta/report_fill.html`, config)
     : undefined
   const indexUrl = config
-    ? getDataUrl(`suites/${suiteHash}/.eest-meta/index.json`, config)
+    ? getNavigableDataUrl(`suites/${suiteHash}/.eest-meta/index.json`, config)
     : undefined
 
   return (

--- a/ui/src/config/runtime.ts
+++ b/ui/src/config/runtime.ts
@@ -108,6 +108,22 @@ export function getDataUrl(path: string, config: RuntimeConfig): string {
   return `${base}/${path}`
 }
 
+// getNavigableDataUrl returns a URL safe to open directly in the browser
+// (anchor href, iframe src, download link). In S3 + API mode the /files
+// endpoint returns a JSON {"url":...} envelope by default — great for
+// programmatic fetch, but a plain navigation would just render that JSON.
+// Appending ?redirect=true makes the endpoint 302 to the presigned URL so the
+// browser loads the file itself. Local mode serves the bytes directly, so no
+// redirect is needed there.
+export function getNavigableDataUrl(path: string, config: RuntimeConfig): string {
+  const url = getDataUrl(path, config)
+  if (isS3Mode(config) && config.api?.baseUrl) {
+    return `${url}${url.includes('?') ? '&' : '?'}redirect=true`
+  }
+
+  return url
+}
+
 export function toAbsoluteUrl(url: string): string {
   if (url.startsWith('http://') || url.startsWith('https://')) return url
   return `${window.location.origin}${url.startsWith('/') ? '' : '/'}${url}`


### PR DESCRIPTION
## Problem

On the suite details **Source tab**, the EEST Build Metadata "Fill report" buttons (and the embedded report iframe) opened a page showing a raw JSON payload instead of the report, when the API is enabled with files on S3:

```json
{"url":"https://benchmarkoor-results.….r2.cloudflarestorage.com/…/report_fill.html?X-Amz-Algorithm=…&X-Amz-Signature=…"}
```

## Root cause

In S3 + API mode the `/api/v1/files/...` endpoint returns a `{"url": <presigned>}` **JSON envelope** by default — intended for programmatic `fetch` (the client parses `.url` and fetches it). It only **302-redirects** to the presigned URL when `?redirect=true` is set (added precisely so `<a href>` / `curl -L` work).

Several components built direct-navigation targets straight from `getDataUrl(...)`, so in S3 mode the browser navigated to the envelope endpoint and rendered the JSON:

- **EEST Build Metadata** (suite Source tab): "Open fill report", "View fixture index (JSON)", and the embedded fill-report `<iframe>`.
- **State-actor config files**: the "Open raw" link.

`FilesPanel` already worked around this by inlining `?redirect=true` in S3 mode — so the fix pattern was already established, just not applied consistently.

## Fix

Extract the pattern into a shared `getNavigableDataUrl()` helper and route all direct-navigation URLs (anchor `href`, iframe `src`, download links) through it. In S3 + API mode it appends `?redirect=true` so the browser follows the 302 to the presigned URL and loads the actual file; local mode serves bytes directly and is untouched (no redirect appended). `FilesPanel`'s two inline copies are de-duplicated onto the helper.

## Verification

- `tsc -b` typecheck, `eslint`, and full `vite build` all clean.
- Local mode unaffected (helper only appends `redirect=true` when `isS3Mode && api.baseUrl`).

Note: presigned relative assets inside the report HTML are a separate, pre-existing limitation and out of scope — this restores the report itself loading instead of showing JSON.