### PR TITLE
fix(executor): stream step files into the suite hash

### DIFF
--- a/pkg/executor/suite.go
+++ b/pkg/executor/suite.go
@@ -112,41 +112,29 @@ func ComputeSuiteHash(prepared *PreparedSource) (string, error) {
 
 	// Hash pre-run steps first.
 	for _, f := range prepared.PreRunSteps {
-		content, err := getStepContent(f)
-		if err != nil {
+		if err := hashStepContent(h, f); err != nil {
 			return "", fmt.Errorf("reading pre-run step %s: %w", f.Name, err)
 		}
-
-		h.Write(content)
 	}
 
 	// Hash all test step files.
 	for _, test := range prepared.Tests {
 		if test.Setup != nil {
-			content, err := getStepContent(test.Setup)
-			if err != nil {
+			if err := hashStepContent(h, test.Setup); err != nil {
 				return "", fmt.Errorf("reading setup file %s: %w", test.Setup.Name, err)
 			}
-
-			h.Write(content)
 		}
 
 		if test.Test != nil {
-			content, err := getStepContent(test.Test)
-			if err != nil {
+			if err := hashStepContent(h, test.Test); err != nil {
 				return "", fmt.Errorf("reading test file %s: %w", test.Test.Name, err)
 			}
-
-			h.Write(content)
 		}
 
 		if test.Cleanup != nil {
-			content, err := getStepContent(test.Cleanup)
-			if err != nil {
+			if err := hashStepContent(h, test.Cleanup); err != nil {
 				return "", fmt.Errorf("reading cleanup file %s: %w", test.Cleanup.Name, err)
 			}
-
-			h.Write(content)
 		}
 	}
 
@@ -155,12 +143,32 @@ func ComputeSuiteHash(prepared *PreparedSource) (string, error) {
 }
 
 // getStepContent returns the content of a step, either from provider or file.
-func getStepContent(step *StepFile) ([]byte, error) {
+// hashStepContent streams a step's bytes into h.
+//
+// Reading a step whole is fine for a test fixture and fatal for a pre-run
+// bundle: a stateful build now produces bundles of tens of GB, and a 46 GiB
+// one made this single allocation take the runner to 56 GiB RSS before the
+// kernel killed it. io.Copy feeds the hash the same bytes in the same order,
+// so the digest is unchanged — suites keep their existing hashes.
+func hashStepContent(h io.Writer, step *StepFile) error {
 	if step.Provider != nil {
-		return step.Provider.Content(), nil
+		_, err := h.Write(step.Provider.Content())
+
+		return err
 	}
 
-	return os.ReadFile(step.Path)
+	file, err := os.Open(step.Path)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = file.Close() }()
+
+	if _, err := io.Copy(h, file); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // CreateSuiteOutput creates the suite directory structure with copied files and summary.

--- a/pkg/executor/suite_hash_test.go
+++ b/pkg/executor/suite_hash_test.go
@@ -1,0 +1,132 @@
+package executor
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeStepFile(t *testing.T, dir, name, content string) *StepFile {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	return &StepFile{Path: path, Name: name}
+}
+
+// expectedHash is the digest the buffering implementation produced: every
+// step's bytes concatenated in order.
+func expectedHash(parts ...string) string {
+	h := sha256.New()
+	for _, p := range parts {
+		h.Write([]byte(p))
+	}
+
+	// ComputeSuiteHash keeps the first 16 characters.
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+func TestComputeSuiteHashMatchesConcatenatedContent(t *testing.T) {
+	dir := t.TempDir()
+
+	prepared := &PreparedSource{
+		PreRunSteps: []*StepFile{writeStepFile(t, dir, "pre.request", "PRE\n")},
+		Tests: []*TestWithSteps{
+			{
+				Name:    "one",
+				Setup:   writeStepFile(t, dir, "one.setup", "SETUP\n"),
+				Test:    writeStepFile(t, dir, "one.test", "TEST\n"),
+				Cleanup: writeStepFile(t, dir, "one.cleanup", "CLEANUP\n"),
+			},
+			{
+				Name: "two",
+				Test: writeStepFile(t, dir, "two.test", "TEST2\n"),
+			},
+		},
+	}
+
+	got, err := ComputeSuiteHash(prepared)
+	require.NoError(t, err)
+	require.Equal(t, expectedHash("PRE\n", "SETUP\n", "TEST\n", "CLEANUP\n", "TEST2\n"), got)
+}
+
+func TestComputeSuiteHashProviderAndFileAgree(t *testing.T) {
+	dir := t.TempDir()
+	// linesProvider joins with "\n" and adds no trailing newline, so the
+	// equivalent file content carries none either.
+	content := "{\"a\":1}\n{\"b\":2}"
+
+	fromFile, err := ComputeSuiteHash(&PreparedSource{
+		PreRunSteps: []*StepFile{writeStepFile(t, dir, "pre.request", content)},
+	})
+	require.NoError(t, err)
+
+	fromProvider, err := ComputeSuiteHash(&PreparedSource{
+		PreRunSteps: []*StepFile{{
+			Name:     "pre.request",
+			Provider: &linesProvider{lines: []string{`{"a":1}`, `{"b":2}`}},
+		}},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, fromFile, fromProvider,
+		"a step must hash the same whether it is read from disk or held in memory")
+}
+
+func TestComputeSuiteHashMissingFile(t *testing.T) {
+	_, err := ComputeSuiteHash(&PreparedSource{
+		PreRunSteps: []*StepFile{{Path: filepath.Join(t.TempDir(), "absent"), Name: "absent"}},
+	})
+	require.Error(t, err)
+}
+
+// TestComputeSuiteHashDoesNotBufferWholeStep is the regression guard. A 46 GiB
+// pre-run bundle was read whole by getStepContent and the runner was
+// OOM-killed at 56 GiB RSS before it replayed a single line.
+func TestComputeSuiteHashDoesNotBufferWholeStep(t *testing.T) {
+	const size = 256 << 20 // 256 MiB
+
+	path := filepath.Join(t.TempDir(), "big.request")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+
+	chunk := strings.Repeat("z", 1<<20)
+	for range size >> 20 {
+		_, err = fmt.Fprint(file, chunk)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, file.Close())
+
+	prepared := &PreparedSource{
+		PreRunSteps: []*StepFile{{Path: path, Name: "big.request"}},
+	}
+
+	var before, after runtime.MemStats
+
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	_, err = ComputeSuiteHash(prepared)
+	require.NoError(t, err)
+
+	runtime.GC()
+	runtime.ReadMemStats(&after)
+
+	// Peak allocation must not scale with the step. Buffering 256 MiB would
+	// show up here as ~256 MiB of total allocation; streaming stays tiny.
+	allocated := after.TotalAlloc - before.TotalAlloc
+
+	const maxAllocated = 16 << 20
+
+	require.Less(t, allocated, uint64(maxAllocated),
+		"hashing a %d MiB step allocated %d MiB", size>>20, allocated>>20)
+}


### PR DESCRIPTION
## Problem

Run 33202585274 was OOM-killed on a 61 GB host **with #311 already in the
image** (verified: `fileLineSource`, `newFileLineSource` and
`sliceLineSource` are all present in the binary it ran).

```
19:10:00  Test sources ready  pre_run_steps=1  tests=692
19:10:54  Pre-run bundle over the size limit; describing it in the suite
          without storing it  bytes=49722157712
19:11:07  kernel: Out of memory: Killed process 3716085 (benchmarkoor)
          anon-rss:55866828kB
```

No replay progress lines, so it never reached the path #311 fixed. The
allocation that fires first is in `ComputeSuiteHash`
(`executor.go:243`, before the suite is built):

```go
for _, f := range prepared.PreRunSteps {
    content, err := getStepContent(f)   // os.ReadFile -> 46.3 GiB in one go
    ...
    h.Write(content)
}
```

`getStepContent` is `os.ReadFile(step.Path)`. The bundle on disk is
46.31 GiB, which matches the 55.8 GiB RSS once allocator overhead is
counted.

The 51 MiB `maxPreRunUploadSize` guard does not help: it governs whether
the bundle is *stored* in the suite, and by the time it is consulted the
hash has already read the file.

## Fix

Stream each file-backed step into the digest with `io.Copy` rather than
materialising it. The hash covers the same bytes in the same order, so
**existing suite hashes are unchanged** — no suite is invalidated.
Provider-backed steps keep their in-memory path.

## Testing

New `suite_hash_test.go`:

- `ComputeSuiteHash` equals sha256 over the steps' bytes concatenated in
  order, truncated to 16 chars — pinning the digest against the previous
  buffering implementation
- a step hashes identically whether file-backed or provider-backed
- a missing file still errors
- a regression guard hashes a 256 MiB step and asserts total allocation
  stays under 16 MiB, where buffering would allocate the whole 256 MiB

`go test ./pkg/executor/` passes. Two failures elsewhere in `./pkg/...`
(`TestValidateDataDirMethods_SchelkBinary`, `pkg/podman` needing
`gpgme`) reproduce on a clean `master` checkout and are unrelated.

## Relationship to #311

#311 removed the same buffering from the replay path and is still
needed — that read would OOM as soon as a run got past this one. This PR
removes the allocation that fires earlier.
