### PR TITLE
fix(runner): a run that benchmarked nothing must not exit 0

### DIFF
--- a/cmd/benchmarkoor/run.go
+++ b/cmd/benchmarkoor/run.go
@@ -149,6 +149,11 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		log.WithField("signal", sig).Fatal("Received second signal, forcing exit")
 	}()
 
+	// A failed instance does not stop the others, but it must not be swallowed
+	// either: CI runs one client per job, so an instance that never benchmarked
+	// anything reported a green job.
+	var failedInstances []string
+
 	if !cfg.Runner.Benchmark.SkipTestRun {
 		// Filter instances if limits are specified (before validation so we
 		// can scope datadir checks to active instances only).
@@ -347,6 +352,8 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 			if err := r.RunInstance(ctx, &instance); err != nil {
 				log.WithError(err).WithField("instance", instance.ID).Error("Instance failed")
 
+				failedInstances = append(failedInstances, instance.ID)
+
 				// Continue with next instance on failure.
 				continue
 			}
@@ -371,6 +378,15 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		if err := generateSuiteStats(cmd, cfg, resultsOwner); err != nil {
 			log.WithError(err).Warn("Failed to generate suite stats")
 		}
+	}
+
+	// Reported last so the results index, suite stats and markdown summaries are
+	// still written for whatever did run.
+	if len(failedInstances) > 0 {
+		return fmt.Errorf(
+			"%d instance(s) failed: %s",
+			len(failedInstances), strings.Join(failedInstances, ", "),
+		)
 	}
 
 	return nil

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -1465,6 +1465,14 @@ func (r *runner) runContainerLifecycle(
 		return fmt.Errorf("container died during execution")
 	}
 
+	// A run that benchmarked nothing — a pre-run replay that could not be
+	// applied, an RPC that never came up — has already written its results and
+	// logged its status, but returning nil here let the process exit 0 and the
+	// CI job go green on a run that produced no numbers.
+	if runConfig.Status == RunStatusFailed {
+		return fmt.Errorf("run failed: %s", runConfig.TerminationReason)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Problem

A run whose pre-run replay fails sets `runConfig.Status = failed`, logs `Test execution failed`, writes its results — and then returns `nil` all the way out of the process. The CI job goes **green** on a run that produced no numbers.

This is not hypothetical. Two jochemnet nethermind runs died in the pre-run bundle and both reported success:

- [31299851087](https://github.com/ethpandaops/benchmarkoor-tests/actions/runs/31299851087)
- [31300040869](https://github.com/ethpandaops/benchmarkoor-tests/actions/runs/31300040869)

Both logged:

```
ERRO | Test execution failed component=runner error=running pre-run steps before schelk promote: ...
INFO | Run completed component=runner instance=nethermind-bal-full status=failed
```

...and the workflow still concluded `success`. The failure went unnoticed for a day while the jochemnet suite looked healthy.

`action.yaml` propagates exit codes correctly — it just never received a non-zero one.

## Cause

Two places swallow it:

- `pkg/runner/lifecycle.go` — `RunInstance` returns an error only when `containerDied`. The `execErr` path records the status and returns `nil`.
- `cmd/benchmarkoor/run.go` — the instance loop logs `Instance failed` and `continue`s, then the command returns `nil`.

## Fix

- `RunInstance` returns the run's own terminal status when it is `RunStatusFailed`.
- `run.go` collects failed instance IDs and returns a non-zero error at the end.

The aggregate is reported **after** the results index, suite stats and markdown summaries are written, so a failed run still produces all of its artifacts — it just also fails the job.

Continuing past a failed instance is preserved deliberately: a multi-client run should still attempt the rest. Only the final exit code changes. In CI each job runs a single client (`--limit-instance-client`), so a failed instance always means a failed job.

## Verification

- `make build` + `go test ./pkg/runner/... ./cmd/...` pass
- `golangci-lint run` on both changed packages: 0 issues
- Both `RunStatusFailed` assignment sites (`lifecycle.go:1003` waiting-for-RPC, `lifecycle.go:1337` exec error) are genuine failures, so no previously-legitimate green run turns red.