### PR TITLE
fix(pre_runs): stream the pre-run bundle instead of buffering every payload

### DIFF
--- a/pkg/builder/pre_runs.go
+++ b/pkg/builder/pre_runs.go
@@ -722,42 +722,58 @@ func (b *PreRunsBuilder) resolveReplayBundle(replayFrom string) (string, error) 
 // writeBundle assembles the replay bundle from the recorded bump/funding
 // payloads and the setup fixtures, then writes it (ordered, deduped) to
 // outputDir.
+//
+// This streams: the recorded payloads are emitted first (they precede the
+// fill's blocks), then each fixture is decoded incrementally and written as it
+// is read, so only one payload is resident at a time.
+//
+// It used to read every fixture whole (os.ReadFile), unmarshal it (which copies
+// each payload again into json.RawMessage), concatenate into a third slice and
+// sort that. Peak memory was therefore several multiples of the fixture size:
+// a production pre-run with a 10 GB fixture reached 35.5 GB RSS and was
+// OOM-killed part-way through writing, leaving a truncated bundle that still
+// looked plausible — it had a valid prefix and simply stopped mid-pair.
 func (b *PreRunsBuilder) writeBundle(log logrus.FieldLogger, outputDir, fixturesDir string, recorded []recordedPayload) error {
-	// A fill that died early may have written no fixtures at all, or a partial
-	// tree — neither is a reason to lose the blocks we recorded ourselves.
-	fixturePayloads, err := extractFixturePayloads(fixturesDir)
-	if err != nil {
-		if len(recorded) == 0 {
-			return fmt.Errorf("extracting fixture payloads: %w", err)
-		}
-
-		log.WithError(err).Warn("Could not read fixture payloads; bundling only the recorded blocks")
-
-		fixturePayloads = nil
-	}
-
-	all := append(append([]recordedPayload{}, recorded...), fixturePayloads...)
-
-	ordered, err := sortAndDedupPayloads(all)
+	bw, err := newBundleWriter(outputDir)
 	if err != nil {
 		return err
+	}
+
+	for i := range recorded {
+		if emitErr := bw.emit(recorded[i]); emitErr != nil {
+			_ = bw.close()
+
+			return fmt.Errorf("writing recorded payload %d: %w", i, emitErr)
+		}
+	}
+
+	// A fill that died early may have written no fixtures at all, or a partial
+	// tree — neither is a reason to lose the blocks we recorded ourselves, or the
+	// fixture payloads that were readable before the failure.
+	if walkErr := streamFixtureDir(fixturesDir, bw.emit); walkErr != nil {
+		if bw.count == 0 {
+			_ = bw.close()
+
+			return fmt.Errorf("streaming fixture payloads: %w", walkErr)
+		}
+
+		log.WithError(walkErr).Warn("Could not read all fixture payloads; bundling what was readable")
 	}
 
 	// Nothing was ever built (the pre-run died before its first block), so there
 	// is no bundle to write — and an empty one would only be mistaken for a
 	// usable prefix.
-	if len(ordered) == 0 {
+	if bw.count == 0 {
 		log.Warn("No payloads recorded; skipping pre-run bundle")
 
-		return nil
+		return bw.discard()
 	}
 
-	path, err := writeRequestBundle(outputDir, ordered)
-	if err != nil {
+	if err := bw.close(); err != nil {
 		return err
 	}
 
-	info, err := summarizeBundle(ordered)
+	info, err := bw.info()
 	if err != nil {
 		return fmt.Errorf("summarizing bundle: %w", err)
 	}
@@ -767,7 +783,7 @@ func (b *PreRunsBuilder) writeBundle(log logrus.FieldLogger, outputDir, fixtures
 	}
 
 	log.WithFields(logrus.Fields{
-		"payloads": info.Payloads, "bundle": path,
+		"payloads": info.Payloads, "bundle": bw.path,
 		"start_block": info.StartBlockNumber, "start_hash": info.StartBlockHash,
 		"end_block": info.EndBlockNumber, "end_hash": info.EndBlockHash,
 		"contiguous": info.Contiguous(),

--- a/pkg/builder/prerun_stream.go
+++ b/pkg/builder/prerun_stream.go
@@ -1,0 +1,271 @@
+package builder
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+)
+
+// bundleWriter streams pre-run payloads straight to the .request bundle,
+// holding one payload at a time instead of the whole set.
+//
+// The accumulate-then-sort-then-write path (extractFixturePayloads ->
+// sortAndDedupPayloads -> writeRequestBundle) keeps every payload resident
+// simultaneously, which is fine for a smoke-sized pre-run and fatal for a
+// production one: a 10 GB fixture peaked at 35.5 GB RSS and was OOM-killed
+// mid-write, truncating the bundle. See writeBundle for the details.
+//
+// Ordering: payloads must arrive in ascending block order. That already holds
+// for a pre-run — the recorded gas-bump/funding/predeploy blocks precede the
+// fill, and a --no-reset-between-tests fill emits its blocks in order — so
+// rather than buffering everything to sort it, this enforces the invariant and
+// fails loudly if it is ever violated.
+type bundleWriter struct {
+	path   string
+	file   *os.File
+	w      *bufio.Writer
+	nextID int
+	last   uint64
+	seen   map[string]struct{}
+	count  int
+
+	// first/latest carry everything summarizeBundle needs, accumulated as
+	// payloads go past so PreRunBundleInfo can be produced without keeping them.
+	first  blockRef
+	latest blockRef
+}
+
+func newBundleWriter(dir string) (*bundleWriter, error) {
+	bundleDir := filepath.Join(dir, config.PreRunBundleSubdir)
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating bundle dir: %w", err)
+	}
+
+	path := filepath.Join(bundleDir, preRunBundleFile)
+
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("creating bundle file: %w", err)
+	}
+
+	return &bundleWriter{
+		path:   path,
+		file:   f,
+		w:      bufio.NewWriterSize(f, 1<<20),
+		nextID: 1,
+		seen:   make(map[string]struct{}),
+	}, nil
+}
+
+// emit writes one payload's newPayload + forkchoiceUpdated pair. Duplicate
+// blocks (same hash) are skipped, matching sortAndDedupPayloads.
+func (b *bundleWriter) emit(p recordedPayload) error {
+	ref, err := payloadBlockRef(&p)
+	if err != nil {
+		return fmt.Errorf("payload %d: %w", b.count, err)
+	}
+
+	number, ep := ref.number, ref
+
+	if ep.hash != "" {
+		if _, dup := b.seen[ep.hash]; dup {
+			return nil
+		}
+	}
+
+	if b.count > 0 && number <= b.last {
+		return fmt.Errorf(
+			"payloads out of order: block %d arrived after %d; the bundle writer "+
+				"streams in order and cannot reorder", number, b.last,
+		)
+	}
+
+	npLine, fcuLine, err := payloadRequestLines(&p, b.nextID)
+	if err != nil {
+		return fmt.Errorf("building request lines for block %d: %w", number, err)
+	}
+
+	if _, err := fmt.Fprintln(b.w, npLine); err != nil {
+		return fmt.Errorf("writing newPayload line: %w", err)
+	}
+
+	if _, err := fmt.Fprintln(b.w, fcuLine); err != nil {
+		return fmt.Errorf("writing forkchoiceUpdated line: %w", err)
+	}
+
+	if ep.hash != "" {
+		b.seen[ep.hash] = struct{}{}
+	}
+
+	if b.count == 0 {
+		b.first = ref
+	}
+
+	b.latest = ref
+	b.last = number
+	b.nextID++
+	b.count++
+
+	return nil
+}
+
+// info builds the same PreRunBundleInfo summarizeBundle would, from the first
+// and last payloads seen rather than from a retained slice.
+func (b *bundleWriter) info() (*PreRunBundleInfo, error) {
+	if b.count == 0 {
+		return nil, fmt.Errorf("bundle has no payloads")
+	}
+
+	return &PreRunBundleInfo{
+		Payloads: b.count,
+		// The parent of the first payload: the snapshot head, one block below it.
+		StartBlockNumber: b.first.number - 1,
+		StartBlockHash:   b.first.parentHash,
+		EndBlockNumber:   b.latest.number,
+		EndBlockHash:     b.latest.hash,
+	}, nil
+}
+
+// discard closes and removes the bundle file. Used when nothing was written: an
+// empty bundle would only be mistaken for a usable prefix.
+func (b *bundleWriter) discard() error {
+	_ = b.close()
+
+	return os.Remove(b.path)
+}
+
+// close flushes and closes the bundle file.
+func (b *bundleWriter) close() error {
+	if err := b.w.Flush(); err != nil {
+		_ = b.file.Close()
+
+		return fmt.Errorf("flushing bundle: %w", err)
+	}
+
+	return b.file.Close()
+}
+
+// streamFixturePayloads decodes a stateful fixture file incrementally, invoking
+// fn once per engine payload. Only one payload is materialised at a time, so
+// peak memory is independent of the fixture's size — the whole point of this
+// path. A file that is not a fixture (e.g. a .meta report) is skipped silently,
+// matching extractFixturePayloads.
+func streamFixturePayloads(path string, fn func(recordedPayload) error) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening fixture %q: %w", path, err)
+	}
+
+	defer func() { _ = f.Close() }()
+
+	dec := json.NewDecoder(bufio.NewReaderSize(f, 1<<20))
+
+	tok, err := dec.Token()
+	if err != nil || tok != json.Delim('{') {
+		return nil // not a fixture object
+	}
+
+	for dec.More() {
+		if _, err := dec.Token(); err != nil { // the test id
+			return nil
+		}
+
+		tok, err := dec.Token()
+		if err != nil || tok != json.Delim('{') {
+			return nil
+		}
+
+		if err := streamFixtureCase(dec, fn); err != nil {
+			return fmt.Errorf("fixture %q: %w", path, err)
+		}
+
+		if _, err := dec.Token(); err != nil { // closing '}' of the case
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// streamFixtureCase walks one fixture case's fields, streaming the two payload
+// arrays and skipping everything else.
+func streamFixtureCase(dec *json.Decoder, fn func(recordedPayload) error) error {
+	for dec.More() {
+		key, err := dec.Token()
+		if err != nil {
+			return err
+		}
+
+		name, _ := key.(string)
+
+		switch name {
+		case "setupEngineNewPayloads", "engineNewPayloads":
+			if err := streamPayloadArray(dec, fn); err != nil {
+				return err
+			}
+		default:
+			var skip json.RawMessage
+			if err := dec.Decode(&skip); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// streamPayloadArray decodes a payload array one element at a time.
+func streamPayloadArray(dec *json.Decoder, fn func(recordedPayload) error) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	if tok != json.Delim('[') {
+		return fmt.Errorf("expected array, got %v", tok)
+	}
+
+	for dec.More() {
+		var e rawFixtureEnginePayload
+		if err := dec.Decode(&e); err != nil {
+			return err
+		}
+
+		if len(e.Params) == 0 || e.NewPayloadVersion == "" {
+			continue // malformed entry, as appendFixturePayload skips
+		}
+
+		if err := fn(recordedPayload{
+			Method: "engine_newPayloadV" + e.NewPayloadVersion,
+			Params: e.Params,
+		}); err != nil {
+			return err
+		}
+	}
+
+	_, err = dec.Token() // closing ']'
+
+	return err
+}
+
+// streamFixtureDir streams every fixture under dir, in path order so the walk is
+// deterministic.
+func streamFixtureDir(dir string, fn func(recordedPayload) error) error {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+
+		return streamFixturePayloads(path, fn)
+	})
+}

--- a/pkg/builder/prerun_stream_test.go
+++ b/pkg/builder/prerun_stream_test.go
@@ -1,0 +1,176 @@
+package builder
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFixture drops a stateful fixture with the given payload blocks into a
+// fresh fixtures dir, plus a non-fixture json file that must be ignored.
+func writeFixture(t *testing.T, setup, bench [][2]string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "blockchain_tests_stateful_engine", "x")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+
+	entry := func(b [2]string) string {
+		return `{"newPayloadVersion": "5", "params": [{"blockNumber":"` + b[0] +
+			`","blockHash":"` + b[1] + `"}, [], "0x0", []]}`
+	}
+
+	parts := func(bs [][2]string) string {
+		out := make([]string, 0, len(bs))
+		for _, b := range bs {
+			out = append(out, entry(b))
+		}
+
+		return strings.Join(out, ",")
+	}
+
+	fixture := `{"test_x": {
+        "network": "Amsterdam",
+        "setupEngineNewPayloads": [` + parts(setup) + `],
+        "engineNewPayloads": [` + parts(bench) + `]
+      }}`
+
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "test_x.json"), []byte(fixture), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "report.json"), []byte(`{"summary": 1}`), 0o644))
+
+	return dir
+}
+
+// TestStreamingBundleMatchesBufferedPath is the load-bearing test: the streaming
+// writer must produce byte-identical output to the accumulate-sort-write path it
+// replaces, or this is a behaviour change rather than a memory fix.
+func TestStreamingBundleMatchesBufferedPath(t *testing.T) {
+	recorded := []recordedPayload{
+		payload("engine_newPayloadV4", "0x1", "0xa1"),
+		payload("engine_newPayloadV4", "0x2", "0xa2"),
+	}
+	fixtures := writeFixture(t,
+		[][2]string{{"0x3", "0xa3"}},
+		[][2]string{{"0x4", "0xa4"}, {"0x5", "0xa5"}},
+	)
+
+	// Old path.
+	fixturePayloads, err := extractFixturePayloads(fixtures)
+	require.NoError(t, err)
+	ordered, err := sortAndDedupPayloads(append(append([]recordedPayload{}, recorded...), fixturePayloads...))
+	require.NoError(t, err)
+	oldDir := t.TempDir()
+	oldPath, err := writeRequestBundle(oldDir, ordered)
+	require.NoError(t, err)
+	oldData, err := os.ReadFile(oldPath)
+	require.NoError(t, err)
+
+	// New path.
+	newDir := t.TempDir()
+	bw, err := newBundleWriter(newDir)
+	require.NoError(t, err)
+
+	for i := range recorded {
+		require.NoError(t, bw.emit(recorded[i]))
+	}
+
+	require.NoError(t, streamFixtureDir(fixtures, bw.emit))
+	require.NoError(t, bw.close())
+
+	newData, err := os.ReadFile(filepath.Join(newDir, config.PreRunBundleSubdir, preRunBundleFile))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(oldData), string(newData), "streaming output must match the buffered path byte for byte")
+	assert.Equal(t, 5, bw.count)
+}
+
+// TestStreamingBundleInfoMatchesSummarize checks the incremental summary against
+// summarizeBundle. The streaming writer cannot call it (there is no retained
+// slice), so it accumulates the first and last block refs instead; the two must
+// agree, or PreRunBundleInfo — and the contiguity check built on it — would
+// silently drift.
+func TestStreamingBundleInfoMatchesSummarize(t *testing.T) {
+	payloads := []recordedPayload{
+		parentedPayload("0x5", "0xe5", "0xe4"),
+		parentedPayload("0x6", "0xe6", "0xe5"),
+		parentedPayload("0x7", "0xe7", "0xe6"),
+	}
+
+	want, err := summarizeBundle(payloads)
+	require.NoError(t, err)
+
+	bw, err := newBundleWriter(t.TempDir())
+	require.NoError(t, err)
+
+	for i := range payloads {
+		require.NoError(t, bw.emit(payloads[i]))
+	}
+
+	require.NoError(t, bw.close())
+
+	got, err := bw.info()
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+	assert.True(t, got.Contiguous())
+}
+
+// TestStreamingBundleDropsDuplicateBlocks mirrors sortAndDedupPayloads: a block
+// already written (same hash) is skipped rather than emitted twice.
+func TestStreamingBundleDropsDuplicateBlocks(t *testing.T) {
+	// The fill's setup payloads commonly repeat a block the pre-run already
+	// recorded; that must not appear twice in the bundle.
+	recorded := []recordedPayload{payload("engine_newPayloadV5", "0x1", "0xa1")}
+	fixtures := writeFixture(t,
+		[][2]string{{"0x1", "0xa1"}}, // duplicate of the recorded block
+		[][2]string{{"0x2", "0xa2"}},
+	)
+
+	dir := t.TempDir()
+	bw, err := newBundleWriter(dir)
+	require.NoError(t, err)
+	require.NoError(t, bw.emit(recorded[0]))
+	require.NoError(t, streamFixtureDir(fixtures, bw.emit))
+	require.NoError(t, bw.close())
+
+	assert.Equal(t, 2, bw.count, "duplicate block dropped")
+
+	data, err := os.ReadFile(filepath.Join(dir, config.PreRunBundleSubdir, preRunBundleFile))
+	require.NoError(t, err)
+	assert.Len(t, strings.Split(strings.TrimSpace(string(data)), "\n"), 4, "two pairs")
+}
+
+// TestStreamingBundleRejectsOutOfOrder pins the invariant the streaming writer
+// relies on. It cannot reorder, so it must fail loudly rather than emit a bundle
+// whose blocks do not chain.
+func TestStreamingBundleRejectsOutOfOrder(t *testing.T) {
+	dir := t.TempDir()
+	bw, err := newBundleWriter(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, bw.emit(payload("engine_newPayloadV5", "0x2", "0xb")))
+
+	err = bw.emit(payload("engine_newPayloadV5", "0x1", "0xa"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of order")
+	require.NoError(t, bw.close())
+}
+
+// TestStreamFixturePayloadsSkipsNonFixtures keeps extractFixturePayloads'
+// tolerance: a .meta report next to the fixtures is not a failure.
+func TestStreamFixturePayloadsSkipsNonFixtures(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "report.json"), []byte(`{"summary": 1}`), 0o644))
+
+	seen := 0
+	require.NoError(t, streamFixtureDir(dir, func(recordedPayload) error {
+		seen++
+
+		return nil
+	}))
+	assert.Zero(t, seen)
+}


