### PR TITLE
fix(datadir): wait out schelk state-lock contention instead of failing the job

### DIFF
--- a/pkg/datadir/schelk.go
+++ b/pkg/datadir/schelk.go
@@ -363,10 +363,13 @@ const (
 
 // schelkLockHeld reports whether schelk failed only because another process
 // holds the state lock. That is transient and clears on its own, unlike the
-// mount errors we want to surface immediately.
+// mount errors we want to surface immediately. Matching is deliberately narrow:
+// naming the lock file is not enough, since an unwritable or missing lock path
+// reports it too and would then be retried for the whole budget instead of
+// surfacing.
 func schelkLockHeld(output []byte) bool {
 	return bytes.Contains(output, []byte("Another schelk process is already running")) ||
-		bytes.Contains(output, []byte("schelk.lock"))
+		bytes.Contains(output, []byte("EAGAIN"))
 }
 
 // mountWaitingForLock runs `schelk mount`, retrying while the state lock is
@@ -393,8 +396,10 @@ func mountWaitingForLock(
 				bin, err, strings.TrimSpace(string(output)))
 		}
 
-		log.WithFields(logrus.Fields{"attempt": attempt, "retry_in": poll}).
-			Warn("schelk state lock held by another process; waiting")
+		if log != nil {
+			log.WithFields(logrus.Fields{"attempt": attempt, "retry_in": poll}).
+				Warn("schelk state lock held by another process; waiting")
+		}
 
 		select {
 		case <-ctx.Done():

--- a/pkg/datadir/schelk.go
+++ b/pkg/datadir/schelk.go
@@ -346,14 +346,62 @@ func EnsureSchelkMounted(ctx context.Context, log logrus.FieldLogger) error {
 			SchelkStatePath(), state.MountPoint, bin,
 		)
 	case !mounted:
-		output, runErr := RunSchelk(ctx, log, "mount", "-y")
-		if runErr != nil {
-			return fmt.Errorf("`%s mount` failed: %w (output: %s)",
-				bin, runErr, strings.TrimSpace(string(output)))
+		if err := mountWaitingForLock(ctx, log, bin, schelkLockPollWait); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+// SchelkLockWait bounds how long EnsureSchelkMounted waits for another schelk
+// process to release the state lock before giving up.
+const (
+	SchelkLockWait     = 10 * time.Minute
+	schelkLockPollWait = 15 * time.Second
+)
+
+// schelkLockHeld reports whether schelk failed only because another process
+// holds the state lock. That is transient and clears on its own, unlike the
+// mount errors we want to surface immediately.
+func schelkLockHeld(output []byte) bool {
+	return bytes.Contains(output, []byte("Another schelk process is already running")) ||
+		bytes.Contains(output, []byte("schelk.lock"))
+}
+
+// mountWaitingForLock runs `schelk mount`, retrying while the state lock is
+// held elsewhere. Runners serialise schelk work through a single flock, so a
+// concurrent promote or recover makes mount fail with EAGAIN; treating that as
+// fatal throws away a multi-hour benchmark job over a condition that resolves
+// itself. Every other failure still returns on the first attempt.
+func mountWaitingForLock(
+	ctx context.Context,
+	log logrus.FieldLogger,
+	bin string,
+	poll time.Duration,
+) error {
+	deadline := time.Now().Add(SchelkLockWait)
+
+	for attempt := 1; ; attempt++ {
+		output, err := RunSchelk(ctx, log, "mount", "-y")
+		if err == nil {
+			return nil
+		}
+
+		if !schelkLockHeld(output) || time.Now().After(deadline) {
+			return fmt.Errorf("`%s mount` failed: %w (output: %s)",
+				bin, err, strings.TrimSpace(string(output)))
+		}
+
+		log.WithFields(logrus.Fields{"attempt": attempt, "retry_in": poll}).
+			Warn("schelk state lock held by another process; waiting")
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(poll):
+		}
+	}
 }
 
 // SchelkPromote persists the current scratch contents as the new virgin

--- a/pkg/datadir/schelk_test.go
+++ b/pkg/datadir/schelk_test.go
@@ -150,6 +150,31 @@ func TestSchelkLockHeld(t *testing.T) {
 	assert.True(t, schelkLockHeld([]byte(lockErr)))
 	assert.False(t, schelkLockHeld([]byte("Volume is already mounted")))
 	assert.False(t, schelkLockHeld([]byte("no such device")))
+
+	// Naming the lock file is not contention: an unwritable or missing lock
+	// path must surface immediately rather than burn the whole retry budget.
+	assert.False(t, schelkLockHeld(
+		[]byte("failed to open /var/lib/schelk/schelk.lock: permission denied")))
+}
+
+func TestMountWaitingForLock_NilLoggerDoesNotPanic(t *testing.T) {
+	counter := filepath.Join(t.TempDir(), "attempts")
+	installFakeSchelk(t, fmt.Sprintf(`
+n=$(cat %[1]s 2>/dev/null || echo 0)
+n=$((n+1)); echo $n > %[1]s
+if [ "$n" -lt 2 ]; then
+  echo "Another schelk process is already running (flock on /var/lib/schelk/schelk.lock): EAGAIN"
+  exit 1
+fi
+exit 0
+`, counter))
+
+	// config.go calls EnsureSchelkMounted with a nil logger, and RunSchelk
+	// documents that log may be nil — the retry path must honour that.
+	require.NotPanics(t, func() {
+		err := mountWaitingForLock(context.Background(), nil, "schelk", time.Millisecond)
+		require.NoError(t, err)
+	})
 }
 
 func TestMountWaitingForLock_RetriesUntilLockClears(t *testing.T) {

--- a/pkg/datadir/schelk_test.go
+++ b/pkg/datadir/schelk_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -140,4 +141,52 @@ func TestRunSchelk_KilledWhenGraceExpires(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "did not complete within")
 	assert.Less(t, elapsed, 2*time.Second, "should return shortly after grace window")
+}
+
+func TestSchelkLockHeld(t *testing.T) {
+	lockErr := "Error:\n   0: Another schelk process is already running " +
+		"(flock on /var/lib/schelk/schelk.lock): EAGAIN: Try again"
+
+	assert.True(t, schelkLockHeld([]byte(lockErr)))
+	assert.False(t, schelkLockHeld([]byte("Volume is already mounted")))
+	assert.False(t, schelkLockHeld([]byte("no such device")))
+}
+
+func TestMountWaitingForLock_RetriesUntilLockClears(t *testing.T) {
+	counter := filepath.Join(t.TempDir(), "attempts")
+	// Fail with the flock error for the first two attempts, then succeed.
+	installFakeSchelk(t, fmt.Sprintf(`
+n=$(cat %[1]s 2>/dev/null || echo 0)
+n=$((n+1)); echo $n > %[1]s
+if [ "$n" -lt 3 ]; then
+  echo "Another schelk process is already running (flock on /var/lib/schelk/schelk.lock): EAGAIN"
+  exit 1
+fi
+exit 0
+`, counter))
+
+	err := mountWaitingForLock(context.Background(), logrus.New(), "schelk", time.Millisecond)
+	require.NoError(t, err)
+
+	data, readErr := os.ReadFile(counter)
+	require.NoError(t, readErr)
+	assert.Equal(t, "3\n", string(data), "should retry until the lock clears")
+}
+
+func TestMountWaitingForLock_NonLockErrorFailsImmediately(t *testing.T) {
+	counter := filepath.Join(t.TempDir(), "attempts")
+	installFakeSchelk(t, fmt.Sprintf(`
+n=$(cat %[1]s 2>/dev/null || echo 0)
+echo $((n+1)) > %[1]s
+echo "Volume is already mounted"
+exit 1
+`, counter))
+
+	err := mountWaitingForLock(context.Background(), logrus.New(), "schelk", time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Volume is already mounted")
+
+	data, readErr := os.ReadFile(counter)
+	require.NoError(t, readErr)
+	assert.Equal(t, "1\n", string(data), "non-lock errors must not retry")
 }


### PR DESCRIPTION
## What happened

`benchmark-ci-6` destroyed **five consecutive Besu jobs** today, each in ~12 seconds, all in the *Build state-actor data directory* step:

```
Build failed error=ensuring schelk mount: `schelk mount` failed: exit status 1
  0: Another schelk process is already running (flock on /var/lib/schelk/schelk.lock): EAGAIN: Try again
```

Every Besu job that landed on a different runner succeeded. `ci-6` has no successful job at all in its history today.

## Root cause

Runners serialise schelk work through a single flock at `/var/lib/schelk/schelk.lock`. While another schelk process holds it, `schelk mount` exits non-zero with EAGAIN — and `EnsureSchelkMounted` returned that straight to the caller:

```go
output, runErr := RunSchelk(ctx, log, "mount", "-y")
if runErr != nil {
    return fmt.Errorf("`%s mount` failed: %w (output: %s)", bin, runErr, ...)
}
```

So a transient, self-clearing condition discarded a multi-hour benchmark job before it ran a single block.

It also compounds: the job fails in ~12s, the runner is immediately free, so it wins the *next* queued job of that client and burns that one too. One host with a held lock acts as a black hole, and the failure rate scales with how much work is queued.

Note the lock holder is necessarily a **live process** — flock is released on process death, so this is never a stale lock file. Waiting is the correct response.

## Change

Retry `schelk mount` while the failure is lock contention, up to `SchelkLockWait` (10m), polling every 15s. Any other failure still returns on the first attempt, so genuine mount problems — including the `is_mounted` inconsistency that needs `full-recover` — stay fail-fast.

This covers both call sites, since `state_actor.go` and `eest_payloads.go` both go through `EnsureSchelkMounted`.

## Tests

- `TestSchelkLockHeld` — classification, including that "Volume is already mounted" is *not* treated as lock contention
- `TestMountWaitingForLock_RetriesUntilLockClears` — fake schelk fails with the flock error twice then succeeds; asserts exactly 3 attempts
- `TestMountWaitingForLock_NonLockErrorFailsImmediately` — asserts exactly 1 attempt, no retry

`go test ./pkg/datadir/` and `go vet` pass.

## Not a substitute for unblocking ci-6

This stops one stuck host from shredding the queue, but something is still holding that lock on `benchmark-ci-6`. That needs `lsof /var/lib/schelk/schelk.lock` on the host to identify the holder, and the runner pulled from the pool until it is cleared.