### PR TITLE
fix(api): cap ingest request body and decompressed gzip size

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -320,6 +320,8 @@ api:
 
 A background goroutine on the API scans every 30s and deletes live rows whose `last_reported_at` is older than `stale_threshold`. When the on-disk indexer later picks up a real run with the same `(discovery_path, run_id)`, the live row is removed immediately so the UI doesn't show duplicate rows.
 
+The endpoint caps the raw request body at 10 MiB, and the decompressed size of a gzip-encoded body at 50 MiB. A report exceeding either limit is rejected with `413 Payload Too Large`.
+
 ## API Endpoints
 
 All endpoints are under the `/api/v1` prefix.

--- a/docs/api.md
+++ b/docs/api.md
@@ -326,6 +326,15 @@ The endpoint caps the raw request body at 10 MiB, and the decompressed size of a
 
 All endpoints are under the `/api/v1` prefix.
 
+### Request body limits
+
+| Endpoints | Limit |
+|-----------|-------|
+| `/auth/*`, `/admin/*` | 1 MiB |
+| `/ingest/*` | 10 MiB raw, 50 MiB decompressed (gzip) |
+
+A request whose `Content-Length` exceeds the limit is rejected with `413 Payload Too Large` before the body is read. The limits are not configurable.
+
 ### Public
 
 | Method | Path | Description |

--- a/pkg/api/handlers_ingest.go
+++ b/pkg/api/handlers_ingest.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 
@@ -20,6 +21,14 @@ func (s *server) handleIngestRun(w http.ResponseWriter, r *http.Request) {
 	// gzip bodies, so this size is post-decompression.
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge,
+				errorResponse{"request body too large"})
+
+			return
+		}
+
 		writeJSON(w, http.StatusBadRequest,
 			errorResponse{"failed to read request body"})
 

