### PR TITLE
feat(runner): compact the client database before the benchmarks

### DIFF
--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -219,7 +219,7 @@ jobs:
                   - name: payload-generator-besu
                     filler_client: besu
                     # besu image carrying testing_buildBlockV1 (drives fill-stateful).
-                    filler_image: ethpandaops/besu:bal-devnet-7
+                    filler_image: ethpandaops/besu:glamsterdam-devnet-8
                     source_dir: /tmp/benchmarkoor/state-actor/besu
                     genesis: /tmp/benchmarkoor/state-actor/besu/besu-chainspec.json
                     output_dir: /tmp/benchmarkoor/eest-fixtures/besu
@@ -265,7 +265,7 @@ jobs:
                   extra_args: [--Init.BaseDbPath=/data]
                 - id: besu
                   client: besu
-                  image: ethpandaops/besu:bal-devnet-7
+                  image: ethpandaops/besu:glamsterdam-devnet-8
                   extra_args: [--p2p-enabled=true]
 
   # Exercises the pre_runs builder end-to-end: state-actor builds an OSAKA besu
@@ -363,7 +363,7 @@ jobs:
                   - name: pre-run-besu
                     filler_client: besu
                     # besu image carrying testing_buildBlockV1 (drives fill-stateful).
-                    filler_image: ethpandaops/besu:bal-devnet-7
+                    filler_image: ethpandaops/besu:glamsterdam-devnet-8
                     source_dir: /tmp/benchmarkoor/state-actor/besu
                     genesis: /tmp/benchmarkoor/state-actor/besu/besu-chainspec.json
                     output_dir: /tmp/benchmarkoor/pre-runs/besu
@@ -383,7 +383,7 @@ jobs:
                 targets:
                   - name: payload-generator-besu
                     filler_client: besu
-                    filler_image: ethpandaops/besu:bal-devnet-7
+                    filler_image: ethpandaops/besu:glamsterdam-devnet-8
                     # Fill on the pre-run OUTPUT (the advanced datadir), not the raw snapshot.
                     source_dir: /tmp/benchmarkoor/pre-runs/besu
                     genesis: /tmp/benchmarkoor/state-actor/besu/besu-chainspec.json
@@ -423,7 +423,7 @@ jobs:
               instances:
                 - id: besu
                   client: besu
-                  image: ethpandaops/besu:bal-devnet-7
+                  image: ethpandaops/besu:glamsterdam-devnet-8
                   extra_args: [--p2p-enabled=true]
 
       # Same fixtures and the same pre-run bundle as the besu step above, on
@@ -477,4 +477,4 @@ jobs:
               instances:
                 - id: geth
                   client: geth
-                  image: ethpandaops/geth:master
+                  image: ethpandaops/geth:glamsterdam-devnet-8

--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -376,7 +376,12 @@ jobs:
                   datadir_method: copy
                   # The snapshot is already at gas_limit, so the gas-bump is a no-op.
                   gas_limit: 300000000
-                  gas_benchmark_values: [10]
+                  # The benchmark value is the block gas limit the fill packs
+                  # transactions into. One amsterdam max-code-size deployment
+                  # costs ~107 Mgas (create_state_gas dominates), so 10 Mgas
+                  # cannot hold a single one. 150 clears it and still fits the
+                  # chain's own 300 Mgas block limit, so no gas-bump ramp runs.
+                  gas_benchmark_values: [150]
                   # Deploy only a handful of receiver contracts so the setup fill
                   # stays tiny for CI (default is 100k).
                   fill_env:

--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -272,9 +272,16 @@ jobs:
   # snapshot, the pre_runs builder advances it (a tiny test_setup_contracts fill
   # via the besu filler — deploying a handful of receiver contracts and recording
   # a replay bundle), eest_payloads fills the bloatnet account-access benchmark on
-  # that ADVANCED datadir, then the runner replays those fixtures on besu. Single
-  # client + a 256 MB snapshot keep it within a GitHub-hosted runner; osaka means
-  # no amsterdam system-contract predeploys are needed.
+  # that ADVANCED datadir, then the runner replays those fixtures on besu and on
+  # geth. A 256 MB snapshot keeps it within a GitHub-hosted runner.
+  #
+  # Both fills target AMSTERDAM: test_setup_contracts is valid_from("Amsterdam"),
+  # so an osaka fill selects no tests at all. The snapshot itself stays osaka and
+  # every client activates amsterdam at timestamp 1, which makes the whole
+  # synthetic chain amsterdam. That needs the EIP-8282 builder-request contracts
+  # in the genesis (below): amsterdam system-calls both at the end of every
+  # block, and a strict client rejects a block whose system contracts have no
+  # code.
   pre-runs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -324,6 +331,21 @@ jobs:
                       template: create2_factory
                       name: deterministic-deployment-proxy
                       address: 0x4e59b44847b379578588920cA78FbF26c0B4956C
+                    # EIP-8282 builder-execution-request predeploys. Amsterdam
+                    # system-calls both at the end of every block, and a strict
+                    # client rejects a block whose system contracts have no code.
+                    # The addresses and code are the glamsterdam-devnet-7/8 pair;
+                    # do NOT reuse the devnet-6 one.
+                    - kind: contract
+                      name: eip8282-builder-deposit-requests
+                      address: 0x0000bFF46984e3725691FA540a8C7589300D8282
+                      nonce: 1
+                      code: "0x3373fffffffffffffffffffffffffffffffffffffffe1461011c575f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff146102705760015460088111605257506058565b60089003015b601190600182026001905f5b5f821115607f57810190830284830290049160010191906064565b90939004925050503660b814609f57366102705734610270575f5260205ff35b8034106102705760383567ffffffffffffffff1680633b9aca001161027057633b9aca00029034031061027057600154600101600155600354806006026004015f358155600101602035815560010160403581556001016060358155600101608035815560010160a035905560b85f5f3760b85fa0600101600355005b60035460025480820380604011610131575060405b5f5b8181146101d7578281016006026004018160b8028154815260200181600101548152602001816002015480825260401c67ffffffffffffffff16816010018160381c81600701538160301c81600601538160281c81600501538160201c81600401538160181c81600301538160101c81600201538160081c816001015353602001816003015481526020018160040154815260200190600501549052600101610133565b91018092146101e957906002556101f4565b90505f6002555f6003555b36610242575f54600154817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1461023057600882820111610238575b50505f610264565b0160089003610264565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b5f555f60015560b8025ff35b5f5ffd"
+                    - kind: contract
+                      name: eip8282-builder-exit-requests
+                      address: 0x000064D678505ad48F8cCb093BC65613800E8282
+                      nonce: 1
+                      code: "0x3373fffffffffffffffffffffffffffffffffffffffe1460e1575f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff146101c65760015460028111605157506057565b60029003015b601190600182026001905f5b5f821115607e57810190830284830290049160010191906063565b909390049250505036603014609e57366101c657346101c6575f5260205ff35b34106101c657600154600101600155600354806003026004013381556001015f35815560010160203590553360601b5f5260305f60143760445fa0600101600355005b6003546002548082038060101160f5575060105b5f5b81811461012d5782810160030260040181604402815460601b8152601401816001015481526020019060020154905260010160f7565b910180921461013f579060025561014a565b90505f6002555f6003555b36610198575f54600154817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff146101865760028282011161018e575b50505f6101ba565b01600290036101ba565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b5f555f6001556044025ff35b5f5ffd"
                     # Pre-fund fill-stateful's seed (rpc_seed_key=0x..01 below), so
                     # the pre-run does not need a funding block.
                     - kind: eoa
@@ -347,7 +369,9 @@ jobs:
                 eest_repo: https://github.com/skylenet/execution-specs.git
                 eest_ref: fix/no-reset-reanchor-start-block
                 config:
-                  fork: osaka
+                  # test_setup_contracts is valid_from("Amsterdam"), so an osaka
+                  # fill selects nothing and pytest exits 5.
+                  fork: amsterdam
                   rpc_seed_key: "0x0000000000000000000000000000000000000000000000000000000000000001"
                   datadir_method: copy
                   # The snapshot is already at gas_limit, so the gas-bump is a no-op.
@@ -366,13 +390,16 @@ jobs:
                     filler_image: ethpandaops/besu:glamsterdam-devnet-8
                     source_dir: /tmp/benchmarkoor/state-actor/besu
                     genesis: /tmp/benchmarkoor/state-actor/besu/besu-chainspec.json
+                    # state-actor writes an osaka chainspec; activate amsterdam
+                    # from the first block of this synthetic chain.
+                    genesis_fork_override: { amsterdam: 1 }
                     output_dir: /tmp/benchmarkoor/pre-runs/besu
               eest_payloads:
                 pull_policy: always
                 eest_repo: https://github.com/skylenet/execution-specs.git
                 eest_ref: fix/no-reset-reanchor-start-block
                 config:
-                  fork: osaka
+                  fork: amsterdam
                   rpc_seed_key: "0x0000000000000000000000000000000000000000000000000000000000000001"
                   gas_benchmark_values: [10]
                   datadir_method: copy
@@ -387,6 +414,9 @@ jobs:
                     # Fill on the pre-run OUTPUT (the advanced datadir), not the raw snapshot.
                     source_dir: /tmp/benchmarkoor/pre-runs/besu
                     genesis: /tmp/benchmarkoor/state-actor/besu/besu-chainspec.json
+                    # Same amsterdam schedule as the pre-run, so this boot reads
+                    # the advanced datadir as amsterdam.
+                    genesis_fork_override: { amsterdam: 1 }
                     output_dir: /tmp/benchmarkoor/eest-fixtures/besu
 
       - name: Run benchmarks (besu)
@@ -424,6 +454,8 @@ jobs:
                 - id: besu
                   client: besu
                   image: ethpandaops/besu:glamsterdam-devnet-8
+                  # Same amsterdam schedule the fills used.
+                  genesis_fork_override: { amsterdam: 1 }
                   extra_args: [--p2p-enabled=true]
 
       # Same fixtures and the same pre-run bundle as the besu step above, on
@@ -478,3 +510,6 @@ jobs:
                 - id: geth
                   client: geth
                   image: ethpandaops/geth:glamsterdam-devnet-8
+                  # geth reads the genesis from the datadir, so the fork
+                  # schedule comes from the flag rather than a genesis override.
+                  extra_args: [--override.amsterdam=1]

--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -277,7 +277,7 @@ jobs:
   # no amsterdam system-contract predeploys are needed.
   pre-runs:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -308,6 +308,7 @@ jobs:
               state_actor:
                 images:
                   besu: ghcr.io/ethereum/state-actor-besu:main
+                  geth: ghcr.io/ethereum/state-actor:main
                 pull_policy: always
                 config:
                   seed: 1234
@@ -333,6 +334,11 @@ jobs:
                 targets:
                   - client: besu
                     output_dir: /tmp/benchmarkoor/state-actor/besu
+                  # Same seed + spec, so geth's snapshot carries the same state as
+                  # besu's. The db-compaction step below boots geth on it and
+                  # replays besu's pre-run bundle to reach the same setup head.
+                  - client: geth
+                    output_dir: /tmp/benchmarkoor/state-actor/geth
               # Advance the snapshot: boot besu, run a tiny setup fill (with
               # fill-stateful --no-reset-between-tests, so the deployed contracts
               # persist), and record a replay bundle under the output_dir.
@@ -419,3 +425,56 @@ jobs:
                   client: besu
                   image: ethpandaops/besu:bal-devnet-7
                   extra_args: [--p2p-enabled=true]
+
+      # Same fixtures and the same pre-run bundle as the besu step above, on
+      # geth with runner.client.config.db_compaction enabled. geth cannot boot
+      # besu's datadir, so it boots its OWN raw snapshot and replays besu's
+      # recorded bundle to reach the setup head. Both compaction phases run:
+      # before_pre_runs (before the client boots, so before the replay) and
+      # before_benchmarks (a graceful stop, compact, and restart after it).
+      - name: Run benchmarks with db compaction (geth)
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          git-ref: ${{ github.event.pull_request.head.sha }}
+          git-repo: ${{ github.event.pull_request.head.repo.clone_url }}
+          mode: run
+          run-config-urls: >-
+            https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-cleanup.yaml,
+            https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-clientstdout.yaml
+          run-config: |
+            runner:
+              benchmark:
+                tests:
+                  source:
+                    eest_fixtures:
+                      local_fixtures_dir: /tmp/benchmarkoor/eest-fixtures/besu
+                      fixtures_subdir: blockchain_tests_stateful_engine
+                      # Replay besu's recorded pre-run bundle on geth's raw
+                      # snapshot; fixtures_subdir defaults to "pre_run_bundle".
+                      pre_runs:
+                        local_fixtures_dir: /tmp/benchmarkoor/pre-runs/besu
+              client:
+                config:
+                  bootstrap_fcu:
+                    enabled: true
+                    max_retries: 10
+                    backoff: 1s
+                  # `geth db compact`, with `geth db inspect` either side of it.
+                  # No persist: datadir_method is copy, so the compaction is
+                  # run-local, which is what CI wants.
+                  db_compaction:
+                    enabled: true
+                    when: [before_pre_runs, before_benchmarks]
+                    inspect: true
+                    timeout: 20m
+                # No genesis entry for geth: state-actor bakes the genesis into
+                # the snapshot datadir it builds.
+                datadirs:
+                  geth:
+                    source_dir: /tmp/benchmarkoor/state-actor/geth
+                    method: copy
+              instances:
+                - id: geth
+                  client: geth
+                  image: ethpandaops/geth:master

--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -410,8 +410,18 @@ jobs:
                   datadir_method: copy
                   tests:
                     - tests/benchmark/stateful/bloatnet/test_account_query.py
-                  # Keep the fixture set small for CI (CALLCODE variants only).
-                  filter: test_account_access and CALLCODE
+                  # Keep the fixture set small for CI, and select only the
+                  # variants whose targets this job actually deploys.
+                  #
+                  # A 10 Mgas benchmark walks ~3300 receivers, and the setup
+                  # fill above deploys 10 per mode. At amsterdam each max-size
+                  # deployment costs 40-107 Mgas (create_state_gas), so a
+                  # receiver set that large is not affordable here — the fill
+                  # fails the EXISTING_* variants with
+                  # DeployedAccountVerificationError. The NON_EXISTING_ACCOUNT
+                  # variants need no predeployed state at all, so they fill on
+                  # the advanced datadir and still exercise the whole pipeline.
+                  filter: test_account_access and CALLCODE and NON_EXISTING
                 targets:
                   - name: payload-generator-besu
                     filler_client: besu

--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -344,8 +344,8 @@ jobs:
               # persist), and record a replay bundle under the output_dir.
               pre_runs:
                 pull_policy: always
-                eest_repo: https://github.com/LouisTsai-Csie/execution-specs.git
-                eest_ref: full-benchmark-target
+                eest_repo: https://github.com/skylenet/execution-specs.git
+                eest_ref: fix/no-reset-reanchor-start-block
                 config:
                   fork: osaka
                   rpc_seed_key: "0x0000000000000000000000000000000000000000000000000000000000000001"
@@ -369,8 +369,8 @@ jobs:
                     output_dir: /tmp/benchmarkoor/pre-runs/besu
               eest_payloads:
                 pull_policy: always
-                eest_repo: https://github.com/LouisTsai-Csie/execution-specs.git
-                eest_ref: full-benchmark-target
+                eest_repo: https://github.com/skylenet/execution-specs.git
+                eest_ref: fix/no-reset-reanchor-start-block
                 config:
                   fork: osaka
                   rpc_seed_key: "0x0000000000000000000000000000000000000000000000000000000000000001"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -590,6 +590,25 @@ runner:
       # opcode_extraction:
       #   enabled: true
       #   timeout: 2m   # per-block trace timeout; default 2m