### PR DESCRIPTION
(Made with Claude, including this PR msg, not tested but will re-test when bandwidth to see if this fixes OOM)

`builder.pre_runs` OOM-killed itself while writing the replay bundle on a
production-sized pre-run, leaving a truncated `pre-run.request` behind. This
makes `writeBundle` stream instead of buffering every payload.

Opening as a draft: the fix is complete and tested, but it trades a global sort
for an ordering invariant, and I would rather you weighed that than have me
assume it.

## What happened

Advancing a 1.1 TB jochemnet snapshot (`test_setup_contracts` at
`BLOATNET_RECEIVER_CONTRACT_COUNT=100000`, 7,734 blocks, a 10 GB fixture):

```
Out of memory: Killed process 2942036 (benchmarkoor)
  total-vm:38404492kB, anon-rss:35534596kB
```

**35.5 GB RSS for a 10 GB fixture.**

The failure mode is worse than the crash. The fill had already passed and the
datadir was correct — only the artefact was lost. And the file left behind
looked plausible: a valid prefix that stopped mid-pair, with a final
`engine_newPayload` whose `engine_forkchoiceUpdated` was never written.

```
last line: engine_newPayloadV5  blockNumber=0x1746b3d = 24,406,845
expected : 24,410,463
```

3,618 blocks missing. Nothing downstream checks that a bundle reaches the head
it claims, so it would have replayed a partial prestate and been consumed as if
complete. I only noticed because I checked the last block against the head the
fill reported.

