### PR TITLE
feat(eest): extract opcode counts from _info.metadata.opcode_counts

### DIFF
--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -1259,7 +1259,8 @@ func buildFillArgs(
 
 	// --extract-opcode-count traces each execution-phase block via
 	// debug_traceBlockByHash with a custom JS tracer and records per-opcode
-	// counts in the fixture's _info.metadata.opcode_count. Works with any filler
+	// counts in the fixture's _info.metadata.opcode_counts (one entry per
+	// engineNewPayloads block). Works with any filler
 	// exposing debug_traceBlockByHash + JS tracer support (geth is validated).
 	if t.ExtractOpcodeCount != nil && *t.ExtractOpcodeCount {
 		args = append(args, "--extract-opcode-count")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -468,7 +468,8 @@ type EESTPayloadTarget struct {
 	// ExtractOpcodeCount enables fill-stateful's --extract-opcode-count: after
 	// building each execution-phase block it is traced via debug_traceBlockByHash
 	// with a custom JS opcode-counting tracer, recording per-opcode execution
-	// counts in the fixture's _info.metadata.opcode_count. The per-block re-trace
+	// counts in the fixture's _info.metadata.opcode_counts (one entry per
+	// engineNewPayloads block). The per-block re-trace
 	// with the custom tracer is what makes it slow, so it's opt-in. Works with any
 	// filler exposing debug_traceBlockByHash + JS tracer support (geth is the
 	// validated one).

--- a/pkg/eest/fixture.go
+++ b/pkg/eest/fixture.go
@@ -46,13 +46,57 @@ type StatefulPreRun struct {
 
 // FixtureInfo contains metadata about the fixture.
 type FixtureInfo struct {
-	FixtureFormat         string         `json:"fixture-format"`
-	Hash                  string         `json:"hash,omitempty"`
-	OpcodeCount           map[string]int `json:"opcode_count,omitempty"`
-	Comment               string         `json:"comment,omitempty"`
-	FillingTransitionTool string         `json:"filling-transition-tool,omitempty"`
-	Description           string         `json:"description,omitempty"`
-	URL                   string         `json:"url,omitempty"`
+	FixtureFormat         string           `json:"fixture-format"`
+	Hash                  string           `json:"hash,omitempty"`
+	OpcodeCount           map[string]int   `json:"opcode_count,omitempty"`
+	Comment               string           `json:"comment,omitempty"`
+	FillingTransitionTool string           `json:"filling-transition-tool,omitempty"`
+	Description           string           `json:"description,omitempty"`
+	URL                   string           `json:"url,omitempty"`
+	Metadata              *FixtureMetadata `json:"metadata,omitempty"`
+}
+
+// FixtureMetadata is the optional _info.metadata block written by
+// fill-stateful at fill time.
+type FixtureMetadata struct {
+	// OpcodeCounts holds per-opcode execution counts, one entry per
+	// EngineNewPayloads block: OpcodeCounts[i] is the count for
+	// EngineNewPayloads[i], or nil when its trace was unavailable.
+	OpcodeCounts []map[string]int `json:"opcode_counts,omitempty"`
+}
+
+// AggregatedOpcodeCount returns the fixture's per-opcode execution counts as a
+// single map. It prefers the per-payload _info.metadata.opcode_counts (summed
+// across payloads, skipping nil entries) and falls back to the legacy flat
+// _info.opcode_count. Returns nil when neither is available.
+func (i *FixtureInfo) AggregatedOpcodeCount() map[string]int {
+	if i == nil {
+		return nil
+	}
+
+	if i.Metadata != nil {
+		hint := 0
+
+		for _, counts := range i.Metadata.OpcodeCounts {
+			if len(counts) > hint {
+				hint = len(counts)
+			}
+		}
+
+		if hint > 0 {
+			total := make(map[string]int, hint)
+
+			for _, counts := range i.Metadata.OpcodeCounts {
+				for op, n := range counts {
+					total[op] += n
+				}
+			}
+
+			return total
+		}
+	}
+
+	return i.OpcodeCount
 }
 
 // IsSupportedFormat returns true if the fixture has a supported format.

--- a/pkg/eest/fixture_test.go
+++ b/pkg/eest/fixture_test.go
@@ -1,0 +1,104 @@
+package eest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixtureInfo_AggregatedOpcodeCount(t *testing.T) {
+	tests := []struct {
+		name string
+		info *FixtureInfo
+		want map[string]int
+	}{
+		{
+			name: "nil info",
+			info: nil,
+			want: nil,
+		},
+		{
+			name: "no opcode data",
+			info: &FixtureInfo{},
+			want: nil,
+		},
+		{
+			name: "legacy flat opcode_count only",
+			info: &FixtureInfo{
+				OpcodeCount: map[string]int{"PUSH1": 3, "ADD": 1},
+			},
+			want: map[string]int{"PUSH1": 3, "ADD": 1},
+		},
+		{
+			name: "metadata opcode_counts summed across payloads",
+			info: &FixtureInfo{
+				Metadata: &FixtureMetadata{
+					OpcodeCounts: []map[string]int{
+						{"PUSH1": 3, "ADD": 1},
+						{"PUSH1": 2, "MUL": 4},
+					},
+				},
+			},
+			want: map[string]int{"PUSH1": 5, "ADD": 1, "MUL": 4},
+		},
+		{
+			name: "nil entries (unavailable traces) are skipped",
+			info: &FixtureInfo{
+				Metadata: &FixtureMetadata{
+					OpcodeCounts: []map[string]int{
+						nil,
+						{"PUSH1": 2},
+						nil,
+					},
+				},
+			},
+			want: map[string]int{"PUSH1": 2},
+		},
+		{
+			name: "metadata opcode_counts preferred over legacy flat",
+			info: &FixtureInfo{
+				OpcodeCount: map[string]int{"PUSH1": 99},
+				Metadata: &FixtureMetadata{
+					OpcodeCounts: []map[string]int{{"PUSH1": 2}},
+				},
+			},
+			want: map[string]int{"PUSH1": 2},
+		},
+		{
+			name: "all-nil metadata entries fall back to legacy flat",
+			info: &FixtureInfo{
+				OpcodeCount: map[string]int{"PUSH1": 3},
+				Metadata: &FixtureMetadata{
+					OpcodeCounts: []map[string]int{nil, nil},
+				},
+			},
+			want: map[string]int{"PUSH1": 3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.info.AggregatedOpcodeCount())
+		})
+	}
+}
+
+func TestFixtureInfo_ParsesMetadataOpcodeCounts(t *testing.T) {
+	raw := `{
+		"fixture-format": "blockchain_test_stateful_engine",
+		"metadata": {
+			"opcode_counts": [{"PUSH1": 3, "ADD": 1}, null, {"MUL": 2}]
+		}
+	}`
+
+	var info FixtureInfo
+	require.NoError(t, json.Unmarshal([]byte(raw), &info))
+	require.NotNil(t, info.Metadata)
+	require.Len(t, info.Metadata.OpcodeCounts, 3)
+	assert.Equal(t, map[string]int{"PUSH1": 3, "ADD": 1}, info.Metadata.OpcodeCounts[0])
+	assert.Nil(t, info.Metadata.OpcodeCounts[1])
+	assert.Equal(t, map[string]int{"MUL": 2}, info.Metadata.OpcodeCounts[2])
+	assert.Equal(t, map[string]int{"PUSH1": 3, "ADD": 1, "MUL": 2}, info.AggregatedOpcodeCount())
+}

--- a/pkg/executor/suite.go
+++ b/pkg/executor/suite.go
@@ -221,7 +221,7 @@ func CreateSuiteOutput(
 
 			if test.EESTInfo != nil {
 				suiteTest.EEST = &SuiteTestEEST{Info: test.EESTInfo}
-				suiteTest.OpcodeCount = test.EESTInfo.OpcodeCount
+				suiteTest.OpcodeCount = test.EESTInfo.AggregatedOpcodeCount()
 			}
 
 			// External opcode data takes precedence over EEST-derived opcodes.
@@ -492,8 +492,8 @@ func mergeOpcodeData(existing []SuiteTest, prepared *PreparedSource) {
 	for _, t := range prepared.Tests {
 		if t.OpcodeCount != nil {
 			opcodeByName[t.Name] = t.OpcodeCount
-		} else if t.EESTInfo != nil && t.EESTInfo.OpcodeCount != nil {
-			opcodeByName[t.Name] = t.EESTInfo.OpcodeCount
+		} else if counts := t.EESTInfo.AggregatedOpcodeCount(); counts != nil {
+			opcodeByName[t.Name] = counts
 		}
 	}
 

--- a/pkg/executor/suite_test.go
+++ b/pkg/executor/suite_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethpandaops/benchmarkoor/pkg/eest"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,6 +62,70 @@ func TestCreateSuiteOutput_WritesPayloadSizes(t *testing.T) {
 	assert.Greater(t, tps.SSZFull[0], uint64(100))
 	assert.Greater(t, tps.SSZFullSnappy[0], uint64(0))
 	assert.LessOrEqual(t, tps.SSZFullSnappy[0], tps.SSZFull[0])
+}
+
+func TestCreateSuiteOutput_AggregatesMetadataOpcodeCounts(t *testing.T) {
+	tmp := t.TempDir()
+	prepared := &PreparedSource{
+		Tests: []*TestWithSteps{
+			{
+				Name: "test_opcode_counts",
+				EESTInfo: &eest.FixtureInfo{
+					FixtureFormat: eest.SupportedStatefulFixtureFormat,
+					Metadata: &eest.FixtureMetadata{
+						OpcodeCounts: []map[string]int{
+							{"PUSH1": 3, "ADD": 1},
+							nil,
+							{"PUSH1": 2, "MUL": 4},
+						},
+					},
+				},
+			},
+		},
+	}
+	info := &SuiteInfo{Hash: "cafe"}
+	err := CreateSuiteOutput(logrus.New(), tmp, "cafe", info, prepared, nil)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(tmp, "suites", "cafe", "summary.json"))
+	require.NoError(t, err)
+
+	var parsed SuiteInfo
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	require.Len(t, parsed.Tests, 1)
+	assert.Equal(t,
+		map[string]int{"PUSH1": 5, "ADD": 1, "MUL": 4},
+		parsed.Tests[0].OpcodeCount,
+	)
+	// The raw per-payload counts stay available under eest.info.metadata.
+	require.NotNil(t, parsed.Tests[0].EEST)
+	require.NotNil(t, parsed.Tests[0].EEST.Info.Metadata)
+	assert.Len(t, parsed.Tests[0].EEST.Info.Metadata.OpcodeCounts, 3)
+}
+
+func TestMergeOpcodeData_UsesMetadataOpcodeCounts(t *testing.T) {
+	existing := []SuiteTest{{Name: "test_a"}, {Name: "test_b"}}
+	prepared := &PreparedSource{
+		Tests: []*TestWithSteps{
+			{
+				Name: "test_a",
+				EESTInfo: &eest.FixtureInfo{
+					Metadata: &eest.FixtureMetadata{
+						OpcodeCounts: []map[string]int{{"PUSH1": 2}, {"PUSH1": 1}},
+					},
+				},
+			},
+			{
+				Name:     "test_b",
+				EESTInfo: &eest.FixtureInfo{OpcodeCount: map[string]int{"ADD": 7}},
+			},
+		},
+	}
+
+	mergeOpcodeData(existing, prepared)
+
+	assert.Equal(t, map[string]int{"PUSH1": 3}, existing[0].OpcodeCount)
+	assert.Equal(t, map[string]int{"ADD": 7}, existing[1].OpcodeCount)
 }
 
 func TestSuiteInfo_BackwardCompat_LoadsOldSummary(t *testing.T) {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -502,6 +502,14 @@ export interface SuiteTestEEST {
     'filling-transition-tool'?: string
     description?: string
     url?: string
+    metadata?: {
+      /**
+       * Per-payload opcode counts, one entry per engineNewPayloads block
+       * (null when that block's trace was unavailable). The suite writer
+       * aggregates these into the test's top-level opcode_count.
+       */
+      opcode_counts?: (Record<string, number> | null)[]
+    }
   }
 }
 


### PR DESCRIPTION
## What

Adds support for the new `_info.metadata.opcode_counts` field written by `fill-stateful --extract-opcode-count` (https://github.com/ethereum/execution-specs/pull/3124) — an array with one entry per `engineNewPayloads` block, where an entry is `null` when that block's trace was unavailable.

## How

- `pkg/eest`: `FixtureInfo` now parses `_info.metadata.opcode_counts`, and a new `AggregatedOpcodeCount()` helper sums the non-null per-payload entries into a single map, falling back to the legacy flat `_info.opcode_count` used by older fixture releases (or when all entries are null).
- `pkg/executor`: suite creation and `mergeOpcodeData` (the backfill path for suites already on disk) use the helper, so `summary.json`'s per-test top-level `opcode_count` is populated from either source. Since the whole fixture info is serialized into `summary.json`, the raw per-payload array also stays available under `eest.info.metadata.opcode_counts`.
- `ui`: documented the new field in the `summary.json` types. No UI logic changes needed — the UI reads the test's top-level `opcode_count`, which the Go side now always populates.
- Updated stale comments referencing the PR's earlier singular `_info.metadata.opcode_count` path.

## Testing

- New unit tests cover aggregation across payloads, null-entry skipping, precedence over the legacy flat field, JSON parsing, suite output, and the merge path.
- `go test -race ./pkg/eest ./pkg/executor` passes; `golangci-lint --new-from-rev=origin/master` reports 0 issues; `tsc --noEmit` clean.