### PR TITLE
fix(ui): show the state-actor Elapsed as a human-readable duration

### DIFF
--- a/ui/src/components/run-detail/StateActorConfiguration.tsx
+++ b/ui/src/components/run-detail/StateActorConfiguration.tsx
@@ -11,7 +11,7 @@ import type { StateActorManifest } from '@/api/types'
 import { Badge } from '@/components/shared/Badge'
 import { Card } from '@/components/shared/Card'
 import { getNavigableDataUrl, loadRuntimeConfig } from '@/config/runtime'
-import { formatBytes, formatNumber } from '@/utils/format'
+import { formatBytes, formatDurationMs, formatNumber } from '@/utils/format'
 
 interface StateActorConfigurationProps {
   manifest: StateActorManifest
@@ -246,7 +246,7 @@ export function StateActorConfiguration({ manifest, runId }: StateActorConfigura
             <Field label="Contracts created" value={formatNumber(result.contracts_created)} />
             <Field label="Storage slots" value={formatNumber(result.storage_slots)} />
             <Field label="DB size" value={formatBytes(result.total_db_size_bytes)} />
-            <Field label="Elapsed" value={`${formatNumber(result.elapsed_ms)} ms`} />
+            <Field label="Elapsed" value={formatDurationMs(result.elapsed_ms)} />
           </Section>
         )}
 

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -21,6 +21,12 @@ export function formatDuration(nanoseconds: number): string {
   return `${minutes}m${seconds}s`
 }
 
+// formatDurationMs renders a millisecond duration in human-readable form
+// (e.g. 6006337 -> "1h40m6s"), reusing the nanosecond formatter.
+export function formatDurationMs(milliseconds: number): string {
+  return formatDuration(milliseconds * 1_000_000)
+}
+
 export function formatNumber(num: number): string {
   return new Intl.NumberFormat().format(num)
 }


### PR DESCRIPTION
## Problem

On the run details page, the **Database** section rendered the state-actor generation time as a raw millisecond count:

> Elapsed: **6,006,337 ms**

## Fix

Add a small `formatDurationMs()` helper to `utils/format.ts` (reusing the existing nanosecond `formatDuration`) and use it for the Elapsed field:

> Elapsed: **1h40m6s**

`tsc -b` and `eslint` clean.