### PR TITLE
fix(action): retry transient failures when downloading configs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -163,7 +163,11 @@ runs:
           for i in "${!CONFIG_URLS[@]}"; do
             URL=$(echo "${CONFIG_URLS[$i]}" | xargs)  # trim whitespace
             echo "Downloading build config from ${URL}"
-            curl -fsSL "${URL}" -o "${{ runner.temp }}/benchmarkoor-build-config-url-${i}.yaml"
+            # --retry covers the transient class (5xx, 429, 408, timeouts) and
+            # still fails fast on a 404, so a raw.githubusercontent.com blip
+            # cannot kill a multi-hour benchmark before it starts.
+            curl -fsSL --retry 5 --retry-delay 2 --retry-max-time 120 \
+              "${URL}" -o "${{ runner.temp }}/benchmarkoor-build-config-url-${i}.yaml"
           done
         fi
 
@@ -291,7 +295,10 @@ runs:
           for i in "${!CONFIG_URLS[@]}"; do
             URL=$(echo "${CONFIG_URLS[$i]}" | xargs)  # trim whitespace
             echo "Downloading config from ${URL}"
-            curl -fsSL "${URL}" -o "${{ runner.temp }}/benchmarkoor-config-url-${i}.yaml"
+            # See the build-config download above: retry the transient class,
+            # fail fast on a genuine 404.
+            curl -fsSL --retry 5 --retry-delay 2 --retry-max-time 120 \
+              "${URL}" -o "${{ runner.temp }}/benchmarkoor-config-url-${i}.yaml"
           done
         fi
 


### PR DESCRIPTION
A single `503` from `raw.githubusercontent.com` kills the job before benchmarkoor starts. It just destroyed a stateful Besu run ([30826993105](https://github.com/ethpandaops/benchmarkoor-tests/actions/runs/30826993105)) that had *already completed* its state-actor build:

```
Downloading config from https://raw.githubusercontent.com/ethpandaops/benchmarkoor-tests/b711e361/configs/global.yaml
curl: (22) The requested URL returned error: 503
##[error]Process completed with exit code 22.
```

Both config downloads used bare `curl -fsSL` with no retry, so any blip on GitHub's raw CDN throws away the job — and for a stateful run that is a multi-hour slot on a scarce client-pinned runner.

## Change

```
curl -fsSL --retry 5 --retry-delay 2 --retry-max-time 120
```

on both the build-config and run-config downloads.

`--retry` covers exactly the transient class — 5xx, 429, 408, connection timeouts — and leaves a genuine 404 failing on the **first** attempt, so a config typo still surfaces immediately instead of hiding behind two minutes of pointless retries. I deliberately did not use `--retry-all-errors`, which would blur that line.

`--retry-max-time 120` bounds the worst case.

## Why it matters beyond this one job

This is the same shape as #290: a transient, self-clearing condition treated as fatal, discarding hours of work. Worth a sweep for other unguarded network calls in the action — this one only surfaced because it happened to fire during an incident I was already watching.

action.yaml parses cleanly.