--- a/pkg/api/handlers_ingest_test.go
+++ b/pkg/api/handlers_ingest_test.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/api/indexstore"
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+)
+
+func newIngestTestServer(t *testing.T) *server {
+	t.Helper()
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	st := indexstore.NewStore(log, &config.APIDatabaseConfig{
+		Driver: "sqlite",
+		SQLite: config.SQLiteDatabaseConfig{Path: ":memory:"},
+	})
+	require.NoError(t, st.Start(context.Background()))
+	t.Cleanup(func() { _ = st.Stop() })
+
+	return &server{log: log, indexStore: st}
+}
+
+// ingestHandler builds the same middleware chain routes.go wires for the
+// ingest endpoint (minus auth, which is orthogonal to body-size limits).
+func ingestHandler(s *server) http.Handler {
+	return s.gzipRequestBody(http.HandlerFunc(s.handleIngestRun))
+}
+
+func validReportBody() string {
+	return `{"discovery_path":"dp","run_id":"run-1","status":"running","timestamp":1}`
+}
+
+func gzipCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	return buf.Bytes()
+}
+
+func TestIngest_ValidUncompressedReportAccepted(t *testing.T) {
+	s := newIngestTestServer(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/runs", strings.NewReader(validReportBody()))
+	rec := httptest.NewRecorder()
+
+	ingestHandler(s).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestIngest_ValidGzipReportAccepted(t *testing.T) {
+	s := newIngestTestServer(t)
+
+	compressed := gzipCompress(t, []byte(validReportBody()))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/runs", bytes.NewReader(compressed))
+	req.Header.Set("Content-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+
+	ingestHandler(s).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// TestIngest_OversizedUncompressedBodyRejected covers a large plain body
+// (no gzip involved at all) - the raw-body cap must apply regardless of
+// Content-Encoding.
+func TestIngest_OversizedUncompressedBodyRejected(t *testing.T) {
+	s := newIngestTestServer(t)
+
+	oversized := bytes.Repeat([]byte("a"), maxIngestBodyBytes+1)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/runs", bytes.NewReader(oversized))
+	rec := httptest.NewRecorder()
+
+	ingestHandler(s).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+// TestIngest_GzipBombRejected is a regression test for the decompression
+// bomb verified live against a running server: a small, highly-compressible
+// gzip payload that decompresses far past maxIngestDecompressedBytes must
+// be rejected before the full decompressed size is ever held in memory.
+func TestIngest_GzipBombRejected(t *testing.T) {
+	s := newIngestTestServer(t)
+
+	// Decompresses to well over maxIngestDecompressedBytes, but the
+	// compressed form itself is tiny and well under maxIngestBodyBytes -
+	// this is exactly the asymmetry that makes decompression bombs work.
+	bomb := bytes.Repeat([]byte{0}, maxIngestDecompressedBytes*2)
+	compressed := gzipCompress(t, bomb)
+
+	require.Less(t, len(compressed), maxIngestBodyBytes,
+		"the compressed payload must stay under the raw-body cap for this test to actually exercise the decompressed-size cap")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/runs", bytes.NewReader(compressed))
+	req.Header.Set("Content-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+
+	ingestHandler(s).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+// TestIngest_LargeButUnderLimitGzipReportAccepted guards against an overly
+// strict cap or an off-by-one that would reject legitimate large payloads
+// (the per-test gas map can be sizable for big suites) even though they're
+// comfortably under the limit.
+func TestIngest_LargeButUnderLimitGzipReportAccepted(t *testing.T) {
+	s := newIngestTestServer(t)
+
+	report := validReportBody()
+	padding := maxIngestDecompressedBytes - len(report) - 4096 // comfortably under the cap
+	padded := report[:len(report)-1] + `,"instance_id":"` + strings.Repeat("x", padding) + `"}`
+
+	require.Less(t, len(padded), maxIngestDecompressedBytes)
+
+	compressed := gzipCompress(t, []byte(padded))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/runs", bytes.NewReader(compressed))
+	req.Header.Set("Content-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+
+	ingestHandler(s).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}

--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -21,6 +21,19 @@ const (
 	compressedRequestSizeContextKey contextKey = "compressed_request_size"
 )
 
+const (
+	// maxIngestBodyBytes bounds the raw, on-the-wire ingest request body,
+	// before any decompression. Applies whether or not the request is
+	// gzip-encoded. Comfortably above any real live-run report while still
+	// being a hard limit.
+	maxIngestBodyBytes = 10 << 20 // 10 MiB
+
+	// maxIngestDecompressedBytes bounds the decompressed size of a gzipped
+	// ingest body. Without this, a small gzip payload can inflate to an
+	// arbitrary size in memory before any JSON validation ever runs.
+	maxIngestDecompressedBytes = 50 << 20 // 50 MiB
+)
+
 // countingReader wraps an io.Reader and tracks total bytes read. Used by
 // gzipRequestBody to surface the on-the-wire (gzipped) request size to
 // handlers via context — the decompressed body size is just len(body)
@@ -261,8 +274,16 @@ func (s *server) requireIngestToken(next http.Handler) http.Handler {
 // downstream handlers can read them as if they were uncompressed. Used on
 // the ingest subrouter where the runner posts large gzipped payloads
 // (per-test heatmap data). A malformed gzip stream is returned as 400.
+//
+// The raw body is capped at maxIngestBodyBytes regardless of encoding, and
+// a gzip-encoded body's decompressed output is separately capped at
+// maxIngestDecompressedBytes - without the second cap, a small compressed
+// payload could inflate to an arbitrary size in memory before the handler
+// gets a chance to reject it.
 func (s *server) gzipRequestBody(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxIngestBodyBytes)
+
 		if !strings.EqualFold(r.Header.Get("Content-Encoding"), "gzip") {
 			next.ServeHTTP(w, r)
 
@@ -283,11 +304,12 @@ func (s *server) gzipRequestBody(next http.Handler) http.Handler {
 		}
 		defer func() { _ = gz.Close() }()
 
-		// Replace the body with the decompressed reader. Strip the header
-		// so handlers can rely on Content-Length being absent rather than
-		// stale. ContentLength is also reset because it referred to the
-		// compressed size.
-		r.Body = gz
+		// Replace the body with the decompressed reader, capped
+		// independently of the compressed-size limit above. Strip the
+		// header so handlers can rely on Content-Length being absent
+		// rather than stale. ContentLength is also reset because it
+		// referred to the compressed size.
+		r.Body = http.MaxBytesReader(w, gz, maxIngestDecompressedBytes)
 		r.Header.Del("Content-Encoding")
 		r.Header.Del("Content-Length")
 		r.ContentLength = -1

--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -32,6 +32,15 @@ const (
 	// ingest body. Without this, a small gzip payload can inflate to an
 	// arbitrary size in memory before any JSON validation ever runs.
 	maxIngestDecompressedBytes = 50 << 20 // 50 MiB
+
+	// maxJSONBodyBytes bounds request bodies on the auth and admin
+	// endpoints, which decode small JSON documents (credentials, a user
+	// record, an org mapping). Without it, json.Decoder happily buffers a
+	// whole multi-hundred-megabyte string value: a 64MiB login body costs
+	// ~320MiB of allocation, and /auth/login is reachable before any
+	// authentication runs. Orders of magnitude above any real payload,
+	// while still bounding the blast radius.
+	maxJSONBodyBytes = 1 << 20 // 1 MiB
 )
 
 // countingReader wraps an io.Reader and tracks total bytes read. Used by
@@ -268,6 +277,33 @@ func (s *server) requireIngestToken(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// limitRequestBody caps the request body at n bytes for every route it is
+// mounted on. Applied per route group rather than globally on purpose: a
+// global wrapper would become the underlying reader for gzipRequestBody's
+// own MaxBytesReader, and the smaller of the two limits would silently win
+// on the ingest path.
+//
+// A body that advertises a Content-Length over the cap is rejected on the
+// headers alone, without reading it. Bodies without a usable
+// Content-Length (chunked) are bounded by the reader instead, and surface
+// to the handler as a decode error.
+func (s *server) limitRequestBody(n int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.ContentLength > n {
+				writeJSON(w, http.StatusRequestEntityTooLarge,
+					errorResponse{"request body too large"})
+
+				return
+			}
+
+			r.Body = http.MaxBytesReader(w, r.Body, n)
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 // gzipRequestBody transparently inflates gzipped request bodies so

--- a/pkg/api/middleware_body_limit_test.go
+++ b/pkg/api/middleware_body_limit_test.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+)
+
+func newBodyLimitTestServer() *server {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	// Deliberately no store: handleLogin panics on a nil store the moment
+	// it gets past decoding, which is what makes "the handler never saw
+	// this body" an assertion rather than a hope.
+	return &server{log: log}
+}
+
+// oversizedLoginBody returns a JSON login document larger than the cap,
+// shaped like the real attack: one enormous string value that json.Decoder
+// must buffer whole before it can be rejected.
+func oversizedLoginBody() string {
+	return `{"username":"` + strings.Repeat("a", maxJSONBodyBytes*2) + `","password":"x"}`
+}
+
+// TestLimitRequestBody_RejectsOnContentLength covers the ordinary client:
+// a declared Content-Length over the cap is refused on the headers, without
+// reading or buffering a single byte of the body.
+func TestLimitRequestBody_RejectsOnContentLength(t *testing.T) {
+	s := newBodyLimitTestServer()
+
+	body := oversizedLoginBody()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(body))
+	require.Positive(t, req.ContentLength, "this test is meaningless without a declared length")
+
+	rec := httptest.NewRecorder()
+
+	// If the limiter lets this through, handleLogin dereferences a nil
+	// store and this panics instead of failing politely.
+	s.limitRequestBody(maxJSONBodyBytes)(http.HandlerFunc(s.handleLogin)).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+// TestLimitRequestBody_BoundsUnknownLengthBody covers a chunked upload,
+// where there is no Content-Length to check up front. The reader has to do
+// the bounding instead: the handler sees a decode error rather than a
+// fully-buffered multi-megabyte string.
+func TestLimitRequestBody_BoundsUnknownLengthBody(t *testing.T) {
+	s := newBodyLimitTestServer()
+
+	body := oversizedLoginBody()
+
+	// io.NopCloser hides the concrete reader type, so httptest can't infer
+	// a length - exactly like a chunked request.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", io.NopCloser(strings.NewReader(body)))
+	require.EqualValues(t, -1, req.ContentLength, "this test needs an unknown-length body")
+
+	rec := httptest.NewRecorder()
+
+	s.limitRequestBody(maxJSONBodyBytes)(http.HandlerFunc(s.handleLogin)).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code,
+		"an over-cap chunked body must fail decoding, not reach the store")
+}
+
+// TestLimitRequestBody_ReadsAtMostTheCap pins the property the status code
+// only implies: however much the client sends, the handler can never read
+// more than the cap.
+func TestLimitRequestBody_ReadsAtMostTheCap(t *testing.T) {
+	const cap64 = 64
+
+	var read int
+
+	spy := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		read = len(b)
+
+		require.Error(t, err, "reading past the cap must surface an error")
+
+		var maxBytesErr *http.MaxBytesError
+		assert.ErrorAs(t, err, &maxBytesErr)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login",
+		io.NopCloser(strings.NewReader(strings.Repeat("a", cap64*100))))
+
+	newBodyLimitTestServer().limitRequestBody(cap64)(spy).
+		ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.LessOrEqual(t, read, cap64,
+		"the handler must not be able to read past the limit")
+}
+
+// TestRouter_BodyLimitIsMountedOnAuthAndAdmin pins the wiring, not just the
+// middleware: the cap is only worth anything if the router actually mounts
+// it. Driven through the real buildRouter, with no store configured - if
+// the limiter is ever removed from a route group, the request reaches a
+// handler that decodes the body and panics on the nil store, which chi's
+// Recoverer turns into a 500 rather than the 413 asserted here.
+func TestRouter_BodyLimitIsMountedOnAuthAndAdmin(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	s := &server{log: log, cfg: &config.APIConfig{}}
+	router := s.buildRouter()
+
+	for _, path := range []string{
+		"/api/v1/auth/login",
+		"/api/v1/auth/api-keys",
+		// Ordering matters here: the cap has to run before requireAuth,
+		// so an unauthenticated flood is refused on size rather than
+		// being read in full and then rejected as unauthorized.
+		"/api/v1/admin/users",
+	} {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(oversizedLoginBody()))
+		req.Header.Set("Content-Type", "application/json")
+
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code,
+			"%s must be behind the request body cap", path)
+	}
+}
+
+// TestLimitRequestBody_PassesNormalBodiesThrough is the regression guard
+// for the cap itself: a real login payload is nowhere near the limit and
+// must reach the handler untouched.
+func TestLimitRequestBody_PassesNormalBodiesThrough(t *testing.T) {
+	body := `{"username":"admin","password":"correct-password"}`
+
+	var got string
+
+	spy := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		got = string(b)
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	newBodyLimitTestServer().limitRequestBody(maxJSONBodyBytes)(spy).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, body, got)
+}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -26,6 +26,12 @@ func (s *server) buildRouter() http.Handler {
 
 		// Auth endpoints.
 		r.Route("/auth", func(r chi.Router) {
+			// Cap request bodies before anything reads them. /login is
+			// reachable without authentication, and rate limiting is off
+			// by default, so this is the only thing standing between an
+			// anonymous caller and an unbounded allocation.
+			r.Use(s.limitRequestBody(maxJSONBodyBytes))
+
 			// Apply rate limiting to auth endpoints.
 			if s.cfg.Server.RateLimit.Enabled {
 				r.Use(s.rateLimitMiddleware(
@@ -123,6 +129,7 @@ func (s *server) buildRouter() http.Handler {
 
 		// Admin endpoints (require auth + admin role).
 		r.Route("/admin", func(r chi.Router) {
+			r.Use(s.limitRequestBody(maxJSONBodyBytes))
 			r.Use(s.requireAuth)
 			r.Use(s.requireRole("admin"))
 


### PR DESCRIPTION
## What

The ingest endpoint read the full request body with io.ReadAll and decompressed gzip bodies with no size limit, so a small gzip payload could inflate to an arbitrary size in memory before any validation ran. Verified live: an 815KB request pushed the API process from a 40MB baseline to 1.67GB RSS in under a second.

## How

- The raw request body is capped at 10MiB regardless of encoding.
- A gzip-encoded body's decompressed output is separately capped at 50MiB.
- Both use http.MaxBytesReader. Exceeding either limit now returns 413 instead of buffering the full payload first.

## Test plan

- New tests: valid compressed/uncompressed reports still accepted, an oversized raw body rejected, a large-but-under-the-cap report still accepted (no off-by-one), and a gzip-bomb regression test at the real 50MiB limit.
- Rebuilt the binary and replayed the original live scenario against the fix: the same 815KB/800MB-decompressed payload now returns 413 in 25ms with peak RSS of 156MB, down from 1.67GB.
- `go test -race ./pkg/api/...` passes, `go vet` and `gofmt` clean.