### PR TITLE
fix(eest): make the fill report self-contained so it renders from S3

### DIFF
--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -989,7 +989,14 @@ func (b *EESTPayloadsBuilder) runFill(
 		// passed/failed tally for the build summary (the json-report plugin ships
 		// in the fill image). fill-stateful continues through failures, so a
 		// partial fill still records how many tests failed.
-		"PYTEST_ADDOPTS": "-o cache_dir=/tmp/.pytest_cache --json-report --json-report-file=" + fillOutputPath + "/" + pytestReportFile,
+		//
+		// --self-contained-html inlines the pytest-html report's CSS into
+		// .meta/report_fill.html so it has no relative assets/ references. That
+		// lets the UI serve it from a presigned S3 URL (or an iframe) with full
+		// styling — a linked assets/style.css would resolve to an unsigned S3
+		// URL and 403. EEST only sets htmlpath, not self_contained_html, so this
+		// flag is honored.
+		"PYTEST_ADDOPTS": "-o cache_dir=/tmp/.pytest_cache --self-contained-html --json-report --json-report-file=" + fillOutputPath + "/" + pytestReportFile,
 		// fill-stateful reads its commit hash from the /eest git checkout; as a
 		// non-root user git can refuse with "dubious ownership". Inject
 		// safe.directory=* via git's env-based config so it trusts the repo.


### PR DESCRIPTION
## Problem

Follow-up to #277. With the report links now redirecting to the presigned S3 URL, the EEST fill report opened/embedded **unstyled**. The pytest-html report links its stylesheet **relatively**:

```html
<link href="assets/style.css" rel="stylesheet" type="text/css"/>
```

When the report loads from a presigned S3 URL (`…/report_fill.html?X-Amz-Signature=…`), the browser resolves `assets/style.css` to an **unsigned** S3 URL → **403** on the private bucket → no styling. (Verified against a real report: it's pytest-html, one inline `<script>`, and a single external asset `assets/style.css`.)

## Fix

Add `--self-contained-html` to `PYTEST_ADDOPTS` for the fill run. pytest-html then **inlines the CSS** into `report_fill.html`, so the report is a single self-contained file with **no `assets/` references** and renders fully styled from any URL — including the presigned S3 URL and the iframe embed.

EEST's filler plugin only sets `htmlpath` (`.meta/report_fill.html`) and does **not** set `self_contained_html`, so the flag is honored (confirmed in `execution-specs` `filler.py`). The JS is already inline, so nothing else needs bundling.

## Why this over a server-side proxy

The alternative — streaming the report + its assets through the API so relative URLs resolve on the API origin — would serve our HTML **same-origin as the API**, giving up the origin isolation the presigned S3 URL provides (the report can't touch API cookies from the S3 origin). Fixing it at generation time keeps that isolation, needs no new route, and removes the sub-resource entirely instead of proxying it.

## Scope

- Applies to **newly filled** fixtures. Existing reports already on S3 keep their relative `assets/` link until their next build re-generates the report.
- No behavior change for the JSON sidecars or fixtures — only the pytest-html report output format.

`go build` + golangci-lint (`--new-from-rev=origin/master`) clean.