### PR TITLE
fix: default nimbus config

### DIFF
--- a/config.example.docker.yaml
+++ b/config.example.docker.yaml
@@ -38,7 +38,9 @@ runner:
       client: erigon
     - id: besu
       client: besu
-
+    - id: nimbus
+      client: nimbus
+      
 api:
   server:
     listen: ":9090"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - BENCHMARKOOR_RUNNER_CPU_SYSFS_PATH=/host_sys_cpu
       - BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_DATADIR=${PWD}/tmp/data
       - BENCHMARKOOR_RUNNER_DIRECTORIES_TMP_CACHEDIR=${PWD}/tmp/cache
+      - BENCHMARKOOR_GLOBAL_DIRECTORIES_CACHEDIR=${PWD}/tmp/global-cache
       - BENCHMARKOOR_RUNNER_BENCHMARK_RESULTS_OWNER=${USER_UID}:${USER_GID}
     volumes:
       # The docker socket is required to interact with docker containers

--- a/pkg/client/nimbus.go
+++ b/pkg/client/nimbus.go
@@ -15,17 +15,19 @@ func (s *nimbusSpec) Type() ClientType {
 }
 
 func (s *nimbusSpec) DefaultImage() string {
-	return "statusim/nimbus-eth1:performance"
+	return "statusim/nimbus-eth1:master"
 }
 
 func (s *nimbusSpec) DefaultCommand() []string {
 	return []string{
+		"executionClient",
 		// Data directory - should always point to /data
 		"--data-dir=/data",
 		// Peering
 		"--max-peers=0",
 		// "Public" JSON RPC API
 		"--rpc=true",
+		"--rpc-api=eth,debug",
 		"--http-address=0.0.0.0",
 		"--http-port=8545",
 		// "Engine" JSON RPC API
@@ -42,7 +44,7 @@ func (s *nimbusSpec) DefaultCommand() []string {
 }
 
 func (s *nimbusSpec) GenesisFlag() string {
-	return "--custom-network="
+	return "--network="
 }
 
 func (s *nimbusSpec) RequiresInit() bool {
@@ -82,7 +84,10 @@ func (s *nimbusSpec) DefaultEnvironment() map[string]string {
 }
 
 func (s *nimbusSpec) RPCRollbackSpec() *RPCRollbackSpec {
-	return nil
+	return &RPCRollbackSpec{
+		Method:    RollbackMethodSetHeadHex,
+		RPCMethod: "debug_setHead",
+	}
 }
 
 func (s *nimbusSpec) DefaultConfigFiles() map[string]string {


### PR DESCRIPTION
These changes are needed to get nimbus working in the benchmarkoor tests. 

Once this PR is merged https://github.com/status-im/nimbus-eth1/pull/4507 then nimbus passes all the tests when running the default runner (without any state snapshot setup).

