### PR TITLE
feat: exclude overhead_baseline calibration tests from stats (server-side classification)

### DIFF
--- a/pkg/api/handlers_index.go
+++ b/pkg/api/handlers_index.go
@@ -175,8 +175,12 @@ func (s *server) handleSuiteStats(w http.ResponseWriter, r *http.Request) {
 
 	maxRuns = max(1, min(200, maxRuns))
 
+	// Baseline calibration tests are excluded from stats by default;
+	// pass include_baseline=true for the raw view.
+	includeBaseline := r.URL.Query().Get("include_baseline") == "true"
+
 	durations, err := s.indexStore.ListTestStatsBySuiteRecent(
-		r.Context(), suiteHash, maxRuns,
+		r.Context(), suiteHash, maxRuns, includeBaseline,
 	)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError,

--- a/pkg/api/indexer/indexer.go
+++ b/pkg/api/indexer/indexer.go
@@ -549,6 +549,7 @@ func (idx *indexer) indexTestStats(
 				TestName:     testName,
 				RunID:        runID,
 				Client:       dur.Client,
+				Baseline:     indexstore.IsBaselineTest(testName),
 				TotalGasUsed: dur.GasUsed,
 				TotalTimeNs:  dur.Time,
 				TotalMGasS:   indexstore.ComputeMGasS(dur.GasUsed, dur.Time),

--- a/pkg/api/indexstore/baseline_test.go
+++ b/pkg/api/indexstore/baseline_test.go
@@ -1,0 +1,90 @@
+package indexstore_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/api/indexstore"
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+)
+
+const baselineName = "tests/benchmark/stateful/bloatnet/test_sload.py::" +
+	"test_sload_bloated[fork_Amsterdam-blockchain_test_stateful_engine-" +
+	"overhead_baseline_True-benchmark-gas-value_200M]"
+
+func TestIsBaselineTest(t *testing.T) {
+	assert.True(t, indexstore.IsBaselineTest(baselineName))
+	assert.True(t, indexstore.IsBaselineTest("x-overhead_baseline_true-y"),
+		"match must be case-insensitive")
+	assert.False(t, indexstore.IsBaselineTest(
+		"test_sload_bloated[overhead_baseline_False-benchmark-gas-value_200M]"),
+		"the _False twin is the real workload measurement")
+	assert.False(t, indexstore.IsBaselineTest("test_keccak[gas-value_200M]"))
+}
+
+func TestListRecentExcludesBaselineByDefault(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	suite := "suite-baseline"
+
+	workload := stat(suite, "run-A", "t1", "geth", 300)
+	baseline := stat(suite, "run-A", baselineName, "geth", 300)
+	baseline.Baseline = true
+
+	require.NoError(t, s.BulkUpsertTestStats(
+		ctx, []*indexstore.TestStat{workload, baseline},
+	))
+
+	got, err := s.ListTestStatsBySuiteRecent(ctx, suite, 2, false)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "t1", got[0].TestName,
+		"baseline rows must be excluded by default")
+
+	got, err = s.ListTestStatsBySuiteRecent(ctx, suite, 2, true)
+	require.NoError(t, err)
+	assert.Len(t, got, 2, "includeBaseline must return the raw set")
+}
+
+// Rows indexed before the baseline column existed carry baseline=false even
+// when their name matches; Start must backfill them.
+func TestStartBackfillsBaselineFlag(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "index.db")
+
+	cfg := &config.APIDatabaseConfig{
+		Driver: "sqlite",
+		SQLite: config.SQLiteDatabaseConfig{Path: dbPath},
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	s := indexstore.NewStore(log, cfg)
+	require.NoError(t, s.Start(ctx))
+
+	// Simulate a legacy row: baseline-named but unflagged.
+	legacy := stat("suite-bf", "run-A", baselineName, "geth", 300)
+	require.NoError(t, s.BulkUpsertTestStats(ctx, []*indexstore.TestStat{legacy}))
+	require.NoError(t, s.Stop())
+
+	// Restarting runs the migration backfill.
+	s = indexstore.NewStore(log, cfg)
+	require.NoError(t, s.Start(ctx))
+
+	t.Cleanup(func() { _ = s.Stop() })
+
+	got, err := s.ListTestStatsBySuiteRecent(ctx, "suite-bf", 2, false)
+	require.NoError(t, err)
+	assert.Empty(t, got, "backfilled baseline row must be excluded")
+
+	got, err = s.ListTestStatsBySuiteRecent(ctx, "suite-bf", 2, true)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.True(t, got[0].Baseline, "flag must be backfilled on Start")
+}

