### PR TITLE
feat(checkpoint-restore): add restore_in_place option

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -442,6 +442,13 @@ runner:
       #   # Whether to restart the container before taking a CRIU checkpoint.
       #   # Restarting ensures a clean process state (cold caches, clean DB shutdown).
       #   restart_container: false
+      #   # Restore the checkpointed container in place between tests instead of
+      #   # importing the checkpoint archive into a fresh container. Skips the
+      #   # per-test archive extraction and container creation, cutting the
+      #   # restore latency roughly to CRIU's page-restore time. The checkpoint
+      #   # data is kept in the container's storage directory; tmpfs_threshold /
+      #   # tmpfs_max_size do not apply in this mode.
+      #   restore_in_place: false
       # Optional: Wait duration after RPC becomes ready before running tests.
       # Useful for clients like Erigon that need time to complete internal sync pipelines
       # after their RPC endpoint becomes available.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -852,6 +852,7 @@ Options for the `container-checkpoint-restore` rollback strategy, nested under `
 | `tmpfs_max_size` | string | 2× `tmpfs_threshold` | Maximum size of the tmpfs mount for checkpoint storage. Same format as `tmpfs_threshold` (e.g., `"16g"`, `"1024m"`). When not set, defaults to twice the `tmpfs_threshold` value. |
 | `wait_after_tcp_drop_connections` | string | `10s` | How long to wait after dropping TCP connections before checkpointing, giving the process time to close file descriptors (Go duration string). |
 | `restart_container` | bool | `false` | Whether to restart the container before taking a CRIU checkpoint. Restarting ensures a clean process state (cold caches, clean DB shutdown). |
