### PR TITLE
fix(api): stop rate limit bypass via spoofed X-Forwarded-For and close login timing oracle

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -338,6 +338,10 @@ runner:
 #     # an unset list means X-Forwarded-For is never trusted for rate
 #     # limiting, since honoring it from an arbitrary client would let
 #     # every request claim a different IP and bypass the limit above.
+#     # List every proxy in the chain (e.g. CDN egress ranges as well as
+#     # the load balancer): the header is read right-to-left and the first
+#     # hop that isn't a trusted proxy is used as the client address, so a
+#     # missing entry keys every client on that proxy instead.
 #     # trusted_proxies:
 #     #   - 10.0.0.0/8
 #   auth:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -333,6 +333,13 @@ runner:
 #     #     requests_per_minute: 60   # Health/config endpoints
 #     #   authenticated:
 #     #     requests_per_minute: 120  # Admin endpoints
+#     # Trust X-Forwarded-For only from these reverse proxy/load balancer
+#     # IPs or CIDR ranges. Leave unset if the API is reachable directly —
+#     # an unset list means X-Forwarded-For is never trusted for rate
+#     # limiting, since honoring it from an arbitrary client would let
+#     # every request claim a different IP and bypass the limit above.
+#     # trusted_proxies:
+#     #   - 10.0.0.0/8
 #   auth:
 #     session_ttl: 24h  # How long sessions last before expiring
 #     # Allow unauthenticated users to access /files/ endpoints (default: false).

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,8 @@ api:
         requests_per_minute: 60
       authenticated:
         requests_per_minute: 120