--- a/pkg/api/indexstore/indexstore.go
+++ b/pkg/api/indexstore/indexstore.go
@@ -43,8 +43,12 @@ type Store interface {
 	ListTestStatsBySuite(
 		ctx context.Context, suiteHash string,
 	) ([]TestStat, error)
+	// ListTestStatsBySuiteRecent returns the per-test stats of each client's
+	// most recent runs. Baseline calibration rows are excluded unless
+	// includeBaseline is set (see IsBaselineTest).
 	ListTestStatsBySuiteRecent(
 		ctx context.Context, suiteHash string, maxRunsPerClient int,
+		includeBaseline bool,
 	) ([]TestStat, error)
 	DeleteTestStatsForRun(ctx context.Context, runID string) error
 
@@ -155,6 +159,18 @@ func (s *store) Start(ctx context.Context) error {
 		if err := s.db.Migrator().DropColumn(&TestStat{}, "steps_json"); err != nil {
 			s.log.WithError(err).Warn("Failed to drop steps_json column")
 		}
+	}
+
+	// Backfill the baseline flag for rows indexed before the column existed.
+	// Idempotent — only rewrites rows still unflagged; new rows are stamped by
+	// the indexer. LOWER() keeps the match aligned with IsBaselineTest on both
+	// SQLite and Postgres.
+	if err := s.db.WithContext(ctx).
+		Model(&TestStat{}).
+		Where("baseline = ? AND LOWER(test_name) LIKE ?",
+			false, "%overhead_baseline_true%").
+		Update("baseline", true).Error; err != nil {
+		s.log.WithError(err).Warn("Failed to backfill test_stats.baseline")
 	}
 
 	s.log.WithField("driver", s.cfg.Driver).
@@ -674,6 +690,7 @@ type clientRunRow struct {
 // which can be millions of rows for large suites.
 func (s *store) ListTestStatsBySuiteRecent(
 	ctx context.Context, suiteHash string, maxRunsPerClient int,
+	includeBaseline bool,
 ) ([]TestStat, error) {
 	// Step 1: lightweight query to get one row per client/run combo. We group by
 	// client and run_id (rather than SELECT DISTINCT over run_start too) so that
@@ -725,11 +742,15 @@ func (s *store) ListTestStatsBySuiteRecent(
 		end := min(i+batchSize, len(runIDs))
 		batch := runIDs[i:end]
 
-		var batchStats []TestStat
-		if err := s.readDB.WithContext(ctx).
+		q := s.readDB.WithContext(ctx).
 			Where("suite_hash = ? AND run_id IN ?",
-				suiteHash, batch).
-			Find(&batchStats).Error; err != nil {
+				suiteHash, batch)
+		if !includeBaseline {
+			q = q.Where("baseline = ?", false)
+		}
+
+		var batchStats []TestStat
+		if err := q.Find(&batchStats).Error; err != nil {
 			return nil, fmt.Errorf(
 				"listing test stats for recent runs: %w", err,
 			)

--- a/pkg/api/indexstore/query.go
+++ b/pkg/api/indexstore/query.go
@@ -62,6 +62,7 @@ var allowedTestStatColumns = map[string]bool{
 	"test_name":      true,
 	"run_id":         true,
 	"client":         true,
+	"baseline":       true,
 	"total_gas_used": true,
 	"total_time_ns":  true,
 	"total_mgas_s":   true,

--- a/pkg/api/indexstore/test_stat.go
+++ b/pkg/api/indexstore/test_stat.go
@@ -1,5 +1,7 @@
 package indexstore
 
+import "strings"
+
 // TestStat represents a single per-test timing entry for suite stats.
 type TestStat struct {
 	ID        uint   `gorm:"primaryKey"`
@@ -9,6 +11,10 @@ type TestStat struct {
 	Client    string
 	RunStart  int64 `gorm:"index:idx_ts_suite_run_start;index:idx_ts_suite_start_ttime"`
 	RunEnd    int64
+
+	// Baseline marks calibration variants (see IsBaselineTest). Stamped by the
+	// indexer; rows from before the column existed are backfilled on Start.
+	Baseline bool
 
 	// Total (sum of all steps).
 	TotalGasUsed uint64
@@ -40,6 +46,16 @@ type TestStat struct {
 	TestResourceDiskWriteB   uint64  `gorm:"column:test_resource_disk_write_bytes"`
 	TestResourceDiskReadOps  uint64  `gorm:"column:test_resource_disk_read_iops"`
 	TestResourceDiskWriteOps uint64  `gorm:"column:test_resource_disk_write_iops"`
+}
+
+// IsBaselineTest reports whether an EEST test name is an overhead-baseline
+// calibration variant: the test's keccak-overhead loop without the real
+// workload (~7 Mgas against 200M+ gas targets), present only so the
+// workload's cost can be isolated by subtraction. These execute and are
+// stored like any test, but stats endpoints exclude them by default —
+// including them skews every aggregate low.
+func IsBaselineTest(name string) bool {
+	return strings.Contains(strings.ToLower(name), "overhead_baseline_true")
 }
 
 // ComputeMGasS calculates megagas per second from gas used and time in

--- a/pkg/api/indexstore/upsert_recent_test.go
+++ b/pkg/api/indexstore/upsert_recent_test.go
@@ -129,7 +129,7 @@ func TestListRecentCountsInconsistentRunStartAsOneRun(t *testing.T) {
 		stat(suite, "run-B", "t1", "geth", 200),
 	}))
 
-	got, err := s.ListTestStatsBySuiteRecent(ctx, suite, 2)
+	got, err := s.ListTestStatsBySuiteRecent(ctx, suite, 2, false)
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{"run-A", "run-B"}, distinctRunIDs(got),
@@ -147,7 +147,7 @@ func TestListRecentRespectsPerClientCap(t *testing.T) {
 		stat(suite, "run-C", "t1", "geth", 100),
 	}))
 
-	got, err := s.ListTestStatsBySuiteRecent(ctx, suite, 2)
+	got, err := s.ListTestStatsBySuiteRecent(ctx, suite, 2, false)
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{"run-A", "run-B"}, distinctRunIDs(got),

--- a/ui/src/api/hooks/useRunResult.ts
+++ b/ui/src/api/hooks/useRunResult.ts
@@ -1,6 +1,19 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchData } from '../client'
 import type { RunResult } from '../types'
+import { withoutBaselineTests } from '@/utils/baselineTests'
+
+// fetchRunResult fetches a run's result.json from the storage backend.
+// Baseline calibration tests are dropped here so every consumer (tables,
+// heatmaps, aggregates, compare pages) is unskewed by them. All fetches of
+// result.json must go through this function — the compare pages share the
+// ['run', runId, 'result'] cache key with useRunResult, so a filtered and an
+// unfiltered fetcher on the same key would race to define the cached shape.
+export async function fetchRunResult(runId: string): Promise<RunResult | null> {
+  const { data } = await fetchData<RunResult>(`runs/${runId}/result.json`)
+  if (!data) return null
+  return { ...data, tests: withoutBaselineTests(data.tests) }
+}
 
 // useRunResult fetches a run's result.json from the storage backend.
 // Pass enabled=false to skip the fetch (e.g. for runs we already know
@@ -8,10 +21,7 @@ import type { RunResult } from '../types'
 export function useRunResult(runId: string, enabled = true) {
   return useQuery({
     queryKey: ['run', runId, 'result'],
-    queryFn: async () => {
-      const { data } = await fetchData<RunResult>(`runs/${runId}/result.json`)
-      return data ?? null
-    },
+    queryFn: () => fetchRunResult(runId),
     enabled: !!runId && enabled,
   })
 }

--- a/ui/src/api/hooks/useSuiteStats.ts
+++ b/ui/src/api/hooks/useSuiteStats.ts
@@ -20,6 +20,8 @@ export function useSuiteStats(suiteHash: string | undefined) {
           throw new Error(`Failed to fetch suite stats: ${response.status}`)
         }
 
+        // The API already excludes baseline rows by default; the client-side
+        // filter stays for rollout skew against older API deployments.
         const stats = (await response.json()) as SuiteStats
         return withoutBaselineTests(stats)
       }

--- a/ui/src/api/hooks/useSuiteStats.ts
+++ b/ui/src/api/hooks/useSuiteStats.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchData } from '../client'
 import type { SuiteStats } from '../types'
 import { loadRuntimeConfig, isIndexingEnabled } from '@/config/runtime'
+import { withoutBaselineTests } from '@/utils/baselineTests'
 
 export function useSuiteStats(suiteHash: string | undefined) {
   return useQuery({
@@ -19,14 +20,15 @@ export function useSuiteStats(suiteHash: string | undefined) {
           throw new Error(`Failed to fetch suite stats: ${response.status}`)
         }
 
-        return response.json() as Promise<SuiteStats>
+        const stats = (await response.json()) as SuiteStats
+        return withoutBaselineTests(stats)
       }
 
       const { data, status } = await fetchData<SuiteStats>(`suites/${suiteHash}/stats.json`)
       if (!data) {
         throw new Error(`Failed to fetch suite stats: ${status}`)
       }
-      return data
+      return withoutBaselineTests(data)
     },
     enabled: !!suiteHash,
   })

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -14,6 +14,7 @@ import { LiveRunLogPanel } from '@/components/run-detail/LiveRunLogPanel'
 import { useSuite } from '@/api/hooks/useSuite'
 import { useIndex } from '@/api/hooks/useIndex'
 import { formatTimestamp } from '@/utils/date'