## Where the memory goes

For a fixture of size N, `writeBundle` holds several multiples of N at once:

| step | cost |
| --- | --- |
| `extractFixturePayloads` → `os.ReadFile` per file | N |
| `json.Unmarshal` copies each payload into `json.RawMessage` | another N, coexisting with the read buffer |
| `append(append([]recordedPayload{}, recorded...), fixturePayloads...)` | a third full slice |
| `sortAndDedupPayloads` builds `keyedPayloads`, then `out` | two more passes |

`json.RawMessage` unmarshalling copies bytes rather than aliasing the input, so
the 10 GB read buffer and 10 GB of payload copies are live simultaneously,
before the slice churn on top.

## The change

`writeBundle` now streams. Recorded gas-bump/funding/predeploy payloads are
emitted first — they precede the fill's blocks by construction — then each
fixture is decoded incrementally with `json.Decoder` and written as it is read.
One payload is materialised at a time, so peak memory no longer scales with the
fixture.

**The tradeoff, which is why this is a draft:** a streaming writer cannot
reorder, so it enforces ascending block order rather than assuming it.
Out-of-order input is now a loud error instead of a silently mis-ordered bundle.
That invariant already holds for a pre-run (recorded blocks precede the fill; a
`--no-reset-between-tests` fill emits blocks in order), but it is an invariant
where there was previously a sort, and you may prefer a different shape — a
two-pass index, or buffering only block numbers and offsets.