+| `restore_in_place` | bool | `false` | Restore the checkpointed container in place between tests instead of importing the checkpoint archive into a fresh container. The checkpoint data is kept in the container's storage directory and the same container (same name, mounts, and IP) is restored repeatedly. This skips the per-test archive extraction and container creation of the export/import path, cutting the restore latency roughly to CRIU's page-restore time (e.g. ~15s → ~3s for an ~8g checkpoint). `tmpfs_threshold` / `tmpfs_max_size` do not apply in this mode. |
 
 ```yaml
 runner:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1088,6 +1088,7 @@ type CheckpointRestoreStrategyOptions struct {
 	TmpfsMaxSize          string `yaml:"tmpfs_max_size,omitempty" mapstructure:"tmpfs_max_size" json:"tmpfs_max_size,omitempty"`
 	WaitAfterTCPDropConns string `yaml:"wait_after_tcp_drop_connections,omitempty" mapstructure:"wait_after_tcp_drop_connections" json:"wait_after_tcp_drop_connections,omitempty"`
 	RestartContainer      bool   `yaml:"restart_container,omitempty" mapstructure:"restart_container" json:"restart_container,omitempty"`
+	RestoreInPlace        bool   `yaml:"restore_in_place,omitempty" mapstructure:"restore_in_place" json:"restore_in_place,omitempty"`
 }
 
 // BootstrapFCUConfig configures the bootstrap FCU call used to confirm the
@@ -2937,6 +2938,22 @@ func (c *Config) GetCheckpointRestartContainer(instance *ClientInstance) bool {
 	}
 
 	return opts.RestartContainer
+}
+
+// GetCheckpointRestoreInPlace returns whether per-test rollbacks restore the
+// checkpointed container in place from the checkpoint data kept in its
+// storage directory, instead of importing the checkpoint archive into a
+// fresh container. In-place restores skip the per-test archive extraction
+// and container creation, cutting the per-test restore latency roughly to
+// CRIU's page-restore time. Instance-level setting takes precedence over
+// global default.
+func (c *Config) GetCheckpointRestoreInPlace(instance *ClientInstance) bool {
+	opts := c.GetCheckpointRestoreStrategyOptions(instance)
+	if opts == nil {
+		return false
+	}
+
+	return opts.RestoreInPlace
 }
 
 // GetMetadataLabels returns the merged metadata labels for an instance.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2156,6 +2156,58 @@ func TestGetCheckpointTmpfsThreshold(t *testing.T) {
 	}
 }
 
+func TestGetCheckpointRestoreInPlace(t *testing.T) {
+	tests := []struct {
+		name     string
+		global   *CheckpointRestoreStrategyOptions
+		instance *CheckpointRestoreStrategyOptions
+		expected bool
+	}{
+		{
+			name:     "no options defaults to false",
+			global:   nil,
+			instance: nil,
+			expected: false,
+		},
+		{
+			name:     "global enabled, no instance options inherits global",
+			global:   &CheckpointRestoreStrategyOptions{RestoreInPlace: true},
+			instance: nil,
+			expected: true,
+		},
+		{
+			name:     "instance options replace global entirely",
+			global:   &CheckpointRestoreStrategyOptions{RestoreInPlace: true},
+			instance: &CheckpointRestoreStrategyOptions{TmpfsThreshold: "4g"},
+			expected: false,
+		},
+		{
+			name:     "instance enabled",
+			global:   nil,
+			instance: &CheckpointRestoreStrategyOptions{RestoreInPlace: true},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Runner: RunnerConfig{
+					Client: ClientConfig{
+						Config: ClientDefaults{
+							CheckpointRestoreStrategyOptions: tt.global,
+						},
+					},
+				},
+			}
+			instance := &ClientInstance{
+				CheckpointRestoreStrategyOptions: tt.instance,
+			}
+			assert.Equal(t, tt.expected, cfg.GetCheckpointRestoreInPlace(instance))
+		})
+	}
+}
+
 // createTestTarball creates a minimal .tar.gz file at the given path for testing.
 func createTestTarball(t *testing.T, path string) {
 	t.Helper()

--- a/pkg/podman/checkpoint.go
+++ b/pkg/podman/checkpoint.go
@@ -39,6 +39,22 @@ type CheckpointManager interface {
 	// export file. Returns the new container's ID.
 	RestoreContainer(ctx context.Context, exportPath string, opts *RestoreOptions) (string, error)
 
+	// CheckpointContainerLocal checkpoints a running container, keeping the
+	// checkpoint data inside the container's storage directory instead of
+	// exporting an archive. The container stops after checkpointing. The
+	// kept checkpoint data allows repeated in-place restores of the same
+	// container via RestoreContainerInPlace.
+	CheckpointContainerLocal(
+		ctx context.Context, containerID string,
+		waitAfterTCPDrop time.Duration,
+	) error
+
+	// RestoreContainerInPlace restores a previously checkpointed container
+	// from the checkpoint data kept in its storage directory (no archive
+	// import, no new container). The checkpoint data is kept after the
+	// restore so the container can be stopped and restored again.
+	RestoreContainerInPlace(ctx context.Context, containerID string) error
+
 	// ReadFileFromImage extracts a file from an OCI image by running a
 	// throwaway container. Used to read config files that need patching
 	// before the real container starts.
@@ -139,6 +155,131 @@ func (m *manager) CheckpointContainer(
 	}
 
 	m.log.WithFields(fields).Info("Container checkpointed successfully")
+
+	return nil
+}
+
+// CheckpointContainerLocal checkpoints a running container, keeping the
+// checkpoint data in the container's storage directory (no export archive).
+// The container stops as part of the checkpoint. Because the checkpoint
+// data stays on disk (Keep), the same container can be restored in place
+// repeatedly — podman accepts a restore of a stopped container whenever
+// its kept checkpoint data is present.
+func (m *manager) CheckpointContainerLocal(
+	ctx context.Context,
+	containerID string,
+	waitAfterTCPDrop time.Duration,
+) error {
+	m.log.WithField("container", containerID[:12]).Info(
+		"Checkpointing container (local, in-place restores)",
+	)
+
+	// Same connection-drop dance as the export path: CRIU refuses to
+	// checkpoint established connections without --tcp-established, and
+	// even though in-place restores keep the container IP, dropping the
+	// sockets keeps both checkpoint flavours behaviourally identical.
+	if err := m.dropConnections(ctx, containerID, waitAfterTCPDrop); err != nil {
+		m.log.WithError(err).Warn("Failed to drop connections before checkpoint")
+	}
+
+	checkpointStart := time.Now()
+
+	fileLocks := true
+	keep := true
+	tcpEstablished := true
+	printStats := true
+
+	conn, connCancel := m.connWithCtx(ctx)
+	defer connCancel()
+
+	report, err := containers.Checkpoint(conn, containerID, &containers.CheckpointOptions{
+		FileLocks:      &fileLocks,
+		Keep:           &keep,
+		TCPEstablished: &tcpEstablished,
+		PrintStats:     &printStats,
+	})
+	if err != nil {
+		m.logCRIUDumpLog(containerID)
+
+		return fmt.Errorf("checkpointing container %s locally: %w", containerID[:12], err)
+	}
+
+	fields := logrus.Fields{
+		"duration":         time.Since(checkpointStart).Round(time.Millisecond),
+		"runtime_duration": time.Duration(report.RuntimeDuration) * time.Microsecond,
+	}
+
+	if s := report.CRIUStatistics; s != nil {
+		fields["freezing_time"] = time.Duration(s.FreezingTime) * time.Microsecond
+		fields["frozen_time"] = time.Duration(s.FrozenTime) * time.Microsecond
+		fields["memdump_time"] = time.Duration(s.MemdumpTime) * time.Microsecond
+		fields["memwrite_time"] = time.Duration(s.MemwriteTime) * time.Microsecond
+		fields["pages_scanned"] = s.PagesScanned
+		fields["pages_written"] = s.PagesWritten
+	}
+
+	m.log.WithFields(fields).Info("Container checkpointed successfully (local)")
+
+	return nil
+}
+
+// RestoreContainerInPlace restores a stopped, previously checkpointed
+// container from the checkpoint data kept in its storage directory. The
+// process resumes mid-execution with its original name, mounts, and IP.
+// Keep leaves the checkpoint data in place for the next restore.
+func (m *manager) RestoreContainerInPlace(
+	ctx context.Context,
+	containerID string,
+) error {
+	m.log.WithField("container", containerID[:12]).Info(
+		"Restoring container in place from kept checkpoint",
+	)
+
+	restoreStart := time.Now()
+
+	fileLocks := true
+	keep := true
+	tcpEstablished := true
+	tcpClose := true
+	printStats := true
+
+	// Note: no Name option — renaming is only valid for archive imports.
+	// The container to restore is addressed via the positional nameOrID.
+	restoreOpts := &containers.RestoreOptions{
+		FileLocks:      &fileLocks,
+		Keep:           &keep,
+		TCPEstablished: &tcpEstablished,
+		TCPClose:       &tcpClose,
+		PrintStats:     &printStats,
+	}
+
+	conn, connCancel := m.connWithCtx(ctx)
+	defer connCancel()
+
+	report, err := containers.Restore(conn, containerID, restoreOpts)
+	if err != nil {
+		m.logCRIURestoreLog(containerID)
+
+		return fmt.Errorf(
+			"restoring container %s in place: %w", containerID[:12], err,
+		)
+	}
+
+	fields := logrus.Fields{
+		"id":               report.Id[:12],
+		"duration":         time.Since(restoreStart).Round(time.Millisecond),
+		"runtime_duration": time.Duration(report.RuntimeDuration) * time.Microsecond,
+	}
+
+	if s := report.CRIUStatistics; s != nil {
+		fields["forking_time"] = time.Duration(s.ForkingTime) * time.Microsecond
+		fields["restore_time"] = time.Duration(s.RestoreTime) * time.Microsecond
+		fields["pages_compared"] = s.PagesCompared
+		fields["pages_skipped_cow"] = s.PagesSkippedCow
+		fields["pages_restored"] = s.PagesRestored
+	}
+
+	m.log.WithFields(fields).Info("Container restored in place successfully")
 
 	return nil
 }

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -192,6 +192,13 @@ func (r *runner) runTestsWithCheckpointRestore(
 		log.WithField("steps", n).Info("Pre-run steps completed before checkpoint")
 	}
 
+	// In-place mode keeps the checkpoint data in the container's storage
+	// directory and repeatedly restores the same container, skipping the
+	// per-test archive extraction and container creation of the
+	// export/import path. tmpfs_threshold/tmpfs_max_size only apply to the
+	// export archive, so they are ignored in this mode.
+	restoreInPlace := r.cfg.FullConfig.GetCheckpointRestoreInPlace(params.Instance)
+
 	// 3. Decide checkpoint export path: tmpfs (RAM) or disk.
 	//
 	// When checkpoint_tmpfs_threshold is configured and the container's
@@ -201,6 +208,10 @@ func (r *runner) runTestsWithCheckpointRestore(
 	tmpfsDir := ""
 
 	thresholdStr := r.cfg.FullConfig.GetCheckpointTmpfsThreshold(params.Instance)
+	if restoreInPlace {
+		thresholdStr = ""
+	}
+
 	if thresholdStr != "" {
 		threshold, parseErr := config.ParseByteSize(thresholdStr)
 		if parseErr != nil {
@@ -288,8 +299,14 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 	cpStart := time.Now()
 
-	if err := cpMgr.CheckpointContainer(ctx, containerID, exportPath, waitAfterTCPDrop); err != nil {
-		return nil, fmt.Errorf("checkpointing container: %w", err)
+	if restoreInPlace {
+		if err := cpMgr.CheckpointContainerLocal(ctx, containerID, waitAfterTCPDrop); err != nil {
+			return nil, fmt.Errorf("checkpointing container locally: %w", err)
+		}
+	} else {
+		if err := cpMgr.CheckpointContainer(ctx, containerID, exportPath, waitAfterTCPDrop); err != nil {
+			return nil, fmt.Errorf("checkpointing container: %w", err)
+		}
 	}
 
 	log.WithField("duration", time.Since(cpStart)).Info(
@@ -297,6 +314,10 @@ func (r *runner) runTestsWithCheckpointRestore(
 	)
 
 	defer func() {
+		if restoreInPlace {
+			return
+		}
+
 		_ = os.Remove(exportPath)
 
 		if tmpfsDir != "" {
@@ -430,35 +451,63 @@ func (r *runner) runTestsWithCheckpointRestore(
 		}
 
 		// Restore container from checkpoint.
-		restoreName := fmt.Sprintf("%s-restore-%d", params.ContainerSpec.Name, i)
-		testLog.Info("Restoring container from checkpoint")
+		var (
+			restoreName string
+			restoredID  string
+			err         error
+		)
 
 		restoreStart := time.Now()
 
-		restoredID, err := cpMgr.RestoreContainer(ctx, exportPath, &podman.RestoreOptions{
-			Name:        restoreName,
-			NetworkName: r.cfg.ContainerNetwork,
-		})
-		if err != nil {
-			combined.TotalDuration = time.Since(startTime)
+		if restoreInPlace {
+			// Restore the original container from its kept checkpoint
+			// data — same ID, name, mounts, and IP every iteration.
+			restoreName = params.ContainerSpec.Name
+			restoredID = containerID
 
-			return combined, fmt.Errorf("restoring container for test %d: %w", i, err)
+			testLog.Info("Restoring container in place from checkpoint")
+
+			if err = cpMgr.RestoreContainerInPlace(ctx, containerID); err != nil {
+				combined.TotalDuration = time.Since(startTime)
+
+				return combined, fmt.Errorf(
+					"restoring container in place for test %d: %w", i, err,
+				)
+			}
+		} else {
+			restoreName = fmt.Sprintf("%s-restore-%d", params.ContainerSpec.Name, i)
+
+			testLog.Info("Restoring container from checkpoint")
+
+			restoredID, err = cpMgr.RestoreContainer(ctx, exportPath, &podman.RestoreOptions{
+				Name:        restoreName,
+				NetworkName: r.cfg.ContainerNetwork,
+			})
+			if err != nil {
+				combined.TotalDuration = time.Since(startTime)
+
+				return combined, fmt.Errorf("restoring container for test %d: %w", i, err)
+			}
 		}
 
 		testLog.WithField("duration", time.Since(restoreStart)).Info(
 			"Container restored from checkpoint",
 		)
 
-		// Register cleanup for this iteration.
-		iterID := restoredID
+		// Register cleanup for this iteration. In-place mode reuses the
+		// original container, whose removal is already handled by the
+		// container lifecycle cleanup.
+		if !restoreInPlace {
+			iterID := restoredID
 
-		*cleanupFuncs = append(*cleanupFuncs, func() {
-			if rmErr := r.containerMgr.RemoveContainer(
-				context.Background(), iterID,
-			); rmErr != nil && !isContainerNotFound(rmErr) {
-				testLog.WithError(rmErr).Warn("Failed to remove restored container")
-			}
-		})
+			*cleanupFuncs = append(*cleanupFuncs, func() {
+				if rmErr := r.containerMgr.RemoveContainer(
+					context.Background(), iterID,
+				); rmErr != nil && !isContainerNotFound(rmErr) {
+					testLog.WithError(rmErr).Warn("Failed to remove restored container")
+				}
+			})
+		}
 
 		// Get container IP.
 		restoredIP, err := r.containerMgr.GetContainerIP(
@@ -523,28 +572,44 @@ func (r *runner) runTestsWithCheckpointRestore(
 			testLog.WithError(execErr).Error("Test execution failed")
 		}
 
-		// Force-remove the container (no graceful stop needed — ZFS
-		// rollback discards the datadir anyway). Use a fresh context
-		// so this succeeds even if the parent was cancelled (CTRL+C).
-		testLog.Info("Force-removing restored container")
-
+		// Tear the restored container down for the next iteration. Use a
+		// fresh context so this succeeds even if the parent was cancelled
+		// (CTRL+C). In-place mode only stops the container (SIGKILL via
+		// zero timeout — the datadir rollback discards its writes anyway),
+		// keeping it and its checkpoint data for the next restore; the
+		// export/import mode removes the throwaway container entirely.
 		rmStart := time.Now()
 		rmCtx, rmCancel := context.WithTimeout(
 			context.Background(), 30*time.Second,
 		)
 
-		if rmErr := r.containerMgr.RemoveContainer(
-			rmCtx, restoredID,
-		); rmErr != nil && !isContainerNotFound(rmErr) {
-			testLog.WithError(rmErr).Warn(
-				"Failed to remove restored container",
-			)
+		if restoreInPlace {
+			testLog.Info("Stopping restored container")
+
+			zeroTimeout := 0
+			if stopErr := r.containerMgr.StopContainer(
+				rmCtx, restoredID, &zeroTimeout,
+			); stopErr != nil && !isContainerNotFound(stopErr) {
+				testLog.WithError(stopErr).Warn(
+					"Failed to stop restored container",
+				)
+			}
+		} else {
+			testLog.Info("Force-removing restored container")
+
+			if rmErr := r.containerMgr.RemoveContainer(
+				rmCtx, restoredID,
+			); rmErr != nil && !isContainerNotFound(rmErr) {
+				testLog.WithError(rmErr).Warn(
+					"Failed to remove restored container",
+				)
+			}
 		}
 
 		rmCancel()
 
 		testLog.WithField("duration", time.Since(rmStart)).Info(
-			"Restored container removed",
+			"Restored container torn down",
 		)
 
 		waitForLogDrain(logDone, logCancel, logDrainTimeout)

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -312,6 +312,7 @@ export interface CheckpointRestoreStrategyOptions {
   tmpfs_max_size?: string
   wait_after_tcp_drop_connections?: string
   restart_container?: boolean
+  restore_in_place?: boolean
 }
 
 export interface OpcodeExtractionConfig {

--- a/ui/src/components/run-detail/RunConfiguration.tsx
+++ b/ui/src/components/run-detail/RunConfiguration.tsx
@@ -271,6 +271,12 @@ export function RunConfiguration({ instance, system, startBlock, metadata, bench
                           {instance.checkpoint_restore_strategy_options.restart_container ? 'true' : 'false'}
                         </div>
                       )}
+                      {instance.checkpoint_restore_strategy_options.restore_in_place !== undefined && (
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">restore_in_place: </span>
+                          {instance.checkpoint_restore_strategy_options.restore_in_place ? 'true' : 'false'}
+                        </div>
+                      )}
                     </div>
                     <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
                       Options for the container-checkpoint-restore rollback strategy.


### PR DESCRIPTION
# feat(checkpoint-restore): add `restore_in_place` option

## What

Adds an opt-in `checkpoint_restore_strategy_options.restore_in_place` flag to the `container-checkpoint-restore` rollback strategy. When enabled, the checkpoint is taken locally (`Keep`, no `Export`) so the CRIU images stay in the container's storage directory, and the **same container** — same name, mounts, and IP — is restored in place before every test, with a zero-timeout stop between tests. Default (`false`) keeps the current export/import behavior unchanged.

## Why

On the export/import path, every test pays for extracting the checkpoint archive into container storage plus creating and wiring a fresh container — CRIU itself is a small fraction of the per-test restore:

| | export/import (current) | restore_in_place |
|---|---|---|
| checkpoint (once) | 23.1 s | 12.4 s |
| per-test podman restore | **15.0 s** | **4.1 s** |
| …of which CRIU page restore | 2.9 s | 4.0 s |
| …of which podman overhead (archive extract + container create) | ~12 s | ~0.1 s |

Measured on a Nethermind instance with a ~7.5 GB memory image (1.89 M pages) over the jochemnet stateful suite (gas-benchmarks repricing tests), identical 11-test filter, same host, `tmpfs_threshold` active on the export/import side. For a 550-test suite this saves ~100 minutes of pure restore overhead per run.

## Podman semantics (verified empirically)

The design relies on podman restoring a stopped container repeatedly from kept checkpoint data. Verified on podman 5.x + CRIU (ubuntu-24.04 and a self-hosted runner): `podman container checkpoint <ctr>` → (`podman container restore --keep <ctr>` → `podman kill` / `podman stop -t 0`)×N loops indefinitely; the process resumes from the identical memory state every time (counter-in-a-loop probe), the `Checkpointed=false` state flag after the first restore does not block subsequent restores, and the container IP is stable across restores.

Notes:
- `--name` is not passed on the in-place restore (import-only option).
- `tmpfs_threshold` / `tmpfs_max_size` only concern the export archive and are documented as not applying in this mode.
- The datadir rollback (ZFS or copy-based) is unchanged: the mount path is identical across restores, so the rolled-back content is picked up transparently; `restart_container` composes with this option as before.

## Changes

- `pkg/podman`: `CheckpointContainerLocal` + `RestoreContainerInPlace` (with CRIU stats logging, mirroring the existing methods)
- `pkg/runner/strategy_checkpoint.go`: branch the checkpoint phase, per-test restore, and per-test teardown (stop instead of remove)
- `pkg/config`: option field + `GetCheckpointRestoreInPlace` getter + unit tests
- `docs/configuration.md`, `config.example.yaml`: documentation
- `ui`: `restore_in_place` in `CheckpointRestoreStrategyOptions` type and the RunConfiguration panel