+import { withoutBaselineTests } from '@/utils/baselineTests'
 import { formatNumber } from '@/utils/format'
 import { computeLiveEta, formatEtaShort, formatEtaTooltip, formatHoursMinutes, formatClockHoursMinutes } from '@/components/runs/liveEta'
 import { DEFAULT_INDEX_STEP_FILTER } from '@/api/types'
@@ -73,7 +74,7 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
   // been processed yet, so we render it as soon as we have *either* the
   // suite or some completed tests.
   const heatmapTests = useMemo(
-    () => (run.tests ? liveTestsToHeatmapEntries(run.tests) : {}),
+    () => (run.tests ? liveTestsToHeatmapEntries(withoutBaselineTests(run.tests)) : {}),
     [run.tests],
   )
   const showHeatmap =

--- a/ui/src/pages/CompareGroupsPage.tsx
+++ b/ui/src/pages/CompareGroupsPage.tsx
@@ -7,6 +7,7 @@ import { fetchData } from '@/api/client'
 import { testNameMatches, toggleSearchTerm, TEST_FILTER_HINT } from '@/utils/eestNameFilter'
 import { useIndex } from '@/api/hooks/useIndex'
 import { useSuite } from '@/api/hooks/useSuite'
+import { fetchRunResult } from '@/api/hooks/useRunResult'
 import { LoadingState } from '@/components/shared/Spinner'
 import { JDenticon } from '@/components/shared/JDenticon'
 import { FacetPanel } from '@/components/shared/FacetPanel'