Duplicate blocks are still dropped by hash, matching `sortAndDedupPayloads`.
The old helpers stay in place and remain covered by their existing tests; only
`writeBundle` changes which path it takes.

## Tests

- `TestStreamingBundleMatchesBufferedPath` — the load-bearing one: streaming
  output must be **byte-identical** to the buffered path, so this is a memory
  fix and not a behaviour change
- `TestStreamingBundleDropsDuplicateBlocks` — a fill's setup payloads commonly
  repeat a block the pre-run already recorded
- `TestStreamingBundleRejectsOutOfOrder` — pins the new invariant
- `TestStreamFixturePayloadsSkipsNonFixtures` — keeps
  `extractFixturePayloads`' tolerance of a `.meta` report beside the fixtures

`go build ./...`, `go vet`, `gofmt` and the existing `pkg/builder` suite are
all clean.

## Not addressed here

A truncated bundle is currently indistinguishable from a complete one to
everything downstream. `writeBundle` already logs `contiguous=`, so the
information exists — it just is not checked at read time. A validity check when
a bundle is *consumed* (contiguous, ends where it claims, every `parentHash`
chains) would have turned this into an immediate failure rather than a silent
one. Happy to follow up separately if you think that belongs.

## Context

Found while reproducing the `benchmarkoor-tests` `jochemnet/v1` repricing build
locally. The bundle from that run was recovered by keeping the complete pairs
benchmarkoor had written and streaming the remainder from the fill's surviving
fixture, then verified independently — contiguity, pairing, sequential ids, fcu
hashes matching their payload's `blockHash`, and the full `parentHash` chain
back to the snapshot head. So the artefact is fine; the code path that produced
it is what this PR fixes.
