### PR TITLE
fix(executor): stream step files instead of buffering them

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -826,14 +825,18 @@ func (e *executor) runStepFile(
 ) error {
 	// Use provider if available, otherwise read from file.
 	if step.Provider != nil {
-		return e.runStepLines(ctx, opts, step.Name, step.Provider.Lines(), result,
+		return e.runStepLines(ctx, opts, step.Name, newSliceLineSource(step.Provider.Lines()), result,
 			captureBlockLogs, betweenLineSleep, stepType)
 	}
 
 	return e.runStepFromFile(ctx, opts, step, result, captureBlockLogs, betweenLineSleep, stepType)
 }
 
-// runStepFromFile reads and executes lines from a file.
+// runStepFromFile streams and executes lines from a file.
+//
+// The lines are replayed as they are read. A stateful pre-run bundle can be
+// tens of GB, and collecting one into a []string first cost the runner 56 GiB
+// of RSS on a 46 GiB bundle before the kernel killed it.
 func (e *executor) runStepFromFile(
 	ctx context.Context,
 	opts *ExecuteOptions,
@@ -843,35 +846,14 @@ func (e *executor) runStepFromFile(
 	betweenLineSleep time.Duration,
 	stepType StepType,
 ) error {
-	file, err := os.Open(step.Path)
+	src, err := newFileLineSource(step.Path)
 	if err != nil {
-		return fmt.Errorf("opening step file: %w", err)
+		return err
 	}
 
-	defer func() { _ = file.Close() }()
+	defer func() { _ = src.Close() }()
 
-	reader := bufio.NewReader(file)
-
-	var lines []string
-
-	for {
-		line, err := reader.ReadString('\n')
-		if len(line) > 0 {
-			if trimmed := strings.TrimSpace(line); trimmed != "" {
-				lines = append(lines, trimmed)
-			}
-		}
-
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-
-			return fmt.Errorf("reading step file: %w", err)
-		}
-	}
-
-	return e.runStepLines(ctx, opts, step.Name, lines, result, captureBlockLogs,
+	return e.runStepLines(ctx, opts, step.Name, src, result, captureBlockLogs,
 		betweenLineSleep, stepType)
 }
 
@@ -883,7 +865,7 @@ func (e *executor) runStepLines(
 	ctx context.Context,
 	opts *ExecuteOptions,
 	stepName string,
-	lines []string,
+	src lineSource,
 	result *TestResult,
 	captureBlockLogs bool,
 	betweenLineSleep time.Duration,
@@ -911,7 +893,18 @@ func (e *executor) runStepLines(
 	skipping := opts.SkipUntilBlockNumber > 0 && stepType == StepTypePreRun
 	skippedCount := 0
 
-	for lineNum, line := range lines {
+	total := src.Total()
+
+	for lineNum := 0; ; lineNum++ {
+		line, ok, err := src.Next()
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			break
+		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -983,9 +976,9 @@ func (e *executor) runStepLines(
 
 		e.log.WithFields(logrus.Fields{
 			"step":          stepName,
-			"pos":           fmt.Sprintf("%d/%d", lineNum+1, len(lines)),
-			"progress":      fmt.Sprintf("%.1f%%", float64(lineNum+1)*100/float64(len(lines))),
-			"eta":           estimateETA(stepStart, lineNum+1, len(lines)),
+			"pos":           fmt.Sprintf("%d/%d", lineNum+1, total),
+			"progress":      fmt.Sprintf("%.1f%%", float64(lineNum+1)*100/float64(total)),
+			"eta":           estimateETA(stepStart, lineNum+1, total),
 			"method":        method,
 			"duration":      time.Duration(duration),
 			"full_duration": time.Duration(fullDuration),
@@ -1008,7 +1001,7 @@ func (e *executor) runStepLines(
 					"client at %s unreachable for %d consecutive calls (last: %w) — "+
 						"it has most likely exited; abandoning %q at line %d of %d",
 					opts.EngineEndpoint, consecutiveUnreachable, err,
-					stepName, lineNum+1, len(lines),
+					stepName, lineNum+1, total,
 				)
 			}
 		} else {
@@ -1093,7 +1086,7 @@ func (e *executor) runStepLines(
 		}
 
 		// Pace the replay if requested. Skip the wait after the final call.
-		if betweenLineSleep > 0 && lineNum < len(lines)-1 {
+		if betweenLineSleep > 0 && lineNum < total-1 {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()

--- a/pkg/executor/step_lines.go
+++ b/pkg/executor/step_lines.go
@@ -1,0 +1,148 @@
+package executor
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// stepReadBufferSize is the read buffer for step files. A single JSON-RPC
+// line carries a whole block payload, so it is routinely megabytes; a small
+// buffer just means more syscalls per line.
+const stepReadBufferSize = 1 << 20
+
+// lineSource yields a step's JSON-RPC lines in order.
+//
+// A step file is usually small, but a stateful pre-run bundle is not: one
+// reached 46 GiB, and reading it into a []string before replaying it took the
+// whole runner with it (RSS 56 GiB, OOM-killed). The file-backed source
+// therefore holds one line at a time and nothing else.
+type lineSource interface {
+	// Total is how many lines the source yields, for progress and ETA.
+	Total() int
+	// Next returns the next line. ok is false once the source is exhausted.
+	Next() (line string, ok bool, err error)
+	// Close releases anything the source holds.
+	Close() error
+}
+
+// sliceLineSource serves lines already in memory, for provider-backed steps.
+type sliceLineSource struct {
+	lines []string
+	pos   int
+}
+
+func newSliceLineSource(lines []string) *sliceLineSource {
+	return &sliceLineSource{lines: lines}
+}
+
+func (s *sliceLineSource) Total() int { return len(s.lines) }
+
+func (s *sliceLineSource) Next() (string, bool, error) {
+	if s.pos >= len(s.lines) {
+		return "", false, nil
+	}
+
+	line := s.lines[s.pos]
+	s.pos++
+
+	return line, true, nil
+}
+
+func (s *sliceLineSource) Close() error { return nil }
+
+// fileLineSource streams lines off disk, never holding more than the current
+// one. Counting up front costs a second sequential pass, which keeps the
+// progress and ETA output identical to what buffering the file produced.
+type fileLineSource struct {
+	file   *os.File
+	reader *bufio.Reader
+	total  int
+	done   bool
+}
+
+func newFileLineSource(path string) (*fileLineSource, error) {
+	total, err := countStepLines(path)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening step file: %w", err)
+	}
+
+	return &fileLineSource{
+		file:   file,
+		reader: bufio.NewReaderSize(file, stepReadBufferSize),
+		total:  total,
+	}, nil
+}
+
+func (s *fileLineSource) Total() int { return s.total }
+
+func (s *fileLineSource) Next() (string, bool, error) {
+	for {
+		if s.done {
+			return "", false, nil
+		}
+
+		line, err := s.reader.ReadString('\n')
+
+		// A final line without a trailing newline arrives together with EOF,
+		// so check the content before acting on the error.
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			if err != nil {
+				s.done = true
+				if err != io.EOF {
+					return "", false, fmt.Errorf("reading step file: %w", err)
+				}
+			}
+
+			return trimmed, true, nil
+		}
+
+		if err != nil {
+			s.done = true
+
+			if err == io.EOF {
+				return "", false, nil
+			}
+
+			return "", false, fmt.Errorf("reading step file: %w", err)
+		}
+	}
+}
+
+func (s *fileLineSource) Close() error { return s.file.Close() }
+
+// countStepLines counts the non-empty lines of a step file without keeping
+// any of them.
+func countStepLines(path string) (int, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("opening step file: %w", err)
+	}
+
+	defer func() { _ = file.Close() }()
+
+	reader := bufio.NewReaderSize(file, stepReadBufferSize)
+	count := 0
+
+	for {
+		line, err := reader.ReadString('\n')
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+
+		if err != nil {
+			if err == io.EOF {
+				return count, nil
+			}
+
+			return 0, fmt.Errorf("reading step file: %w", err)
+		}
+	}
+}

--- a/pkg/executor/step_lines_test.go
+++ b/pkg/executor/step_lines_test.go
@@ -1,0 +1,167 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// drain reads a source to exhaustion.
+func drain(t *testing.T, src lineSource) []string {
+	t.Helper()
+
+	var got []string
+
+	for {
+		line, ok, err := src.Next()
+		require.NoError(t, err)
+
+		if !ok {
+			break
+		}
+
+		got = append(got, line)
+	}
+
+	return got
+}
+
+func writeStep(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "pre_run.request")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	return path
+}
+
+func TestFileLineSourceMatchesSlice(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{"empty", "", nil},
+		{"single line with newline", "{\"a\":1}\n", []string{`{"a":1}`}},
+		{"single line no trailing newline", "{\"a\":1}", []string{`{"a":1}`}},
+		{"blank lines skipped", "{\"a\":1}\n\n   \n{\"b\":2}\n", []string{`{"a":1}`, `{"b":2}`}},
+		{"whitespace trimmed", "  {\"a\":1}  \n\t{\"b\":2}\t\n", []string{`{"a":1}`, `{"b":2}`}},
+		{"no trailing newline after blanks", "{\"a\":1}\n\n{\"b\":2}", []string{`{"a":1}`, `{"b":2}`}},
+		{"only blank lines", "\n\n   \n", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src, err := newFileLineSource(writeStep(t, tc.content))
+			require.NoError(t, err)
+
+			defer func() { _ = src.Close() }()
+
+			require.Equal(t, tc.want, drain(t, src))
+			// Total must agree with what was yielded, or progress and ETA lie.
+			require.Equal(t, len(tc.want), src.Total())
+		})
+	}
+}
+
+func TestFileLineSourceHandlesLinesLargerThanBuffer(t *testing.T) {
+	// One JSON-RPC line carries a whole block payload and routinely exceeds
+	// the read buffer, which is what rules out bufio.Scanner here.
+	big := strings.Repeat("x", stepReadBufferSize*3)
+	path := writeStep(t, fmt.Sprintf("{\"a\":\"%s\"}\n{\"b\":2}\n", big))
+
+	src, err := newFileLineSource(path)
+	require.NoError(t, err)
+
+	defer func() { _ = src.Close() }()
+
+	got := drain(t, src)
+	require.Len(t, got, 2)
+	require.Equal(t, 2, src.Total())
+	require.Equal(t, fmt.Sprintf("{\"a\":\"%s\"}", big), got[0])
+	require.Equal(t, `{"b":2}`, got[1])
+}
+
+func TestSliceLineSource(t *testing.T) {
+	src := newSliceLineSource([]string{"a", "b", "c"})
+	require.Equal(t, 3, src.Total())
+	require.Equal(t, []string{"a", "b", "c"}, drain(t, src))
+	require.NoError(t, src.Close())
+
+	empty := newSliceLineSource(nil)
+	require.Equal(t, 0, empty.Total())
+	require.Nil(t, drain(t, empty))
+}
+
+func TestFileLineSourceMissingFile(t *testing.T) {
+	_, err := newFileLineSource(filepath.Join(t.TempDir(), "absent"))
+	require.Error(t, err)
+}
+
+// TestFileLineSourceDoesNotBufferWholeFile is the regression guard: a 46 GiB
+// pre-run bundle was read into a []string and the runner was OOM-killed at
+// 56 GiB RSS. Replaying must stay flat in the size of the step, not linear.
+func TestFileLineSourceDoesNotBufferWholeFile(t *testing.T) {
+	const (
+		lineSize = 1 << 20
+		lines    = 256 // 256 MiB of step file
+	)
+
+	path := filepath.Join(t.TempDir(), "big.request")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+
+	payload := strings.Repeat("y", lineSize)
+	for range lines {
+		_, err = fmt.Fprintf(file, "{\"p\":\"%s\"}\n", payload)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, file.Close())
+
+	src, err := newFileLineSource(path)
+	require.NoError(t, err)
+
+	defer func() { _ = src.Close() }()
+
+	require.Equal(t, lines, src.Total())
+
+	var before, after runtime.MemStats
+
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	count := 0
+
+	for {
+		_, ok, err := src.Next()
+		require.NoError(t, err)
+
+		if !ok {
+			break
+		}
+
+		count++
+	}
+
+	runtime.GC()
+	runtime.ReadMemStats(&after)
+
+	require.Equal(t, lines, count)
+
+	// Held bytes must not scale with the file. Allow generous headroom for
+	// the read buffer and one in-flight line; buffering the whole file would
+	// land two orders of magnitude above this.
+	const maxHeld = 32 << 20
+
+	if after.HeapAlloc > before.HeapAlloc {
+		require.Less(t, after.HeapAlloc-before.HeapAlloc, uint64(maxHeld),
+			"replaying a %d MiB step retained %d MiB", (lineSize*lines)>>20,
+			(after.HeapAlloc-before.HeapAlloc)>>20)
+	}
+}


### PR DESCRIPTION
## Problem

A `benchmarkoor run` was OOM-killed on a 61 GB host replaying a stateful
pre-run bundle:

```
18:14:02  Discovered EEST fixtures  count=692
18:14:02  Loaded pre-run bundle steps  pre_run_steps=1  tests=692
18:15:01  Pre-run bundle over the size limit; describing it in the suite
          without storing it  bytes=49722157712  max=53687091
18:15:17  kernel: Out of memory: Killed process 209258 (benchmarkoor)
          anon-rss:56017868kB
```

The bundle is **46.3 GiB**. `runStepFromFile` streams it with a
`bufio.Reader` but appends every line to a `[]string` before replaying
any of them, so the whole file lands on the heap:

```go
var lines []string
for {
    line, err := reader.ReadString('\n')
    if len(line) > 0 {
        if trimmed := strings.TrimSpace(line); trimmed != "" {
            lines = append(lines, trimmed)   // <- the whole file
        }
    }
    ...
}
return e.runStepLines(ctx, opts, step.Name, lines, ...)
```

`copyPreRunStepFile`'s size guard does not protect this. It correctly
declines to *store* an oversized bundle — that is the 18:15:01 line
above — but the replay path had already read it.

This only started biting now because pre-runs got bigger: a stateful
pre-run that completes both `code_size` variants builds ~41k blocks, and
its bundle is two orders of magnitude past the 51 MiB storage limit.
Earlier bundles were small because the pre-run died early.

## Fix

Replay from a `lineSource` rather than a materialised slice:

- `fileLineSource` holds one line at a time.
- `sliceLineSource` keeps the existing in-memory path for provider-backed
  steps, which are small by construction.

`runStepLines` is otherwise untouched — it already consumed the slice
strictly in order, using `len(lines)` only for `pos`, `progress`, `eta`
and the inter-line sleep. Counting the file up front costs a second
sequential pass and keeps all four byte-identical to what buffering
produced, rather than degrading operator output to an unknown total.

`bufio.Scanner` is not usable here: one JSON-RPC line carries a whole
block payload and routinely exceeds any fixed token limit.

## Testing

New `step_lines_test.go`:

- file and slice sources agree, across trailing-newline, blank-line,
  whitespace and empty-file cases, with `Total()` matching what is
  yielded so progress and ETA stay honest
- a line 3x the read buffer round-trips intact
- a regression guard replaying a 256 MiB step and asserting retained heap
  stays flat rather than scaling with the file

`go test ./pkg/executor/` passes. Two failures elsewhere in `./pkg/...`
(`TestValidateDataDirMethods_SchelkBinary`, and `pkg/podman` needing
`gpgme`) reproduce on a clean checkout of `master` and are unrelated —
both are local-environment gaps.
