### PR TITLE
feat(eest): resolve the pre-run bundle inside the fixtures artifact

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -844,6 +844,20 @@ const PreRunBundleSubdir = "pre_run_bundle"
 // EESTPreRunsSource locates a builder.pre_runs payload bundle for the runner to
 // replay before the benchmark fixtures. It mirrors the fixtures source's local
 // layout: FixturesSubdir defaults to PreRunBundleSubdir.
+//
+// LocalFixturesDir is optional. Left empty, the bundle is looked up inside the
+// fixtures artifact this source already extracted, exactly as FixturesSubdir
+// locates the fixtures within it — a build writes both into the same tarball,
+// so a release consumer needs only:
+//
+//	eest_fixtures:
+//	  fixtures_url: https://…/eest-payloads-…-geth.tar.gz
+//	  fixtures_subdir: benchmarkoor-build-artifacts/eest-payloads/geth/blockchain_tests_stateful_engine
+//	  pre_runs:
+//	    fixtures_subdir: benchmarkoor-build-artifacts/pre-runs/geth/pre_run_bundle
+//
+// Set LocalFixturesDir when the bundle lives outside the fixtures artifact, as
+// it does for a target whose bundle_dir moved it off the advanced datadir.
 type EESTPreRunsSource struct {
 	LocalFixturesDir string `yaml:"local_fixtures_dir,omitempty" mapstructure:"local_fixtures_dir"`
 	FixturesSubdir   string `yaml:"fixtures_subdir,omitempty" mapstructure:"fixtures_subdir"`

--- a/pkg/executor/eest_source.go
+++ b/pkg/executor/eest_source.go
@@ -1004,8 +1004,25 @@ func (s *EESTSource) discoverTests() (*PreparedSource, error) {
 // loadPreRunBundleSteps returns the configured builder.pre_runs bundle as
 // pre-run steps (the runner replays them before the fixtures). Returns nil when
 // no pre_runs source is configured.
+//
+// The bundle is read from LocalFixturesDir when set, and otherwise from the
+// already-extracted fixtures artifact — resolved against the same root
+// FixturesSubdir resolves the fixtures against. A build ships the bundle and
+// the fixtures in one tarball, so a release consumer can reach both from a
+// single fixtures_url instead of staging the bundle on every runner host.
 func (s *EESTSource) loadPreRunBundleSteps() ([]*StepFile, error) {
-	if s.cfg.PreRuns == nil || s.cfg.PreRuns.LocalFixturesDir == "" {
+	if s.cfg.PreRuns == nil {
+		return nil, nil
+	}
+
+	base := s.cfg.PreRuns.LocalFixturesDir
+	if base == "" {
+		base = s.fixturesDir
+	}
+
+	// Nothing to resolve against: no local directory configured and no
+	// fixtures extracted for this source.
+	if base == "" {
 		return nil, nil
 	}
 
@@ -1014,7 +1031,7 @@ func (s *EESTSource) loadPreRunBundleSteps() ([]*StepFile, error) {
 		subdir = config.PreRunBundleSubdir
 	}
 
-	bundleDir := filepath.Join(s.cfg.PreRuns.LocalFixturesDir, subdir)
+	bundleDir := filepath.Join(base, subdir)
 
 	entries, err := filepath.Glob(filepath.Join(bundleDir, "*.request"))
 	if err != nil {

--- a/pkg/executor/eest_source_test.go
+++ b/pkg/executor/eest_source_test.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
 	"github.com/ethpandaops/benchmarkoor/pkg/eest"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,4 +87,99 @@ func TestParseGitHubArtifactURL(t *testing.T) {
 
 	_, _, _, ok = parseGitHubArtifactURL("https://example.com/fixtures.tar.gz")
 	assert.False(t, ok)
+}
+
+func TestLoadPreRunBundleSteps(t *testing.T) {
+	// writeBundle creates <root>/<subdir>/pre-run.request and returns root.
+	writeBundle := func(t *testing.T, subdir string) string {
+		t.Helper()
+
+		root := t.TempDir()
+		dir := filepath.Join(root, subdir)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "pre-run.request"), []byte("{}\n"), 0o644))
+
+		return root
+	}
+
+	t.Run("no pre_runs source is a no-op", func(t *testing.T) {
+		s := &EESTSource{log: logrus.New(), cfg: &config.EESTFixturesSource{}}
+		steps, err := s.loadPreRunBundleSteps()
+		require.NoError(t, err)
+		assert.Nil(t, steps)
+	})
+
+	t.Run("nothing to resolve against is a no-op", func(t *testing.T) {
+		// pre_runs configured, but neither a local dir nor extracted fixtures.
+		s := &EESTSource{
+			log: logrus.New(),
+			cfg: &config.EESTFixturesSource{PreRuns: &config.EESTPreRunsSource{}},
+		}
+		steps, err := s.loadPreRunBundleSteps()
+		require.NoError(t, err)
+		assert.Nil(t, steps)
+	})
+
+	t.Run("local_fixtures_dir wins over the extracted fixtures", func(t *testing.T) {
+		local := writeBundle(t, config.PreRunBundleSubdir)
+		s := &EESTSource{
+			log:         logrus.New(),
+			fixturesDir: t.TempDir(), // no bundle here — must not be consulted
+			cfg: &config.EESTFixturesSource{
+				PreRuns: &config.EESTPreRunsSource{LocalFixturesDir: local},
+			},
+		}
+
+		steps, err := s.loadPreRunBundleSteps()
+		require.NoError(t, err)
+		require.Len(t, steps, 1)
+		assert.Equal(t, filepath.Join(local, config.PreRunBundleSubdir, "pre-run.request"), steps[0].Path)
+	})
+
+	t.Run("falls back to the extracted fixtures artifact", func(t *testing.T) {
+		// The layout a benchmarkoor build ships: fixtures and bundle in one
+		// tarball, the bundle addressed by a subdir under the extract root.
+		subdir := filepath.Join("benchmarkoor-build-artifacts", "pre-runs", "geth", "pre_run_bundle")
+		root := writeBundle(t, subdir)
+		s := &EESTSource{
+			log:         logrus.New(),
+			fixturesDir: root,
+			cfg: &config.EESTFixturesSource{
+				PreRuns: &config.EESTPreRunsSource{FixturesSubdir: subdir},
+			},
+		}
+
+		steps, err := s.loadPreRunBundleSteps()
+		require.NoError(t, err)
+		require.Len(t, steps, 1)
+		assert.Equal(t, filepath.Join(root, subdir, "pre-run.request"), steps[0].Path)
+		assert.Equal(t, "pre_run/pre-run.request", steps[0].Name)
+	})
+
+	t.Run("subdir defaults to the bundle subdir under the artifact", func(t *testing.T) {
+		root := writeBundle(t, config.PreRunBundleSubdir)
+		s := &EESTSource{
+			log:         logrus.New(),
+			fixturesDir: root,
+			cfg:         &config.EESTFixturesSource{PreRuns: &config.EESTPreRunsSource{}},
+		}
+
+		steps, err := s.loadPreRunBundleSteps()
+		require.NoError(t, err)
+		require.Len(t, steps, 1)
+	})
+
+	t.Run("a configured bundle that is missing is an error", func(t *testing.T) {
+		s := &EESTSource{
+			log:         logrus.New(),
+			fixturesDir: t.TempDir(),
+			cfg: &config.EESTFixturesSource{
+				PreRuns: &config.EESTPreRunsSource{FixturesSubdir: "nope"},
+			},
+		}
+
+		_, err := s.loadPreRunBundleSteps()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no pre-run bundle")
+	})
 }


### PR DESCRIPTION
A `builder.pre_runs` build writes the replay bundle and the benchmark fixtures into the same artifact, and `benchmarkoor-release` ships them in one tarball:

```
benchmarkoor-build-artifacts/
  eest-payloads/geth/blockchain_tests_stateful_engine/…
  pre-runs/geth/pre_run_bundle/pre-run.request
```

The runner could not reach the bundle there. `EESTPreRunsSource` accepts only `local_fixtures_dir`, and `loadPreRunBundleSteps` returns nil unless it is set — so a consumer whose fixtures come from `fixtures_url` had to stage the bundle separately on every runner host. Pointing at the copy the runner already downloaded was not expressible either: that extracts under `<cache>/eest-url/<hash-of-url>/fixtures`, a path config cannot name and which changes with every release.

## Change

When `local_fixtures_dir` is empty, resolve the bundle against this source's extracted fixtures root — the same root `fixtures_subdir` already resolves the fixtures against:

```yaml
eest_fixtures:
  fixtures_url: https://…/eest-payloads-jochemnet-v1-amsterdam-stateful-geth.tar.gz
  fixtures_subdir: benchmarkoor-build-artifacts/eest-payloads/geth/blockchain_tests_stateful_engine
  pre_runs:
    fixtures_subdir: benchmarkoor-build-artifacts/pre-runs/geth/pre_run_bundle
```

One download serves both, and a release becomes self-contained for a stateful run.

## Behaviour

- `local_fixtures_dir` still wins where set — the case where a target's `bundle_dir` moved the bundle off the advanced datadir.
- `fixtures_subdir` keeps defaulting to `pre_run_bundle`, now relative to the artifact root.
- A `pre_runs` block with neither a local dir nor extracted fixtures stays a no-op rather than becoming an error.
- No change for sources that set `local_fixtures_dir`, which is every existing config.

## Testing

Six subtests in `TestLoadPreRunBundleSteps` cover: no `pre_runs`; nothing to resolve against; local dir preferred over the artifact; the artifact fallback; the default subdir; and a configured-but-missing bundle erroring.

`go build`, `go vet`, and `golangci-lint run --new-from-rev=origin/master` are clean on `pkg/executor` and `pkg/config`; `go test ./pkg/executor/... -race` passes. `pkg/config` has 6 pre-existing failures on macOS (`TestValidateDataDirMethods_SchelkBinary`, which needs `/proc/mounts`) — identical count before and after this change.

## Verified against a real release

`eest-payloads-jochemnet-v1-amsterdam-stateful-d9ad55b3-20260807-000744` contains `benchmarkoor-build-artifacts/pre-runs/geth/pre_run_bundle/pre-run.request` (7736 payloads, contiguous, blocks 24402727 → 24410463), which the new fallback addresses with the `pre_runs.fixtures_subdir` shown above.