### PR TITLE
fix(runner): keep the client alive after a container-recreate schelk promote

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -5,11 +5,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
 	"net/http"
 	"net/http/httptrace"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -877,6 +879,15 @@ func (e *executor) runStepLines(
 ) error {
 	stepStart := time.Now()
 
+	// A client that answers with a JSON-RPC error is alive and the step carries
+	// on. One that cannot be reached at all may be gone — and a dead endpoint
+	// answers nothing, so every remaining line burns its full dial timeout. Left
+	// unchecked that turns a dead container into a run that grinds on for days
+	// (observed: a stopped client with 1547 payloads left reported eta=128h)
+	// instead of failing in seconds. Count consecutive transport failures and
+	// give up once it is clear nobody is listening.
+	consecutiveUnreachable := 0
+
 	// skipping is true when we're dropping already-applied lines at the
 	// start of the file (resume scenario). Cleared once we encounter the
 	// first engine_newPayload whose blockNumber > SkipUntilBlockNumber.
@@ -970,6 +981,21 @@ func (e *executor) runStepLines(
 				"method": method,
 				"step":   stepName,
 			}).WithError(err).Warn("RPC call failed")
+		}
+
+		if isTransportError(err) {
+			consecutiveUnreachable++
+
+			if consecutiveUnreachable >= unreachableClientThreshold {
+				return fmt.Errorf(
+					"client at %s unreachable for %d consecutive calls (last: %w) — "+
+						"it has most likely exited; abandoning %q at line %d of %d",
+					opts.EngineEndpoint, consecutiveUnreachable, err,
+					stepName, lineNum+1, len(lines),
+				)
+			}
+		} else {
+			consecutiveUnreachable = 0
 		}
 
 		// Validate response AFTER timing, BEFORE storing result. Track the
@@ -1782,4 +1808,25 @@ func (e *executor) dumpPostTestResponse(
 	}
 
 	return nil
+}
+
+// unreachableClientThreshold is how many consecutive transport failures mean the
+// client is gone rather than momentarily unhappy. Small on purpose: the runner
+// waits for RPC readiness before a step starts and after any restart it performs,
+// so a step should never see the endpoint disappear transiently.
+const unreachableClientThreshold = 3
+
+// isTransportError reports whether err is the HTTP request failing to complete —
+// the endpoint could not be dialled, the connection dropped, or it timed out.
+// executeRPC only returns an error in that case (and for request construction);
+// a client that answers with a JSON-RPC error produces a response, not an error.
+// So this distinguishes "nobody is listening" from "the client said no".
+func isTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var urlErr *url.Error
+
+	return errors.As(err, &urlErr)
 }

--- a/pkg/executor/unreachable_client_test.go
+++ b/pkg/executor/unreachable_client_test.go
@@ -1,0 +1,62 @@
+package executor
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The distinction that matters: a client which ANSWERS is alive, even when the
+// answer is an error. Only a request that never completes means nobody is there.
+func TestIsTransportError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// What a dead container actually produced:
+			// executing request: Post "http://10.89.0.91:8551": dial tcp ...: i/o timeout
+			name: "dial failure through executeRPC's wrapping",
+			err: fmt.Errorf("executing request: %w", &url.Error{
+				Op: "Post", URL: "http://10.89.0.91:8551", Err: syscall.ECONNREFUSED,
+			}),
+			want: true,
+		},
+		{
+			name: "bare url error",
+			err:  &url.Error{Op: "Post", URL: "http://x:8551", Err: errors.New("i/o timeout")},
+			want: true,
+		},
+		{
+			name: "JSON-RPC error the client answered with",
+			err:  errors.New("JSONRPCError(code=-32602, message=Invalid parameters)"),
+			want: false,
+		},
+		{
+			name: "JWT generation failure is not the client being gone",
+			err:  errors.New("generating JWT: bad secret"),
+			want: false,
+		},
+		{name: "no error", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isTransportError(tt.err))
+		})
+	}
+}
+
+// A dead client must be given up on quickly. The threshold exists only to ride
+// out a single blip, not to keep dialling for hours.
+func TestUnreachableClientThresholdIsSmall(t *testing.T) {
+	assert.LessOrEqual(t, unreachableClientThreshold, 5,
+		"a dead endpoint burns a full dial timeout per call; the run must not grind on")
+	assert.Positive(t, unreachableClientThreshold,
+		"a single transient failure should not abandon the run")
+}

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -217,10 +217,16 @@ func (r *runner) runTestsWithContainerStrategy(
 				"so every recreated container starts post-pre-run",
 		)
 