@@ -164,10 +165,7 @@ export function CompareGroupsPage() {
   const resultQueries = useQueries({
     queries: allRunIds.map((runId) => ({
       queryKey: ['run', runId, 'result'],
-      queryFn: async () => {
-        const { data } = await fetchData<RunResult>(`runs/${runId}/result.json`)
-        return data ?? null
-      },
+      queryFn: () => fetchRunResult(runId),
       enabled: !!runId,
     })),
   })

--- a/ui/src/pages/ComparePage.tsx
+++ b/ui/src/pages/ComparePage.tsx
@@ -3,10 +3,11 @@ import clsx from 'clsx'
 import { Link, useSearch, useNavigate } from '@tanstack/react-router'
 import { useQueries } from '@tanstack/react-query'
 import { type IndexStepType, ALL_INDEX_STEP_TYPES } from '@/api/types'
-import type { BlockLogs, RunConfig, RunResult } from '@/api/types'
+import type { BlockLogs, RunConfig } from '@/api/types'
 import { fetchData } from '@/api/client'
 import { testNameMatches, toggleSearchTerm, TEST_FILTER_HINT } from '@/utils/eestNameFilter'
 import { useSuite } from '@/api/hooks/useSuite'
+import { fetchRunResult } from '@/api/hooks/useRunResult'
 import { LoadingState } from '@/components/shared/Spinner'
 import { ErrorState } from '@/components/shared/ErrorState'
 import { JDenticon } from '@/components/shared/JDenticon'
@@ -88,10 +89,7 @@ export function ComparePage() {
   const resultQueries = useQueries({
     queries: runIds.map((runId) => ({
       queryKey: ['run', runId, 'result'],
-      queryFn: async () => {
-        const { data } = await fetchData<RunResult>(`runs/${runId}/result.json`)
-        return data ?? null
-      },
+      queryFn: () => fetchRunResult(runId),
       enabled: !!runId,
     })),
   })

--- a/ui/src/utils/baselineTests.test.ts
+++ b/ui/src/utils/baselineTests.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { isBaselineTest, withoutBaselineTests } from './baselineTests'
+
+const BASELINE_NAME =
+  'tests/benchmark/stateful/bloatnet/test_sload.py::test_sload_bloated[fork_Amsterdam-blockchain_test_stateful_engine-overhead_baseline_True-benchmark-gas-value_200M]'
+const WORKLOAD_NAME =
+  'tests/benchmark/stateful/bloatnet/test_sload.py::test_sload_bloated[fork_Amsterdam-blockchain_test_stateful_engine-overhead_baseline_False-benchmark-gas-value_200M]'
+
+describe('isBaselineTest', () => {
+  it('matches overhead_baseline_True variants', () => {
+    expect(isBaselineTest(BASELINE_NAME)).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isBaselineTest(BASELINE_NAME.replace('_True', '_true'))).toBe(true)
+  })
+
+  it('does not match the _False workload twin', () => {
+    expect(isBaselineTest(WORKLOAD_NAME)).toBe(false)
+  })
+
+  it('does not match unrelated tests', () => {
+    expect(isBaselineTest('tests/benchmark/compute/instruction/test_keccak.py::test_keccak')).toBe(
+      false,
+    )
+  })
+})
+
+describe('withoutBaselineTests', () => {
+  it('drops baseline keys and keeps the rest', () => {
+    const filtered = withoutBaselineTests({ [BASELINE_NAME]: 1, [WORKLOAD_NAME]: 2 })
+    expect(Object.keys(filtered)).toEqual([WORKLOAD_NAME])
+  })
+
+  it('returns the same reference when nothing matches', () => {
+    const input = { [WORKLOAD_NAME]: 1 }
+    expect(withoutBaselineTests(input)).toBe(input)
+  })
+})

--- a/ui/src/utils/baselineTests.ts
+++ b/ui/src/utils/baselineTests.ts
@@ -1,0 +1,36 @@
+/**
+ * `overhead_baseline_True` test variants are calibration helpers: they run the
+ * test's keccak-overhead loop without the real workload (~7 Mgas against a
+ * 200M+ target), existing only so the workload cost can be isolated by
+ * subtraction. Any aggregate that includes them — average MGas/s, heatmaps,
+ * comparisons — is skewed low, so the UI treats them as if they don't exist.
+ * They still execute and remain in result.json / the index for offline
+ * analysis.
+ */
+const BASELINE_RE = /overhead_baseline_true/i
+
+export function isBaselineTest(name: string): boolean {
+  return BASELINE_RE.test(name)
+}
+
+/**
+ * Returns `record` without baseline-test keys. Works on any test-name-keyed
+ * map (RunResult.tests, SuiteStats). Returns the input unchanged when no key
+ * matches, so unaffected suites don't pay a re-allocation.
+ */
+export function withoutBaselineTests<T>(record: Record<string, T>): Record<string, T> {
+  let hasBaseline = false
+  for (const name in record) {
+    if (isBaselineTest(name)) {
+      hasBaseline = true
+      break
+    }
+  }
+  if (!hasBaseline) return record
+
+  const filtered: Record<string, T> = {}
+  for (const [name, value] of Object.entries(record)) {
+    if (!isBaselineTest(name)) filtered[name] = value
+  }
+  return filtered
+}


### PR DESCRIPTION
Per the ask in #benchmarking: `overhead_baseline_True` test variants are calibration helpers — they run the test's keccak-overhead loop *without* the real workload (~7 Mgas against a 200M+ gas target), existing only so the workload's cost can be isolated by subtraction. Every aggregate that includes them (avg MGas/s, heatmaps, comparisons) is skewed low. Agreed behavior: they keep executing and stay stored; statistics ignore them.

## Design

"Is a calibration helper" is a property of the test, so it's classified **server-side, in one place**, and excluded where data is served — a UI-only filter would give API consumers different numbers than the charts and decay silently if the naming convention ever changes.

- `indexstore.IsBaselineTest` is the single Go definition of the rule (case-insensitive `overhead_baseline_true`; the `_False` twins are the real workload runs and are untouched).
- The indexer stamps a `baseline` column on every `TestStat`; `Start()` backfills rows indexed before the column existed via one idempotent SQL `UPDATE` — **retroactive without a reindex**, on SQLite and Postgres.
- `GET /suites/{hash}/stats` excludes flagged rows in SQL by default; `?include_baseline=true` returns the raw set.
- The query builder gains `baseline` as a filterable/selectable column and stays raw by default — that's where you go to *see* these rows.

The UI keeps a matching predicate only where no API exists: static-mode `stats.json`, raw `result.json` (run detail + compare pages, which now share one `fetchRunResult` — they reuse `useRunResult`'s react-query cache key, so a filtered and an unfiltered fetcher on the same key would race to define the cached shape), and rollout skew against older API deployments.

## Deliberately not covered

- **Live run headline MGas/s** — computed from runner-reported scalars, transient progress number; a runner-side change if ever wanted.
- **Suite file listing** — the fixtures exist; only statistics ignore them.
- **Long term**: the naming-convention coupling should die upstream — EEST marking the calibration role in fixture metadata; will raise it on the execution-specs side.

Go: `go test ./pkg/api/...` green incl. new predicate/exclusion/backfill tests; tagged build + vet clean. UI: vitest 13/13, eslint 0 errors, `tsc && vite build` clean.