+    trusted_proxies:
+      - 10.0.0.0/8
 ```
 
 | Option | Type | Default | Description |
@@ -47,6 +49,7 @@ api:
 | `rate_limit.auth.requests_per_minute` | int | `10` | Rate limit for auth endpoints (login/logout) |
 | `rate_limit.public.requests_per_minute` | int | `60` | Rate limit for public endpoints (health/config) |
 | `rate_limit.authenticated.requests_per_minute` | int | `120` | Rate limit for authenticated endpoints (admin) |
+| `trusted_proxies` | []string | none | IPs or CIDR ranges (e.g. `10.0.0.0/8`) of reverse proxies/load balancers in front of the API. When the direct connection comes from one of these, rate limiting keys on the right-most `X-Forwarded-For` entry instead of the connection's address. Leave unset if the API is reachable directly — an unset or empty list means `X-Forwarded-For` is never trusted, since honoring it from an arbitrary client lets every request claim a different IP and bypass rate limiting entirely |
 
 ## Authentication
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,7 +49,11 @@ api:
 | `rate_limit.auth.requests_per_minute` | int | `10` | Rate limit for auth endpoints (login/logout) |
 | `rate_limit.public.requests_per_minute` | int | `60` | Rate limit for public endpoints (health/config) |
 | `rate_limit.authenticated.requests_per_minute` | int | `120` | Rate limit for authenticated endpoints (admin) |
-| `trusted_proxies` | []string | none | IPs or CIDR ranges (e.g. `10.0.0.0/8`) of reverse proxies/load balancers in front of the API. When the direct connection comes from one of these, rate limiting keys on the right-most `X-Forwarded-For` entry instead of the connection's address. Leave unset if the API is reachable directly — an unset or empty list means `X-Forwarded-For` is never trusted, since honoring it from an arbitrary client lets every request claim a different IP and bypass rate limiting entirely |
+| `trusted_proxies` | []string | none | IPs or CIDR ranges (e.g. `10.0.0.0/8`) of reverse proxies/load balancers in front of the API. When the direct connection comes from one of these, rate limiting keys on the client address taken from `X-Forwarded-For` instead of the connection's address. Leave unset if the API is reachable directly — an unset or empty list means `X-Forwarded-For` is never trusted, since honoring it from an arbitrary client lets every request claim a different IP and bypass rate limiting entirely |
+
+**List every proxy in the chain.** `X-Forwarded-For` is read right-to-left and the first entry that is *not* itself a trusted proxy is used as the client address. With a chain (say a CDN in front of a load balancer), the right-most entries are hops your own infrastructure appended, so both the load balancer and the CDN egress ranges belong in `trusted_proxies` — otherwise every client is keyed on the CDN's address and shares a single rate limit bucket. Entries that don't parse as an IP or CIDR range are skipped with a warning at startup, and a hop that doesn't parse as an IP is never used as a rate limit key.
+
+If the API sits behind a proxy and `trusted_proxies` is left unset, rate limiting keys every request on the proxy's address, so all clients behind it share one bucket. The server logs a warning once when it sees `X-Forwarded-For` on a request with no trusted proxies configured.
 
 ## Authentication
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -45,6 +45,14 @@ type server struct {
 	wg             sync.WaitGroup
 	done           chan struct{}
 
+	// trustedProxies holds the parsed api.server.trusted_proxies networks.
+	// Parsed once here rather than per middleware tier so the config is
+	// validated (and complained about) a single time at construction, and
+	// so every consumer of a request's client IP resolves it identically.
+	// See extractIP.
+	trustedProxies []*net.IPNet
+	xffWarnOnce    sync.Once
+
 	// indexCache holds the marshaled /index response keyed by the runs-table
 	// generation, so repeated polls don't rebuild it. See handleIndex.
 	indexCacheMu   sync.Mutex
@@ -60,10 +68,11 @@ func NewServer(
 	componentLog := log.WithField("component", "api")
 
 	return &server{
-		log:   componentLog,
-		cfg:   cfg,
-		done:  make(chan struct{}),
-		wsHub: newWsHub(componentLog),
+		log:            componentLog,
+		cfg:            cfg,
+		done:           make(chan struct{}),
+		wsHub:          newWsHub(componentLog),
+		trustedProxies: parseTrustedProxies(componentLog, cfg.Server.TrustedProxies),
 	}
 }
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -220,20 +220,25 @@ func (s *server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, err := s.store.GetUserByUsername(r.Context(), req.Username)
-	if err != nil {
-		// Run the same bcrypt comparison a real user lookup would incur, so a
-		// non-existent username takes the same time as a wrong password for
-		// an existing one. Without this, the missing comparison is a timing
-		// oracle that lets a caller enumerate valid usernames.
-		checkPassword(dummyPasswordHash, req.Password)
 
-		writeJSON(w, http.StatusUnauthorized,
-			errorResponse{"invalid credentials"})
+	// Every login attempt must cost exactly one bcrypt comparison, whatever
+	// the lookup found. A username that doesn't exist has no hash to compare,
+	// and a GitHub-sourced account has an empty one that bcrypt rejects on a
+	// length check in microseconds - either shortcut turns response time into
+	// an oracle for enumerating accounts. Both fall back to a fixed dummy
+	// hash of the same cost, and hasCredential (not the comparison result)
+	// decides whether authentication can succeed, so a caller who somehow
+	// guessed the dummy password still can't log in as anyone.
+	hash := dummyPasswordHash
 
-		return
+	hasCredential := err == nil && user != nil && isBcryptHash(user.PasswordHash)
+	if hasCredential {
+		hash = user.PasswordHash
 	}
 
-	if !checkPassword(user.PasswordHash, req.Password) {
+	passwordOK := checkPassword(hash, req.Password)
+
+	if !hasCredential || !passwordOK {
 		writeJSON(w, http.StatusUnauthorized,
 			errorResponse{"invalid credentials"})
 
@@ -327,23 +332,29 @@ func checkPassword(hash, password string) bool {
 	) == nil
 }
 
-// dummyPasswordHash is a bcrypt hash of a fixed placeholder password,
-// computed once at startup and compared against on every login attempt for
-// a username that doesn't exist. This keeps the "user not found" path the
-// same cost as the "wrong password" path. See checkPassword's use in
-// handleLogin.
-var dummyPasswordHash = mustHashDummyPassword()
+// isBcryptHash reports whether hash is a well-formed bcrypt hash, i.e. one
+// that CompareHashAndPassword will actually spend a key derivation on.
+// Accounts without a usable password (GitHub logins store an empty hash)
+// must not be authenticated by, or measurably faster than, a real compare.
+func isBcryptHash(hash string) bool {
+	_, err := bcrypt.Cost([]byte(hash))
 
-func mustHashDummyPassword() string {
-	hash, err := bcrypt.GenerateFromPassword(
-		[]byte("benchmarkoor-dummy-password-for-timing-parity"), bcrypt.DefaultCost,
-	)
-	if err != nil {
-		panic("generating dummy password hash: " + err.Error())
-	}
-
-	return string(hash)
+	return err == nil
 }
+
+// dummyPasswordHash is a bcrypt hash of dummyPassword at bcrypt.DefaultCost,
+// compared against on every login attempt that has no real hash to check.
+// This keeps those paths the same cost as a genuine wrong-password check.
+//
+// It is a pre-generated constant rather than something hashed at startup so
+// that binaries which never serve a login don't pay a bcrypt derivation
+// during package init. TestDummyPasswordHash_MatchesRealUserCost guards the
+// cost matching what real users are hashed with; if bcrypt.DefaultCost ever
+// changes, regenerate this from dummyPassword.
+const (
+	dummyPassword     = "benchmarkoor-dummy-password-for-timing-parity"
+	dummyPasswordHash = "$2a$10$84TC40fhRS1Wdjgk3xIF4OtF88k3UnTNGHw9X91VxI/wncL9i.EZC"
+)
 
 // --- API key handlers ---
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -221,6 +221,12 @@ func (s *server) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 	user, err := s.store.GetUserByUsername(r.Context(), req.Username)
 	if err != nil {
+		// Run the same bcrypt comparison a real user lookup would incur, so a
+		// non-existent username takes the same time as a wrong password for
+		// an existing one. Without this, the missing comparison is a timing
+		// oracle that lets a caller enumerate valid usernames.
+		checkPassword(dummyPasswordHash, req.Password)
+
 		writeJSON(w, http.StatusUnauthorized,
 			errorResponse{"invalid credentials"})
 
@@ -319,6 +325,24 @@ func checkPassword(hash, password string) bool {
 	return bcrypt.CompareHashAndPassword(
 		[]byte(hash), []byte(password),
 	) == nil
+}
+
+// dummyPasswordHash is a bcrypt hash of a fixed placeholder password,
+// computed once at startup and compared against on every login attempt for
+// a username that doesn't exist. This keeps the "user not found" path the
+// same cost as the "wrong password" path. See checkPassword's use in
+// handleLogin.
+var dummyPasswordHash = mustHashDummyPassword()
+
+func mustHashDummyPassword() string {
+	hash, err := bcrypt.GenerateFromPassword(
+		[]byte("benchmarkoor-dummy-password-for-timing-parity"), bcrypt.DefaultCost,
+	)
+	if err != nil {
+		panic("generating dummy password hash: " + err.Error())
+	}
+
+	return string(hash)
 }
 
 // --- API key handlers ---

--- a/pkg/api/login_timing_test.go
+++ b/pkg/api/login_timing_test.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
@@ -21,8 +21,7 @@ import (
 func newLoginTestServer(t *testing.T) *server {
 	t.Helper()
 
-	log := logrus.New()
-	log.SetLevel(logrus.ErrorLevel)
+	log, _ := newTestLogger()
 
 	st := store.NewStore(log, &config.APIDatabaseConfig{
 		Driver: "sqlite",
@@ -33,6 +32,15 @@ func newLoginTestServer(t *testing.T) *server {
 
 	require.NoError(t, st.SeedUsers(context.Background(), []config.BasicAuthUser{
 		{Username: "admin", Password: "correct-password", Role: "admin"},
+	}))
+
+	// A GitHub-sourced account: exists, but has no password hash to compare
+	// against. See github.go, which stores an empty hash for these.
+	require.NoError(t, st.CreateUser(context.Background(), &store.User{
+		Username:     "github-user",
+		PasswordHash: "",
+		Role:         "user",
+		Source:       store.SourceGitHub,
 	}))
 
 	return &server{
@@ -75,34 +83,90 @@ func TestDummyPasswordHash_MatchesRealUserCost(t *testing.T) {
 
 	assert.Equal(t, bcrypt.DefaultCost, cost,
 		"the dummy hash must use the same cost as real user hashes (store.SeedUsers uses bcrypt.DefaultCost), or the timing parity it exists for breaks")
+
+	require.NoError(t, bcrypt.CompareHashAndPassword([]byte(dummyPasswordHash), []byte(dummyPassword)),
+		"dummyPasswordHash must be a hash of dummyPassword - regenerate it if either changes")
 }
 
-func TestHandleLogin_NonexistentAndWrongPassword_SameResponse(t *testing.T) {
+func TestIsBcryptHash(t *testing.T) {
+	assert.True(t, isBcryptHash(dummyPasswordHash))
+	assert.False(t, isBcryptHash(""), "GitHub-sourced users store an empty hash")
+	assert.False(t, isBcryptHash("not-a-hash"))
+	assert.False(t, isBcryptHash("$2a$"))
+}
+
+func TestHandleLogin_AllFailureModes_SameResponse(t *testing.T) {
 	s := newLoginTestServer(t)
 
-	nonexistent := doLogin(t, s, "no-such-user", "irrelevant")
 	wrongPassword := doLogin(t, s, "admin", "wrong-password")
+	nonexistent := doLogin(t, s, "no-such-user", "irrelevant")
+	passwordless := doLogin(t, s, "github-user", "irrelevant")
 
-	assert.Equal(t, http.StatusUnauthorized, nonexistent.Code)
+	for name, rec := range map[string]*httptest.ResponseRecorder{
+		"nonexistent user":  nonexistent,
+		"passwordless user": passwordless,
+	} {
+		assert.Equal(t, http.StatusUnauthorized, rec.Code, name)
+		assert.JSONEq(t, wrongPassword.Body.String(), rec.Body.String(), name)
+	}
+
 	assert.Equal(t, http.StatusUnauthorized, wrongPassword.Code)
-	assert.JSONEq(t, nonexistent.Body.String(), wrongPassword.Body.String())
 }
 
-// TestHandleLogin_NonexistentUser_StillRunsBcrypt is a regression guard for
-// the login timing oracle: without the dummy-hash comparison, a
-// non-existent username returns after a cheap DB miss in well under a
-// millisecond, while an existing user's wrong-password path costs a full
-// bcrypt compare (tens of milliseconds at the default cost). The threshold
-// here is set far below the real bcrypt cost and far above a no-op DB miss,
-// so it catches the mitigation being silently removed without being flaky
-// on slower CI hardware.
-func TestHandleLogin_NonexistentUser_StillRunsBcrypt(t *testing.T) {
+// TestHandleLogin_PasswordlessUser_CannotAuthenticate pins the security
+// property that makes the timing fix safe: the dummy hash is only ever a
+// comparison target, never a credential. Submitting the dummy password
+// against an account with no usable hash must still be rejected.
+func TestHandleLogin_PasswordlessUser_CannotAuthenticate(t *testing.T) {
 	s := newLoginTestServer(t)
 
-	start := time.Now()
-	doLogin(t, s, "no-such-user", "irrelevant")
-	elapsed := time.Since(start)
+	rec := doLogin(t, s, "github-user", dummyPassword)
 
-	assert.Greater(t, elapsed, 5*time.Millisecond,
-		"a non-existent username should still pay the bcrypt cost, not return immediately after the DB miss")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"knowing the dummy password must never authenticate an account that has no password set")
+	assert.Empty(t, rec.Result().Cookies(), "no session cookie may be issued")
+}
+
+// medianLoginDuration times a handful of login attempts and returns the
+// median, so a single scheduling hiccup can't decide the outcome.
+func medianLoginDuration(t *testing.T, s *server, username, password string) time.Duration {
+	t.Helper()
+
+	const samples = 3
+
+	durations := make([]time.Duration, 0, samples)
+
+	for i := 0; i < samples; i++ {
+		start := time.Now()
+		doLogin(t, s, username, password)
+		durations = append(durations, time.Since(start))
+	}
+
+	slices.Sort(durations)
+
+	return durations[len(durations)/2]
+}
+
+// TestHandleLogin_FailurePathsCostTheSame is the regression guard for the
+// login timing oracle. It compares the failing paths against each other
+// rather than against an absolute threshold: an absolute floor passes for
+// any implementation that is merely slow (a sleep, a lower bcrypt cost),
+// while the property that actually matters is that a caller can't tell the
+// three failure modes apart. The 50% band is wide enough to absorb CI noise
+// and narrow enough that dropping a bcrypt compare (~3 orders of magnitude
+// faster) always trips it.
+func TestHandleLogin_FailurePathsCostTheSame(t *testing.T) {
+	s := newLoginTestServer(t)
+
+	baseline := medianLoginDuration(t, s, "admin", "wrong-password")
+	require.Positive(t, baseline)
+
+	for name, elapsed := range map[string]time.Duration{
+		"nonexistent user":  medianLoginDuration(t, s, "no-such-user", "irrelevant"),
+		"passwordless user": medianLoginDuration(t, s, "github-user", "irrelevant"),
+	} {
+		assert.Greater(t, elapsed, baseline/2,
+			"%s must cost about as much as an existing user's wrong password (baseline %s), "+
+				"otherwise response time enumerates accounts", name, baseline)
+	}
 }

--- a/pkg/api/login_timing_test.go
+++ b/pkg/api/login_timing_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/api/store"
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+)
+
+func newLoginTestServer(t *testing.T) *server {
+	t.Helper()
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	st := store.NewStore(log, &config.APIDatabaseConfig{
+		Driver: "sqlite",
+		SQLite: config.SQLiteDatabaseConfig{Path: ":memory:"},
+	})
+	require.NoError(t, st.Start(context.Background()))
+	t.Cleanup(func() { _ = st.Stop() })
+
+	require.NoError(t, st.SeedUsers(context.Background(), []config.BasicAuthUser{
+		{Username: "admin", Password: "correct-password", Role: "admin"},
+	}))
+
+	return &server{
+		log:   log,
+		store: st,
+		cfg: &config.APIConfig{
+			Auth: config.APIAuthConfig{SessionTTL: "24h"},
+		},
+	}
+}
+
+func doLogin(t *testing.T, s *server, username, password string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{"username": username, "password": password})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	s.handleLogin(rec, req)
+
+	return rec
+}
+
+func TestDummyPasswordHash_NeverAuthenticates(t *testing.T) {
+	// No real login attempt should ever match the dummy hash - it exists
+	// purely as a fixed comparison target, not a credential anyone should
+	// be able to guess their way into.
+	assert.False(t, checkPassword(dummyPasswordHash, ""))
+	assert.False(t, checkPassword(dummyPasswordHash, "correct-password"))
+	assert.False(t, checkPassword(dummyPasswordHash, "admin"))
+	assert.False(t, checkPassword(dummyPasswordHash, "password"))
+}
+
+func TestDummyPasswordHash_MatchesRealUserCost(t *testing.T) {
+	cost, err := bcrypt.Cost([]byte(dummyPasswordHash))
+	require.NoError(t, err)
+
+	assert.Equal(t, bcrypt.DefaultCost, cost,
+		"the dummy hash must use the same cost as real user hashes (store.SeedUsers uses bcrypt.DefaultCost), or the timing parity it exists for breaks")
+}
+
+func TestHandleLogin_NonexistentAndWrongPassword_SameResponse(t *testing.T) {
+	s := newLoginTestServer(t)
+
+	nonexistent := doLogin(t, s, "no-such-user", "irrelevant")
+	wrongPassword := doLogin(t, s, "admin", "wrong-password")
+
+	assert.Equal(t, http.StatusUnauthorized, nonexistent.Code)
+	assert.Equal(t, http.StatusUnauthorized, wrongPassword.Code)
+	assert.JSONEq(t, nonexistent.Body.String(), wrongPassword.Body.String())
+}
+
+// TestHandleLogin_NonexistentUser_StillRunsBcrypt is a regression guard for
+// the login timing oracle: without the dummy-hash comparison, a
+// non-existent username returns after a cheap DB miss in well under a
+// millisecond, while an existing user's wrong-password path costs a full
+// bcrypt compare (tens of milliseconds at the default cost). The threshold
+// here is set far below the real bcrypt cost and far above a no-op DB miss,
+// so it catches the mitigation being silently removed without being flaky
+// on slower CI hardware.
+func TestHandleLogin_NonexistentUser_StillRunsBcrypt(t *testing.T) {
+	s := newLoginTestServer(t)
+
+	start := time.Now()
+	doLogin(t, s, "no-such-user", "irrelevant")
+	elapsed := time.Since(start)
+
+	assert.Greater(t, elapsed, 5*time.Millisecond,
+		"a non-existent username should still pay the bcrypt cost, not return immediately after the DB miss")
+}

--- a/pkg/api/ratelimit.go
+++ b/pkg/api/ratelimit.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -84,10 +86,11 @@ func (s *server) rateLimitMiddleware(
 	tier config.RateLimitTier,
 ) func(http.Handler) http.Handler {
 	limiterMap := newRateLimiterMap(tier.RequestsPerMinute)
+	trustedProxies := parseTrustedProxies(s.cfg.Server.TrustedProxies)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ip := extractIP(r)
+			ip := extractIP(r, trustedProxies)
 			limiter := limiterMap.getLimiter(ip)
 
 			if !limiter.Allow() {
@@ -102,27 +105,96 @@ func (s *server) rateLimitMiddleware(
 	}
 }
 
-// extractIP returns the client's IP address from the request.
-func extractIP(r *http.Request) string {
-	// Check X-Forwarded-For first (common with reverse proxies).
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// Take the first IP in the chain.
-		if idx := len(xff); idx > 0 {
-			for i, c := range xff {
-				if c == ',' {
-					return xff[:i]
-				}
-			}
+// extractIP returns the client's IP address for rate-limiting purposes.
+//
+// X-Forwarded-For is only honored when the direct connection (RemoteAddr)
+// comes from a configured trusted proxy - otherwise it's an arbitrary,
+// attacker-controlled header that would let every request claim a fresh
+// identity and bypass the limiter entirely. When trusted, the right-most
+// entry in the header is used, since that's the hop our trusted proxy
+// itself observed and appended - anything to its left could have been
+// forged by the client.
+func extractIP(r *http.Request, trustedProxies []*net.IPNet) string {
+	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		remoteIP = r.RemoteAddr
+	}
 
-			return xff
+	if !isTrustedProxy(remoteIP, trustedProxies) {
+		return remoteIP
+	}
+
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff == "" {
+		return remoteIP
+	}
+
+	hops := strings.Split(xff, ",")
+
+	clientIP := strings.TrimSpace(hops[len(hops)-1])
+	if clientIP == "" {
+		return remoteIP
+	}
+
+	return clientIP
+}
+
+// isTrustedProxy reports whether ip falls within any of the configured
+// trusted proxy networks.
+func isTrustedProxy(ip string, trustedProxies []*net.IPNet) bool {
+	if len(trustedProxies) == 0 {
+		return false
+	}
+
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+
+	for _, network := range trustedProxies {
+		if network.Contains(parsed) {
+			return true
 		}
 	}
 
-	// Fall back to RemoteAddr.
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
+	return false
+}
+
+// parseTrustedProxies parses a list of bare IPs or CIDR ranges into
+// networks suitable for membership checks. Bare IPs are treated as
+// single-address networks. Entries that fail to parse are skipped, which
+// fails closed: a malformed entry simply never matches, rather than
+// granting broader trust than configured.
+func parseTrustedProxies(proxies []string) []*net.IPNet {
+	networks := make([]*net.IPNet, 0, len(proxies))
+
+	for _, p := range proxies {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+
+		if !strings.Contains(p, "/") {
+			ip := net.ParseIP(p)
+			if ip == nil {
+				continue
+			}
+
+			bits := 32
+			if ip.To4() == nil {
+				bits = 128
+			}
+
+			p = fmt.Sprintf("%s/%d", p, bits)
+		}
+
+		_, network, err := net.ParseCIDR(p)
+		if err != nil {
+			continue
+		}
+
+		networks = append(networks, network)
 	}
 
-	return ip
+	return networks
 }

--- a/pkg/api/ratelimit.go
+++ b/pkg/api/ratelimit.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 )
 
@@ -86,11 +87,12 @@ func (s *server) rateLimitMiddleware(
 	tier config.RateLimitTier,
 ) func(http.Handler) http.Handler {
 	limiterMap := newRateLimiterMap(tier.RequestsPerMinute)
-	trustedProxies := parseTrustedProxies(s.cfg.Server.TrustedProxies)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ip := extractIP(r, trustedProxies)
+			s.warnOnUntrustedForwardedFor(r)
+
+			ip := extractIP(r, s.trustedProxies)
 			limiter := limiterMap.getLimiter(ip)
 
 			if !limiter.Allow() {
@@ -105,15 +107,42 @@ func (s *server) rateLimitMiddleware(
 	}
 }
 
+// warnOnUntrustedForwardedFor logs once if requests arrive carrying an
+// X-Forwarded-For header while no trusted proxies are configured. That
+// combination means a reverse proxy is almost certainly in front of the API
+// but isn't declared, so every client behind it is rate limited as a single
+// address - a silent lockout that is otherwise very hard to diagnose.
+func (s *server) warnOnUntrustedForwardedFor(r *http.Request) {
+	if len(s.trustedProxies) > 0 || r.Header.Get("X-Forwarded-For") == "" {
+		return
+	}
+
+	s.xffWarnOnce.Do(func() {
+		s.log.Warn(
+			"Requests carry X-Forwarded-For but api.server.trusted_proxies " +
+				"is empty, so rate limiting keys on the direct connection " +
+				"address. If a reverse proxy fronts this API, list every " +
+				"proxy in the chain under trusted_proxies - otherwise all " +
+				"clients behind it share a single rate limit bucket.",
+		)
+	})
+}
+
 // extractIP returns the client's IP address for rate-limiting purposes.
 //
 // X-Forwarded-For is only honored when the direct connection (RemoteAddr)
 // comes from a configured trusted proxy - otherwise it's an arbitrary,
 // attacker-controlled header that would let every request claim a fresh
-// identity and bypass the limiter entirely. When trusted, the right-most
-// entry in the header is used, since that's the hop our trusted proxy
-// itself observed and appended - anything to its left could have been
-// forged by the client.
+// identity and bypass the limiter entirely.
+//
+// When trusted, the header is walked right-to-left and the first entry that
+// is not itself a trusted proxy is returned: with a chain of proxies (say a
+// CDN in front of a load balancer) the right-most entries are the hops our
+// own infrastructure appended, and only the first untrusted address below
+// them is attributable. Anything further left could have been forged by the
+// client, so a malformed or exhausted chain falls back to RemoteAddr rather
+// than trusting a value we can't vouch for. Every candidate must parse as an
+// IP, so arbitrary strings never become limiter keys.
 func extractIP(r *http.Request, trustedProxies []*net.IPNet) string {
 	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
@@ -131,12 +160,21 @@ func extractIP(r *http.Request, trustedProxies []*net.IPNet) string {
 
 	hops := strings.Split(xff, ",")
 
-	clientIP := strings.TrimSpace(hops[len(hops)-1])
-	if clientIP == "" {
-		return remoteIP
+	for i := len(hops) - 1; i >= 0; i-- {
+		hop := strings.TrimSpace(hops[i])
+
+		if net.ParseIP(hop) == nil {
+			// A hop we can't parse breaks the chain: everything further
+			// left is unverifiable, so fall back to the connection address.
+			break
+		}
+
+		if !isTrustedProxy(hop, trustedProxies) {
+			return hop
+		}
 	}
 
-	return clientIP
+	return remoteIP
 }
 
 // isTrustedProxy reports whether ip falls within any of the configured
@@ -164,19 +202,27 @@ func isTrustedProxy(ip string, trustedProxies []*net.IPNet) bool {
 // networks suitable for membership checks. Bare IPs are treated as
 // single-address networks. Entries that fail to parse are skipped, which
 // fails closed: a malformed entry simply never matches, rather than
-// granting broader trust than configured.
-func parseTrustedProxies(proxies []string) []*net.IPNet {
+// granting broader trust than configured. Skipped entries are logged at
+// warn level, since a typo silently demotes a real proxy to untrusted and
+// collapses everyone behind it into one rate limit bucket.
+func parseTrustedProxies(log logrus.FieldLogger, proxies []string) []*net.IPNet {
 	networks := make([]*net.IPNet, 0, len(proxies))
 
 	for _, p := range proxies {
-		p = strings.TrimSpace(p)
-		if p == "" {
+		entry := strings.TrimSpace(p)
+		if entry == "" {
 			continue
 		}
 
-		if !strings.Contains(p, "/") {
-			ip := net.ParseIP(p)
+		cidr := entry
+
+		if !strings.Contains(cidr, "/") {
+			ip := net.ParseIP(cidr)
 			if ip == nil {
+				log.WithField("entry", entry).Warn(
+					"Ignoring api.server.trusted_proxies entry: not a valid IP or CIDR range",
+				)
+
 				continue
 			}
 
@@ -185,11 +231,15 @@ func parseTrustedProxies(proxies []string) []*net.IPNet {
 				bits = 128
 			}
 
-			p = fmt.Sprintf("%s/%d", p, bits)
+			cidr = fmt.Sprintf("%s/%d", cidr, bits)
 		}
 
-		_, network, err := net.ParseCIDR(p)
+		_, network, err := net.ParseCIDR(cidr)
 		if err != nil {
+			log.WithField("entry", entry).WithError(err).Warn(
+				"Ignoring api.server.trusted_proxies entry: not a valid IP or CIDR range",
+			)
+
 			continue
 		}
 

--- a/pkg/api/ratelimit_test.go
+++ b/pkg/api/ratelimit_test.go
@@ -113,7 +113,7 @@ func TestExtractIP_MalformedHopsAreNeverUsedAsKeys(t *testing.T) {
 		got := extractIP(req, trusted)
 
 		assert.Equal(t, "10.0.0.1", got,
-			"an unparseable hop (%q) breaks the chain and must fall back to RemoteAddr, never become a limiter key", xff)
+			"an unparsable hop (%q) breaks the chain and must fall back to RemoteAddr, never become a limiter key", xff)
 	}
 }
 

--- a/pkg/api/ratelimit_test.go
+++ b/pkg/api/ratelimit_test.go
@@ -2,16 +2,35 @@ package api
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
 )
+
+// newTestLogger returns a logger that discards output but keeps a hook so
+// tests can assert on what was logged.
+func newTestLogger() (*logrus.Logger, *logtest.Hook) {
+	log, hook := logtest.NewNullLogger()
+	log.SetLevel(logrus.DebugLevel)
+
+	return log, hook
+}
+
+func testTrustedProxies(t *testing.T, entries ...string) []*net.IPNet {
+	t.Helper()
+
+	log, _ := newTestLogger()
+
+	return parseTrustedProxies(log, entries)
+}
 
 func TestExtractIP_IgnoresXFFWithoutTrustedProxy(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
@@ -25,7 +44,7 @@ func TestExtractIP_IgnoresXFFWithoutTrustedProxy(t *testing.T) {
 }
 
 func TestExtractIP_HonorsXFFFromTrustedProxy(t *testing.T) {
-	trusted := parseTrustedProxies([]string{"10.0.0.0/8"})
+	trusted := testTrustedProxies(t, "10.0.0.0/8")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
 	req.RemoteAddr = "10.0.0.1:54321"
@@ -37,8 +56,8 @@ func TestExtractIP_HonorsXFFFromTrustedProxy(t *testing.T) {
 		"when RemoteAddr is a trusted proxy, the XFF value it appended should be used")
 }
 
-func TestExtractIP_UsesRightmostHop(t *testing.T) {
-	trusted := parseTrustedProxies([]string{"10.0.0.1"})
+func TestExtractIP_UsesRightmostUntrustedHop(t *testing.T) {
+	trusted := testTrustedProxies(t, "10.0.0.1")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
 	req.RemoteAddr = "10.0.0.1:54321"
@@ -52,10 +71,77 @@ func TestExtractIP_UsesRightmostHop(t *testing.T) {
 		"only the right-most hop (appended by our trusted proxy) should be trusted, not attacker-supplied left-most entries")
 }
 
+// TestExtractIP_SkipsTrustedHopsInChain covers a chain of proxies (a CDN in
+// front of a load balancer). Taking the right-most entry unconditionally
+// would key every request on the CDN's egress address, collapsing the whole
+// user base into a single rate limit bucket.
+func TestExtractIP_SkipsTrustedHopsInChain(t *testing.T) {
+	trusted := testTrustedProxies(t, "10.0.0.0/8", "192.0.2.0/24")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	req.RemoteAddr = "10.0.0.1:54321"
+	// Client, then the CDN egress our load balancer observed and appended.
+	req.Header.Set("X-Forwarded-For", "198.51.100.7, 192.0.2.5")
+
+	got := extractIP(req, trusted)
+
+	assert.Equal(t, "198.51.100.7", got,
+		"hops that are themselves trusted proxies must be skipped in favour of the first untrusted address")
+}
+
+func TestExtractIP_AllHopsTrustedFallsBackToRemoteAddr(t *testing.T) {
+	trusted := testTrustedProxies(t, "10.0.0.0/8")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	req.RemoteAddr = "10.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "10.0.0.9, 10.0.0.8")
+
+	got := extractIP(req, trusted)
+
+	assert.Equal(t, "10.0.0.1", got,
+		"with no untrusted hop to attribute, the connection address is the only honest key")
+}
+
+func TestExtractIP_MalformedHopsAreNeverUsedAsKeys(t *testing.T) {
+	trusted := testTrustedProxies(t, "10.0.0.0/8")
+
+	for _, xff := range []string{"unknown", "", "   ", "1.2.3.4, not-an-ip", "<script>"} {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+		req.RemoteAddr = "10.0.0.1:54321"
+		req.Header.Set("X-Forwarded-For", xff)
+
+		got := extractIP(req, trusted)
+
+		assert.Equal(t, "10.0.0.1", got,
+			"an unparseable hop (%q) breaks the chain and must fall back to RemoteAddr, never become a limiter key", xff)
+	}
+}
+
+// TestExtractIP_PassthroughProxyCannotMintBuckets covers a trusted proxy
+// that forwards the client's header verbatim instead of appending to it.
+// Only parseable IPs are ever returned, so a caller can't mint a fresh
+// limiter key per request out of arbitrary strings.
+func TestExtractIP_PassthroughProxyCannotMintBuckets(t *testing.T) {
+	trusted := testTrustedProxies(t, "10.0.0.0/8")
+
+	seen := make(map[string]struct{}, 3)
+
+	for _, spoof := range []string{"bucket-a", "bucket-b", "bucket-c"} {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+		req.RemoteAddr = "10.0.0.1:54321"
+		req.Header.Set("X-Forwarded-For", spoof)
+
+		seen[extractIP(req, trusted)] = struct{}{}
+	}
+
+	assert.Len(t, seen, 1,
+		"non-IP X-Forwarded-For values must all collapse onto the connection address, not one bucket each")
+}
+
 func TestExtractIP_IgnoresXFFFromUntrustedDirectConnection(t *testing.T) {
 	// trusted_proxies is configured, but this specific request bypassed the
 	// proxy and connected directly - the XFF header must still be ignored.
-	trusted := parseTrustedProxies([]string{"10.0.0.0/8"})
+	trusted := testTrustedProxies(t, "10.0.0.0/8")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
 	req.RemoteAddr = "203.0.113.5:54321"
@@ -68,13 +154,13 @@ func TestExtractIP_IgnoresXFFFromUntrustedDirectConnection(t *testing.T) {
 }
 
 func TestParseTrustedProxies(t *testing.T) {
-	networks := parseTrustedProxies([]string{
+	networks := testTrustedProxies(t,
 		"10.0.0.0/8",
 		"192.168.1.1",
 		"not-an-ip",
 		"",
 		"::1",
-	})
+	)
 
 	require.Len(t, networks, 3, "malformed/empty entries should be skipped, not error out")
 
@@ -83,6 +169,28 @@ func TestParseTrustedProxies(t *testing.T) {
 	assert.False(t, isTrustedProxy("192.168.1.2", networks), "bare IP entries should match only that exact address")
 	assert.True(t, isTrustedProxy("::1", networks))
 	assert.False(t, isTrustedProxy("8.8.8.8", networks))
+}
+
+// TestParseTrustedProxies_WarnsOnSkippedEntries guards the diagnosability of
+// a typo: a skipped entry silently demotes a real proxy to untrusted, which
+// puts every client behind it into one bucket.
+func TestParseTrustedProxies_WarnsOnSkippedEntries(t *testing.T) {
+	log, hook := newTestLogger()
+
+	networks := parseTrustedProxies(log, []string{"10.0.0/8", "not-an-ip", "10.0.0.0/8"})
+
+	require.Len(t, networks, 1)
+
+	var warnings []string
+
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel {
+			warnings = append(warnings, e.Message)
+		}
+	}
+
+	assert.Len(t, warnings, 2,
+		"every skipped trusted_proxies entry must be logged, or a typo is undiagnosable")
 }
 
 func TestIsTrustedProxy_EmptyList(t *testing.T) {
@@ -95,8 +203,7 @@ func TestIsTrustedProxy_EmptyList(t *testing.T) {
 // trusted_proxies configured, sending a unique X-Forwarded-For value on
 // every request must not grant a fresh rate-limit bucket per request.
 func TestRateLimitMiddleware_SpoofedXFFCannotBypassLimit(t *testing.T) {
-	log := logrus.New()
-	log.SetLevel(logrus.ErrorLevel)
+	log, _ := newTestLogger()
 
 	s := &server{
 		log: log,
@@ -131,6 +238,51 @@ func TestRateLimitMiddleware_SpoofedXFFCannotBypassLimit(t *testing.T) {
 
 	assert.True(t, tripped,
 		"the limiter must trip within a small multiple of the configured cap even when every request carries a unique spoofed X-Forwarded-For value")
+}
+
+// TestRateLimitMiddleware_WarnsOnceOnUntrustedXFF covers the deployment that
+// silently regressed: an API behind a reverse proxy with no trusted_proxies
+// set now keys every client on the proxy address, so operators need a signal
+// rather than unexplained 429s.
+func TestRateLimitMiddleware_WarnsOnceOnUntrustedXFF(t *testing.T) {
+	log, hook := newTestLogger()
+
+	s := &server{
+		log: log,
+		cfg: &config.APIConfig{
+			Server: config.APIServerConfig{
+				RateLimit: config.RateLimitConfig{Enabled: true},
+			},
+		},
+	}
+
+	handler := s.rateLimitMiddleware(config.RateLimitTier{RequestsPerMinute: 100})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }),
+	)
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+		req.RemoteAddr = "203.0.113.5:54321"
+		req.Header.Set("X-Forwarded-For", "1.2.3.4")
+
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	// A request without the header must not warn on its own.
+	direct := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	direct.RemoteAddr = "203.0.113.6:54321"
+	handler.ServeHTTP(httptest.NewRecorder(), direct)
+
+	warnings := 0
+
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel {
+			warnings++
+		}
+	}
+
+	assert.Equal(t, 1, warnings,
+		"the untrusted-XFF warning must fire once, not once per request")
 }
 
 func spoofedIPFor(i int) string {

--- a/pkg/api/ratelimit_test.go
+++ b/pkg/api/ratelimit_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+)
+
+func TestExtractIP_IgnoresXFFWithoutTrustedProxy(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	req.RemoteAddr = "203.0.113.5:54321"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+
+	got := extractIP(req, nil)
+
+	assert.Equal(t, "203.0.113.5", got,
+		"with no trusted proxies configured, a client-supplied XFF header must never override RemoteAddr")
+}
+
+func TestExtractIP_HonorsXFFFromTrustedProxy(t *testing.T) {
+	trusted := parseTrustedProxies([]string{"10.0.0.0/8"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	req.RemoteAddr = "10.0.0.1:54321"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7")
+
+	got := extractIP(req, trusted)
+
+	assert.Equal(t, "198.51.100.7", got,
+		"when RemoteAddr is a trusted proxy, the XFF value it appended should be used")
+}
+
+func TestExtractIP_UsesRightmostHop(t *testing.T) {
+	trusted := parseTrustedProxies([]string{"10.0.0.1"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	req.RemoteAddr = "10.0.0.1:54321"
+	// A client claiming an arbitrary left-most IP, followed by the hop our
+	// trusted proxy actually observed and appended.
+	req.Header.Set("X-Forwarded-For", "9.9.9.9, 198.51.100.7")
+
+	got := extractIP(req, trusted)
+
+	assert.Equal(t, "198.51.100.7", got,
+		"only the right-most hop (appended by our trusted proxy) should be trusted, not attacker-supplied left-most entries")
+}
+
+func TestExtractIP_IgnoresXFFFromUntrustedDirectConnection(t *testing.T) {
+	// trusted_proxies is configured, but this specific request bypassed the
+	// proxy and connected directly - the XFF header must still be ignored.
+	trusted := parseTrustedProxies([]string{"10.0.0.0/8"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	req.RemoteAddr = "203.0.113.5:54321"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+
+	got := extractIP(req, trusted)
+
+	assert.Equal(t, "203.0.113.5", got,
+		"a direct connection from outside the trusted proxy ranges must not be able to spoof its IP via XFF")
+}
+
+func TestParseTrustedProxies(t *testing.T) {
+	networks := parseTrustedProxies([]string{
+		"10.0.0.0/8",
+		"192.168.1.1",
+		"not-an-ip",
+		"",
+		"::1",
+	})
+
+	require.Len(t, networks, 3, "malformed/empty entries should be skipped, not error out")
+
+	assert.True(t, isTrustedProxy("10.1.2.3", networks))
+	assert.True(t, isTrustedProxy("192.168.1.1", networks))
+	assert.False(t, isTrustedProxy("192.168.1.2", networks), "bare IP entries should match only that exact address")
+	assert.True(t, isTrustedProxy("::1", networks))
+	assert.False(t, isTrustedProxy("8.8.8.8", networks))
+}
+
+func TestIsTrustedProxy_EmptyList(t *testing.T) {
+	assert.False(t, isTrustedProxy("10.0.0.1", nil),
+		"an empty trusted proxy list must never treat any address as trusted")
+}
+
+// TestRateLimitMiddleware_SpoofedXFFCannotBypassLimit is a regression test
+// for the exploit verified live against a running server: with no
+// trusted_proxies configured, sending a unique X-Forwarded-For value on
+// every request must not grant a fresh rate-limit bucket per request.
+func TestRateLimitMiddleware_SpoofedXFFCannotBypassLimit(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	s := &server{
+		log: log,
+		cfg: &config.APIConfig{
+			Server: config.APIServerConfig{
+				RateLimit: config.RateLimitConfig{Enabled: true},
+			},
+		},
+	}
+
+	limit := config.RateLimitTier{RequestsPerMinute: 5}
+	handler := s.rateLimitMiddleware(limit)(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) },
+	))
+
+	tripped := false
+
+	for i := 0; i < 20; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+		req.RemoteAddr = "203.0.113.5:54321"
+		req.Header.Set("X-Forwarded-For", spoofedIPFor(i))
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code == http.StatusTooManyRequests {
+			tripped = true
+
+			break
+		}
+	}
+
+	assert.True(t, tripped,
+		"the limiter must trip within a small multiple of the configured cap even when every request carries a unique spoofed X-Forwarded-For value")
+}
+
+func spoofedIPFor(i int) string {
+	return fmt.Sprintf("10.0.%d.1", i)
+}

--- a/pkg/config/api.go
+++ b/pkg/config/api.go
@@ -86,9 +86,10 @@ type APIS3PresignedURLConfig struct {
 
 // APIServerConfig contains HTTP server settings.
 type APIServerConfig struct {
-	Listen      string          `yaml:"listen" mapstructure:"listen"`
-	CORSOrigins []string        `yaml:"cors_origins,omitempty" mapstructure:"cors_origins"`
-	RateLimit   RateLimitConfig `yaml:"rate_limit,omitempty" mapstructure:"rate_limit"`
+	Listen         string          `yaml:"listen" mapstructure:"listen"`
+	CORSOrigins    []string        `yaml:"cors_origins,omitempty" mapstructure:"cors_origins"`
+	RateLimit      RateLimitConfig `yaml:"rate_limit,omitempty" mapstructure:"rate_limit"`
+	TrustedProxies []string        `yaml:"trusted_proxies,omitempty" mapstructure:"trusted_proxies"`
 }
 
 // RateLimitConfig configures per-IP rate limiting.


### PR DESCRIPTION
## What

Two issues in the login path:

1. The rate limiter keyed on X-Forwarded-For unconditionally. A client could send a unique value on every request and get a fresh limiter bucket each time, fully bypassing the only brute-force protection on login. Verified live: 20 login attempts with a unique spoofed XFF per request all returned 401, never 429.

2. Login skipped the password hash comparison entirely when a username did not exist, making response time a reliable oracle for enumerating valid accounts. Measured live: ~45ms delta between an existing user (wrong password) and a nonexistent user, with zero overlap across 120 samples.

## How

- X-Forwarded-For is now only trusted when the direct connection comes from a configured `trusted_proxies` entry (IP or CIDR), falling back to the connection address otherwise. Unset means XFF is never trusted, so this is safe by default with no config changes required.
- Login now runs the same bcrypt comparison against a fixed dummy hash when a username lookup misses, so that path costs the same as a real wrong-password check.

## Test plan

- New unit tests for extractIP (trusted/untrusted proxy, rightmost hop, no-config default) and a regression test replaying the spoofed-XFF bypass against the rate limit middleware.
- New unit tests for the login timing fix, including a coarse timing regression guard.
- Rebuilt the binary and re-ran both original live scenarios against the fix: the XFF bypass now trips 429 at the configured cap, and the timing delta collapsed from ~45ms to ~0.12ms (within one stdev).
- `go test -race ./pkg/api/...` passes, `go vet` and `gofmt` clean.