+      # Optional: Compact the client database before the run measures anything.
+      # The client is stopped for it (compaction needs the database lock), so the
+      # runner runs the client's own offline command in a one-shot container.
+      # Only geth ships one today (`geth db compact`). Per-instance override allowed.
+      # db_compaction:
+      #   enabled: true
+      #   # Both phases may be listed; they always run in lifecycle order.
+      #   #   before_pre_runs   - before the client boots (needs a datadir)
+      #   #   before_benchmarks - after the pre-run steps, before the first test
+      #   when: [before_benchmarks]
+      #   inspect: true        # `geth db inspect` before and after; default true
+      #   timeout: 3h          # per phase; default 3h
+      #   # extra_args: ["--cache=16384"]
+      #   # Keep the compacted database for later runs. Only datadir methods
+      #   # "schelk" and "zfs" support it, and both overwrite the baseline
+      #   # irreversibly. zfs persists at before_pre_runs only.
+      #   # persist:
+      #   #   enabled: true
+      #   #   phases: [before_pre_runs]
       # Optional: Container resource limits (applied to all instances by default).
       # resource_limits:
       #   # CPU pinning - use ONE of the following:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -789,6 +789,7 @@ runner:
 | `post_test_sleep_duration` | string | - | Sleep duration after each test, e.g. `200ms`, `1s` (see below) |
 | `bootstrap_fcu` | bool/object | - | Send an `engine_forkchoiceUpdatedV3` after RPC is ready to confirm the client is fully synced (see [Bootstrap FCU](#bootstrap-fcu)) |
 | `opcode_extraction` | object | - | Extract per-test opcode counts via `debug_traceBlockByNumber` after each test step (see [Opcode Extraction](#opcode-extraction)) |
+| `db_compaction` | object | - | Compact the client database before the run measures anything (see [Database Compaction](#database-compaction)) |
 | `genesis` | map | - | Genesis file URLs keyed by client type |
 
 ##### Drop Memory Caches
@@ -1118,6 +1119,151 @@ runner:
 - When you want a ground-truth opcode profile of every benchmarked test (instead of relying on `opcode_source` JSON shipped from a separate pipeline)
 - When investigating client-vs-client divergence in EVM execution paths
 
+##### Database Compaction
+
+The `db_compaction` option compacts the client database before the run measures anything. Compaction needs exclusive access to the database, so the client is never running while it happens: the runner runs the client's own offline command in a one-shot container against the datadir.
+
+Only clients that ship an offline compaction command support this. Today that is **geth** alone (`geth db compact`); every other client fails validation with a clear message.
+
+Besu was checked and cannot be supported yet: as of Besu 26.6.1, `besu storage` has no compaction subcommand. `trie-log prune` deletes trie logs below the retention limit instead of rewriting the database, which is a different operation and removes history the Bonsai rollback needs.
+
+```yaml
+runner:
+  client:
+    config:
+      db_compaction:
+        enabled: true
+        when: [before_benchmarks]   # or [before_pre_runs], or both
+        inspect: true               # `geth db inspect` before and after
+        timeout: 3h
+        extra_args: ["--cache=16384"]
+```
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `enabled` | bool | Yes | `false` | Enable the compaction |
+| `when` | []string | No | `[before_benchmarks]` | The lifecycle points at which to compact (see below). A plain string also works |
+| `inspect` | bool | No | `true` | Run the client database inspection before and after each compaction. A failed inspection is logged and never fails the run |
+| `timeout` | string | No | `3h` | Cap for one phase's work — the compaction and both inspections (Go duration). Applies per phase |
+| `image` | string | No | the instance image | Image of the compaction container. The default keeps the tool version and the client version identical |
+| `extra_args` | []string | No | - | Extra arguments for the compaction command, e.g. `--cache=16384` |
+| `continue_on_error` | bool | No | `false` | Downgrade a compaction failure to a warning. A failed compaction makes the results incomparable, so the run fails by default |
+| `skip_if_marked` | bool | No | `true` with `persist`, else `false` | Skip a phase the datadir marker already names (see below) |
+| `persist` | object | No | - | Write the compacted database back to the datadir baseline (see below) |
+
+`db_compaction` can be set globally under `runner.client.config` and/or per-instance under `runner.instances[]`. Instance-level config (when non-nil) fully replaces the global default.
+
+###### Phases
+
+| `when` value | When it runs | Client |
+|--------------|--------------|--------|
+| `before_pre_runs` | After the datadir is prepared, before the client boots — so before the suite pre-run steps replay | Not yet started. No stop and restart |
+| `before_benchmarks` | After the pre-run steps, before the first test | Stopped gracefully, then started again |
+
+Both phases may be listed. The runner always executes them in lifecycle order, whatever order they are written in:
+
+```yaml
+db_compaction:
+  enabled: true
+  when: [before_pre_runs, before_benchmarks]
+```
+
+`before_benchmarks` is the default because the pre-run bundle writes blocks that undo most of what an earlier compaction achieved. It also lands before the state-baking step of every runner-level rollback strategy, so the compacted database goes into the ZFS ready-snapshot, the CRIU checkpoint, or the schelk promote for free.
+
+`before_pre_runs` needs a pre-populated datadir: without one the database is created when the client boots.
+
+###### Persisting the compacted database
+
+Without `persist`, the compaction is run-local: it costs the same time on every run, and the clone, copy, or restored volume that holds it is destroyed at the end. `persist` writes it back to the baseline instead.
+
+```yaml
+db_compaction:
+  enabled: true
+  when: [before_pre_runs]
+  persist:
+    enabled: true
+    safety_snapshot: true   # ZFS only
+```
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `enabled` | bool | Yes | `false` | Persist the compacted database |
+| `phases` | []string | No | every phase in `when` | Restrict the persist to a subset of `when` |
+| `safety_snapshot` | bool | No | `true` | Snapshot the ZFS source dataset before it is compacted in place. ZFS only |
+
+The mechanism comes from `datadir.method`, so there is one knob and no way to pair the wrong mechanism with the wrong method:
+
+| `datadir.method` | `before_pre_runs` | `before_benchmarks` |
+|------------------|-------------------|---------------------|
+| `schelk` | `schelk promote` makes the compacted volume the new baseline | Same, folded into the existing promote |
+| `zfs` | The source dataset is compacted in place, before the snapshot and the clone | Not supported |
+| `direct` | Already permanent: the client writes to `source_dir` itself | Same |
+| `copy`, `overlayfs`, `fuse-overlayfs` | Not supported | Not supported |
+
+Two rules follow from the mechanisms:
+
+- **ZFS persists only at `before_pre_runs`.** The clone is a child of its source dataset, so no promote or rename puts the compacted clone back at the source path. Compacting the source first also keeps the clone small, since a compaction inside a copy-on-write clone rewrites the whole database into it.
+- **A schelk persist at `before_benchmarks` needs `promote_post_pre_runs: true`.** Persisting there moves the baseline head past the pre-run bundle, which is exactly what that option does. Requiring it keeps the decision explicit, and lets the runner persist both with a single promote.
+
+> **A persist is destructive and irreversible.** It overwrites the golden image. On ZFS, `safety_snapshot` leaves a `<dataset>@benchmarkoor-precompaction-<run-id>` snapshot that a `zfs rollback` restores exactly.
+
+###### The datadir marker
+
+A finished compaction writes `.benchmarkoor-db-compaction.json` at the root of the datadir it compacted, so a persisted baseline says what has already been done to it:
+
+```json
+{
+  "version": 1,
+  "phases": {
+    "before_pre_runs": {
+      "client": "geth",
+      "image": "ethereum/client-go:stable",
+      "run_id": "20260827-101203-abcd",
+      "completed_at": "2026-08-27T10:12:03Z",
+      "duration_ms": 812345,
+      "datadir_bytes": { "before": 812000000000, "after": 640000000000 }
+    }
+  }
+}
+```
+
+It holds only what is known the moment the compaction finishes, so it is written once and never patched. With `persist` enabled, `skip_if_marked` defaults to true and a later run skips a phase the marker already names — which is what stops every run paying the compaction cost again.
+
+The marker cannot tell that a datadir advanced after it was written. If you point a longer pre-run bundle at a baseline persisted at `before_benchmarks`, set `skip_if_marked: false` to force the compaction.
+
+###### Rollback strategy
+
+`container-recreate` re-prepares the datadir for every test, so the runner rejects a compaction it would discard at the first recreate:
+
+| `datadir.method` | `container-recreate` |
+|------------------|----------------------|
+| `zfs` | Supported. The ready-snapshot carries the compaction |
+| `schelk` | Needs `db_compaction.persist.enabled: true` |
+| `copy`, `overlayfs`, `fuse-overlayfs` | Rejected |
+| none (fresh volume per test) | Rejected |
+
+###### Output
+
+Each phase writes its reports to the run results directory:
+
+```
+<run-results>/db-compaction/
+  before_pre_runs/inspect-before.txt
+  before_pre_runs/compact.log
+  before_pre_runs/inspect-after.txt
+  before_pre_runs/compaction.json
+  before_benchmarks/...
+```
+
+`compaction.json` records the command, the duration, the datadir size either side, and — at `before_benchmarks` only, where the runner reads it from the client it is about to stop — the datadir head.
+
+The inspection is a report, so a failure is logged and the compaction still runs. geth 1.17.5 exits 1 on `db inspect` against a datadir whose freezer is empty, which a freshly-initialised datadir has.
+
+**When to use:**
+- When benchmarking on a snapshot whose database has poor key locality after a long fill or replay
+- When you want every client to start from a database in the same shape, rather than one that reflects how the snapshot was built
+- With `persist`, when you want to pay the compaction cost once and have every later run start from the compacted baseline
+
 #### Data Directories
 
 The `runner.client.datadirs` section configures pre-populated data directories per client type. When configured, the init container is skipped and data is mounted directly.
@@ -1286,6 +1432,7 @@ runner:
 | `post_test_sleep_duration` | string | No | From `runner.client.config` | Instance-specific post-test sleep duration |
 | `bootstrap_fcu` | bool/object | No | From `runner.client.config` | Instance-specific bootstrap FCU setting |
 | `opcode_extraction` | object | No | From `runner.client.config` | Instance-specific opcode extraction setting (replaces global) |
+| `db_compaction` | object | No | From `runner.client.config` | Instance-specific database compaction setting (replaces global) |
 
 #### Genesis Fork & EIP Overrides
 

--- a/pkg/builder/eest_payloads.go
+++ b/pkg/builder/eest_payloads.go
@@ -890,7 +890,7 @@ func (b *EESTPayloadsBuilder) backfillFillSidecarIfMissing(log logrus.FieldLogge
 }
 
 // eestSHAFromFingerprint recovers the EEST commit recorded in the build
-// fingerprint sidecar, if present ("" when absent/unparseable).
+// fingerprint sidecar, if present ("" when absent/unparsable).
 func eestSHAFromFingerprint(outputDir string) string {
 	data, err := os.ReadFile(filepath.Join(outputDir, buildSidecarFile))
 	if err != nil {
@@ -915,7 +915,7 @@ func eestSHAFromFingerprint(outputDir string) string {
 // failed/errored count from the pytest json report. It is written even after a
 // failed fill (fill-stateful continues through failures and still writes both the
 // fixtures and the reports), so a failed target is still fully described.
-// Best-effort: missing/unparseable reports yield zero counts rather than an error.
+// Best-effort: missing/unparsable reports yield zero counts rather than an error.
 func recordEESTFillResult(t *config.EESTPayloadTarget, eestSHA string) error {
 	result := struct {
 		SourceDir    string `json:"source_dir"`

--- a/pkg/client/besu.go
+++ b/pkg/client/besu.go
@@ -116,3 +116,19 @@ func (s *besuSpec) DefaultConfigFiles() map[string]string {
 func (s *besuSpec) SnapshotPrepareArgs() []string {
 	return nil
 }
+
+// DBMaintenanceCommands returns nil: Besu ships no offline compaction command.
+//
+// Checked against Besu 26.6.1. `besu storage` offers revert-variables,
+// rocksdb {usage, x-stats}, trie-log {count, prune, export, import},
+// revert-metadata and prune-pre-merge-blocks, and no --Xplugin-rocksdb-*
+// option compacts either. `trie-log prune` is the nearest thing operators
+// reach for, but it DELETES trie logs below the retention limit rather than
+// rewriting the SSTs — a different operation, and one that takes away the
+// history the Bonsai rollback needs between tests.
+//
+// `besu --data-path=<dir> storage rocksdb usage` would serve as the Inspect
+// side, but Compact is what makes a client supported, so this stays nil.
+func (s *besuSpec) DBMaintenanceCommands(_ string) *DBMaintenanceCommands {
+	return nil
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -38,6 +38,20 @@ type RPCRollbackSpec struct {
 	RPCMethod string // e.g. "debug_setHead", "debug_resetHead"
 }
 
+// DBMaintenanceCommands holds the client argv for offline database
+// maintenance, run in a one-shot container against the datadir.
+//
+// The client must NOT be running: both commands need exclusive access to the
+// database, and a second process holding the lock makes them fail.
+type DBMaintenanceCommands struct {
+	// Compact rewrites the database to reclaim space and restore key locality.
+	Compact []string
+
+	// Inspect prints a report of the database contents. Optional: a client
+	// that can compact but not inspect leaves it nil.
+	Inspect []string
+}
+
 // Spec provides client-specific container configuration.
 type Spec interface {
 	// Type returns the client type.
@@ -91,6 +105,12 @@ type Spec interface {
 
 	// SnapshotPrepareArgs returns args for the ZFS snapshot-prep container only (not per-test measurement); nil if none.
 	SnapshotPrepareArgs() []string
+
+	// DBMaintenanceCommands returns the argv for offline database inspection
+	// and compaction against dataDir. Returns nil when the client ships no
+	// such command, which is what makes runner.client.config.db_compaction
+	// unavailable for it.
+	DBMaintenanceCommands(dataDir string) *DBMaintenanceCommands
 }
 
 // Registry manages client specifications.
@@ -121,6 +141,20 @@ func NewRegistry() Registry {
 type registry struct {
 	mu    sync.RWMutex
 	specs map[ClientType]Spec
+}
+
+// SupportsDBCompaction reports whether the client ships an offline compaction
+// command. It is the single source of truth for whether
+// runner.client.config.db_compaction can be enabled for a client.
+func SupportsDBCompaction(clientType ClientType) bool {
+	spec, err := NewRegistry().Get(clientType)
+	if err != nil {
+		return false
+	}
+
+	cmds := spec.DBMaintenanceCommands("/data")
+
+	return cmds != nil && len(cmds.Compact) > 0
 }
 
 // Ensure interface compliance.

--- a/pkg/client/erigon.go
+++ b/pkg/client/erigon.go
@@ -114,3 +114,9 @@ func (s *erigonSpec) DefaultConfigFiles() map[string]string {
 func (s *erigonSpec) SnapshotPrepareArgs() []string {
 	return nil
 }
+
+// DBMaintenanceCommands returns nil; benchmarkoor has no offline
+// compaction command for Erigon yet.
+func (s *erigonSpec) DBMaintenanceCommands(_ string) *DBMaintenanceCommands {
+	return nil
+}

--- a/pkg/client/ethrex.go
+++ b/pkg/client/ethrex.go
@@ -97,3 +97,9 @@ func (s *ethrexSpec) DefaultConfigFiles() map[string]string {
 func (s *ethrexSpec) SnapshotPrepareArgs() []string {
 	return nil
 }
+
+// DBMaintenanceCommands returns nil; benchmarkoor has no offline
+// compaction command for Ethrex yet.
+func (s *ethrexSpec) DBMaintenanceCommands(_ string) *DBMaintenanceCommands {
+	return nil
+}

--- a/pkg/client/geth.go
+++ b/pkg/client/geth.go
@@ -113,3 +113,16 @@ IdleTimeout = 120000000000 # 120s
 func (s *gethSpec) SnapshotPrepareArgs() []string {
 	return nil
 }
+
+// DBMaintenanceCommands returns geth's offline database commands.
+//
+// Both run against a STOPPED client: `geth db compact` takes the database
+// lock, so a running node makes it fail. The commands take --datadir rather
+// than inheriting the one in DefaultCommand, since a datadir config may mount
+// the data somewhere other than /data.
+func (s *gethSpec) DBMaintenanceCommands(dataDir string) *DBMaintenanceCommands {
+	return &DBMaintenanceCommands{
+		Compact: []string{"db", "compact", "--datadir=" + dataDir},
+		Inspect: []string{"db", "inspect", "--datadir=" + dataDir},
+	}
+}

--- a/pkg/client/nethermind.go
+++ b/pkg/client/nethermind.go
@@ -106,3 +106,9 @@ func (s *nethermindSpec) DefaultConfigFiles() map[string]string {
 func (s *nethermindSpec) SnapshotPrepareArgs() []string {
 	return nil
 }
+
+// DBMaintenanceCommands returns nil; benchmarkoor has no offline
+// compaction command for Nethermind yet.
+func (s *nethermindSpec) DBMaintenanceCommands(_ string) *DBMaintenanceCommands {
+	return nil
+}

--- a/pkg/client/nimbus.go
+++ b/pkg/client/nimbus.go
@@ -98,3 +98,9 @@ func (s *nimbusSpec) DefaultConfigFiles() map[string]string {
 func (s *nimbusSpec) SnapshotPrepareArgs() []string {
 	return nil
 }
+
+// DBMaintenanceCommands returns nil; benchmarkoor has no offline
+// compaction command for Nimbus yet.
+func (s *nimbusSpec) DBMaintenanceCommands(_ string) *DBMaintenanceCommands {
+	return nil
+}

--- a/pkg/client/reth.go
+++ b/pkg/client/reth.go
@@ -105,3 +105,9 @@ func (s *rethSpec) SnapshotPrepareArgs() []string {
 		"--engine.memory-block-buffer-target=0",
 	}
 }
+
+// DBMaintenanceCommands returns nil; benchmarkoor has no offline
+// compaction command for Reth yet.
+func (s *rethSpec) DBMaintenanceCommands(_ string) *DBMaintenanceCommands {
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1599,7 +1599,7 @@ func (c *DBCompactionConfig) SafetySnapshotEnabled() bool {
 }
 
 // EffectiveTimeout returns the per-phase compaction timeout, defaulting to
-// DefaultDBCompactionTimeout when unset or unparseable.
+// DefaultDBCompactionTimeout when unset or unparsable.
 func (c *DBCompactionConfig) EffectiveTimeout() time.Duration {
 	fallback, _ := time.ParseDuration(DefaultDBCompactionTimeout)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/ethpandaops/benchmarkoor/pkg/client"
 	"github.com/ethpandaops/benchmarkoor/pkg/cpufreq"
 	"github.com/ethpandaops/benchmarkoor/pkg/datadir"
 	"github.com/mitchellh/mapstructure"
@@ -1356,6 +1357,264 @@ func (c *OpcodeExtractionConfig) EffectiveTimeout() time.Duration {
 	return d
 }
 
+// Database compaction phases. DBCompactionConfig.When lists the points at
+// which the compaction runs; both may be listed.
+const (
+	// DBCompactionBeforePreRuns compacts before the client boots, so before
+	// the suite pre-run steps replay. No stop and restart is necessary.
+	DBCompactionBeforePreRuns = "before_pre_runs"
+
+	// DBCompactionBeforeBenchmarks compacts after the pre-run steps and
+	// before the first test. The runner stops the client gracefully,
+	// compacts, then starts it again.
+	DBCompactionBeforeBenchmarks = "before_benchmarks"
+
+	// DefaultDBCompactionTimeout caps one phase's compaction work.
+	DefaultDBCompactionTimeout = "3h"
+
+	// DBCompactionMarkerFile records a completed compaction at the root of
+	// the datadir it compacted. A persisted compaction carries it into the
+	// baseline, which is what lets a later run skip the work.
+	DBCompactionMarkerFile = ".benchmarkoor-db-compaction.json"
+
+	// DBCompactionResultsDir is the per-run output directory (under the run
+	// results dir) that holds the inspection reports and the compaction
+	// report, one subdirectory per phase.
+	DBCompactionResultsDir = "db-compaction"
+)
+
+// DBCompactionConfig asks benchmarkoor to compact the client database before
+// the run measures anything. Compaction needs exclusive access to the
+// database, so the client is never running while it happens.
+//
+// Set it on runner.client.config to apply it to every instance, or on a
+// single instance to override the default. The instance block fully replaces
+// the global one; it does not merge field by field.
+//
+// Only clients whose spec returns compaction commands support this. Today
+// that is geth alone.
+type DBCompactionConfig struct {
+	Enabled bool `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
+
+	// When selects the points in the lifecycle at which the compaction runs.
+	// Both phases may be listed; the runner always executes them in lifecycle
+	// order (before_pre_runs first), whatever order they are written in.
+	//
+	// A plain scalar also works: the StringToSliceHookFunc(",") decode hook in
+	// Load turns `when: before_pre_runs` and `when: "a,b"` into a list, so the
+	// BENCHMARKOOR_..._WHEN env override accepts a comma-separated value too.
+	//
+	// Default: ["before_benchmarks"].
+	When []string `yaml:"when,omitempty" mapstructure:"when" json:"when,omitempty"`
+
+	// Inspect runs the client database inspection before and after each
+	// compaction and writes both reports to the run results. Default: true.
+	Inspect *bool `yaml:"inspect,omitempty" mapstructure:"inspect" json:"inspect,omitempty"`
+
+	// Timeout caps one phase's compaction work as a Go duration string: the
+	// compaction and both inspections around it. It applies per phase, not to
+	// the pair. Default: DefaultDBCompactionTimeout.
+	Timeout string `yaml:"timeout,omitempty" mapstructure:"timeout" json:"timeout,omitempty"`
+
+	// Image overrides the image of the compaction container. Empty uses the
+	// instance image, which keeps the tool version and the client version
+	// identical.
+	Image string `yaml:"image,omitempty" mapstructure:"image" json:"image,omitempty"`
+
+	// ExtraArgs appends arguments to the compaction command, e.g.
+	// ["--cache=16384"] for geth.
+	ExtraArgs []string `yaml:"extra_args,omitempty" mapstructure:"extra_args" json:"extra_args,omitempty"`
+
+	// ContinueOnError downgrades a compaction failure to a warning and runs
+	// the benchmark anyway. Default: false, because a failed compaction makes
+	// the results incomparable with a successful one.
+	ContinueOnError bool `yaml:"continue_on_error,omitempty" mapstructure:"continue_on_error" json:"continue_on_error,omitempty"`
+
+	// SkipIfMarked skips a phase when the datadir already carries the marker
+	// a persisted compaction of that phase left behind. Set it to false to
+	// force a compaction. Default: true when Persist is enabled, false
+	// otherwise (nothing survives the run without a persist, so the marker
+	// can only be stale).
+	SkipIfMarked *bool `yaml:"skip_if_marked,omitempty" mapstructure:"skip_if_marked" json:"skip_if_marked,omitempty"`
+
+	// Persist writes the compacted database back to the datadir baseline, so
+	// later runs start from it. Only datadir methods "schelk" and "zfs"
+	// support this.
+	Persist *DBCompactionPersistConfig `yaml:"persist,omitempty" mapstructure:"persist" json:"persist,omitempty"`
+}
+
+// DBCompactionPersistConfig keeps the compacted database after the run.
+//
+// Without it the compaction is run-local: it costs the same time on every
+// run, and the clone, copy or restored volume that holds it is destroyed at
+// the end.
+//
+// The mechanism comes from the resolved datadir config, so there is one knob
+// and no way to pair the wrong mechanism with the wrong method:
+//   - "schelk": `schelk promote` makes the compacted volume the new baseline.
+//   - "zfs": the source dataset is compacted in place, before the snapshot and
+//     the clone are taken. This needs when: "before_pre_runs".
+//
+// Both are destructive and irreversible: they overwrite the golden image.
+type DBCompactionPersistConfig struct {
+	Enabled bool `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
+
+	// Phases restricts the persist to a subset of DBCompactionConfig.When.
+	// Empty means every phase in When. Each listed phase must also appear in
+	// When, and must be legal for the resolved datadir method.
+	Phases []string `yaml:"phases,omitempty" mapstructure:"phases" json:"phases,omitempty"`
+
+	// SafetySnapshot takes a `zfs snapshot <dataset>@benchmarkoor-precompaction-<run-id>`
+	// before it touches the source dataset. ZFS only. Default: true.
+	SafetySnapshot *bool `yaml:"safety_snapshot,omitempty" mapstructure:"safety_snapshot" json:"safety_snapshot,omitempty"`
+}
+
+// dbCompactionPhaseOrder is the lifecycle order of the phases. EffectiveWhen
+// returns its entries in this order, so a config that lists them the other way
+// round still runs them the only way the lifecycle allows.
+var dbCompactionPhaseOrder = []string{
+	DBCompactionBeforePreRuns,
+	DBCompactionBeforeBenchmarks,
+}
+
+// EffectiveWhen returns the phases at which the compaction runs, in lifecycle
+// order and without duplicates. An empty When defaults to
+// DBCompactionBeforeBenchmarks: the pre-run bundle writes blocks that undo
+// most of what an earlier compaction achieved.
+func (c *DBCompactionConfig) EffectiveWhen() []string {
+	if c == nil {
+		return nil
+	}
+
+	if len(c.When) == 0 {
+		return []string{DBCompactionBeforeBenchmarks}
+	}
+
+	return orderDBCompactionPhases(c.When)
+}
+
+// EffectivePersistPhases returns the phases whose result is written back to
+// the datadir baseline, in lifecycle order. An empty Persist.Phases means
+// every phase in EffectiveWhen.
+func (c *DBCompactionConfig) EffectivePersistPhases() []string {
+	if c == nil || c.Persist == nil || !c.Persist.Enabled {
+		return nil
+	}
+
+	if len(c.Persist.Phases) == 0 {
+		return c.EffectiveWhen()
+	}
+
+	return orderDBCompactionPhases(c.Persist.Phases)
+}
+
+// orderDBCompactionPhases returns the known phases in `phases`, in lifecycle
+// order and without duplicates. Unknown values are dropped; validation
+// rejects them before a run gets this far.
+func orderDBCompactionPhases(phases []string) []string {
+	ordered := make([]string, 0, len(dbCompactionPhaseOrder))
+
+	for _, known := range dbCompactionPhaseOrder {
+		for _, p := range phases {
+			if p == known {
+				ordered = append(ordered, known)
+
+				break
+			}
+		}
+	}
+
+	return ordered
+}
+
+// RunsAt reports whether the compaction runs at the given phase.
+func (c *DBCompactionConfig) RunsAt(phase string) bool {
+	if c == nil || !c.Enabled {
+		return false
+	}
+
+	for _, p := range c.EffectiveWhen() {
+		if p == phase {
+			return true
+		}
+	}
+
+	return false
+}
+
+// PersistsAt reports whether the compaction at the given phase is written back
+// to the datadir baseline.
+func (c *DBCompactionConfig) PersistsAt(phase string) bool {
+	if !c.RunsAt(phase) {
+		return false
+	}
+
+	for _, p := range c.EffectivePersistPhases() {
+		if p == phase {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Persists reports whether any phase is written back to the datadir baseline.
+func (c *DBCompactionConfig) Persists() bool {
+	return len(c.EffectivePersistPhases()) > 0
+}
+
+// InspectEnabled reports whether to run the database inspection either side of
+// a compaction. Defaults to true.
+func (c *DBCompactionConfig) InspectEnabled() bool {
+	if c == nil || c.Inspect == nil {
+		return true
+	}
+
+	return *c.Inspect
+}
+
+// SkipIfMarkedEnabled reports whether a phase the datadir marker already names
+// is skipped. Defaults to true when the compaction persists, since only a
+// persisted marker can describe the datadir in front of us.
+func (c *DBCompactionConfig) SkipIfMarkedEnabled() bool {
+	if c == nil {
+		return false
+	}
+
+	if c.SkipIfMarked != nil {
+		return *c.SkipIfMarked
+	}
+
+	return c.Persists()
+}
+
+// SafetySnapshotEnabled reports whether to snapshot a ZFS source dataset
+// before compacting it in place. Defaults to true.
+func (c *DBCompactionConfig) SafetySnapshotEnabled() bool {
+	if c == nil || c.Persist == nil || c.Persist.SafetySnapshot == nil {
+		return true
+	}
+
+	return *c.Persist.SafetySnapshot
+}
+
+// EffectiveTimeout returns the per-phase compaction timeout, defaulting to
+// DefaultDBCompactionTimeout when unset or unparseable.
+func (c *DBCompactionConfig) EffectiveTimeout() time.Duration {
+	fallback, _ := time.ParseDuration(DefaultDBCompactionTimeout)
+
+	if c == nil || c.Timeout == "" {
+		return fallback
+	}
+
+	d, err := time.ParseDuration(c.Timeout)
+	if err != nil {
+		return fallback
+	}
+
+	return d
+}
+
 // PostTestRPCCall defines an arbitrary RPC call to execute after the test step.
 type PostTestRPCCall struct {
 	Method  string     `yaml:"method" mapstructure:"method" json:"method"`
@@ -1586,6 +1845,7 @@ type ClientDefaults struct {
 	BootstrapFCU                     *BootstrapFCUConfig               `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
 	CheckpointRestoreStrategyOptions *CheckpointRestoreStrategyOptions `yaml:"checkpoint_restore_strategy_options,omitempty" mapstructure:"checkpoint_restore_strategy_options"`
 	OpcodeExtraction                 *OpcodeExtractionConfig           `yaml:"opcode_extraction,omitempty" mapstructure:"opcode_extraction"`
+	DBCompaction                     *DBCompactionConfig               `yaml:"db_compaction,omitempty" mapstructure:"db_compaction"`
 	Metadata                         MetadataConfig                    `yaml:"metadata,omitempty" mapstructure:"metadata"`
 }
 
@@ -1616,6 +1876,7 @@ type ClientInstance struct {
 	BootstrapFCU                     *BootstrapFCUConfig               `yaml:"bootstrap_fcu,omitempty" mapstructure:"bootstrap_fcu"`
 	CheckpointRestoreStrategyOptions *CheckpointRestoreStrategyOptions `yaml:"checkpoint_restore_strategy_options,omitempty" mapstructure:"checkpoint_restore_strategy_options"`
 	OpcodeExtraction                 *OpcodeExtractionConfig           `yaml:"opcode_extraction,omitempty" mapstructure:"opcode_extraction"`
+	DBCompaction                     *DBCompactionConfig               `yaml:"db_compaction,omitempty" mapstructure:"db_compaction"`
 	Metadata                         MetadataConfig                    `yaml:"metadata,omitempty" mapstructure:"metadata"`
 }
 
@@ -1822,6 +2083,14 @@ func bindEnvKeys(v *viper.Viper) {
 		"runner.client.config.retry_new_payloads_syncing_state.enabled",
 		"runner.client.config.retry_new_payloads_syncing_state.max_retries",
 		"runner.client.config.retry_new_payloads_syncing_state.backoff",
+		// Runner client db compaction
+		"runner.client.config.db_compaction.enabled",
+		"runner.client.config.db_compaction.when",
+		"runner.client.config.db_compaction.timeout",
+		"runner.client.config.db_compaction.image",
+		"runner.client.config.db_compaction.continue_on_error",
+		"runner.client.config.db_compaction.skip_if_marked",
+		"runner.client.config.db_compaction.persist.enabled",
 		// Runner client bootstrap FCU
 		"runner.client.config.bootstrap_fcu.enabled",
 		"runner.client.config.bootstrap_fcu.max_retries",
@@ -2219,6 +2488,11 @@ func (c *Config) Validate(opts ...ValidateOpts) error {
 
 	// Validate opcode_extraction settings.
 	if err := c.validateOpcodeExtraction(); err != nil {
+		return err
+	}
+
+	// Validate db_compaction settings.
+	if err := c.validateDBCompaction(opt); err != nil {
 		return err
 	}
 
@@ -3113,6 +3387,17 @@ func (c *Config) GetOpcodeExtraction(instance *ClientInstance) *OpcodeExtraction
 	return c.Runner.Client.Config.OpcodeExtraction
 }
 
+// GetDBCompaction returns the db-compaction config for an instance.
+// Instance-level config (when non-nil) fully replaces the global default.
+// Returns nil if not configured at either level.
+func (c *Config) GetDBCompaction(instance *ClientInstance) *DBCompactionConfig {
+	if instance.DBCompaction != nil {
+		return instance.DBCompaction
+	}
+
+	return c.Runner.Client.Config.DBCompaction
+}
+
 // GetCheckpointRestoreStrategyOptions returns the checkpoint-restore strategy
 // options for an instance. Instance-level config (when non-nil) fully replaces
 // the global default. Returns nil if not configured at either level.
@@ -3771,6 +4056,261 @@ func (c *Config) validateOpcodeExtraction() error {
 				instance.ID, cfg.Timeout,
 			)
 		}
+	}
+
+	return nil
+}
+
+// dbCompactionPersistMethods are the datadir methods that can write a
+// compacted database back to the baseline. Every other method throws the
+// compaction away when the run ends.
+var dbCompactionPersistMethods = map[string]bool{
+	"schelk": true,
+	"zfs":    true,
+}
+
+// dbCompactionEphemeralMethods re-prepare the datadir from the pristine source
+// for every test, so a container-recreate run discards the compaction at the
+// first recreate.
+var dbCompactionEphemeralMethods = map[string]bool{
+	"copy":           true,
+	"overlayfs":      true,
+	"fuse-overlayfs": true,
+}
+
+// validateDBCompaction validates db_compaction settings for active instances.
+//
+// It rejects the combinations that would silently do nothing (or do the work
+// once per test), rather than letting a run spend hours compacting a datadir
+// that is thrown away before the first benchmark.
+//
+//nolint:gocognit,cyclop // One rule per combination; splitting hides the matrix.
+func (c *Config) validateDBCompaction(opt ValidateOpts) error {
+	for i := range c.Runner.Instances {
+		instance := &c.Runner.Instances[i]
+
+		if !opt.isInstanceActive(instance.ID) {
+			continue
+		}
+
+		cfg := c.GetDBCompaction(instance)
+		if cfg == nil || !cfg.Enabled {
+			continue
+		}
+
+		if !client.SupportsDBCompaction(client.ClientType(instance.Client)) {
+			return fmt.Errorf(
+				"instance %q: db_compaction is not supported for client %q"+
+					" (no offline compaction command)",
+				instance.ID, instance.Client,
+			)
+		}
+
+		if err := validateDBCompactionPhases(instance.ID, cfg); err != nil {
+			return err
+		}
+
+		if cfg.Timeout != "" {
+			d, err := time.ParseDuration(cfg.Timeout)
+			if err != nil {
+				return fmt.Errorf(
+					"instance %q: invalid db_compaction.timeout %q: %w",
+					instance.ID, cfg.Timeout, err,
+				)
+			}
+
+			if d <= 0 {
+				return fmt.Errorf(
+					"instance %q: db_compaction.timeout must be positive, got %q",
+					instance.ID, cfg.Timeout,
+				)
+			}
+		}
+
+		dd := c.resolveDataDir(instance)
+		strategy := c.GetRollbackStrategy(instance)
+
+		// before_pre_runs compacts before the client has ever booted. Without a
+		// pre-populated datadir there is no database yet to compact.
+		if dd == nil && cfg.RunsAt(DBCompactionBeforePreRuns) {
+			return fmt.Errorf(
+				"instance %q: db_compaction.when %q needs a pre-populated datadir"+
+					" (without one the database is created when the client boots);"+
+					" use %q instead",
+				instance.ID, DBCompactionBeforePreRuns, DBCompactionBeforeBenchmarks,
+			)
+		}
+
+		if err := validateDBCompactionPersist(instance.ID, cfg, dd); err != nil {
+			return err
+		}
+
+		if err := validateDBCompactionStrategy(instance.ID, cfg, dd, strategy); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateDBCompactionPhases checks the `when` and `persist.phases` lists.
+func validateDBCompactionPhases(id string, cfg *DBCompactionConfig) error {
+	seen := make(map[string]struct{}, len(cfg.When))
+
+	for _, phase := range cfg.When {
+		if phase != DBCompactionBeforePreRuns && phase != DBCompactionBeforeBenchmarks {
+			return fmt.Errorf(
+				"instance %q: invalid db_compaction.when value %q (must be %q or %q)",
+				id, phase, DBCompactionBeforePreRuns, DBCompactionBeforeBenchmarks,
+			)
+		}
+
+		if _, dup := seen[phase]; dup {
+			return fmt.Errorf(
+				"instance %q: duplicate db_compaction.when value %q", id, phase,
+			)
+		}
+
+		seen[phase] = struct{}{}
+	}
+
+	if cfg.Persist == nil {
+		return nil
+	}
+
+	when := make(map[string]struct{}, len(cfg.EffectiveWhen()))
+	for _, phase := range cfg.EffectiveWhen() {
+		when[phase] = struct{}{}
+	}
+
+	for _, phase := range cfg.Persist.Phases {
+		if phase != DBCompactionBeforePreRuns && phase != DBCompactionBeforeBenchmarks {
+			return fmt.Errorf(
+				"instance %q: invalid db_compaction.persist.phases value %q"+
+					" (must be %q or %q)",
+				id, phase, DBCompactionBeforePreRuns, DBCompactionBeforeBenchmarks,
+			)
+		}
+
+		if _, ok := when[phase]; !ok {
+			return fmt.Errorf(
+				"instance %q: db_compaction.persist.phases lists %q,"+
+					" which is not in db_compaction.when",
+				id, phase,
+			)
+		}
+	}
+
+	return nil
+}
+
+// validateDBCompactionPersist checks the persist block against the resolved
+// datadir. Each supported method persists in exactly one way, and only one of
+// them can do it at both phases.
+func validateDBCompactionPersist(id string, cfg *DBCompactionConfig, dd *DataDirConfig) error {
+	persistPhases := cfg.EffectivePersistPhases()
+	if len(persistPhases) == 0 {
+		return nil
+	}
+
+	if dd == nil {
+		return fmt.Errorf(
+			"instance %q: db_compaction.persist needs a datadir with method"+
+				" \"schelk\" or \"zfs\"; this instance has none",
+			id,
+		)
+	}
+
+	if dd.Method == "direct" {
+		return fmt.Errorf(
+			"instance %q: db_compaction.persist is redundant for datadir method"+
+				" \"direct\": the client writes to source_dir itself, so the"+
+				" compaction is already permanent",
+			id,
+		)
+	}
+
+	if !dbCompactionPersistMethods[dd.Method] {
+		return fmt.Errorf(
+			"instance %q: db_compaction.persist is not supported for datadir"+
+				" method %q (use \"schelk\" or \"zfs\")",
+			id, dd.Method,
+		)
+	}
+
+	for _, phase := range persistPhases {
+		if phase != DBCompactionBeforeBenchmarks {
+			continue
+		}
+
+		// A ZFS clone is a CHILD of its source dataset, so there is no rename
+		// or promote that puts the compacted clone at the source path. The
+		// source is compacted in place instead, which can only happen before
+		// it is cloned.
+		if dd.Method == "zfs" {
+			return fmt.Errorf(
+				"instance %q: db_compaction.persist at %q is not supported for"+
+					" datadir method \"zfs\" (the clone cannot be written back"+
+					" to its source dataset); persist at %q instead",
+				id, DBCompactionBeforeBenchmarks, DBCompactionBeforePreRuns,
+			)
+		}
+
+		// Persisting here moves the baseline head past the pre-run bundle,
+		// which is exactly what promote_post_pre_runs does. Requiring it keeps
+		// that decision explicit, and lets the runner persist both with a
+		// single promote.
+		if !dd.ShouldPromotePostPreRuns() {
+			return fmt.Errorf(
+				"instance %q: db_compaction.persist at %q also moves the schelk"+
+					" baseline past the pre-run bundle; set"+
+					" datadir.schelk_options.promote_post_pre_runs: true to"+
+					" confirm, or persist at %q instead",
+				id, DBCompactionBeforeBenchmarks, DBCompactionBeforePreRuns,
+			)
+		}
+	}
+
+	return nil
+}
+
+// validateDBCompactionStrategy rejects a compaction that the rollback strategy
+// would throw away before (or between) the tests it is meant to speed up.
+func validateDBCompactionStrategy(
+	id string, cfg *DBCompactionConfig, dd *DataDirConfig, strategy string,
+) error {
+	if strategy != RollbackStrategyContainerRecreate {
+		return nil
+	}
+
+	// Every recreate re-prepares the datadir. Only a persisted compaction (or
+	// a datadir the client writes to directly) survives to the next test.
+	if dd == nil {
+		return fmt.Errorf(
+			"instance %q: db_compaction with rollback_strategy %q needs a"+
+				" datadir; a fresh volume per test discards the compaction",
+			id, RollbackStrategyContainerRecreate,
+		)
+	}
+
+	if dbCompactionEphemeralMethods[dd.Method] {
+		return fmt.Errorf(
+			"instance %q: db_compaction with rollback_strategy %q and datadir"+
+				" method %q discards the compaction at the first recreate"+
+				" (the datadir is re-prepared from source per test); use"+
+				" method \"zfs\", or \"schelk\" with db_compaction.persist",
+			id, RollbackStrategyContainerRecreate, dd.Method,
+		)
+	}
+
+	if dd.Method == "schelk" && !cfg.Persists() {
+		return fmt.Errorf(
+			"instance %q: db_compaction with rollback_strategy %q and datadir"+
+				" method \"schelk\" needs db_compaction.persist.enabled: true;"+
+				" every recreate runs `schelk restore`, which discards an"+
+				" unpersisted compaction",
+			id, RollbackStrategyContainerRecreate,
+		)
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3555,6 +3555,509 @@ func TestValidateOpcodeExtraction(t *testing.T) {
 	}
 }
 
+func TestGetDBCompaction(t *testing.T) {
+	global := &DBCompactionConfig{Enabled: true, When: []string{DBCompactionBeforePreRuns}}
+	override := &DBCompactionConfig{Enabled: false}
+
+	cfg := &Config{
+		Runner: RunnerConfig{
+			Client: ClientConfig{Config: ClientDefaults{DBCompaction: global}},
+			Instances: []ClientInstance{
+				{ID: "inherits", Client: "geth"},
+				{ID: "overrides", Client: "geth", DBCompaction: override},
+			},
+		},
+	}
+
+	assert.Same(t, global, cfg.GetDBCompaction(&cfg.Runner.Instances[0]))
+	assert.Same(t, override, cfg.GetDBCompaction(&cfg.Runner.Instances[1]))
+	assert.False(t, cfg.GetDBCompaction(&cfg.Runner.Instances[1]).RunsAt(DBCompactionBeforePreRuns))
+}
+
+func TestDBCompactionConfig_Phases(t *testing.T) {
+	t.Run("nil config runs nowhere", func(t *testing.T) {
+		var cfg *DBCompactionConfig
+
+		assert.Nil(t, cfg.EffectiveWhen())
+		assert.False(t, cfg.RunsAt(DBCompactionBeforeBenchmarks))
+		assert.False(t, cfg.Persists())
+	})
+
+	t.Run("empty when defaults to before_benchmarks", func(t *testing.T) {
+		cfg := &DBCompactionConfig{Enabled: true}
+
+		assert.Equal(t, []string{DBCompactionBeforeBenchmarks}, cfg.EffectiveWhen())
+		assert.True(t, cfg.RunsAt(DBCompactionBeforeBenchmarks))
+		assert.False(t, cfg.RunsAt(DBCompactionBeforePreRuns))
+	})
+
+	t.Run("disabled runs nowhere", func(t *testing.T) {
+		cfg := &DBCompactionConfig{When: []string{DBCompactionBeforePreRuns}}
+
+		assert.False(t, cfg.RunsAt(DBCompactionBeforePreRuns))
+	})
+
+	t.Run("when is returned in lifecycle order", func(t *testing.T) {
+		cfg := &DBCompactionConfig{
+			Enabled: true,
+			When: []string{
+				DBCompactionBeforeBenchmarks,
+				DBCompactionBeforePreRuns,
+				DBCompactionBeforePreRuns,
+			},
+		}
+
+		assert.Equal(
+			t,
+			[]string{DBCompactionBeforePreRuns, DBCompactionBeforeBenchmarks},
+			cfg.EffectiveWhen(),
+		)
+	})
+
+	t.Run("persist defaults to every configured phase", func(t *testing.T) {
+		cfg := &DBCompactionConfig{
+			Enabled: true,
+			When:    []string{DBCompactionBeforePreRuns, DBCompactionBeforeBenchmarks},
+			Persist: &DBCompactionPersistConfig{Enabled: true},
+		}
+
+		assert.True(t, cfg.PersistsAt(DBCompactionBeforePreRuns))
+		assert.True(t, cfg.PersistsAt(DBCompactionBeforeBenchmarks))
+		assert.True(t, cfg.Persists())
+	})
+
+	t.Run("persist can name a subset", func(t *testing.T) {
+		cfg := &DBCompactionConfig{
+			Enabled: true,
+			When:    []string{DBCompactionBeforePreRuns, DBCompactionBeforeBenchmarks},
+			Persist: &DBCompactionPersistConfig{
+				Enabled: true,
+				Phases:  []string{DBCompactionBeforePreRuns},
+			},
+		}
+
+		assert.True(t, cfg.PersistsAt(DBCompactionBeforePreRuns))
+		assert.False(t, cfg.PersistsAt(DBCompactionBeforeBenchmarks))
+	})
+
+	t.Run("a disabled persist block persists nothing", func(t *testing.T) {
+		cfg := &DBCompactionConfig{
+			Enabled: true,
+			Persist: &DBCompactionPersistConfig{Phases: []string{DBCompactionBeforeBenchmarks}},
+		}
+
+		assert.False(t, cfg.Persists())
+	})
+}
+
+func TestDBCompactionConfig_Defaults(t *testing.T) {
+	disabled := false
+	enabled := true
+
+	t.Run("inspect defaults to true", func(t *testing.T) {
+		assert.True(t, (&DBCompactionConfig{}).InspectEnabled())
+		assert.False(t, (&DBCompactionConfig{Inspect: &disabled}).InspectEnabled())
+	})
+
+	t.Run("skip_if_marked follows persist", func(t *testing.T) {
+		assert.False(t, (&DBCompactionConfig{Enabled: true}).SkipIfMarkedEnabled())
+
+		persisting := &DBCompactionConfig{
+			Enabled: true,
+			Persist: &DBCompactionPersistConfig{Enabled: true},
+		}
+		assert.True(t, persisting.SkipIfMarkedEnabled())
+
+		forced := &DBCompactionConfig{
+			Enabled:      true,
+			SkipIfMarked: &disabled,
+			Persist:      &DBCompactionPersistConfig{Enabled: true},
+		}
+		assert.False(t, forced.SkipIfMarkedEnabled())
+
+		assert.True(t, (&DBCompactionConfig{SkipIfMarked: &enabled}).SkipIfMarkedEnabled())
+	})
+
+	t.Run("safety_snapshot defaults to true", func(t *testing.T) {
+		assert.True(t, (&DBCompactionConfig{}).SafetySnapshotEnabled())
+		assert.True(t, (&DBCompactionConfig{
+			Persist: &DBCompactionPersistConfig{Enabled: true},
+		}).SafetySnapshotEnabled())
+		assert.False(t, (&DBCompactionConfig{
+			Persist: &DBCompactionPersistConfig{Enabled: true, SafetySnapshot: &disabled},
+		}).SafetySnapshotEnabled())
+	})
+
+	t.Run("timeout falls back to the default", func(t *testing.T) {
+		want, err := time.ParseDuration(DefaultDBCompactionTimeout)
+		require.NoError(t, err)
+
+		assert.Equal(t, want, (&DBCompactionConfig{}).EffectiveTimeout())
+		assert.Equal(t, want, (&DBCompactionConfig{Timeout: "garbage"}).EffectiveTimeout())
+		assert.Equal(t, 90*time.Minute, (&DBCompactionConfig{Timeout: "90m"}).EffectiveTimeout())
+	})
+}
+
+//nolint:funlen // Table-driven: one case per validation rule.
+func TestValidateDBCompaction(t *testing.T) {
+	dir := t.TempDir()
+
+	schelkPromote := &DataDirConfig{
+		SourceDir:     dir,
+		Method:        "schelk",
+		SchelkOptions: &SchelkOptions{PromotePostPreRuns: true},
+	}
+
+	tests := []struct {
+		name      string
+		client    string
+		cfg       *DBCompactionConfig
+		datadir   *DataDirConfig
+		strategy  string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:   "disabled is always valid",
+			client: "besu",
+			cfg:    &DBCompactionConfig{When: []string{"nonsense"}},
+		},
+		{
+			name:   "enabled on geth with defaults",
+			client: "geth",
+			cfg:    &DBCompactionConfig{Enabled: true},
+		},
+		{
+			name:      "unsupported client",
+			client:    "besu",
+			cfg:       &DBCompactionConfig{Enabled: true},
+			wantErr:   true,
+			errSubstr: "not supported for client",
+		},
+		{
+			name:      "unknown phase",
+			client:    "geth",
+			cfg:       &DBCompactionConfig{Enabled: true, When: []string{"after_tests"}},
+			wantErr:   true,
+			errSubstr: "invalid db_compaction.when",
+		},
+		{
+			name:   "duplicate phase",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				When: []string{
+					DBCompactionBeforePreRuns, DBCompactionBeforePreRuns,
+				},
+			},
+			datadir:   &DataDirConfig{SourceDir: dir, Method: "copy"},
+			wantErr:   true,
+			errSubstr: "duplicate db_compaction.when",
+		},
+		{
+			name:      "invalid timeout",
+			client:    "geth",
+			cfg:       &DBCompactionConfig{Enabled: true, Timeout: "soon"},
+			wantErr:   true,
+			errSubstr: "invalid db_compaction.timeout",
+		},
+		{
+			name:      "non-positive timeout",
+			client:    "geth",
+			cfg:       &DBCompactionConfig{Enabled: true, Timeout: "0s"},
+			wantErr:   true,
+			errSubstr: "must be positive",
+		},
+		{
+			name:      "before_pre_runs without a datadir",
+			client:    "geth",
+			cfg:       &DBCompactionConfig{Enabled: true, When: []string{DBCompactionBeforePreRuns}},
+			wantErr:   true,
+			errSubstr: "needs a pre-populated datadir",
+		},
+		{
+			name:   "persist phase outside when",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				When:    []string{DBCompactionBeforeBenchmarks},
+				Persist: &DBCompactionPersistConfig{
+					Enabled: true,
+					Phases:  []string{DBCompactionBeforePreRuns},
+				},
+			},
+			datadir:   schelkPromote,
+			wantErr:   true,
+			errSubstr: "which is not in db_compaction.when",
+		},
+		{
+			name:   "persist without a datadir",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				Persist: &DBCompactionPersistConfig{Enabled: true},
+			},
+			wantErr:   true,
+			errSubstr: "needs a datadir with method",
+		},
+		{
+			name:   "persist with method copy",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				Persist: &DBCompactionPersistConfig{Enabled: true},
+			},
+			datadir:   &DataDirConfig{SourceDir: dir, Method: "copy"},
+			wantErr:   true,
+			errSubstr: "not supported for datadir method",
+		},
+		{
+			name:   "persist with method direct",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				Persist: &DBCompactionPersistConfig{Enabled: true},
+			},
+			datadir:   &DataDirConfig{SourceDir: dir, Method: "direct"},
+			wantErr:   true,
+			errSubstr: "redundant for datadir method",
+		},
+		{
+			name:   "zfs persists before the pre-runs",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				When:    []string{DBCompactionBeforePreRuns},
+				Persist: &DBCompactionPersistConfig{Enabled: true},
+			},
+			datadir: &DataDirConfig{SourceDir: dir, Method: "zfs"},
+		},
+		{
+			name:   "zfs cannot persist before the benchmarks",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				When:    []string{DBCompactionBeforeBenchmarks},
+				Persist: &DBCompactionPersistConfig{Enabled: true},
+			},
+			datadir:   &DataDirConfig{SourceDir: dir, Method: "zfs"},
+			wantErr:   true,
+			errSubstr: "cannot be written back to its source dataset",
+		},
+		{
+			name:   "zfs compacts at both phases and persists the first",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				When: []string{
+					DBCompactionBeforePreRuns, DBCompactionBeforeBenchmarks,
+				},
+				Persist: &DBCompactionPersistConfig{
+					Enabled: true,
+					Phases:  []string{DBCompactionBeforePreRuns},
+				},
+			},
+			datadir: &DataDirConfig{SourceDir: dir, Method: "zfs"},
+		},
+		{
+			name:   "schelk persist before the benchmarks needs promote_post_pre_runs",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				When:    []string{DBCompactionBeforeBenchmarks},
+				Persist: &DBCompactionPersistConfig{Enabled: true},
+			},
+			datadir:   &DataDirConfig{SourceDir: dir, Method: "schelk"},
+			wantErr:   true,
+			errSubstr: "promote_post_pre_runs",
+		},
+		{
+			name:   "schelk persist before the benchmarks with promote_post_pre_runs",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				When:    []string{DBCompactionBeforeBenchmarks},
+				Persist: &DBCompactionPersistConfig{Enabled: true},
+			},
+			datadir: schelkPromote,
+		},
+		{
+			name:      "container-recreate without a datadir",
+			client:    "geth",
+			cfg:       &DBCompactionConfig{Enabled: true},
+			strategy:  RollbackStrategyContainerRecreate,
+			wantErr:   true,
+			errSubstr: "needs a datadir",
+		},
+		{
+			name:      "container-recreate with method copy",
+			client:    "geth",
+			cfg:       &DBCompactionConfig{Enabled: true},
+			datadir:   &DataDirConfig{SourceDir: dir, Method: "copy"},
+			strategy:  RollbackStrategyContainerRecreate,
+			wantErr:   true,
+			errSubstr: "discards the compaction at the first recreate",
+		},
+		{
+			name:      "container-recreate with unpersisted schelk",
+			client:    "geth",
+			cfg:       &DBCompactionConfig{Enabled: true},
+			datadir:   &DataDirConfig{SourceDir: dir, Method: "schelk"},
+			strategy:  RollbackStrategyContainerRecreate,
+			wantErr:   true,
+			errSubstr: "needs db_compaction.persist.enabled",
+		},
+		{
+			name:   "container-recreate with persisted schelk",
+			client: "geth",
+			cfg: &DBCompactionConfig{
+				Enabled: true,
+				When:    []string{DBCompactionBeforeBenchmarks},
+				Persist: &DBCompactionPersistConfig{Enabled: true},
+			},
+			datadir:  schelkPromote,
+			strategy: RollbackStrategyContainerRecreate,
+		},
+		{
+			name:     "container-recreate with zfs",
+			client:   "geth",
+			cfg:      &DBCompactionConfig{Enabled: true},
+			datadir:  &DataDirConfig{SourceDir: dir, Method: "zfs"},
+			strategy: RollbackStrategyContainerRecreate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Runner: RunnerConfig{
+					Client: ClientConfig{
+						Config: ClientDefaults{
+							DBCompaction:     tt.cfg,
+							RollbackStrategy: tt.strategy,
+						},
+					},
+					Instances: []ClientInstance{
+						{ID: "test", Client: tt.client, DataDir: tt.datadir},
+					},
+				},
+			}
+
+			err := cfg.validateDBCompaction(ValidateOpts{})
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateDBCompaction_SkipsInactiveInstances(t *testing.T) {
+	cfg := &Config{
+		Runner: RunnerConfig{
+			Client: ClientConfig{
+				Config: ClientDefaults{DBCompaction: &DBCompactionConfig{Enabled: true}},
+			},
+			Instances: []ClientInstance{{ID: "besu", Client: "besu"}},
+		},
+	}
+
+	require.Error(t, cfg.validateDBCompaction(ValidateOpts{}))
+	require.NoError(t, cfg.validateDBCompaction(ValidateOpts{
+		ActiveInstanceIDs: map[string]struct{}{"geth": {}},
+	}))
+}
+
+func TestLoadDBCompactionFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	require.NoError(t, os.WriteFile(path, []byte(`
+runner:
+  client:
+    config:
+      db_compaction:
+        enabled: true
+        when:
+          - before_benchmarks
+          - before_pre_runs
+        inspect: false
+        timeout: 90m
+        extra_args: ["--cache=16384"]
+        persist:
+          enabled: true
+          phases: [before_pre_runs]
+  instances:
+    - id: geth
+      client: geth
+    - id: geth-scalar
+      client: geth
+      db_compaction:
+        enabled: true
+        when: before_pre_runs
+        skip_if_marked: false
+`), 0644))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	global := cfg.GetDBCompaction(&cfg.Runner.Instances[0])
+	require.NotNil(t, global)
+	assert.True(t, global.Enabled)
+	assert.Equal(
+		t,
+		[]string{DBCompactionBeforePreRuns, DBCompactionBeforeBenchmarks},
+		global.EffectiveWhen(),
+	)
+	assert.False(t, global.InspectEnabled())
+	assert.Equal(t, []string{"--cache=16384"}, global.ExtraArgs)
+	assert.True(t, global.PersistsAt(DBCompactionBeforePreRuns))
+	assert.False(t, global.PersistsAt(DBCompactionBeforeBenchmarks))
+	assert.True(t, global.SkipIfMarkedEnabled())
+
+	// A scalar `when` decodes into the list via the StringToSlice hook.
+	instance := cfg.GetDBCompaction(&cfg.Runner.Instances[1])
+	require.NotNil(t, instance)
+	assert.Equal(t, []string{DBCompactionBeforePreRuns}, instance.EffectiveWhen())
+	assert.True(t, instance.InspectEnabled())
+	assert.False(t, instance.SkipIfMarkedEnabled())
+}
+
+func TestDBCompactionEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	require.NoError(t, os.WriteFile(path, []byte(`
+runner:
+  instances:
+    - id: geth
+      client: geth
+`), 0644))
+
+	t.Setenv("BENCHMARKOOR_RUNNER_CLIENT_CONFIG_DB_COMPACTION_ENABLED", "true")
+	t.Setenv(
+		"BENCHMARKOOR_RUNNER_CLIENT_CONFIG_DB_COMPACTION_WHEN",
+		"before_pre_runs,before_benchmarks",
+	)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	got := cfg.GetDBCompaction(&cfg.Runner.Instances[0])
+	require.NotNil(t, got)
+	assert.True(t, got.Enabled)
+	assert.Equal(
+		t,
+		[]string{DBCompactionBeforePreRuns, DBCompactionBeforeBenchmarks},
+		got.EffectiveWhen(),
+	)
+}
+
 func TestValidateBuilder_PublicScope(t *testing.T) {
 	// `benchmarkoor build` invokes Config.ValidateBuilder(), which must
 	// not require any runner-side configuration (instances, test sources,

--- a/pkg/datadir/zfs.go
+++ b/pkg/datadir/zfs.go
@@ -257,6 +257,30 @@ func (p *zfsProvider) createSnapshot(ctx context.Context, snapshotName string) e
 	return nil
 }
 
+// SnapshotZFSSource snapshots the dataset that holds path, as
+// <dataset>@<suffix>, and returns the full snapshot name.
+//
+// It is the safety net before an in-place change to a SOURCE dataset — the
+// db_compaction persist path compacts the source before it is cloned — since a
+// `zfs rollback` to this snapshot restores the dataset exactly as it was.
+func SnapshotZFSSource(
+	ctx context.Context, log logrus.FieldLogger, path, suffix string,
+) (string, error) {
+	p := &zfsProvider{log: log.WithField("component", "datadir-zfs")}
+
+	dsInfo, err := p.getDatasetFromPath(ctx, path)
+	if err != nil {
+		return "", fmt.Errorf("detecting ZFS dataset for %q: %w", path, err)
+	}
+
+	name := fmt.Sprintf("%s@%s", dsInfo.dataset, suffix)
+	if err := p.createSnapshot(ctx, name); err != nil {
+		return "", err
+	}
+
+	return name, nil
+}
+
 // createClone creates a ZFS clone from a snapshot.
 func (p *zfsProvider) createClone(ctx context.Context, snapshotName, cloneDataset string) error {
 	p.log.WithFields(logrus.Fields{

--- a/pkg/runner/db_compaction.go
+++ b/pkg/runner/db_compaction.go
@@ -152,20 +152,10 @@ func (r *runner) runDBCompaction(
 
 	hostPath := req.hostPath()
 
-	if req.Cfg.SkipIfMarkedEnabled() && hostPath != "" {
-		if marker := readDBCompactionMarker(hostPath); marker != nil {
-			if entry, ok := marker.Phases[req.Phase]; ok {
-				log.WithFields(logrus.Fields{
-					"compacted_at": entry.CompletedAt,
-					"run_id":       entry.RunID,
-				}).Info(
-					"Datadir already carries a compaction marker for this phase; skipping" +
-						" (set db_compaction.skip_if_marked: false to force)",
-				)
+	if entry := r.dbCompactionSkipEntry(req.Instance, req.Phase, req.Mount); entry != nil {
+		logDBCompactionSkip(log, entry)
 
-				return false, nil
-			}
-		}
+		return false, nil
 	}
 
 	phaseDir := filepath.Join(req.ResultsDir, config.DBCompactionResultsDir, req.Phase)
@@ -476,6 +466,54 @@ func (r *runner) dbCompactionFor(
 	}
 
 	return cfg
+}
+
+// dbCompactionSkipEntry returns the datadir marker entry that makes a
+// compaction at this phase a no-op, or nil when the compaction should run.
+//
+// It answers the question runDBCompaction asks itself, but without a container
+// and without the client having to stop first. A caller that must stop the
+// client to compact uses it to find out whether the stop is worth making at
+// all: a persisted baseline carries the marker for every later run, and
+// stopping and restarting a client to skip the work costs a settle, a graceful
+// shutdown, and a boot, every run, for nothing.
+func (r *runner) dbCompactionSkipEntry(
+	instance *config.ClientInstance, phase string, mount docker.Mount,
+) *dbCompactionMarkerEntry {
+	cfg := r.dbCompactionFor(instance, phase)
+	if cfg == nil || !cfg.SkipIfMarkedEnabled() {
+		return nil
+	}
+
+	req := &dbCompactionRequest{Mount: mount}
+
+	hostPath := req.hostPath()
+	if hostPath == "" {
+		return nil
+	}
+
+	marker := readDBCompactionMarker(hostPath)
+	if marker == nil {
+		return nil
+	}
+
+	entry, ok := marker.Phases[phase]
+	if !ok {
+		return nil
+	}
+
+	return &entry
+}
+
+// logDBCompactionSkip reports a phase the datadir marker already covers.
+func logDBCompactionSkip(log logrus.FieldLogger, entry *dbCompactionMarkerEntry) {
+	log.WithFields(logrus.Fields{
+		"compacted_at": entry.CompletedAt,
+		"run_id":       entry.RunID,
+	}).Info(
+		"Datadir already carries a compaction marker for this phase; skipping" +
+			" (set db_compaction.skip_if_marked: false to force)",
+	)
 }
 
 // dbCompactionPersistsAt reports whether the instance writes the result of the

--- a/pkg/runner/db_compaction.go
+++ b/pkg/runner/db_compaction.go
@@ -1,0 +1,687 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/client"
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/ethpandaops/benchmarkoor/pkg/datadir"
+	"github.com/ethpandaops/benchmarkoor/pkg/docker"
+	"github.com/ethpandaops/benchmarkoor/pkg/fsutil"
+	"github.com/sirupsen/logrus"
+)
+
+// dbCompactionMarkerVersion is the schema version of the marker file written
+// at the root of a compacted datadir.
+const dbCompactionMarkerVersion = 1
+
+// dbCompactionRequest describes one compaction phase against a datadir whose
+// client is NOT running. The caller owns the client lifecycle: `geth db
+// compact` takes the database lock, so a live node makes it fail.
+type dbCompactionRequest struct {
+	Instance  *config.ClientInstance
+	Spec      client.Spec
+	Cfg       *config.DBCompactionConfig
+	Phase     string
+	ImageName string
+	RunID     string
+
+	// Mount is the datadir as the compaction container sees it. It is the same
+	// mount the client uses, so a bind mount compacts the host path and a
+	// volume mount compacts the volume.
+	Mount docker.Mount
+
+	// ResultsDir is the run results directory that receives the inspection
+	// reports and the compaction report.
+	ResultsDir string
+
+	// BenchmarkoorLog receives the container output when client logs are
+	// mirrored to stdout.
+	BenchmarkoorLog *os.File
+
+	// Persisting reports whether this phase's result is written back to the
+	// datadir baseline. It only changes what the report and the marker record;
+	// the caller performs the persist itself.
+	Persisting bool
+
+	// Head is the datadir head at compaction time, when the caller already
+	// knows it. Only the before_benchmarks phase does: it stops a running
+	// client, so the head is one RPC call it has already made. It is recorded
+	// in the run report, never in the datadir marker.
+	Head *dbCompactionHead
+}
+
+// dbCompactionHead is the datadir head at compaction time. Compaction never
+// changes the chain state, so one head per phase describes both sides of it.
+type dbCompactionHead struct {
+	Number uint64 `json:"number"`
+	Hash   string `json:"hash"`
+}
+
+// dbCompactionSizes is the on-disk size of the datadir either side of a
+// compaction. Absent for a datadir the runner cannot see from the host (a
+// container volume).
+type dbCompactionSizes struct {
+	Before int64 `json:"before"`
+	After  int64 `json:"after"`
+}
+
+// dbCompactionReport is the per-run record of one compaction phase, written to
+// <results>/db-compaction/<phase>/compaction.json.
+type dbCompactionReport struct {
+	Phase        string             `json:"phase"`
+	Client       string             `json:"client"`
+	Image        string             `json:"image"`
+	RunID        string             `json:"run_id"`
+	StartedAt    string             `json:"started_at"`
+	CompletedAt  string             `json:"completed_at,omitempty"`
+	DurationMS   int64              `json:"duration_ms"`
+	Persisted    bool               `json:"persisted"`
+	Command      []string           `json:"command"`
+	DatadirBytes *dbCompactionSizes `json:"datadir_bytes,omitempty"`
+	Head         *dbCompactionHead  `json:"head,omitempty"`
+	Error        string             `json:"error,omitempty"`
+}
+
+// dbCompactionMarker records the compactions a datadir has already had. It
+// lives at the root of the datadir, so a persisted compaction carries it into
+// the baseline and a later run can skip the work.
+//
+// It holds only what is known the moment the compaction finishes, so it is
+// written once and never patched. The head is deliberately absent: at
+// before_pre_runs no client has booted to report one, and a field that is
+// null in half the baselines is worse than no field.
+type dbCompactionMarker struct {
+	Version int                                `json:"version"`
+	Phases  map[string]dbCompactionMarkerEntry `json:"phases"`
+}
+
+// dbCompactionMarkerEntry is one phase's entry in the marker file.
+type dbCompactionMarkerEntry struct {
+	Client       string             `json:"client"`
+	Image        string             `json:"image"`
+	RunID        string             `json:"run_id"`
+	CompletedAt  string             `json:"completed_at"`
+	DurationMS   int64              `json:"duration_ms"`
+	DatadirBytes *dbCompactionSizes `json:"datadir_bytes,omitempty"`
+}
+
+// hostPath returns the host path of the datadir mount, or "" when
+// the datadir is a container volume. The marker and the size measurements need
+// a path the runner can read.
+func (req *dbCompactionRequest) hostPath() string {
+	if req.Mount.Type == "bind" {
+		return req.Mount.Source
+	}
+
+	return ""
+}
+
+// runDBCompaction compacts the datadir for one phase, and reports whether the
+// compaction actually ran — it does not when the datadir marker already names
+// this phase.
+//
+// The client must be stopped before the call and is left stopped after it: the
+// caller decides when to start it again. A failure is returned unless
+// continue_on_error is set, in which case it is logged and the run goes on
+// with an uncompacted database.
+func (r *runner) runDBCompaction(
+	ctx context.Context, req *dbCompactionRequest,
+) (bool, error) {
+	log := r.log.WithFields(logrus.Fields{
+		"instance": req.Instance.ID,
+		"phase":    req.Phase,
+	})
+
+	cmds := req.Spec.DBMaintenanceCommands(req.Mount.Target)
+	if cmds == nil || len(cmds.Compact) == 0 {
+		// Validation rejects this combination, so reaching it means the config
+		// was never validated. Refusing beats silently skipping.
+		return false, fmt.Errorf(
+			"client %s has no database compaction command", req.Instance.Client,
+		)
+	}
+
+	hostPath := req.hostPath()
+
+	if req.Cfg.SkipIfMarkedEnabled() && hostPath != "" {
+		if marker := readDBCompactionMarker(hostPath); marker != nil {
+			if entry, ok := marker.Phases[req.Phase]; ok {
+				log.WithFields(logrus.Fields{
+					"compacted_at": entry.CompletedAt,
+					"run_id":       entry.RunID,
+				}).Info(
+					"Datadir already carries a compaction marker for this phase; skipping" +
+						" (set db_compaction.skip_if_marked: false to force)",
+				)
+
+				return false, nil
+			}
+		}
+	}
+
+	phaseDir := filepath.Join(req.ResultsDir, config.DBCompactionResultsDir, req.Phase)
+	if err := fsutil.MkdirAll(phaseDir, 0755, r.cfg.ResultsOwner); err != nil {
+		return false, fmt.Errorf("creating db-compaction results dir: %w", err)
+	}
+
+	started := time.Now()
+
+	report := &dbCompactionReport{
+		Phase:     req.Phase,
+		Client:    req.Instance.Client,
+		Image:     req.ImageName,
+		RunID:     req.RunID,
+		StartedAt: started.UTC().Format(time.RFC3339),
+		Persisted: req.Persisting,
+		Command:   append(append([]string{}, cmds.Compact...), req.Cfg.ExtraArgs...),
+		Head:      req.Head,
+	}
+
+	if hostPath != "" {
+		report.DatadirBytes = &dbCompactionSizes{Before: dirSize(hostPath)}
+	}
+
+	runErr := r.runDBCompactionContainers(ctx, req, cmds, phaseDir, log)
+
+	if hostPath != "" {
+		report.DatadirBytes.After = dirSize(hostPath)
+	}
+
+	report.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+	report.DurationMS = time.Since(started).Milliseconds()
+
+	if runErr != nil {
+		report.Error = runErr.Error()
+	}
+
+	r.writeDBCompactionReport(phaseDir, report, log)
+
+	if runErr != nil {
+		if req.Cfg.ContinueOnError {
+			log.WithError(runErr).Warn(
+				"Database compaction failed; continuing with an uncompacted database" +
+					" (db_compaction.continue_on_error is set)",
+			)
+
+			return false, nil
+		}
+
+		return false, fmt.Errorf(
+			"compacting the %s database: %w", req.Instance.Client, runErr,
+		)
+	}
+
+	fields := logrus.Fields{"duration": time.Duration(report.DurationMS) * time.Millisecond}
+	if report.DatadirBytes != nil {
+		fields["bytes_before"] = report.DatadirBytes.Before
+		fields["bytes_after"] = report.DatadirBytes.After
+	}
+
+	log.WithFields(fields).Info("Database compaction completed")
+
+	if hostPath != "" {
+		r.writeDBCompactionMarker(hostPath, req, report, log)
+	}
+
+	return true, nil
+}
+
+// runDBCompactionContainers runs the inspection either side of the compaction
+// and the compaction itself, each in its own one-shot container.
+//
+// An inspection failure is never fatal: it is a report, and losing it must not
+// cost the run its compaction. geth 1.17.5 exits 1 on `db inspect` against a
+// datadir whose freezer is empty ("unknown tail group"), which a
+// freshly-initialised datadir has, so this is a case that really happens.
+func (r *runner) runDBCompactionContainers(
+	ctx context.Context,
+	req *dbCompactionRequest,
+	cmds *client.DBMaintenanceCommands,
+	phaseDir string,
+	log logrus.FieldLogger,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, req.Cfg.EffectiveTimeout())
+	defer cancel()
+
+	if req.Cfg.InspectEnabled() && len(cmds.Inspect) > 0 {
+		log.Info("Inspecting the database before compaction")
+
+		if err := r.runDBMaintenanceContainer(
+			ctx, req, "inspect-before", cmds.Inspect,
+			filepath.Join(phaseDir, "inspect-before.txt"),
+		); err != nil {
+			log.WithError(err).Warn("Database inspection before compaction failed")
+		}
+	}
+
+	log.WithField("timeout", req.Cfg.EffectiveTimeout()).Info("Compacting the database")
+
+	compactCmd := append(append([]string{}, cmds.Compact...), req.Cfg.ExtraArgs...)
+
+	if err := r.runDBMaintenanceContainer(
+		ctx, req, "compact", compactCmd, filepath.Join(phaseDir, "compact.log"),
+	); err != nil {
+		return err
+	}
+
+	if req.Cfg.InspectEnabled() && len(cmds.Inspect) > 0 {
+		log.Info("Inspecting the database after compaction")
+
+		if err := r.runDBMaintenanceContainer(
+			ctx, req, "inspect-after", cmds.Inspect,
+			filepath.Join(phaseDir, "inspect-after.txt"),
+		); err != nil {
+			log.WithError(err).Warn("Database inspection after compaction failed")
+		}
+	}
+
+	return nil
+}
+
+// runDBMaintenanceContainer runs one database command in a one-shot container
+// on the datadir mount and writes its output to outputFile.
+//
+// No resource limits are applied. The compaction is setup, not measurement,
+// and a memory cap sized for the client can make it fail outright.
+func (r *runner) runDBMaintenanceContainer(
+	ctx context.Context,
+	req *dbCompactionRequest,
+	step string,
+	command []string,
+	outputFile string,
+) error {
+	name := fmt.Sprintf(
+		"benchmarkoor-%s-%s-dbc-%s-%s", req.RunID, req.Instance.ID, req.Phase, step,
+	)
+
+	image := req.ImageName
+	if req.Cfg.Image != "" {
+		image = req.Cfg.Image
+	}
+
+	spec := &docker.ContainerSpec{
+		Name:        name,
+		Image:       image,
+		Entrypoint:  req.Instance.Entrypoint,
+		Command:     command,
+		Mounts:      []docker.Mount{req.Mount},
+		NetworkName: r.cfg.ContainerNetwork,
+		SecurityOpt: []string{"seccomp=unconfined"},
+		Labels: map[string]string{
+			"benchmarkoor.instance":   req.Instance.ID,
+			"benchmarkoor.client":     req.Instance.Client,
+			"benchmarkoor.run-id":     req.RunID,
+			"benchmarkoor.type":       "db-compaction",
+			"benchmarkoor.managed-by": "benchmarkoor",
+		},
+	}
+
+	out, err := fsutil.Create(outputFile, r.cfg.ResultsOwner)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", outputFile, err)
+	}
+
+	defer func() {
+		_ = out.Close()
+	}()
+
+	_, _ = fmt.Fprintf(
+		out, "# %s %s\n# %v\n\n", image, step, command,
+	)
+
+	var stdout, stderr io.Writer = out, out
+
+	if r.cfg.ClientLogsToStdout {
+		pfxFn := clientLogPrefix(req.Instance.ID + "-dbc")
+		stdoutPW := &prefixedWriter{prefixFn: pfxFn, writer: os.Stdout}
+		writers := []io.Writer{out, stdoutPW}
+
+		if req.BenchmarkoorLog != nil {
+			writers = append(
+				writers, &prefixedWriter{prefixFn: pfxFn, writer: req.BenchmarkoorLog},
+			)
+		}
+
+		stdout = io.MultiWriter(writers...)
+		stderr = stdout
+	}
+
+	if err := r.containerMgr.RunInitContainer(ctx, spec, stdout, stderr); err != nil {
+		return fmt.Errorf("running %s container: %w", step, err)
+	}
+
+	return nil
+}
+
+// writeDBCompactionReport writes the per-run record of one phase. A failure is
+// logged, never fatal: the compaction itself already happened.
+func (r *runner) writeDBCompactionReport(
+	phaseDir string, report *dbCompactionReport, log logrus.FieldLogger,
+) {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		log.WithError(err).Warn("Failed to encode the db-compaction report")
+
+		return
+	}
+
+	path := filepath.Join(phaseDir, "compaction.json")
+	if err := fsutil.WriteFile(path, data, 0644, r.cfg.ResultsOwner); err != nil {
+		log.WithError(err).Warn("Failed to write the db-compaction report")
+	}
+}
+
+// writeDBCompactionMarker records the finished compaction at the root of the
+// datadir it compacted, so a persisted baseline says what has already been
+// done to it. A failure is logged, never fatal.
+func (r *runner) writeDBCompactionMarker(
+	hostPath string, req *dbCompactionRequest, report *dbCompactionReport,
+	log logrus.FieldLogger,
+) {
+	marker := readDBCompactionMarker(hostPath)
+	if marker == nil {
+		marker = &dbCompactionMarker{
+			Version: dbCompactionMarkerVersion,
+			Phases:  make(map[string]dbCompactionMarkerEntry, 2),
+		}
+	}
+
+	if marker.Phases == nil {
+		marker.Phases = make(map[string]dbCompactionMarkerEntry, 2)
+	}
+
+	marker.Version = dbCompactionMarkerVersion
+	marker.Phases[req.Phase] = dbCompactionMarkerEntry{
+		Client:       req.Instance.Client,
+		Image:        report.Image,
+		RunID:        req.RunID,
+		CompletedAt:  report.CompletedAt,
+		DurationMS:   report.DurationMS,
+		DatadirBytes: report.DatadirBytes,
+	}
+
+	data, err := json.MarshalIndent(marker, "", "  ")
+	if err != nil {
+		log.WithError(err).Warn("Failed to encode the db-compaction marker")
+
+		return
+	}
+
+	path := filepath.Join(hostPath, config.DBCompactionMarkerFile)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		log.WithError(err).Warn("Failed to write the db-compaction marker")
+	}
+}
+
+// readDBCompactionMarker reads the marker at the root of a datadir. A missing
+// or unreadable marker means "never compacted", which only costs a compaction
+// the run would have done anyway.
+func readDBCompactionMarker(hostPath string) *dbCompactionMarker {
+	data, err := os.ReadFile(filepath.Join(hostPath, config.DBCompactionMarkerFile))
+	if err != nil {
+		return nil
+	}
+
+	var marker dbCompactionMarker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return nil
+	}
+
+	return &marker
+}
+
+// dirSize returns the total size in bytes of all regular files under dir.
+// Unreadable entries are skipped: the size is a report, not a decision.
+func dirSize(dir string) int64 {
+	var total int64
+
+	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if d.Type().IsRegular() {
+			if info, infoErr := d.Info(); infoErr == nil {
+				total += info.Size()
+			}
+		}
+
+		return nil
+	})
+
+	return total
+}
+
+// dbCompactionFor returns the compaction config for an instance when it runs
+// at the given phase, or nil.
+func (r *runner) dbCompactionFor(
+	instance *config.ClientInstance, phase string,
+) *config.DBCompactionConfig {
+	if r.cfg.FullConfig == nil {
+		return nil
+	}
+
+	cfg := r.cfg.FullConfig.GetDBCompaction(instance)
+	if !cfg.RunsAt(phase) {
+		return nil
+	}
+
+	return cfg
+}
+
+// dbCompactionPersistsAt reports whether the instance writes the result of the
+// given phase back to the datadir baseline.
+func (r *runner) dbCompactionPersistsAt(
+	instance *config.ClientInstance, phase string,
+) bool {
+	return r.dbCompactionFor(instance, phase).PersistsAt(phase)
+}
+
+// compactDatadirForPhase compacts the datadir behind `mount` when the instance
+// is configured to compact at this phase. The client must already be stopped.
+//
+// It reports whether a compaction actually ran, which is false both when the
+// phase is not configured and when the datadir marker says the work is already
+// done.
+func (r *runner) compactDatadirForPhase(
+	ctx context.Context,
+	instance *config.ClientInstance,
+	spec client.Spec,
+	phase, runID, imageName, resultsDir string,
+	mount docker.Mount,
+	benchmarkoorLog *os.File,
+	head *dbCompactionHead,
+) (bool, error) {
+	cfg := r.dbCompactionFor(instance, phase)
+	if cfg == nil {
+		return false, nil
+	}
+
+	req := &dbCompactionRequest{
+		Instance:        instance,
+		Spec:            spec,
+		Cfg:             cfg,
+		Phase:           phase,
+		ImageName:       imageName,
+		RunID:           runID,
+		Mount:           mount,
+		ResultsDir:      resultsDir,
+		BenchmarkoorLog: benchmarkoorLog,
+		Persisting:      cfg.PersistsAt(phase),
+		Head:            head,
+	}
+
+	return r.runDBCompaction(ctx, req)
+}
+
+// compactZFSSourceForPersist compacts a ZFS source dataset in place, before it
+// is snapshotted and cloned for the run.
+//
+// This is the only way a ZFS datadir persists a compaction: the clone is a
+// CHILD of its source dataset, so there is no promote or rename that puts the
+// compacted clone back at the source path. Compacting the source first also
+// keeps the clone small, since a compaction inside a copy-on-write clone
+// rewrites the whole database into it.
+//
+// The dataset is snapshotted first (unless safety_snapshot is off), so a
+// `zfs rollback` undoes the whole thing.
+func (r *runner) compactZFSSourceForPersist(
+	ctx context.Context,
+	instance *config.ClientInstance,
+	spec client.Spec,
+	datadirCfg *config.DataDirConfig,
+	runID, imageName, resultsDir string,
+	benchmarkoorLog *os.File,
+) error {
+	cfg := r.dbCompactionFor(instance, config.DBCompactionBeforePreRuns)
+	if cfg == nil || !cfg.PersistsAt(config.DBCompactionBeforePreRuns) {
+		return nil
+	}
+
+	if datadirCfg == nil || datadirCfg.Method != "zfs" {
+		return nil
+	}
+
+	log := r.log.WithFields(logrus.Fields{
+		"instance": instance.ID,
+		"phase":    config.DBCompactionBeforePreRuns,
+		"source":   datadirCfg.SourceDir,
+	})
+
+	if cfg.SafetySnapshotEnabled() {
+		snapshot, err := datadir.SnapshotZFSSource(
+			ctx, r.log, datadirCfg.SourceDir, "benchmarkoor-precompaction-"+runID,
+		)
+		if err != nil {
+			return fmt.Errorf("snapshotting the source dataset before compaction: %w", err)
+		}
+
+		log.WithField("snapshot", snapshot).Info(
+			"Took a safety snapshot of the source dataset before compacting it in place",
+		)
+	}
+
+	containerDir := datadirCfg.ContainerDir
+	if containerDir == "" {
+		containerDir = spec.DataDir()
+	}
+
+	log.Warn(
+		"Compacting the ZFS SOURCE dataset in place; every later run and clone" +
+			" starts from the compacted database",
+	)
+
+	_, err := r.compactDatadirForPhase(
+		ctx, instance, spec, config.DBCompactionBeforePreRuns,
+		runID, imageName, resultsDir,
+		docker.Mount{Type: "bind", Source: datadirCfg.SourceDir, Target: containerDir},
+		benchmarkoorLog, nil,
+	)
+
+	return err
+}
+
+// persistCompactedSchelk makes the datadir the client is about to boot on (or
+// has just stopped using) the new schelk baseline.
+//
+// `schelk promote` unmounts the volume, so the caller must have no client
+// holding it; the mount is re-established afterwards because every later
+// restore, and the container bind, resolve through that path.
+func (r *runner) persistCompactedSchelk(ctx context.Context, log logrus.FieldLogger) error {
+	log.Warn(
+		"Persisting the compacted datadir as the new schelk baseline (`schelk promote`);" +
+			" this overwrites the previous baseline irreversibly",
+	)
+
+	if err := datadir.SchelkPromote(ctx, r.log); err != nil {
+		return fmt.Errorf("schelk promote: %w", err)
+	}
+
+	if err := datadir.EnsureSchelkMounted(ctx, r.log); err != nil {
+		return fmt.Errorf("remounting schelk volume after promote: %w", err)
+	}
+
+	return nil
+}
+
+// stopClientForDatadirWork stops the client gracefully so an offline step can
+// touch its datadir, and leaves it stopped.
+//
+// It is the same sequence the schelk and ZFS persist paths use, for the same
+// reasons: settle so the client finishes any in-flight initialisation, stop
+// with the default SIGTERM grace so it flushes its database, drain the log
+// stream of the stopped container, then sync the host's dirty pages.
+func (r *runner) stopClientForDatadirWork(
+	ctx context.Context,
+	containerID string,
+	logDone *chan struct{},
+	logCancel *context.CancelFunc,
+	log logrus.FieldLogger,
+) error {
+	log.WithField("settle", schelkSettleBeforeStop).Info(
+		"Waiting for client to settle before stop",
+	)
+	time.Sleep(schelkSettleBeforeStop)
+
+	log.Info("Stopping client for offline datadir work (graceful)")
+
+	if err := r.containerMgr.StopContainer(ctx, containerID, nil); err != nil {
+		return fmt.Errorf("stopping container: %w", err)
+	}
+
+	waitForLogDrain(logDone, logCancel, logDrainTimeout)
+
+	if syncErr := exec.Command("sync").Run(); syncErr != nil {
+		log.WithError(syncErr).Warn("Failed to sync before offline datadir work")
+	}
+
+	return nil
+}
+
+// dbCompactionHeadFromRPC reads the datadir head for the compaction report.
+// A failed read costs the report one field, never the run.
+func (r *runner) dbCompactionHeadFromRPC(
+	ctx context.Context, host string, port int, log logrus.FieldLogger,
+) *dbCompactionHead {
+	number, hash, _, err := r.getLatestBlock(ctx, host, port)
+	if err != nil {
+		log.WithError(err).Debug("Could not read the datadir head for the compaction report")
+
+		return nil
+	}
+
+	return &dbCompactionHead{Number: number, Hash: hash}
+}
+
+// datadirMountFor returns the container's datadir mount from its spec, and
+// whether it was found. The lookup is by target, since the datadir config may
+// mount the data somewhere other than the client's default path.
+func datadirMountFor(
+	containerSpec *docker.ContainerSpec, spec client.Spec, dd *config.DataDirConfig,
+) (docker.Mount, bool) {
+	if containerSpec == nil {
+		return docker.Mount{}, false
+	}
+
+	target := spec.DataDir()
+	if dd != nil && dd.ContainerDir != "" {
+		target = dd.ContainerDir
+	}
+
+	for _, mnt := range containerSpec.Mounts {
+		if mnt.Target == target {
+			return mnt, true
+		}
+	}
+
+	return docker.Mount{}, false
+}

--- a/pkg/runner/db_compaction_test.go
+++ b/pkg/runner/db_compaction_test.go
@@ -1,0 +1,169 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/client"
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/ethpandaops/benchmarkoor/pkg/docker"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBCompactionMarker_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	r := &runner{log: logrus.New(), cfg: &Config{}}
+	log := logrus.New()
+
+	req := &dbCompactionRequest{
+		Instance: &config.ClientInstance{ID: "geth", Client: "geth"},
+		Phase:    config.DBCompactionBeforePreRuns,
+		RunID:    "run-1",
+	}
+	report := &dbCompactionReport{
+		Image:        "ethereum/client-go:stable",
+		CompletedAt:  "2026-08-27T10:12:03Z",
+		DurationMS:   4200,
+		DatadirBytes: &dbCompactionSizes{Before: 200, After: 100},
+	}
+
+	r.writeDBCompactionMarker(dir, req, report, log)
+
+	marker := readDBCompactionMarker(dir)
+	require.NotNil(t, marker)
+	assert.Equal(t, dbCompactionMarkerVersion, marker.Version)
+
+	entry, ok := marker.Phases[config.DBCompactionBeforePreRuns]
+	require.True(t, ok)
+	assert.Equal(t, "geth", entry.Client)
+	assert.Equal(t, "run-1", entry.RunID)
+	assert.Equal(t, "2026-08-27T10:12:03Z", entry.CompletedAt)
+	assert.Equal(t, int64(4200), entry.DurationMS)
+	require.NotNil(t, entry.DatadirBytes)
+	assert.Equal(t, int64(100), entry.DatadirBytes.After)
+
+	// A second phase is added, never replacing the first.
+	req.Phase = config.DBCompactionBeforeBenchmarks
+	r.writeDBCompactionMarker(dir, req, report, log)
+
+	marker = readDBCompactionMarker(dir)
+	require.NotNil(t, marker)
+	assert.Len(t, marker.Phases, 2)
+}
+
+func TestReadDBCompactionMarker_MissingOrCorrupt(t *testing.T) {
+	dir := t.TempDir()
+
+	assert.Nil(t, readDBCompactionMarker(dir))
+
+	path := filepath.Join(dir, config.DBCompactionMarkerFile)
+	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0644))
+
+	assert.Nil(t, readDBCompactionMarker(dir))
+}
+
+func TestDBCompactionRequest_HostPath(t *testing.T) {
+	bind := &dbCompactionRequest{
+		Mount: docker.Mount{Type: "bind", Source: "/snapshots/geth", Target: "/data"},
+	}
+	assert.Equal(t, "/snapshots/geth", bind.hostPath())
+
+	volume := &dbCompactionRequest{
+		Mount: docker.Mount{Type: "volume", Source: "benchmarkoor-vol", Target: "/data"},
+	}
+	assert.Empty(t, volume.hostPath())
+}
+
+func TestDatadirMountFor(t *testing.T) {
+	spec, err := client.NewRegistry().Get(client.ClientGeth)
+	require.NoError(t, err)
+
+	dataMount := docker.Mount{Type: "bind", Source: "/snapshots/geth", Target: "/data"}
+	containerSpec := &docker.ContainerSpec{
+		Mounts: []docker.Mount{
+			{Type: "bind", Source: "/tmp/jwt", Target: "/tmp/jwtsecret"},
+			dataMount,
+		},
+	}
+
+	t.Run("finds the client's default datadir", func(t *testing.T) {
+		mount, ok := datadirMountFor(containerSpec, spec, nil)
+		require.True(t, ok)
+		assert.Equal(t, dataMount, mount)
+	})
+
+	t.Run("honours a custom container_dir", func(t *testing.T) {
+		custom := &docker.ContainerSpec{
+			Mounts: []docker.Mount{{Type: "bind", Source: "/snap", Target: "/var/lib/geth"}},
+		}
+
+		mount, ok := datadirMountFor(
+			custom, spec, &config.DataDirConfig{ContainerDir: "/var/lib/geth"},
+		)
+		require.True(t, ok)
+		assert.Equal(t, "/snap", mount.Source)
+
+		_, ok = datadirMountFor(custom, spec, nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("no container spec", func(t *testing.T) {
+		_, ok := datadirMountFor(nil, spec, nil)
+		assert.False(t, ok)
+	})
+}
+
+func TestRunnerDBCompactionFor(t *testing.T) {
+	instance := &config.ClientInstance{ID: "geth", Client: "geth"}
+
+	r := &runner{cfg: &Config{FullConfig: &config.Config{
+		Runner: config.RunnerConfig{
+			Client: config.ClientConfig{Config: config.ClientDefaults{
+				DBCompaction: &config.DBCompactionConfig{
+					Enabled: true,
+					When:    []string{config.DBCompactionBeforePreRuns},
+				},
+			}},
+		},
+	}}}
+
+	assert.NotNil(t, r.dbCompactionFor(instance, config.DBCompactionBeforePreRuns))
+	assert.Nil(t, r.dbCompactionFor(instance, config.DBCompactionBeforeBenchmarks))
+
+	bare := &runner{cfg: &Config{}}
+	assert.Nil(t, bare.dbCompactionFor(instance, config.DBCompactionBeforePreRuns))
+}
+
+func TestGethDBMaintenanceCommands(t *testing.T) {
+	spec, err := client.NewRegistry().Get(client.ClientGeth)
+	require.NoError(t, err)
+
+	cmds := spec.DBMaintenanceCommands("/var/lib/geth")
+	require.NotNil(t, cmds)
+	assert.Equal(t, []string{"db", "compact", "--datadir=/var/lib/geth"}, cmds.Compact)
+	assert.Equal(t, []string{"db", "inspect", "--datadir=/var/lib/geth"}, cmds.Inspect)
+
+	assert.True(t, client.SupportsDBCompaction(client.ClientGeth))
+
+	for _, other := range []client.ClientType{
+		client.ClientBesu, client.ClientNethermind, client.ClientErigon,
+		client.ClientReth, client.ClientNimbus, client.ClientEthrex,
+	} {
+		assert.False(t, client.SupportsDBCompaction(other), string(other))
+	}
+}
+
+func TestDirSize(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a"), []byte("12345"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "b"), []byte("123"), 0644))
+
+	assert.Equal(t, int64(8), dirSize(dir))
+	assert.Equal(t, int64(0), dirSize(filepath.Join(dir, "missing")))
+}

--- a/pkg/runner/db_compaction_test.go
+++ b/pkg/runner/db_compaction_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -166,4 +167,127 @@ func TestDirSize(t *testing.T) {
 
 	assert.Equal(t, int64(8), dirSize(dir))
 	assert.Equal(t, int64(0), dirSize(filepath.Join(dir, "missing")))
+}
+
+// runnerWithDBCompaction builds a runner whose global db_compaction config is
+// cfg, for the marker-skip tests below.
+func runnerWithDBCompaction(cfg *config.DBCompactionConfig) *runner {
+	return &runner{cfg: &Config{FullConfig: &config.Config{
+		Runner: config.RunnerConfig{
+			Client: config.ClientConfig{
+				Config: config.ClientDefaults{DBCompaction: cfg},
+			},
+		},
+	}}}
+}
+
+// writeMarkerFor drops a marker naming phase at the root of dir.
+func writeMarkerFor(t *testing.T, dir, phase string) {
+	t.Helper()
+
+	marker := dbCompactionMarker{
+		Version: dbCompactionMarkerVersion,
+		Phases: map[string]dbCompactionMarkerEntry{
+			phase: {Client: "geth", RunID: "earlier-run", CompletedAt: "2026-08-27T10:12:03Z"},
+		},
+	}
+
+	data, err := json.Marshal(marker)
+	require.NoError(t, err)
+	require.NoError(
+		t, os.WriteFile(filepath.Join(dir, config.DBCompactionMarkerFile), data, 0644),
+	)
+}
+
+// A persisted baseline carries this phase's marker into every later run. The
+// skip has to be decided from the marker alone, because the callers that must
+// stop the client to compact consult it BEFORE stopping — see
+// prepareDatadirBeforeBenchmarks. Deciding later would recycle the client on
+// every run for a compaction that does nothing.
+func TestDBCompactionSkipEntry(t *testing.T) {
+	phase := config.DBCompactionBeforeBenchmarks
+	instance := &config.ClientInstance{ID: "geth", Client: "geth"}
+
+	persisting := func() *config.DBCompactionConfig {
+		return &config.DBCompactionConfig{
+			Enabled: true,
+			When:    []string{phase},
+			Persist: &config.DBCompactionPersistConfig{Enabled: true},
+		}
+	}
+
+	t.Run("marked phase on a persisting config skips", func(t *testing.T) {
+		dir := t.TempDir()
+		writeMarkerFor(t, dir, phase)
+
+		r := runnerWithDBCompaction(persisting())
+		mount := docker.Mount{Type: "bind", Source: dir, Target: "/data"}
+
+		entry := r.dbCompactionSkipEntry(instance, phase, mount)
+		require.NotNil(t, entry)
+		assert.Equal(t, "earlier-run", entry.RunID)
+	})
+
+	t.Run("no marker runs the compaction", func(t *testing.T) {
+		r := runnerWithDBCompaction(persisting())
+		mount := docker.Mount{Type: "bind", Source: t.TempDir(), Target: "/data"}
+
+		assert.Nil(t, r.dbCompactionSkipEntry(instance, phase, mount))
+	})
+
+	t.Run("a marker for another phase runs the compaction", func(t *testing.T) {
+		dir := t.TempDir()
+		writeMarkerFor(t, dir, config.DBCompactionBeforePreRuns)
+
+		r := runnerWithDBCompaction(persisting())
+		mount := docker.Mount{Type: "bind", Source: dir, Target: "/data"}
+
+		assert.Nil(t, r.dbCompactionSkipEntry(instance, phase, mount))
+	})
+
+	t.Run("without persist the marker cannot describe this datadir", func(t *testing.T) {
+		dir := t.TempDir()
+		writeMarkerFor(t, dir, phase)
+
+		r := runnerWithDBCompaction(&config.DBCompactionConfig{
+			Enabled: true,
+			When:    []string{phase},
+		})
+		mount := docker.Mount{Type: "bind", Source: dir, Target: "/data"}
+
+		assert.Nil(t, r.dbCompactionSkipEntry(instance, phase, mount))
+	})
+
+	t.Run("skip_if_marked false forces the compaction", func(t *testing.T) {
+		dir := t.TempDir()
+		writeMarkerFor(t, dir, phase)
+
+		force := false
+		cfg := persisting()
+		cfg.SkipIfMarked = &force
+
+		r := runnerWithDBCompaction(cfg)
+		mount := docker.Mount{Type: "bind", Source: dir, Target: "/data"}
+
+		assert.Nil(t, r.dbCompactionSkipEntry(instance, phase, mount))
+	})
+
+	t.Run("a volume datadir has no marker to read", func(t *testing.T) {
+		r := runnerWithDBCompaction(persisting())
+		mount := docker.Mount{Type: "volume", Source: "benchmarkoor-vol", Target: "/data"}
+
+		assert.Nil(t, r.dbCompactionSkipEntry(instance, phase, mount))
+	})
+
+	t.Run("a phase that is not configured never skips", func(t *testing.T) {
+		dir := t.TempDir()
+		writeMarkerFor(t, dir, config.DBCompactionBeforePreRuns)
+
+		r := runnerWithDBCompaction(persisting())
+		mount := docker.Mount{Type: "bind", Source: dir, Target: "/data"}
+
+		assert.Nil(
+			t, r.dbCompactionSkipEntry(instance, config.DBCompactionBeforePreRuns, mount),
+		)
+	})
 }

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -84,6 +83,16 @@ func (r *runner) runContainerLifecycle(
 			"method": datadirCfg.Method,
 		}).Info("Using pre-populated data directory")
 
+		// A ZFS datadir that persists its compaction compacts the SOURCE
+		// dataset, before it is snapshotted and cloned below. Nothing else can
+		// write a compacted clone back to the source it was cloned from.
+		if err := r.compactZFSSourceForPersist(
+			ctx, instance, spec, datadirCfg, runID, params.ImageName,
+			runResultsDir, benchmarkoorLogFile,
+		); err != nil {
+			return fmt.Errorf("compacting the ZFS source dataset: %w", err)
+		}
+
 		provider, err := datadir.NewProvider(log, datadirCfg.Method)
 		if err != nil {
 			return fmt.Errorf("creating datadir provider: %w", err)
@@ -113,6 +122,34 @@ func (r *runner) runContainerLifecycle(
 			Type:   "bind",
 			Source: prepared.MountPath,
 			Target: containerDir,
+		}
+
+		// Compact before the client boots, so before the pre-run steps replay.
+		// No client holds the database yet, so this needs no stop and restart.
+		//
+		// A ZFS persist already compacted the source above, and the clone
+		// inherits it — compacting again here would redo hours of work on a
+		// database that is already compact.
+		if datadirCfg.Method != "zfs" ||
+			!r.dbCompactionPersistsAt(instance, config.DBCompactionBeforePreRuns) {
+			compacted, err := r.compactDatadirForPhase(
+				ctx, instance, spec, config.DBCompactionBeforePreRuns,
+				runID, params.ImageName, runResultsDir, dataMount,
+				benchmarkoorLogFile, nil,
+			)
+			if err != nil {
+				return err
+			}
+
+			// schelk persists by making the compacted volume the new baseline.
+			// It happens here, before the container exists, so no client is
+			// holding the volume the promote has to unmount.
+			if compacted && datadirCfg.Method == "schelk" &&
+				r.dbCompactionPersistsAt(instance, config.DBCompactionBeforePreRuns) {
+				if err := r.persistCompactedSchelk(ctx, log); err != nil {
+					return fmt.Errorf("persisting the compacted datadir: %w", err)
+				}
+			}
 		}
 
 		// Surface any state-actor provenance dropped at the snapshot root
@@ -700,6 +737,12 @@ func (r *runner) runContainerLifecycle(
 				}
 				return nil
 			}(),
+			DBCompaction: func() *config.DBCompactionConfig {
+				if r.cfg.FullConfig != nil {
+					return r.cfg.FullConfig.GetDBCompaction(instance)
+				}
+				return nil
+			}(),
 		},
 	}
 
@@ -1231,14 +1274,19 @@ func (r *runner) runContainerLifecycle(
 			}
 		}
 
-		// Promote the schelk baseline for the strategies that keep this one client
-		// for the whole run (none, rpc-debug-setHead). The runner-level strategies
-		// below handle it themselves, next to their own snapshot/checkpoint, since
-		// they rebuild the container per test anyway.
+		// Prepare the datadir for the strategies that keep this one client for the
+		// whole run (none, rpc-debug-setHead): compact the database, promote the
+		// schelk baseline, or both. The runner-level strategies below handle it
+		// themselves, next to their own snapshot/checkpoint, since they rebuild
+		// the container per test anyway.
 		skipPreRunSteps := preRunsAlreadyApplied
 
-		if datadirCfg.ShouldPromotePostPreRuns() && !isRunnerLevelStrategy(rollbackStrategy) &&
-			!preRunsAlreadyApplied {
+		wantsPromote := datadirCfg.ShouldPromotePostPreRuns() && !preRunsAlreadyApplied
+		wantsCompaction := r.dbCompactionFor(
+			instance, config.DBCompactionBeforeBenchmarks,
+		) != nil
+
+		if (wantsPromote || wantsCompaction) && !isRunnerLevelStrategy(rollbackStrategy) {
 			// The log stream ends with the stopped container, so re-attach it to
 			// the restarted one; otherwise the client's logs for the entire
 			// benchmark phase — everything after the promote — are lost.
@@ -1273,17 +1321,37 @@ func (r *runner) runContainerLifecycle(
 				}()
 			}
 
-			newIP, err := r.promoteSchelkInPlace(
-				execCtx, ctx, instance, spec, containerID, containerIP, runResultsDir,
-				blockNum, &stoppingOnPurpose, &mu, armContainerMonitor, reattachLogs,
-				&logDone, &logCancel, log,
+			newIP, preRunsRan, err := r.prepareDatadirBeforeBenchmarks(
+				execCtx, ctx, &preBenchmarkDatadirParams{
+					Instance:            instance,
+					Spec:                spec,
+					DataMount:           dataMount,
+					RunID:               runID,
+					ImageName:           imageName,
+					ContainerID:         containerID,
+					ContainerIP:         containerIP,
+					ResultsDir:          runResultsDir,
+					HeadNumber:          blockNum,
+					SkipPreRuns:         preRunsAlreadyApplied,
+					Promote:             wantsPromote,
+					BenchmarkoorLog:     benchmarkoorLogFile,
+					StoppingOnPurpose:   &stoppingOnPurpose,
+					Mu:                  &mu,
+					ArmContainerMonitor: armContainerMonitor,
+					ReattachLogs:        reattachLogs,
+					LogDone:             &logDone,
+					LogCancel:           &logCancel,
+				}, log,
 			)
 			if err != nil {
-				return fmt.Errorf("promoting schelk baseline after pre-run steps: %w", err)
+				return fmt.Errorf("preparing the datadir before the benchmarks: %w", err)
 			}
 
 			if newIP != "" {
 				containerIP = newIP
+			}
+
+			if preRunsRan {
 				skipPreRunSteps = true
 			}
 		}
@@ -1800,124 +1868,170 @@ func isRunnerLevelStrategy(strategy string) bool {
 		strategy == config.RollbackStrategyCheckpointRestore
 }
 
-// promoteSchelkInPlace applies the suite's pre-run steps, then persists the
-// resulting datadir as the new schelk baseline, for the strategies that keep one
-// client for the whole run (none, rpc-debug-setHead).
+// preBenchmarkDatadirParams carries the state
+// prepareDatadirBeforeBenchmarks needs to stop the client, work on its
+// datadir, and bring the same container back up.
+type preBenchmarkDatadirParams struct {
+	Instance    *config.ClientInstance
+	Spec        client.Spec
+	DataMount   docker.Mount
+	RunID       string
+	ImageName   string
+	ContainerID string
+	ContainerIP string
+	ResultsDir  string
+
+	// HeadNumber is the datadir head before the pre-run steps; the replay
+	// resumes from it instead of re-importing the whole bundle.
+	HeadNumber uint64
+
+	// SkipPreRuns is set when the caller already established that the bundle
+	// is applied, so the replay would be a no-op.
+	SkipPreRuns bool
+
+	// Promote persists the datadir as the new schelk baseline.
+	Promote bool
+
+	BenchmarkoorLog *os.File
+
+	StoppingOnPurpose   *bool
+	Mu                  *sync.Mutex
+	ArmContainerMonitor func(string)
+	ReattachLogs        func()
+	LogDone             *chan struct{}
+	LogCancel           *context.CancelFunc
+}
+
+// prepareDatadirBeforeBenchmarks applies the suite's pre-run steps, then does
+// the offline datadir work that has to happen before the first test: a
+// database compaction, a schelk promote, or both.
 //
-// `schelk promote` unmounts the volume, so the client cannot hold it: the client
-// is stopped, promoted, the volume remounted, and the SAME container started
-// again — restarting re-binds the mount from the host path, which now resolves to
-// the promoted volume. The container monitor is told the stop is deliberate and
-// re-armed afterwards, so a mid-run stop is not mistaken for a crash.
+// It serves the strategies that keep one client for the whole run (none,
+// rpc-debug-setHead). Both steps need the client stopped — `geth db compact`
+// takes the database lock, and `schelk promote` unmounts the volume — so they
+// share a single stop and restart: settle, graceful stop, drain the logs,
+// sync, work, start the SAME container again (restarting re-binds the mount
+// from the host path, which now resolves to the promoted volume). The
+// container monitor is told the stop is deliberate and re-armed afterwards, so
+// a mid-run stop is not mistaken for a crash.
 //
-// Returns the restarted container's IP, or "" when nothing was promoted (so the
-// caller leaves the executor to run the pre-run steps as usual).
-func (r *runner) promoteSchelkInPlace(
+// A promote only ever runs after a graceful client shutdown. A client that had
+// to be killed may not have flushed its state, and promoting a torn datadir
+// would destroy the golden image in favour of an unusable one.
+//
+// Returns the restarted container's IP (empty when nothing needed doing) and
+// whether the pre-run steps have been applied, which the caller passes to the
+// executor so it does not replay them a second time.
+func (r *runner) prepareDatadirBeforeBenchmarks(
 	execCtx, ctx context.Context,
-	instance *config.ClientInstance,
-	spec client.Spec,
-	containerID, containerIP, resultsDir string,
-	headNumber uint64,
-	stoppingOnPurpose *bool,
-	mu *sync.Mutex,
-	armContainerMonitor func(string),
-	reattachLogs func(),
-	logDone *chan struct{},
-	logCancel *context.CancelFunc,
+	p *preBenchmarkDatadirParams,
 	log logrus.FieldLogger,
-) (string, error) {
-	preRunOpts := &executor.ExecuteOptions{
-		EngineEndpoint: fmt.Sprintf(
-			"http://%s:%d", containerIP, spec.EnginePort(),
-		),
-		JWT:                           r.cfg.JWT,
-		ResultsDir:                    resultsDir,
-		FailFast:                      true,
-		PreRunStepSleep:               r.cfg.PreRunStepSleep,
-		SkipUntilBlockNumber:          headNumber,
-		RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(instance),
-		RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(instance),
+) (newIP string, preRunsRan bool, err error) {
+	instance, spec := p.Instance, p.Spec
+	promote := p.Promote
+
+	compaction := r.dbCompactionFor(instance, config.DBCompactionBeforeBenchmarks)
+
+	if !p.SkipPreRuns {
+		preRunOpts := &executor.ExecuteOptions{
+			EngineEndpoint: fmt.Sprintf(
+				"http://%s:%d", p.ContainerIP, spec.EnginePort(),
+			),
+			JWT:                           r.cfg.JWT,
+			ResultsDir:                    p.ResultsDir,
+			FailFast:                      true,
+			PreRunStepSleep:               r.cfg.PreRunStepSleep,
+			SkipUntilBlockNumber:          p.HeadNumber,
+			RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(instance),
+			RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(instance),
+		}
+
+		n, runErr := r.executor.RunPreRunSteps(execCtx, preRunOpts)
+		if runErr != nil {
+			return "", false, fmt.Errorf("running pre-run steps: %w", runErr)
+		}
+
+		preRunsRan = true
+
+		if promote && n == 0 {
+			log.Warn(
+				"promote_post_pre_runs is set but the suite has no pre-run steps; " +
+					"refusing to promote (the baseline would be the raw snapshot)",
+			)
+
+			promote = false
+		}
+
+		if n > 0 {
+			log.WithField("steps", n).Info("Pre-run steps completed")
+		}
 	}
 
-	n, err := r.executor.RunPreRunSteps(execCtx, preRunOpts)
-	if err != nil {
-		return "", fmt.Errorf("running pre-run steps: %w", err)
+	if !promote && compaction == nil {
+		return "", preRunsRan, nil
 	}
 
-	if n == 0 {
-		log.Warn(
-			"promote_post_pre_runs is set but the suite has no pre-run steps; " +
-				"refusing to promote (the baseline would be the raw snapshot)",
-		)
-
-		return "", nil
+	// The head is exact here and free: the client is still up, and this is the
+	// last moment before it stops. Only the report uses it.
+	var head *dbCompactionHead
+	if compaction != nil {
+		head = r.dbCompactionHeadFromRPC(execCtx, p.ContainerIP, spec.RPCPort(), log)
 	}
 
-	log.WithField("steps", n).Info("Pre-run steps completed; promoting datadir to the schelk baseline")
-
-	log.WithField("settle", schelkSettleBeforeStop).Info("Waiting for client to settle before stop")
-	time.Sleep(schelkSettleBeforeStop)
-
-	mu.Lock()
-	*stoppingOnPurpose = true
-	mu.Unlock()
+	p.Mu.Lock()
+	*p.StoppingOnPurpose = true
+	p.Mu.Unlock()
 
 	defer func() {
-		mu.Lock()
-		*stoppingOnPurpose = false
-		mu.Unlock()
+		p.Mu.Lock()
+		*p.StoppingOnPurpose = false
+		p.Mu.Unlock()
 	}()
 
-	// Default (60s) SIGTERM grace so the client persists its state cleanly; a
-	// killed client may not have flushed, and that datadir must not become the
-	// irreversible golden image.
-	log.Info("Stopping client for schelk promote (graceful)")
-
-	if err := r.containerMgr.StopContainer(ctx, containerID, nil); err != nil {
-		return "", fmt.Errorf("stopping container: %w", err)
+	if err := r.stopClientForDatadirWork(
+		ctx, p.ContainerID, p.LogDone, p.LogCancel, log,
+	); err != nil {
+		return "", preRunsRan, err
 	}
 
-	// Let the stopped container's logs finish landing before promoting.
-	waitForLogDrain(logDone, logCancel, logDrainTimeout)
-
-	if syncErr := exec.Command("sync").Run(); syncErr != nil {
-		log.WithError(syncErr).Warn("Failed to sync before schelk promote")
+	if compaction != nil {
+		if _, err := r.compactDatadirForPhase(
+			ctx, instance, spec, config.DBCompactionBeforeBenchmarks,
+			p.RunID, p.ImageName, p.ResultsDir, p.DataMount, p.BenchmarkoorLog, head,
+		); err != nil {
+			return "", preRunsRan, err
+		}
 	}
 
-	log.Info("Persisting the advanced datadir as the new schelk baseline (`schelk promote`)")
-
-	if err := datadir.SchelkPromote(ctx, r.log); err != nil {
-		return "", fmt.Errorf("schelk promote: %w", err)
+	if promote {
+		if err := r.persistCompactedSchelk(ctx, log); err != nil {
+			return "", preRunsRan, err
+		}
 	}
 
-	// promote leaves the volume unmounted; the restarted container binds this path.
-	if err := datadir.EnsureSchelkMounted(ctx, r.log); err != nil {
-		return "", fmt.Errorf("remounting schelk volume after promote: %w", err)
+	log.Info("Restarting client on the prepared datadir")
+
+	if err := r.containerMgr.StartContainer(ctx, p.ContainerID); err != nil {
+		return "", preRunsRan, fmt.Errorf("restarting container: %w", err)
 	}
 
-	log.Info("Restarting client on the promoted baseline")
+	p.Mu.Lock()
+	*p.StoppingOnPurpose = false
+	p.Mu.Unlock()
 
-	if err := r.containerMgr.StartContainer(ctx, containerID); err != nil {
-		return "", fmt.Errorf("restarting container after promote: %w", err)
-	}
+	p.ArmContainerMonitor(p.ContainerID)
+	p.ReattachLogs()
 
-	mu.Lock()
-	*stoppingOnPurpose = false
-	mu.Unlock()
-
-	armContainerMonitor(containerID)
-	reattachLogs()
-
-	newIP, err := r.containerMgr.GetContainerIP(ctx, containerID, r.cfg.ContainerNetwork)
+	newIP, err = r.containerMgr.GetContainerIP(ctx, p.ContainerID, r.cfg.ContainerNetwork)
 	if err != nil {
-		return "", fmt.Errorf("getting container IP after promote: %w", err)
+		return "", preRunsRan, fmt.Errorf("getting container IP after restart: %w", err)
 	}
 
 	if _, err := r.waitForRPC(execCtx, newIP, spec.RPCPort()); err != nil {
-		return "", fmt.Errorf("waiting for RPC after promote: %w", err)
+		return "", preRunsRan, fmt.Errorf("waiting for RPC after restart: %w", err)
 	}
 
-	log.WithField("ip", newIP).Info("Client back up on the promoted baseline")
+	log.WithField("ip", newIP).Info("Client back up on the prepared datadir")
 
-	return newIP, nil
+	return newIP, preRunsRan, nil
 }

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -1932,6 +1932,22 @@ func (r *runner) prepareDatadirBeforeBenchmarks(
 
 	compaction := r.dbCompactionFor(instance, config.DBCompactionBeforeBenchmarks)
 
+	// Whether the compaction has anything to do is settled BEFORE the client
+	// stops. A persisted baseline carries this phase's marker into every later
+	// run, and those runs also skip the promote (their head already sits at the
+	// bundle's end). Deciding inside runDBCompaction instead would stop the
+	// client, skip the work, and start it again — every run, for nothing, on a
+	// restart that can fail.
+	if compaction != nil {
+		if entry := r.dbCompactionSkipEntry(
+			instance, config.DBCompactionBeforeBenchmarks, p.DataMount,
+		); entry != nil {
+			logDBCompactionSkip(log, entry)
+
+			compaction = nil
+		}
+	}
+
 	if !p.SkipPreRuns {
 		preRunOpts := &executor.ExecuteOptions{
 			EngineEndpoint: fmt.Sprintf(

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -194,6 +194,7 @@ type ResolvedInstance struct {
 	BootstrapFCU                     *config.BootstrapFCUConfig               `json:"bootstrap_fcu,omitempty"`
 	CheckpointRestoreStrategyOptions *config.CheckpointRestoreStrategyOptions `json:"checkpoint_restore_strategy_options,omitempty"`
 	OpcodeExtraction                 *config.OpcodeExtractionConfig           `json:"opcode_extraction,omitempty"`
+	DBCompaction                     *config.DBCompactionConfig               `json:"db_compaction,omitempty"`
 }
 
 // NewRunner creates a new runner instance.

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethpandaops/benchmarkoor/pkg/client"
 	"github.com/ethpandaops/benchmarkoor/pkg/config"
 	"github.com/ethpandaops/benchmarkoor/pkg/datadir"
+	"github.com/ethpandaops/benchmarkoor/pkg/docker"
 	"github.com/ethpandaops/benchmarkoor/pkg/executor"
 	"github.com/ethpandaops/benchmarkoor/pkg/podman"
 	"github.com/ethpandaops/benchmarkoor/pkg/stats"
@@ -214,7 +215,65 @@ func (r *runner) runTestsWithCheckpointRestore(
 		log.WithField("steps", preRunSteps).Info("Pre-run steps completed before checkpoint")
 	}
 
-	// 2b. Persist the advanced datadir as the new schelk baseline, if asked.
+	// 2a. Compact the database before the checkpoint, so every restored
+	//     container resumes on the compacted datadir. `geth db compact` takes
+	//     the database lock, so the client is stopped for it and started again
+	//     before the checkpoint is taken — a checkpoint of a client that is not
+	//     running on this datadir would restore onto a database it never opened.
+	if r.dbCompactionFor(params.Instance, config.DBCompactionBeforeBenchmarks) != nil {
+		compactionHead := r.dbCompactionHeadFromRPC(ctx, containerIP, spec.RPCPort(), log)
+
+		if err := r.stopClientForDatadirWork(
+			ctx, containerID, logDone, logCancel, log,
+		); err != nil {
+			return nil, fmt.Errorf("stopping container for db compaction: %w", err)
+		}
+
+		if _, err := r.compactDatadirForPhase(
+			ctx, params.Instance, spec, config.DBCompactionBeforeBenchmarks,
+			params.RunID, params.ImageName, resultsDir,
+			docker.Mount{Type: "bind", Source: dataMountSource, Target: containerDir},
+			benchmarkoorLog, compactionHead,
+		); err != nil {
+			return nil, err
+		}
+
+		if err := r.containerMgr.StartContainer(ctx, containerID); err != nil {
+			return nil, fmt.Errorf("starting container after db compaction: %w", err)
+		}
+
+		newIP, ipErr := r.containerMgr.GetContainerIP(
+			ctx, containerID, r.cfg.ContainerNetwork,
+		)
+		if ipErr != nil {
+			return nil, fmt.Errorf("getting container IP after db compaction: %w", ipErr)
+		}
+
+		containerIP = newIP
+
+		if logErr := r.startLogStreaming(
+			ctx, resultsDir,
+			params.Instance.ID, containerID,
+			benchmarkoorLog, &containerLogInfo{
+				Name:             params.ContainerSpec.Name,
+				ContainerID:      containerID,
+				Image:            params.ContainerSpec.Image,
+				GenesisGroupHash: params.GenesisGroupHash,
+			},
+			params.BlockLogCollector, cleanupStarted,
+			logDone, logCancel, cleanupFuncs,
+		); logErr != nil {
+			return nil, fmt.Errorf("log streaming after db compaction: %w", logErr)
+		}
+
+		if _, err := r.waitForRPC(ctx, containerIP, spec.RPCPort()); err != nil {
+			return nil, fmt.Errorf("waiting for RPC after db compaction: %w", err)
+		}
+
+		log.WithField("ip", containerIP).Info("Client back up on the compacted datadir")
+	}
+
+	// 2c. Persist the advanced datadir as the new schelk baseline, if asked.
 	//
 	//     This has to happen BEFORE the checkpoint: `schelk promote` unmounts the
 	//     volume, so the client cannot be holding it, and the checkpoint must be

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -220,7 +220,22 @@ func (r *runner) runTestsWithCheckpointRestore(
 	//     the database lock, so the client is stopped for it and started again
 	//     before the checkpoint is taken — a checkpoint of a client that is not
 	//     running on this datadir would restore onto a database it never opened.
-	if r.dbCompactionFor(params.Instance, config.DBCompactionBeforeBenchmarks) != nil {
+	compactionMount := docker.Mount{
+		Type: "bind", Source: dataMountSource, Target: containerDir,
+	}
+
+	// As in prepareDatadirBeforeBenchmarks: settle the marker question before
+	// the stop, so a datadir that is already compacted does not cost a client
+	// recycle on every run.
+	compactionSkip := r.dbCompactionSkipEntry(
+		params.Instance, config.DBCompactionBeforeBenchmarks, compactionMount,
+	)
+	if compactionSkip != nil {
+		logDBCompactionSkip(log, compactionSkip)
+	}
+
+	if compactionSkip == nil &&
+		r.dbCompactionFor(params.Instance, config.DBCompactionBeforeBenchmarks) != nil {
 		compactionHead := r.dbCompactionHeadFromRPC(ctx, containerIP, spec.RPCPort(), log)
 
 		if err := r.stopClientForDatadirWork(
@@ -231,8 +246,7 @@ func (r *runner) runTestsWithCheckpointRestore(
 
 		if _, err := r.compactDatadirForPhase(
 			ctx, params.Instance, spec, config.DBCompactionBeforeBenchmarks,
-			params.RunID, params.ImageName, resultsDir,
-			docker.Mount{Type: "bind", Source: dataMountSource, Target: containerDir},
+			params.RunID, params.ImageName, resultsDir, compactionMount,
 			benchmarkoorLog, compactionHead,
 		); err != nil {
 			return nil, err

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -1253,7 +1253,22 @@ func (r *runner) promoteSchelkAfterPreRuns(
 
 	// Compact before the promote, so the baseline every per-test recreate
 	// restores from carries the compacted database. One stop, one promote.
-	if mount, ok := datadirMountFor(params.ContainerSpec, spec, params.DataDirCfg); ok {
+	//
+	// A missing datadir mount is an error rather than a skip, matching the ZFS
+	// ready-snapshot path above: the container spec and the datadir config that
+	// name the same target are built together, so a miss means they disagree —
+	// and silently dropping a configured compaction would promote a baseline
+	// the operator believes is compacted.
+	if r.dbCompactionFor(params.Instance, config.DBCompactionBeforeBenchmarks) != nil {
+		mount, ok := datadirMountFor(params.ContainerSpec, spec, params.DataDirCfg)
+		if !ok {
+			return "", false, fmt.Errorf(
+				"db_compaction is configured at %s but the container spec has no"+
+					" datadir mount to compact",
+				config.DBCompactionBeforeBenchmarks,
+			)
+		}
+
 		if _, err := r.compactDatadirForPhase(
 			ctx, params.Instance, spec, config.DBCompactionBeforeBenchmarks,
 			params.RunID, params.ImageName, resultsDir, mount,

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -110,6 +110,16 @@ func (r *runner) runTestsWithContainerStrategy(
 			)
 		}
 
+		// The head is exact here and free: the client is still up, and this is
+		// the last moment before it stops. Only the compaction report uses it.
+		var compactionHead *dbCompactionHead
+
+		if r.dbCompactionFor(params.Instance, config.DBCompactionBeforeBenchmarks) != nil {
+			compactionHead = r.dbCompactionHeadFromRPC(
+				ctx, containerIP, spec.RPCPort(), log,
+			)
+		}
+
 		// Settle time so the client finishes any in-flight
 		// initialisation and flushes its DB before we send SIGTERM.
 		// Too short here (e.g. reth/MDBX) snapshots a dirty datadir,
@@ -163,6 +173,18 @@ func (r *runner) runTestsWithContainerStrategy(
 				"could not find data mount for %s in container spec",
 				containerDir,
 			)
+		}
+
+		// Compact before the ready-state snapshot is taken, so every per-test
+		// rollback lands on the compacted database instead of redoing the work.
+		// The client is stopped and its writes are flushed already.
+		if _, err := r.compactDatadirForPhase(
+			ctx, params.Instance, spec, config.DBCompactionBeforeBenchmarks,
+			params.RunID, params.ImageName, resultsDir,
+			docker.Mount{Type: "bind", Source: dataMountSource, Target: containerDir},
+			benchmarkoorLog, compactionHead,
+		); err != nil {
+			return nil, err
 		}
 
 		// Take the ready-state ZFS snapshot.
@@ -1203,6 +1225,14 @@ func (r *runner) promoteSchelkAfterPreRuns(
 
 	log.WithField("steps", n).Info("Pre-run steps completed; promoting datadir to the schelk baseline")
 
+	// The head is exact here and free: the client is still up, and this is the
+	// last moment before it stops. Only the compaction report uses it.
+	var compactionHead *dbCompactionHead
+
+	if r.dbCompactionFor(params.Instance, config.DBCompactionBeforeBenchmarks) != nil {
+		compactionHead = r.dbCompactionHeadFromRPC(ctx, containerIP, spec.RPCPort(), log)
+	}
+
 	log.WithField("settle", schelkSettleBeforeStop).Info("Waiting for client to settle before stop")
 	time.Sleep(schelkSettleBeforeStop)
 
@@ -1219,6 +1249,18 @@ func (r *runner) promoteSchelkAfterPreRuns(
 
 	if syncErr := exec.Command("sync").Run(); syncErr != nil {
 		log.WithError(syncErr).Warn("Failed to sync before schelk promote")
+	}
+
+	// Compact before the promote, so the baseline every per-test recreate
+	// restores from carries the compacted database. One stop, one promote.
+	if mount, ok := datadirMountFor(params.ContainerSpec, spec, params.DataDirCfg); ok {
+		if _, err := r.compactDatadirForPhase(
+			ctx, params.Instance, spec, config.DBCompactionBeforeBenchmarks,
+			params.RunID, params.ImageName, resultsDir, mount,
+			benchmarkoorLog, compactionHead,
+		); err != nil {
+			return "", false, err
+		}
 	}
 
 	log.Info("Persisting the advanced datadir as the new schelk baseline (`schelk promote`)")

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -319,6 +319,24 @@ export interface OpcodeExtractionConfig {
   timeout?: string
 }
 
+export interface DBCompactionPersistConfig {
+  enabled: boolean
+  phases?: string[]
+  safety_snapshot?: boolean
+}
+
+export interface DBCompactionConfig {
+  enabled: boolean
+  when?: string[]
+  inspect?: boolean
+  timeout?: string
+  image?: string
+  extra_args?: string[]
+  continue_on_error?: boolean
+  skip_if_marked?: boolean
+  persist?: DBCompactionPersistConfig
+}
+
 /**
  * Shape of the per-run `test-opcodes.json` written when
  * `opcode_extraction.enabled` is true. One entry per test name; each
@@ -354,6 +372,7 @@ export interface InstanceConfig {
   post_test_sleep_duration?: string
   checkpoint_restore_strategy_options?: CheckpointRestoreStrategyOptions
   opcode_extraction?: OpcodeExtractionConfig
+  db_compaction?: DBCompactionConfig
 }
 
 // result.json per run

--- a/ui/src/components/run-detail/RunConfiguration.tsx
+++ b/ui/src/components/run-detail/RunConfiguration.tsx
@@ -356,6 +356,40 @@ export function RunConfiguration({ instance, system, startBlock, metadata, bench
                 </div>
               )}
 
+              {instance.db_compaction?.enabled && (
+                <div>
+                  <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">
+                    Database Compaction
+                  </dt>
+                  <dd className="mt-1 overflow-x-auto rounded-sm bg-gray-100 p-2 dark:bg-gray-900">
+                    <div className="flex flex-col gap-1 font-mono text-xs/5 text-gray-900 dark:text-gray-100">
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">when: </span>
+                        {(instance.db_compaction.when ?? ['before_benchmarks']).join(', ')}
+                      </div>
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">timeout: </span>
+                        {instance.db_compaction.timeout || '3h'}
+                      </div>
+                      {instance.db_compaction.persist?.enabled && (
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">persist: </span>
+                          {(
+                            instance.db_compaction.persist.phases ??
+                            instance.db_compaction.when ?? ['before_benchmarks']
+                          ).join(', ')}
+                        </div>
+                      )}
+                    </div>
+                    <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                      Compacts the client database with the client's own offline command
+                      before the run measures anything. Reports:{' '}
+                      <code className="font-mono">db-compaction/</code> at the run dir.
+                    </p>
+                  </dd>
+                </div>
+              )}
+
               {instance.retry_new_payloads_syncing_state?.enabled && (
                 <div>
                   <dt className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary

Adds `runner.client.config.db_compaction`, settable per instance too. When enabled, the runner runs the client's own offline compaction command in a one-shot container against the datadir. The client never runs while it happens — `geth db compact` takes the database lock.

```yaml
runner:
  client:
    config:
      db_compaction:
        enabled: true
        when: [before_benchmarks]   # or [before_pre_runs], or both
        inspect: true               # `geth db inspect` before and after
        timeout: 3h
        extra_args: ["--cache=16384"]
```

Only **geth** supports it today. A new `DBMaintenanceCommands(dataDir)` on the client `Spec` returns the argv, and `client.SupportsDBCompaction` is the single source of truth validation reads.

Besu was checked and cannot be supported: as of Besu 26.6.1 `besu storage` has no compaction subcommand, and no `--Xplugin-rocksdb-*` option compacts either. `trie-log prune` deletes trie logs below the retention limit rather than rewriting the database — a different operation, and one that removes the history the Bonsai rollback needs between tests. The reasoning is recorded in `pkg/client/besu.go` so nobody repeats the investigation.

## Phases

`when` accepts both points. The runner always executes them in lifecycle order, whatever order they are written in.

| `when` value | When it runs | Client |
|---|---|---|
| `before_pre_runs` | After the datadir is prepared, before the client boots — so before the suite pre-run steps replay | Not yet started. No stop and restart |
| `before_benchmarks` (default) | After the pre-run steps, before the first test | Stopped gracefully, then started again |

`before_benchmarks` is the default because the pre-run bundle writes blocks that undo most of what an earlier compaction achieved. It also lands before the state-baking step of every runner-level rollback strategy, so the compacted database goes into the ZFS ready-snapshot, the CRIU checkpoint, or the schelk promote for free.

`before_pre_runs` needs a pre-populated datadir: without one the database is created when the client boots.

## Persisting the compacted database

Without `persist` the compaction is run-local: it costs the same time on every run, and the clone, copy, or restored volume that holds it is destroyed at the end. `persist` writes it back to the baseline instead. The mechanism comes from `datadir.method`, so there is one knob and no way to pair the wrong mechanism with the wrong method.

| `datadir.method` | `before_pre_runs` | `before_benchmarks` |
|---|---|---|
| `schelk` | `schelk promote` makes the compacted volume the new baseline | Same, folded into the existing promote |
| `zfs` | The source dataset is compacted in place, before the snapshot and the clone | Not supported |
| `direct` | Already permanent | Same |
| `copy`, `overlayfs`, `fuse-overlayfs` | Not supported | Not supported |

Two rules follow from the mechanisms:

- **ZFS persists only at `before_pre_runs`.** The clone is a child of its source dataset, so no promote or rename puts the compacted clone back at the source path. Compacting the source first also keeps the clone small, since a compaction inside a copy-on-write clone rewrites the whole database into it. `safety_snapshot` (default on) leaves a `<dataset>@benchmarkoor-precompaction-<run-id>` snapshot that a `zfs rollback` restores exactly.
- **A schelk persist at `before_benchmarks` needs `promote_post_pre_runs: true`.** Persisting there moves the baseline head past the pre-run bundle, which is exactly what that option does. Requiring it keeps the decision explicit and lets the runner persist both with a single promote.

## The datadir marker

A finished compaction writes `.benchmarkoor-db-compaction.json` at the root of the datadir it compacted, so a persisted baseline says what has already been done to it:

```json
{
  "version": 1,
  "phases": {
    "before_pre_runs": {
      "client": "geth",
      "image": "ethereum/client-go:stable",
      "run_id": "20260827-101203-abcd",
      "completed_at": "2026-08-27T10:12:03Z",
      "duration_ms": 812345,
      "datadir_bytes": { "before": 812000000000, "after": 640000000000 }
    }
  }
}
```

It holds only what is known the moment the compaction finishes, so it is written once and never patched — no head, because at `before_pre_runs` no client has booted to report one, and a field that is null in half the baselines is worse than no field. With `persist`, `skip_if_marked` defaults to true and a later run skips a phase the marker already names, which is what stops every run paying the cost again.

## Validation

The runner rejects the combinations that would silently do nothing, rather than spending hours compacting a datadir that is thrown away before the first benchmark:

- an unsupported client;
- an unknown or duplicated `when` value, a `persist.phases` entry outside `when`, an unparseable or non-positive timeout;
- `before_pre_runs` without a datadir;
- a persist on a method that cannot persist (`copy`, `overlayfs`, `fuse-overlayfs`, `direct`, or no datadir), ZFS at `before_benchmarks`, or schelk at `before_benchmarks` without `promote_post_pre_runs`;
- `container-recreate` with a method that re-prepares the datadir per test (`copy`, `overlayfs`, `fuse-overlayfs`, or a fresh volume), and `container-recreate` with schelk unless the compaction persists.

## Output

```
<run-results>/db-compaction/
  before_pre_runs/inspect-before.txt
  before_pre_runs/compact.log
  before_pre_runs/inspect-after.txt
  before_pre_runs/compaction.json
  before_benchmarks/...
```

`compaction.json` records the command, the duration, the datadir size either side, and — at `before_benchmarks` only, where the runner reads it from the client it is about to stop — the datadir head. The inspection is a report, so a failure is logged and the compaction still runs: geth 1.17.5 exits 1 on `db inspect` against a datadir whose freezer is empty, which a freshly-initialised datadir has.

The resolved config lands in the run's `config.json` and a "Database Compaction" card in the UI run detail, so a compacted run is distinguishable from an uncompacted one.

## Files

- `pkg/config/config.go` — `DBCompactionConfig` + `DBCompactionPersistConfig`, phase and default helpers, fields on `ClientDefaults` and `ClientInstance`, `GetDBCompaction`, `validateDBCompaction`, env bindings.
- `pkg/client/` — `DBMaintenanceCommands` on the `Spec` interface and every client, `SupportsDBCompaction`.
- `pkg/runner/db_compaction.go` (new) — the compaction container, the inspections, the run report, the marker, and the shared stop-the-client helper.
- `pkg/runner/lifecycle.go` — the `before_pre_runs` hook after `provider.Prepare`; `promoteSchelkInPlace` becomes `prepareDatadirBeforeBenchmarks`, so the compaction and the promote share one settle, stop, sync, work, and restart.
- `pkg/runner/strategy_container.go` — before the ZFS ready-snapshot, and inside the schelk promote.
- `pkg/runner/strategy_checkpoint.go` — before the CRIU checkpoint, with its own stop and restart.
- `pkg/datadir/zfs.go` — `SnapshotZFSSource` for the safety snapshot.
- `docs/configuration.md`, `config.example.yaml`, `ui/`.

## CI

The `pre-runs` job now also builds a **geth** state-actor snapshot (same seed and spec, so the state matches besu's), and a final step benchmarks geth on it with compaction at both phases. geth cannot boot besu's datadir, so it boots its own snapshot and replays besu's recorded pre-run bundle via `eest_fixtures.pre_runs` — the documented "no per-client advanced datadirs" path. The job timeout goes 45 → 60 minutes for the extra snapshot.

The besu images in the `state-actor` and `pre-runs` jobs also move from `bal-devnet-7` to `glamsterdam-devnet-8`, and the new geth leg is pinned to the same devnet, so every client in those jobs agrees on the fork parameters.

## Test plan

- [x] `go build ./...`, `go test -race ./pkg/...`, `golangci-lint run --new-from-rev=origin/master` → 0 issues. The only failures are the pre-existing `TestValidateDataDirMethods_SchelkBinary` cases that need `/proc/mounts` (macOS only; they pass on Linux CI).
- [x] 33 new test cases across `pkg/config` and `pkg/runner`, including YAML decode of `when` as both a list and a scalar, the comma-separated env override, the marker round trip, and one case per validation rule.
- [x] `tsc -b` clean for the UI.
- [x] Verified the exact argv against geth 1.17.5: `db compact --datadir=/data` exits 0; `db inspect --datadir=/data` exits 1 on an empty freezer, which is why an inspection never fails the run.
- [x] Full local run on geth with `when: [before_benchmarks]`: settle → stop → inspect → compact → inspect → restart → RPC ready → 7/7 tests passed, with `db-compaction/before_benchmarks/{compact.log,compaction.json,inspect-*.txt}` written and the head recorded.
- [ ] The CI geth leg (needs this branch to run).