-		if err := r.promoteSchelkAfterPreRuns(
-			ctx, params, spec, containerID, containerIP, resultsDir, logCancel, logDone, log,
-		); err != nil {
-			return nil, err
+		newIP, promoteErr := r.promoteSchelkAfterPreRuns(
+			ctx, params, spec, containerID, containerIP, resultsDir,
+			benchmarkoorLog, cleanupFuncs, cleanupStarted, logCancel, logDone, log,
+		)
+		if promoteErr != nil {
+			return nil, promoteErr
+		}
+
+		if newIP != "" {
+			containerIP = newIP
 		}
 	}
 
@@ -1055,10 +1061,13 @@ func (r *runner) promoteSchelkAfterPreRuns(
 	containerID string,
 	containerIP string,
 	resultsDir string,
+	benchmarkoorLog *os.File,
+	cleanupFuncs *[]func(),
+	cleanupStarted chan struct{},
 	logCancel *context.CancelFunc,
 	logDone *chan struct{},
 	log logrus.FieldLogger,
-) error {
+) (string, error) {
 	// Where the datadir already sits decides how much of the bundle to replay. A
 	// promoted baseline is already AT the bundle's end, so replaying from its
 	// first block re-imports thousands of known blocks — minutes of wasted work
@@ -1069,7 +1078,7 @@ func (r *runner) promoteSchelkAfterPreRuns(
 	} else {
 		applied, err := r.verifyPreRunBundleHead(log, headNumber, headHash)
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		if applied {
@@ -1077,7 +1086,7 @@ func (r *runner) promoteSchelkAfterPreRuns(
 				"Pre-run bundle already applied to this datadir; nothing to promote",
 			)
 
-			return nil
+			return "", nil
 		}
 	}
 
@@ -1096,7 +1105,7 @@ func (r *runner) promoteSchelkAfterPreRuns(
 
 	n, err := r.executor.RunPreRunSteps(ctx, preRunOpts)
 	if err != nil {
-		return fmt.Errorf("running pre-run steps before schelk promote: %w", err)
+		return "", fmt.Errorf("running pre-run steps before schelk promote: %w", err)
 	}
 
 	if n == 0 {
@@ -1105,7 +1114,7 @@ func (r *runner) promoteSchelkAfterPreRuns(
 				"refusing to promote (the baseline would be the raw snapshot)",
 		)
 
-		return nil
+		return "", nil
 	}
 
 	log.WithField("steps", n).Info("Pre-run steps completed; promoting datadir to the schelk baseline")
@@ -1119,7 +1128,7 @@ func (r *runner) promoteSchelkAfterPreRuns(
 	log.Info("Stopping container for schelk promote (graceful)")
 
 	if err := r.containerMgr.StopContainer(ctx, containerID, nil); err != nil {
-		return fmt.Errorf("stopping container for schelk promote: %w", err)
+		return "", fmt.Errorf("stopping container for schelk promote: %w", err)
 	}
 
 	waitForLogDrain(logDone, logCancel, logDrainTimeout)
@@ -1131,20 +1140,51 @@ func (r *runner) promoteSchelkAfterPreRuns(
 	log.Info("Persisting the advanced datadir as the new schelk baseline (`schelk promote`)")
 
 	if err := datadir.SchelkPromote(ctx, r.log); err != nil {
-		return fmt.Errorf("schelk promote: %w", err)
+		return "", fmt.Errorf("schelk promote: %w", err)
 	}
 
 	// promote leaves the volume unmounted; the per-test recreate binds this path.
 	if err := datadir.EnsureSchelkMounted(ctx, r.log); err != nil {
-		return fmt.Errorf("remounting schelk volume after promote: %w", err)
+		return "", fmt.Errorf("remounting schelk volume after promote: %w", err)
 	}
 
-	log.Info("Promoted: every recreated container now starts from the post-pre-run datadir")
+	// Bring the SAME container back rather than removing it. Only the ZFS branch
+	// of the per-test loop builds a fresh container for EVERY test; the plain
+	// container-recreate branch recreates from the second test onwards, so test 0
+	// still runs on this one. Removing it here left that first test with no client
+	// and the run retrying a dead endpoint indefinitely.
+	log.Info("Restarting client on the promoted baseline")
 
-	// Remove the initial container; fresh ones are created per test.
-	if err := r.containerMgr.RemoveContainer(ctx, containerID); err != nil {
-		log.WithError(err).Warn("Failed to remove initial container after promote")
+	if err := r.containerMgr.StartContainer(ctx, containerID); err != nil {
+		return "", fmt.Errorf("starting container after schelk promote: %w", err)
 	}
 
-	return nil
+	newIP, ipErr := r.containerMgr.GetContainerIP(ctx, containerID, r.cfg.ContainerNetwork)
+	if ipErr != nil {
+		return "", fmt.Errorf("getting container IP after schelk promote: %w", ipErr)
+	}
+
+	if logErr := r.startLogStreaming(
+		ctx, resultsDir,
+		params.Instance.ID, containerID,
+		benchmarkoorLog, &containerLogInfo{
+			Name:             params.ContainerSpec.Name,
+			ContainerID:      containerID,
+			Image:            params.ContainerSpec.Image,
+			GenesisGroupHash: params.GenesisGroupHash,
+		},
+		params.BlockLogCollector, cleanupStarted,
+		logDone, logCancel, cleanupFuncs,
+	); logErr != nil {
+		return "", fmt.Errorf("log streaming after schelk promote: %w", logErr)
+	}
+
+	if _, err := r.waitForRPC(ctx, newIP, spec.RPCPort()); err != nil {
+		return "", fmt.Errorf("waiting for RPC after schelk promote: %w", err)
+	}
+
+	log.Info("Promoted: the client is back up on the new baseline, and every " +
+		"per-test recreate now restores it")
+
+	return newIP, nil
 }


### PR DESCRIPTION
## What happened

A besu `jochemnet` run hung and had to be cancelled. It was not stuck — it was retrying a dead endpoint at 30s per call, having reached an ETA of **128 hours**:

```
Promoted: every recreated container now starts from the post-pre-run datadir
Running pre-run steps
RPC call failed ... dial tcp 10.89.0.91:8551: i/o timeout   pos=23/1547
eta=128h48m
```

## Cause

`promoteSchelkAfterPreRuns` removed the initial container after promoting. I copied that step from the ZFS ready-snapshot block directly above it, but the two are not interchangeable:

- `case useZFSSnapshot:` in the per-test loop builds a fresh container for **every** test.
- The plain `container-recreate` branch recreates only from the **second** test onwards (`i > 0`); test 0 runs on the initial container.

So the promote deleted the client that test 0 was about to use, and nothing recreated it.

## Fix

Restart the same container rather than removing it. Promote unmounts the volume so the client has to stop, but it comes straight back on the remounted baseline. Test 0 then runs on it, and `i > 0` recreates as before — each recreate restoring the promoted baseline, which is the point of promoting. Log streaming is re-attached across the restart, matching the strategy's own pre-checkpoint restart.

## Not fixed here

benchmarkoor does not notice its client container dying mid-run: the executor retried a dead endpoint for ~20 minutes and would have continued for days. That is independent of this bug — it is what turned a clear failure into a hang — and deserves its own fix.

## Checks

`go build`, `go vet`, `gofmt`, `golangci-lint --new-from-rev=origin/master` (0 issues) and `pkg/runner` under `-race` all clean.