### PR TITLE
feat(blocklog): parse Erigon slow block logs

### DIFF
--- a/docs/block-metrics-log-capture.md
+++ b/docs/block-metrics-log-capture.md
@@ -31,6 +31,7 @@ For more details on the specification and motivation, see:
 | Client | PR |
 |--------|-----|
 | Geth | [#33655](https://github.com/ethereum/go-ethereum/pull/33655) |
+| Erigon | [#23764](https://github.com/erigontech/erigon/pull/23764) |
 | Reth | [#21237](https://github.com/paradigmxyz/reth/pull/21237) |
 | Besu | [#9660](https://github.com/hyperledger/besu/pull/9660) |
 | Nethermind | [#10288](https://github.com/NethermindEth/nethermind/pull/10288) |
@@ -43,10 +44,10 @@ For more details on the specification and motivation, see:
 | Reth | Stub (pending) |
 | Besu | Stub (pending) |
 | Nethermind | Stub (pending) |
-| Erigon | Stub (pending) |
+| Erigon | Fully supported |
 | Nimbus | Stub (pending) |
 
-The parsing infrastructure (`pkg/blocklog`) supports all clients via the `Parser` interface. Currently only Geth's log format parser is implemented. Other client parsers return no matches until their specific log formats are implemented.
+The parsing infrastructure (`pkg/blocklog`) supports all clients via the `Parser` interface. Parsers marked as stubs return no matches until their specific log formats are implemented.
 
 ## Configuration
 
@@ -55,7 +56,7 @@ To enable block metrics capture, add the appropriate flag to the client's `extra
 ### Geth
 
 ```yaml
-client:
+runner:
   instances:
     - id: geth
       client: geth
@@ -65,6 +66,30 @@ client:
 ```
 
 The `--debug.logslowblock=0` flag sets the threshold to 0 milliseconds, meaning every block execution will emit metrics. Higher values (e.g., `--debug.logslowblock=100`) only log blocks taking longer than that threshold.
+
+### Erigon
+
+Requires an Erigon build that carries the slow block record (see the PR in the
+table above); earlier releases reject the flag and the container will not start.
+
+```yaml
+runner:
+  instances:
+    - id: erigon
+      client: erigon
+      image: erigontech/erigon:main-latest
+      extra_args:
+        - --debug.slow-block-threshold=0
+```
+
+`--debug.slow-block-threshold` takes a duration: `0` emits a record for every
+block, a positive value (e.g. `100ms`) only for blocks at or over it, and the
+default of `-1ns` disables the feature. Setting it also switches on Erigon's
+per-domain read counters, so no separate environment variable is needed.
+
+Without the flag no record is emitted at all. With it, every documented field is
+captured except `state_reads.code_bytes` and `state_writes.code_bytes`, which
+Erigon has no per-block source for and omits rather than reporting as zero.
 
 ### Other Clients
 

--- a/docs/block-metrics-log-capture.md
+++ b/docs/block-metrics-log-capture.md
@@ -91,6 +91,10 @@ Without the flag no record is emitted at all. With it, every documented field is
 captured except `state_reads.code_bytes` and `state_writes.code_bytes`, which
 Erigon has no per-block source for and omits rather than reporting as zero.
 
+Both of Erigon's log formats are parsed: the default console line, and
+`--log.json`, which carries the record escaped inside the log entry's own
+`msg` field.
+
 ### Other Clients
 
 Configuration flags for other clients will be documented as their parsers are implemented.

--- a/docs/block-metrics-log-capture.md
+++ b/docs/block-metrics-log-capture.md
@@ -70,18 +70,18 @@ The `--debug.logslowblock=0` flag sets the threshold to 0 milliseconds, meaning 
 
 ### Erigon
 
-`--debug.slow-block-threshold` is not in any published Erigon image yet. It
-arrives with the PR in the table above, and a build without it rejects the
-unknown flag, so the container exits at startup. Until that merges, point
-`image` at a build of the PR head — `erigontech/erigon:main-latest` and the
-default `erigontech/erigon:latest` are both too old.
+`--debug.slow-block-threshold` landed in the PR in the table above, so
+`erigontech/erigon:main-latest` carries it from the first image built after that
+merge. The release tag `erigontech/erigon:latest` will not until the next
+release, and a build without the flag rejects it as unknown, so the container
+exits at startup rather than ignoring it.
 
 ```yaml
 runner:
   instances:
     - id: erigon
       client: erigon
-      image: <a build carrying erigontech/erigon#23764>
+      image: erigontech/erigon:main-latest
       extra_args:
         - --debug.slow-block-threshold=0
 ```
@@ -113,7 +113,8 @@ inside the log entry's own `msg` field.
 
 ### Other Clients
 
-Configuration flags for other clients will be documented as their parsers are implemented.
+Reth, Besu, Nethermind and Ethrex have parsers, but the flag that makes each of
+them emit the record is not documented here yet.
 
 ## Metrics Captured
 

--- a/docs/block-metrics-log-capture.md
+++ b/docs/block-metrics-log-capture.md
@@ -91,9 +91,10 @@ Without the flag no record is emitted at all. With it, every documented field is
 captured except `state_reads.code_bytes` and `state_writes.code_bytes`, which
 Erigon has no per-block source for and omits rather than reporting as zero.
 
-Both of Erigon's log formats are parsed: the default console line, and
-`--log.json`, which carries the record escaped inside the log entry's own
-`msg` field.
+Every envelope Erigon can produce is parsed: the default console line, the
+colourised form it uses on a TTY, the timestamp-less form under
+`ERIGON_LOG_NO_TIMESTAMPS`, and `--log.json`, which carries the record escaped
+inside the log entry's own `msg` field.
 
 ### Other Clients
 

--- a/docs/block-metrics-log-capture.md
+++ b/docs/block-metrics-log-capture.md
@@ -41,10 +41,11 @@ For more details on the specification and motivation, see:
 | Client | Parser Status |
 |--------|---------------|
 | Geth | Fully supported |
-| Reth | Stub (pending) |
-| Besu | Stub (pending) |
-| Nethermind | Stub (pending) |
+| Reth | Fully supported |
+| Besu | Fully supported |
+| Nethermind | Fully supported |
 | Erigon | Fully supported |
+| Ethrex | Fully supported |
 | Nimbus | Stub (pending) |
 
 The parsing infrastructure (`pkg/blocklog`) supports all clients via the `Parser` interface. Parsers marked as stubs return no matches until their specific log formats are implemented.
@@ -69,15 +70,18 @@ The `--debug.logslowblock=0` flag sets the threshold to 0 milliseconds, meaning 
 
 ### Erigon
 
-Requires an Erigon build that carries the slow block record (see the PR in the
-table above); earlier releases reject the flag and the container will not start.
+`--debug.slow-block-threshold` is not in any published Erigon image yet. It
+arrives with the PR in the table above, and a build without it rejects the
+unknown flag, so the container exits at startup. Until that merges, point
+`image` at a build of the PR head — `erigontech/erigon:main-latest` and the
+default `erigontech/erigon:latest` are both too old.
 
 ```yaml
 runner:
   instances:
     - id: erigon
       client: erigon
-      image: erigontech/erigon:main-latest
+      image: <a build carrying erigontech/erigon#23764>
       extra_args:
         - --debug.slow-block-threshold=0
 ```
@@ -88,8 +92,9 @@ default of `-1ns` disables the feature. Setting it also switches on Erigon's
 per-domain read counters, so no separate environment variable is needed.
 
 Without the flag no record is emitted at all. With it, every documented field is
-captured except four, which Erigon has no per-block source for and omits rather
+captured except six, which Erigon has no per-block source for and omits rather
 than reporting as zero: `state_reads.code`, `state_reads.code_bytes`,
+`state_writes.accounts_deleted`, `state_writes.storage_slots_deleted`,
 `state_writes.code_bytes` and the whole `cache.code` object. `state_writes.code`
 is counted and is emitted.
 

--- a/docs/block-metrics-log-capture.md
+++ b/docs/block-metrics-log-capture.md
@@ -24,7 +24,7 @@ This feature correlates these metrics with specific benchmark tests using block 
 This feature implements the unified "slowblock" metrics specification developed across Ethereum execution clients. The specification standardizes how clients report detailed block execution metrics.
 
 For more details on the specification and motivation, see:
-- [ethresear.ch: Unified slowblock metrics specification](https://ethresear.ch/t/unifying-execution-layer-execution-metrics/22089)
+- [ethresear.ch: Unified slowblock metrics specification](https://ethresear.ch/t/a-small-step-towards-data-driven-protocol-decisions-unified-slowblock-metrics-across-clients/23907)
 
 ### Client Implementation PRs
 
@@ -88,8 +88,18 @@ default of `-1ns` disables the feature. Setting it also switches on Erigon's
 per-domain read counters, so no separate environment variable is needed.
 
 Without the flag no record is emitted at all. With it, every documented field is
-captured except `state_reads.code_bytes` and `state_writes.code_bytes`, which
-Erigon has no per-block source for and omits rather than reporting as zero.
+captured except four, which Erigon has no per-block source for and omits rather
+than reporting as zero: `state_reads.code`, `state_reads.code_bytes`,
+`state_writes.code_bytes` and the whole `cache.code` object. `state_writes.code`
+is counted and is emitted.
+
+Two Erigon values do not mean quite what the tables above say. `total_ms` is
+measured end-to-end and covers the header, body and sender stages that sit
+outside the phase breakdown, so it exceeds `execution_ms + state_hash_ms +
+commit_ms` rather than balancing against it. `state_read_ms` sums each execution
+worker's own accumulator, so under the parallel executor it is CPU time across
+workers and can exceed the wall-clock `execution_ms`; do not subtract it from
+`execution_ms`.
 
 Every envelope Erigon can produce is parsed: the default console line, the
 colourised form it uses on a TTY, the timestamp-less form under

--- a/pkg/blocklog/erigon.go
+++ b/pkg/blocklog/erigon.go
@@ -2,15 +2,27 @@ package blocklog
 
 import (
 	"encoding/json"
+	"regexp"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/client"
 )
 
-// erigonParser is a stub parser for Erigon client logs.
-// Returns nil, false until the log format is known.
+// erigonLogPattern matches Erigon slow block log lines (after ANSI stripping).
+// Format: [{LEVEL}] [{timestamp}] {JSON payload}
+// Example: [WARN] [09-01|22:20:12.372] {"level":"warn","msg":"Slow block",...}
+//
+// Erigon abbreviates two of its level names, DBUG and EROR. On a TTY the level
+// is colorised and the brackets and following space are dropped, so the
+// stripped line reads WARN[09-01|...] instead; the separators are matched
+// loosely so a change in level padding cannot silence the parser.
+var erigonLogPattern = regexp.MustCompile(
+	`^\[?(?:TRACE|DBUG|INFO|WARN|EROR|CRIT)\s*\]?\s*\[[^\]]+\]\s+(\{.+\})\s*$`,
+)
+
+// erigonParser parses JSON payloads from Erigon client slow block logs.
 type erigonParser struct{}
 
-// NewErigonParser creates a new Erigon log parser (stub).
+// NewErigonParser creates a new Erigon log parser.
 func NewErigonParser() Parser {
 	return &erigonParser{}
 }
@@ -18,9 +30,36 @@ func NewErigonParser() Parser {
 // Ensure interface compliance.
 var _ Parser = (*erigonParser)(nil)
 
-// ParseLine is a stub that always returns nil, false.
-func (p *erigonParser) ParseLine(_ string) (json.RawMessage, bool) {
-	return nil, false
+// ParseLine extracts JSON from an Erigon slow block log line.
+func (p *erigonParser) ParseLine(line string) (json.RawMessage, bool) {
+	// Strip ANSI escape codes — Erigon colorises the level when on a TTY.
+	line = ansiPattern.ReplaceAllString(line, "")
+
+	matches := erigonLogPattern.FindStringSubmatch(line)
+	if len(matches) < 2 {
+		return nil, false
+	}
+
+	jsonStr := matches[1]
+
+	// Erigon has no dedicated slow block logger, so the message is the only
+	// thing separating this payload from any other JSON logged at WARN. The
+	// timing object is required too, so a bare message cannot be stored as a
+	// record that carries none of the metrics.
+	var probe struct {
+		Msg    string           `json:"msg"`
+		Timing *json.RawMessage `json:"timing"`
+	}
+
+	if err := json.Unmarshal([]byte(jsonStr), &probe); err != nil {
+		return nil, false
+	}
+
+	if probe.Msg != "Slow block" || probe.Timing == nil {
+		return nil, false
+	}
+
+	return json.RawMessage(jsonStr), true
 }
 
 // ClientType returns the client type.

--- a/pkg/blocklog/erigon.go
+++ b/pkg/blocklog/erigon.go
@@ -10,11 +10,8 @@ import (
 // erigonLogPattern matches Erigon slow block log lines (after ANSI stripping).
 // Format: [{LEVEL}] [{timestamp}] {JSON payload}
 // Example: [WARN] [09-01|22:20:12.372] {"level":"warn","msg":"Slow block",...}
-//
-// Erigon abbreviates two of its level names, DBUG and EROR. On a TTY the level
-// is colorised and the brackets and following space are dropped, so the
-// stripped line reads WARN[09-01|...] instead; the separators are matched
-// loosely so a change in level padding cannot silence the parser.
+// On a TTY the brackets are dropped: WARN[09-01|...]. DBUG and EROR are
+// Erigon's own abbreviations; separators are loose so padding cannot silence it.
 var erigonLogPattern = regexp.MustCompile(
 	`^\[?(?:TRACE|DBUG|INFO|WARN|EROR|CRIT)\s*\]?\s*\[[^\]]+\]\s+(\{.+\})\s*$`,
 )
@@ -42,10 +39,7 @@ func (p *erigonParser) ParseLine(line string) (json.RawMessage, bool) {
 
 	jsonStr := matches[1]
 
-	// Erigon has no dedicated slow block logger, so the message is the only
-	// thing separating this payload from any other JSON logged at WARN. The
-	// timing object is required too, so a bare message cannot be stored as a
-	// record that carries none of the metrics.
+	// Erigon has no slow block logger to key on, so the payload is probed.
 	var probe struct {
 		Msg    string           `json:"msg"`
 		Timing *json.RawMessage `json:"timing"`

--- a/pkg/blocklog/erigon.go
+++ b/pkg/blocklog/erigon.go
@@ -32,20 +32,50 @@ func (p *erigonParser) ParseLine(line string) (json.RawMessage, bool) {
 	// Strip ANSI escape codes — Erigon colorises the level when on a TTY.
 	line = ansiPattern.ReplaceAllString(line, "")
 
-	matches := erigonLogPattern.FindStringSubmatch(line)
-	if len(matches) < 2 {
+	payload, ok := erigonConsolePayload(line)
+	if !ok {
+		payload, ok = erigonJSONPayload(line)
+	}
+
+	if !ok {
 		return nil, false
 	}
 
-	jsonStr := matches[1]
+	return erigonSlowBlock(payload)
+}
 
-	// Erigon has no slow block logger to key on, so the payload is probed.
+func erigonConsolePayload(line string) (string, bool) {
+	matches := erigonLogPattern.FindStringSubmatch(line)
+	if len(matches) < 2 {
+		return "", false
+	}
+
+	return matches[1], true
+}
+
+// erigonJSONPayload unwraps the record from --log.json output, where the whole
+// object arrives escaped inside the log line's own msg field.
+func erigonJSONPayload(line string) (string, bool) {
+	var envelope struct {
+		Msg string `json:"msg"`
+	}
+
+	if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+		return "", false
+	}
+
+	return envelope.Msg, envelope.Msg != ""
+}
+
+// erigonSlowBlock keeps the payload only when it is a slow block record.
+// Erigon has no slow block logger to key on, so the payload is probed.
+func erigonSlowBlock(payload string) (json.RawMessage, bool) {
 	var probe struct {
 		Msg    string           `json:"msg"`
 		Timing *json.RawMessage `json:"timing"`
 	}
 
-	if err := json.Unmarshal([]byte(jsonStr), &probe); err != nil {
+	if err := json.Unmarshal([]byte(payload), &probe); err != nil {
 		return nil, false
 	}
 
@@ -53,7 +83,7 @@ func (p *erigonParser) ParseLine(line string) (json.RawMessage, bool) {
 		return nil, false
 	}
 
-	return json.RawMessage(jsonStr), true
+	return json.RawMessage(payload), true
 }
 
 // ClientType returns the client type.

--- a/pkg/blocklog/erigon.go
+++ b/pkg/blocklog/erigon.go
@@ -7,15 +7,12 @@ import (
 	"github.com/ethpandaops/benchmarkoor/pkg/client"
 )
 
-// erigonLogPattern matches Erigon slow block log lines (after ANSI stripping).
-// Format: [{LEVEL}] [{timestamp}] {JSON payload}
-// Example: [WARN] [09-01|22:20:12.372] {"level":"warn","msg":"Slow block",...}
-// On a TTY the brackets are dropped: WARN[09-01|...]. Under
-// ERIGON_LOG_NO_TIMESTAMPS the timestamp group is absent entirely: WARN {...}.
-// DBUG and EROR are Erigon's own abbreviations; separators are loose so padding
-// cannot silence it.
+// erigonLogPattern matches the console form (after ANSI stripping): an
+// optionally bracketed level, an optional bracketed timestamp, then the JSON
+// payload. Requiring a token before the brace is what routes --log.json lines
+// to erigonJSONPayload instead.
 var erigonLogPattern = regexp.MustCompile(
-	`^\[?(?:TRACE|DBUG|INFO|WARN|EROR|CRIT)\s*\]?\s*(?:\[[^\]]+\]\s*)?\s*(\{.+\})\s*$`,
+	`^\[?\w+\s*\]?\s*(?:\[[^\]]+\]\s*)?(\{.+\})\s*$`,
 )
 
 // erigonParser parses JSON payloads from Erigon client slow block logs.

--- a/pkg/blocklog/erigon.go
+++ b/pkg/blocklog/erigon.go
@@ -10,10 +10,12 @@ import (
 // erigonLogPattern matches Erigon slow block log lines (after ANSI stripping).
 // Format: [{LEVEL}] [{timestamp}] {JSON payload}
 // Example: [WARN] [09-01|22:20:12.372] {"level":"warn","msg":"Slow block",...}
-// On a TTY the brackets are dropped: WARN[09-01|...]. DBUG and EROR are
-// Erigon's own abbreviations; separators are loose so padding cannot silence it.
+// On a TTY the brackets are dropped: WARN[09-01|...]. Under
+// ERIGON_LOG_NO_TIMESTAMPS the timestamp group is absent entirely: WARN {...}.
+// DBUG and EROR are Erigon's own abbreviations; separators are loose so padding
+// cannot silence it.
 var erigonLogPattern = regexp.MustCompile(
-	`^\[?(?:TRACE|DBUG|INFO|WARN|EROR|CRIT)\s*\]?\s*\[[^\]]+\]\s+(\{.+\})\s*$`,
+	`^\[?(?:TRACE|DBUG|INFO|WARN|EROR|CRIT)\s*\]?\s*(?:\[[^\]]+\]\s*)?\s*(\{.+\})\s*$`,
 )
 
 // erigonParser parses JSON payloads from Erigon client slow block logs.

--- a/pkg/blocklog/erigon_test.go
+++ b/pkg/blocklog/erigon_test.go
@@ -1,0 +1,167 @@
+package blocklog
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// erigonPayload is the record Erigon emits, taken verbatim from a validated
+// block on a node built with --debug.slow-block-threshold=0.
+const erigonPayload = `{"level":"warn","msg":"Slow block","block":{"number":1,"hash":"0x5c6519e89d3b01dc9846d2b67a07202efd45fcd35d380beada32f7be406fd22d","gas_used":12000,"tx_count":1},"timing":{"execution_ms":0.829174,"state_read_ms":0.001553,"state_hash_ms":0.142427,"commit_ms":0.042781,"total_ms":1.015935},"throughput":{"mgas_per_sec":11.81},"state_reads":{"accounts":3,"storage_slots":0,"code":0},"state_writes":{"accounts":1,"storage_slots":0,"code":0},"cache":{"account":{"hits":3,"misses":0,"hit_rate":1},"storage":{"hits":0,"misses":0,"hit_rate":0},"code":{"hits":0,"misses":0,"hit_rate":0}}}`
+
+func TestErigonParser_ParseLine(t *testing.T) {
+	parser := NewErigonParser()
+
+	tests := []struct {
+		name      string
+		line      string
+		wantOK    bool
+		checkJSON func(t *testing.T, data map[string]any)
+	}{
+		{
+			// Erigon's terminal format leaves a trailing space after the message.
+			name:   "non-TTY line with all fields",
+			line:   `[WARN] [09-01|22:20:12.372] ` + erigonPayload + ` `,
+			wantOK: true,
+			checkJSON: func(t *testing.T, data map[string]any) {
+				t.Helper()
+
+				assert.Equal(t, "warn", data["level"])
+				assert.Equal(t, "Slow block", data["msg"])
+
+				block := data["block"].(map[string]any)
+				assert.Equal(t, float64(1), block["number"])
+				assert.Equal(t, "0x5c6519e89d3b01dc9846d2b67a07202efd45fcd35d380beada32f7be406fd22d", block["hash"])
+				assert.Equal(t, float64(12000), block["gas_used"])
+				assert.Equal(t, float64(1), block["tx_count"])
+
+				timing := data["timing"].(map[string]any)
+				assert.Equal(t, 0.829174, timing["execution_ms"])
+				assert.Equal(t, 0.001553, timing["state_read_ms"])
+				assert.Equal(t, 0.142427, timing["state_hash_ms"])
+				assert.Equal(t, 0.042781, timing["commit_ms"])
+				assert.Equal(t, 1.015935, timing["total_ms"])
+
+				throughput := data["throughput"].(map[string]any)
+				assert.Equal(t, 11.81, throughput["mgas_per_sec"])
+
+				stateReads := data["state_reads"].(map[string]any)
+				assert.Equal(t, float64(3), stateReads["accounts"])
+				assert.Equal(t, float64(0), stateReads["storage_slots"])
+				assert.Equal(t, float64(0), stateReads["code"])
+
+				stateWrites := data["state_writes"].(map[string]any)
+				assert.Equal(t, float64(1), stateWrites["accounts"])
+
+				account := data["cache"].(map[string]any)["account"].(map[string]any)
+				assert.Equal(t, float64(3), account["hits"])
+				assert.Equal(t, float64(0), account["misses"])
+				assert.Equal(t, float64(1), account["hit_rate"])
+			},
+		},
+		{
+			// On a TTY the level is wrapped in colour codes and the space
+			// between it and the timestamp disappears.
+			name:   "TTY line with ANSI escape codes",
+			line:   "\x1b[33mWARN\x1b[0m[09-01|22:20:12.372] " + erigonPayload + " ",
+			wantOK: true,
+			checkJSON: func(t *testing.T, data map[string]any) {
+				t.Helper()
+
+				assert.Equal(t, "Slow block", data["msg"])
+				assert.Equal(t, float64(1), data["block"].(map[string]any)["number"])
+				assert.Equal(t, 0.142427, data["timing"].(map[string]any)["state_hash_ms"])
+			},
+		},
+		{
+			name:   "DBUG level envelope",
+			line:   `[DBUG] [09-01|22:20:12.372] ` + erigonPayload,
+			wantOK: true,
+			checkJSON: func(t *testing.T, data map[string]any) {
+				t.Helper()
+
+				assert.Equal(t, "Slow block", data["msg"])
+			},
+		},
+		{
+			name:   "EROR level envelope",
+			line:   `[EROR] [09-01|22:20:12.372] ` + erigonPayload,
+			wantOK: true,
+			checkJSON: func(t *testing.T, data map[string]any) {
+				t.Helper()
+
+				assert.Equal(t, "Slow block", data["msg"])
+			},
+		},
+		{
+			name:   "padded level",
+			line:   `[WARN ] [09-01|22:20:12.372] ` + erigonPayload,
+			wantOK: true,
+			checkJSON: func(t *testing.T, data map[string]any) {
+				t.Helper()
+
+				assert.Equal(t, "Slow block", data["msg"])
+			},
+		},
+		{
+			name:   "right message but no timing object",
+			line:   `[WARN] [09-01|22:20:12.372] {"level":"warn","msg":"Slow block","block":{"hash":"0xabc"}}`,
+			wantOK: false,
+		},
+		{
+			// Erigon logs plenty of other JSON at WARN; only the slow block
+			// message carries this schema.
+			name:   "JSON payload from another message",
+			line:   `[WARN] [09-01|22:20:12.372] {"level":"warn","msg":"Something else","block":{"number":1}}`,
+			wantOK: false,
+		},
+		{
+			name:   "ordinary erigon log line",
+			line:   `[INFO] [09-01|22:20:12.372] [1/6 OtterSync] Downloading                 progress="98.5% 12/13"`,
+			wantOK: false,
+		},
+		{
+			name:   "invalid JSON",
+			line:   `[WARN] [09-01|22:20:12.372] {not valid json}`,
+			wantOK: false,
+		},
+		{
+			name:   "missing timestamp",
+			line:   `[WARN] ` + erigonPayload,
+			wantOK: false,
+		},
+		{
+			name:   "empty line",
+			line:   "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := parser.ParseLine(tt.line)
+
+			assert.Equal(t, tt.wantOK, ok)
+
+			if tt.wantOK {
+				require.NotNil(t, result)
+
+				var parsed map[string]any
+				err := json.Unmarshal(result, &parsed)
+				require.NoError(t, err)
+
+				tt.checkJSON(t, parsed)
+			} else {
+				assert.Nil(t, result)
+			}
+		})
+	}
+}
+
+func TestErigonParser_ClientType(t *testing.T) {
+	parser := NewErigonParser()
+	assert.Equal(t, "erigon", string(parser.ClientType()))
+}

--- a/pkg/blocklog/erigon_test.go
+++ b/pkg/blocklog/erigon_test.go
@@ -9,7 +9,16 @@ import (
 )
 
 // Taken verbatim from a validated block.
-const erigonPayload = `{"level":"warn","msg":"Slow block","block":{"number":1,"hash":"0x5c6519e89d3b01dc9846d2b67a07202efd45fcd35d380beada32f7be406fd22d","gas_used":12000,"tx_count":1},"timing":{"execution_ms":0.829174,"state_read_ms":0.001553,"state_hash_ms":0.142427,"commit_ms":0.042781,"total_ms":1.015935},"throughput":{"mgas_per_sec":11.81},"state_reads":{"accounts":3,"storage_slots":0,"code":0},"state_writes":{"accounts":1,"storage_slots":0,"code":0},"cache":{"account":{"hits":3,"misses":0,"hit_rate":1},"storage":{"hits":0,"misses":0,"hit_rate":0},"code":{"hits":0,"misses":0,"hit_rate":0}}}`
+const erigonPayload = `{"level":"warn","msg":"Slow block","block":{"number":1,"hash":"0xb8dadbee815351753287e128c38d4bde06d231afd5662739eede2e39dd08138e","gas_used":12000,"tx_count":1},"timing":{"execution_ms":0.854709,"state_read_ms":0.00125,"state_hash_ms":0.077708,"commit_ms":0.233458,"total_ms":1.165875},"throughput":{"mgas_per_sec":14.04},"state_reads":{"accounts":3,"storage_slots":0,"code":0},"state_writes":{"accounts":2,"storage_slots":1,"code":0},"cache":{"account":{"hits":3,"misses":0,"hit_rate":100},"storage":{"hits":0,"misses":0,"hit_rate":0},"code":{"hits":0,"misses":0,"hit_rate":0}}}`
+
+func erigonJSONLine(t *testing.T, payload string) string {
+	t.Helper()
+
+	msg, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	return `{"lvl":"warn","t":"2026-09-03T17:21:56.701597+07:00","msg":` + string(msg) + `}`
+}
 
 func TestErigonParser_ParseLine(t *testing.T) {
 	parser := NewErigonParser()
@@ -32,19 +41,19 @@ func TestErigonParser_ParseLine(t *testing.T) {
 
 				block := data["block"].(map[string]any)
 				assert.Equal(t, float64(1), block["number"])
-				assert.Equal(t, "0x5c6519e89d3b01dc9846d2b67a07202efd45fcd35d380beada32f7be406fd22d", block["hash"])
+				assert.Equal(t, "0xb8dadbee815351753287e128c38d4bde06d231afd5662739eede2e39dd08138e", block["hash"])
 				assert.Equal(t, float64(12000), block["gas_used"])
 				assert.Equal(t, float64(1), block["tx_count"])
 
 				timing := data["timing"].(map[string]any)
-				assert.Equal(t, 0.829174, timing["execution_ms"])
-				assert.Equal(t, 0.001553, timing["state_read_ms"])
-				assert.Equal(t, 0.142427, timing["state_hash_ms"])
-				assert.Equal(t, 0.042781, timing["commit_ms"])
-				assert.Equal(t, 1.015935, timing["total_ms"])
+				assert.Equal(t, 0.854709, timing["execution_ms"])
+				assert.Equal(t, 0.00125, timing["state_read_ms"])
+				assert.Equal(t, 0.077708, timing["state_hash_ms"])
+				assert.Equal(t, 0.233458, timing["commit_ms"])
+				assert.Equal(t, 1.165875, timing["total_ms"])
 
 				throughput := data["throughput"].(map[string]any)
-				assert.Equal(t, 11.81, throughput["mgas_per_sec"])
+				assert.Equal(t, 14.04, throughput["mgas_per_sec"])
 
 				stateReads := data["state_reads"].(map[string]any)
 				assert.Equal(t, float64(3), stateReads["accounts"])
@@ -52,12 +61,12 @@ func TestErigonParser_ParseLine(t *testing.T) {
 				assert.Equal(t, float64(0), stateReads["code"])
 
 				stateWrites := data["state_writes"].(map[string]any)
-				assert.Equal(t, float64(1), stateWrites["accounts"])
+				assert.Equal(t, float64(2), stateWrites["accounts"])
 
 				account := data["cache"].(map[string]any)["account"].(map[string]any)
 				assert.Equal(t, float64(3), account["hits"])
 				assert.Equal(t, float64(0), account["misses"])
-				assert.Equal(t, float64(1), account["hit_rate"])
+				assert.Equal(t, float64(100), account["hit_rate"])
 			},
 		},
 		{
@@ -69,11 +78,11 @@ func TestErigonParser_ParseLine(t *testing.T) {
 
 				assert.Equal(t, "Slow block", data["msg"])
 				assert.Equal(t, float64(1), data["block"].(map[string]any)["number"])
-				assert.Equal(t, 0.142427, data["timing"].(map[string]any)["state_hash_ms"])
+				assert.Equal(t, 0.077708, data["timing"].(map[string]any)["state_hash_ms"])
 			},
 		},
 		{
-			name:   "DBUG level envelope",
+			name:   "envelope level is not the discriminator (DBUG)",
 			line:   `[DBUG] [09-01|22:20:12.372] ` + erigonPayload,
 			wantOK: true,
 			checkJSON: func(t *testing.T, data map[string]any) {
@@ -83,7 +92,7 @@ func TestErigonParser_ParseLine(t *testing.T) {
 			},
 		},
 		{
-			name:   "EROR level envelope",
+			name:   "envelope level is not the discriminator (EROR)",
 			line:   `[EROR] [09-01|22:20:12.372] ` + erigonPayload,
 			wantOK: true,
 			checkJSON: func(t *testing.T, data map[string]any) {
@@ -101,6 +110,23 @@ func TestErigonParser_ParseLine(t *testing.T) {
 
 				assert.Equal(t, "Slow block", data["msg"])
 			},
+		},
+		{
+			name:   "--log.json envelope carries the record escaped in msg",
+			line:   erigonJSONLine(t, erigonPayload),
+			wantOK: true,
+			checkJSON: func(t *testing.T, data map[string]any) {
+				t.Helper()
+
+				assert.Equal(t, "Slow block", data["msg"])
+				assert.Equal(t, float64(12000), data["block"].(map[string]any)["gas_used"])
+				assert.Equal(t, 1.165875, data["timing"].(map[string]any)["total_ms"])
+			},
+		},
+		{
+			name:   "--log.json envelope carrying an ordinary message",
+			line:   erigonJSONLine(t, "Executed blocks"),
+			wantOK: false,
 		},
 		{
 			name:   "right message but no timing object",

--- a/pkg/blocklog/erigon_test.go
+++ b/pkg/blocklog/erigon_test.go
@@ -8,8 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// erigonPayload is the record Erigon emits, taken verbatim from a validated
-// block on a node built with --debug.slow-block-threshold=0.
+// Taken verbatim from a validated block.
 const erigonPayload = `{"level":"warn","msg":"Slow block","block":{"number":1,"hash":"0x5c6519e89d3b01dc9846d2b67a07202efd45fcd35d380beada32f7be406fd22d","gas_used":12000,"tx_count":1},"timing":{"execution_ms":0.829174,"state_read_ms":0.001553,"state_hash_ms":0.142427,"commit_ms":0.042781,"total_ms":1.015935},"throughput":{"mgas_per_sec":11.81},"state_reads":{"accounts":3,"storage_slots":0,"code":0},"state_writes":{"accounts":1,"storage_slots":0,"code":0},"cache":{"account":{"hits":3,"misses":0,"hit_rate":1},"storage":{"hits":0,"misses":0,"hit_rate":0},"code":{"hits":0,"misses":0,"hit_rate":0}}}`
 
 func TestErigonParser_ParseLine(t *testing.T) {
@@ -22,7 +21,6 @@ func TestErigonParser_ParseLine(t *testing.T) {
 		checkJSON func(t *testing.T, data map[string]any)
 	}{
 		{
-			// Erigon's terminal format leaves a trailing space after the message.
 			name:   "non-TTY line with all fields",
 			line:   `[WARN] [09-01|22:20:12.372] ` + erigonPayload + ` `,
 			wantOK: true,
@@ -63,8 +61,6 @@ func TestErigonParser_ParseLine(t *testing.T) {
 			},
 		},
 		{
-			// On a TTY the level is wrapped in colour codes and the space
-			// between it and the timestamp disappears.
 			name:   "TTY line with ANSI escape codes",
 			line:   "\x1b[33mWARN\x1b[0m[09-01|22:20:12.372] " + erigonPayload + " ",
 			wantOK: true,
@@ -112,8 +108,6 @@ func TestErigonParser_ParseLine(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			// Erigon logs plenty of other JSON at WARN; only the slow block
-			// message carries this schema.
 			name:   "JSON payload from another message",
 			line:   `[WARN] [09-01|22:20:12.372] {"level":"warn","msg":"Something else","block":{"number":1}}`,
 			wantOK: false,

--- a/pkg/blocklog/erigon_test.go
+++ b/pkg/blocklog/erigon_test.go
@@ -8,8 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Taken verbatim from a validated block.
-const erigonPayload = `{"level":"warn","msg":"Slow block","block":{"number":1,"hash":"0xb8dadbee815351753287e128c38d4bde06d231afd5662739eede2e39dd08138e","gas_used":12000,"tx_count":1},"timing":{"execution_ms":0.854709,"state_read_ms":0.00125,"state_hash_ms":0.077708,"commit_ms":0.233458,"total_ms":1.165875},"throughput":{"mgas_per_sec":14.04},"state_reads":{"accounts":3,"storage_slots":0,"code":0},"state_writes":{"accounts":2,"storage_slots":1,"code":0},"cache":{"account":{"hits":3,"misses":0,"hit_rate":100},"storage":{"hits":0,"misses":0,"hit_rate":0},"code":{"hits":0,"misses":0,"hit_rate":0}}}`
+// Taken verbatim from a validated block that deploys a contract. Erigon omits
+// state_reads.code and cache.code rather than reporting zero, because it has no
+// CodeDomain read counter; state_writes.code is counted and so is emitted.
+// total_ms is end-to-end and exceeds execution_ms + state_hash_ms + commit_ms.
+const erigonPayload = `{"level":"warn","msg":"Slow block","block":{"number":2,"hash":"0xda4c162eb46b6163de6ab73a4a56d78c34e82771a875687868d4d006e8ac3b37","gas_used":185130,"tx_count":1},"timing":{"execution_ms":0.408167,"state_read_ms":0.001291,"state_hash_ms":0.06425,"commit_ms":0.179,"total_ms":0.744125},"throughput":{"mgas_per_sec":453.56},"state_reads":{"accounts":4,"storage_slots":0},"state_writes":{"accounts":3,"storage_slots":0,"code":1},"cache":{"account":{"hits":4,"misses":0,"hit_rate":100},"storage":{"hits":0,"misses":0,"hit_rate":0}}}`
 
 func erigonJSONLine(t *testing.T, payload string) string {
 	t.Helper()
@@ -40,31 +43,42 @@ func TestErigonParser_ParseLine(t *testing.T) {
 				assert.Equal(t, "Slow block", data["msg"])
 
 				block := data["block"].(map[string]any)
-				assert.Equal(t, float64(1), block["number"])
-				assert.Equal(t, "0xb8dadbee815351753287e128c38d4bde06d231afd5662739eede2e39dd08138e", block["hash"])
-				assert.Equal(t, float64(12000), block["gas_used"])
+				assert.Equal(t, float64(2), block["number"])
+				assert.Equal(t, "0xda4c162eb46b6163de6ab73a4a56d78c34e82771a875687868d4d006e8ac3b37", block["hash"])
+				assert.Equal(t, float64(185130), block["gas_used"])
 				assert.Equal(t, float64(1), block["tx_count"])
 
 				timing := data["timing"].(map[string]any)
-				assert.Equal(t, 0.854709, timing["execution_ms"])
-				assert.Equal(t, 0.00125, timing["state_read_ms"])
-				assert.Equal(t, 0.077708, timing["state_hash_ms"])
-				assert.Equal(t, 0.233458, timing["commit_ms"])
-				assert.Equal(t, 1.165875, timing["total_ms"])
+				assert.Equal(t, 0.408167, timing["execution_ms"])
+				assert.Equal(t, 0.001291, timing["state_read_ms"])
+				assert.Equal(t, 0.06425, timing["state_hash_ms"])
+				assert.Equal(t, 0.179, timing["commit_ms"])
+				assert.Equal(t, 0.744125, timing["total_ms"])
+
+				phases := timing["execution_ms"].(float64) + timing["state_hash_ms"].(float64) + timing["commit_ms"].(float64)
+				assert.Greater(t, timing["total_ms"].(float64)-phases, 0.01,
+					"total_ms is end-to-end, so it exceeds the phase breakdown by the stages outside it")
 
 				throughput := data["throughput"].(map[string]any)
-				assert.Equal(t, 14.04, throughput["mgas_per_sec"])
+				assert.Equal(t, 453.56, throughput["mgas_per_sec"])
 
 				stateReads := data["state_reads"].(map[string]any)
-				assert.Equal(t, float64(3), stateReads["accounts"])
+				assert.Equal(t, float64(4), stateReads["accounts"])
 				assert.Equal(t, float64(0), stateReads["storage_slots"])
-				assert.Equal(t, float64(0), stateReads["code"])
+				assert.NotContains(t, stateReads, "code",
+					"Erigon omits code reads rather than reporting an unmeasured zero")
 
 				stateWrites := data["state_writes"].(map[string]any)
-				assert.Equal(t, float64(2), stateWrites["accounts"])
+				assert.Equal(t, float64(3), stateWrites["accounts"])
+				assert.Equal(t, float64(1), stateWrites["code"],
+					"code writes are counted, so the deploy must survive the round trip")
 
-				account := data["cache"].(map[string]any)["account"].(map[string]any)
-				assert.Equal(t, float64(3), account["hits"])
+				cache := data["cache"].(map[string]any)
+				assert.NotContains(t, cache, "code",
+					"Erigon omits the code cache summary rather than reporting an unmeasured zero")
+
+				account := cache["account"].(map[string]any)
+				assert.Equal(t, float64(4), account["hits"])
 				assert.Equal(t, float64(0), account["misses"])
 				assert.Equal(t, float64(100), account["hit_rate"])
 			},
@@ -77,8 +91,8 @@ func TestErigonParser_ParseLine(t *testing.T) {
 				t.Helper()
 
 				assert.Equal(t, "Slow block", data["msg"])
-				assert.Equal(t, float64(1), data["block"].(map[string]any)["number"])
-				assert.Equal(t, 0.077708, data["timing"].(map[string]any)["state_hash_ms"])
+				assert.Equal(t, float64(2), data["block"].(map[string]any)["number"])
+				assert.Equal(t, 0.06425, data["timing"].(map[string]any)["state_hash_ms"])
 			},
 		},
 		{
@@ -119,8 +133,8 @@ func TestErigonParser_ParseLine(t *testing.T) {
 				t.Helper()
 
 				assert.Equal(t, "Slow block", data["msg"])
-				assert.Equal(t, float64(12000), data["block"].(map[string]any)["gas_used"])
-				assert.Equal(t, 1.165875, data["timing"].(map[string]any)["total_ms"])
+				assert.Equal(t, float64(185130), data["block"].(map[string]any)["gas_used"])
+				assert.Equal(t, 0.744125, data["timing"].(map[string]any)["total_ms"])
 			},
 		},
 		{
@@ -156,7 +170,7 @@ func TestErigonParser_ParseLine(t *testing.T) {
 				t.Helper()
 
 				assert.Equal(t, "Slow block", data["msg"])
-				assert.Equal(t, 1.165875, data["timing"].(map[string]any)["total_ms"])
+				assert.Equal(t, 0.744125, data["timing"].(map[string]any)["total_ms"])
 			},
 		},
 		{

--- a/pkg/blocklog/erigon_test.go
+++ b/pkg/blocklog/erigon_test.go
@@ -14,11 +14,8 @@ import (
 // total_ms is end-to-end and exceeds execution_ms + state_hash_ms + commit_ms.
 const erigonPayload = `{"level":"warn","msg":"Slow block","block":{"number":2,"hash":"0xda4c162eb46b6163de6ab73a4a56d78c34e82771a875687868d4d006e8ac3b37","gas_used":185130,"tx_count":1},"timing":{"execution_ms":0.408167,"state_read_ms":0.001291,"state_hash_ms":0.06425,"commit_ms":0.179,"total_ms":0.744125},"throughput":{"mgas_per_sec":453.56},"state_reads":{"accounts":4,"storage_slots":0},"state_writes":{"accounts":3,"storage_slots":0,"code":1},"cache":{"account":{"hits":4,"misses":0,"hit_rate":100},"storage":{"hits":0,"misses":0,"hit_rate":0}}}`
 
-func erigonJSONLine(t *testing.T, payload string) string {
-	t.Helper()
-
-	msg, err := json.Marshal(payload)
-	require.NoError(t, err)
+func erigonJSONLine(payload string) string {
+	msg, _ := json.Marshal(payload)
 
 	return `{"lvl":"warn","t":"2026-09-03T17:21:56.701597+07:00","msg":` + string(msg) + `}`
 }
@@ -99,35 +96,15 @@ func TestErigonParser_ParseLine(t *testing.T) {
 			name:   "envelope level is not the discriminator (DBUG)",
 			line:   `[DBUG] [09-01|22:20:12.372] ` + erigonPayload,
 			wantOK: true,
-			checkJSON: func(t *testing.T, data map[string]any) {
-				t.Helper()
-
-				assert.Equal(t, "Slow block", data["msg"])
-			},
-		},
-		{
-			name:   "envelope level is not the discriminator (EROR)",
-			line:   `[EROR] [09-01|22:20:12.372] ` + erigonPayload,
-			wantOK: true,
-			checkJSON: func(t *testing.T, data map[string]any) {
-				t.Helper()
-
-				assert.Equal(t, "Slow block", data["msg"])
-			},
 		},
 		{
 			name:   "padded level",
 			line:   `[WARN ] [09-01|22:20:12.372] ` + erigonPayload,
 			wantOK: true,
-			checkJSON: func(t *testing.T, data map[string]any) {
-				t.Helper()
-
-				assert.Equal(t, "Slow block", data["msg"])
-			},
 		},
 		{
 			name:   "--log.json envelope carries the record escaped in msg",
-			line:   erigonJSONLine(t, erigonPayload),
+			line:   erigonJSONLine(erigonPayload),
 			wantOK: true,
 			checkJSON: func(t *testing.T, data map[string]any) {
 				t.Helper()
@@ -139,7 +116,7 @@ func TestErigonParser_ParseLine(t *testing.T) {
 		},
 		{
 			name:   "--log.json envelope carrying an ordinary message",
-			line:   erigonJSONLine(t, "Executed blocks"),
+			line:   erigonJSONLine("Executed blocks"),
 			wantOK: false,
 		},
 		{
@@ -177,11 +154,6 @@ func TestErigonParser_ParseLine(t *testing.T) {
 			name:   "no timestamp, brackets kept",
 			line:   `[WARN] ` + erigonPayload,
 			wantOK: true,
-			checkJSON: func(t *testing.T, data map[string]any) {
-				t.Helper()
-
-				assert.Equal(t, "Slow block", data["msg"])
-			},
 		},
 		{
 			name:   "empty line",
@@ -203,7 +175,9 @@ func TestErigonParser_ParseLine(t *testing.T) {
 				err := json.Unmarshal(result, &parsed)
 				require.NoError(t, err)
 
-				tt.checkJSON(t, parsed)
+				if tt.checkJSON != nil {
+					tt.checkJSON(t, parsed)
+				}
 			} else {
 				assert.Nil(t, result)
 			}

--- a/pkg/blocklog/erigon_test.go
+++ b/pkg/blocklog/erigon_test.go
@@ -149,9 +149,25 @@ func TestErigonParser_ParseLine(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:   "missing timestamp",
+			name:   "ERIGON_LOG_NO_TIMESTAMPS drops the timestamp group",
+			line:   "\x1b[33mWARN\x1b[0m " + erigonPayload + " ",
+			wantOK: true,
+			checkJSON: func(t *testing.T, data map[string]any) {
+				t.Helper()
+
+				assert.Equal(t, "Slow block", data["msg"])
+				assert.Equal(t, 1.165875, data["timing"].(map[string]any)["total_ms"])
+			},
+		},
+		{
+			name:   "no timestamp, brackets kept",
 			line:   `[WARN] ` + erigonPayload,
-			wantOK: false,
+			wantOK: true,
+			checkJSON: func(t *testing.T, data map[string]any) {
+				t.Helper()
+
+				assert.Equal(t, "Slow block", data["msg"])
+			},
 		},
 		{
 			name:   "empty line",

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -670,17 +670,17 @@ export interface BlockLogThroughput {
 export interface BlockLogStateReads {
   accounts: number
   storage_slots: number
-  code: number
-  code_bytes: number
+  code?: number
+  code_bytes?: number
 }
 
 export interface BlockLogStateWrites {
   accounts: number
-  accounts_deleted: number
+  accounts_deleted?: number
   storage_slots: number
-  storage_slots_deleted: number
-  code: number
-  code_bytes: number
+  storage_slots_deleted?: number
+  code?: number
+  code_bytes?: number
 }
 
 export interface BlockLogCacheEntry {
@@ -697,7 +697,7 @@ export interface BlockLogCodeCache extends BlockLogCacheEntry {
 export interface BlockLogCache {
   account: BlockLogCacheEntry
   storage: BlockLogCacheEntry
-  code: BlockLogCodeCache
+  code?: BlockLogCodeCache
 }
 
 export interface BlockLogEntry {

--- a/ui/src/components/compare/BlockLogsComparison.tsx
+++ b/ui/src/components/compare/BlockLogsComparison.tsx
@@ -28,7 +28,7 @@ interface BlockLogDataPoint {
   overheadMs: number
   accountCacheHitRate: number
   storageCacheHitRate: number
-  codeCacheHitRate: number
+  codeCacheHitRate: number | undefined
 }
 
 /** Build a unified, sorted list of test names across all runs. */
@@ -76,7 +76,7 @@ function buildBlockLogDataPoints(
       overheadMs: (entry.timing?.state_read_ms ?? 0) + (entry.timing?.state_hash_ms ?? 0) + (entry.timing?.commit_ms ?? 0),
       accountCacheHitRate: entry.cache?.account?.hit_rate ?? 0,
       storageCacheHitRate: entry.cache?.storage?.hit_rate ?? 0,
-      codeCacheHitRate: entry.cache?.code?.hit_rate ?? 0,
+      codeCacheHitRate: entry.cache?.code?.hit_rate,
     })
   })
   return points

--- a/ui/src/components/compare/TestComparisonTable.tsx
+++ b/ui/src/components/compare/TestComparisonTable.tsx
@@ -57,14 +57,14 @@ const BLOCK_LOG_METRICS: MetricTab[] = [
   { id: 'bl-code-cache', label: 'Code Cache HR', unit: '%', higherIsBetter: true, format: (v) => v.toFixed(1) },
 ]
 
-function extractBlockLogMetric(entry: BlockLogEntry, metricId: string): number {
+function extractBlockLogMetric(entry: BlockLogEntry, metricId: string): number | undefined {
   switch (metricId) {
     case 'bl-throughput': return entry.throughput?.mgas_per_sec ?? 0
     case 'bl-execution': return entry.timing?.execution_ms ?? 0
     case 'bl-overhead': return (entry.timing?.state_read_ms ?? 0) + (entry.timing?.state_hash_ms ?? 0) + (entry.timing?.commit_ms ?? 0)
     case 'bl-account-cache': return entry.cache?.account?.hit_rate ?? 0
     case 'bl-storage-cache': return entry.cache?.storage?.hit_rate ?? 0
-    case 'bl-code-cache': return entry.cache?.code?.hit_rate ?? 0
+    case 'bl-code-cache': return entry.cache?.code?.hit_rate
     default: return 0
   }
 }

--- a/ui/src/components/run-detail/BlockLogDetails.tsx
+++ b/ui/src/components/run-detail/BlockLogDetails.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
-import type { BlockLogEntry } from '@/api/types'
+import type { BlockLogCacheEntry, BlockLogEntry } from '@/api/types'
 import { formatBytes } from '@/utils/format'
 import {
   DEFAULT_SLOW_MS,
@@ -96,7 +96,7 @@ export function BlockLogDetails({ blockLog, threshold = DEFAULT_THRESHOLD, slowM
   const { timing, throughput, state_reads, state_writes, cache } = blockLog
   const hasTiming = timing != null && timing.total_ms != null
   const hasOverhead = hasTiming && timing.state_read_ms != null && timing.state_hash_ms != null && timing.commit_ms != null
-  const hasCache = cache != null && cache.account != null && cache.storage != null && cache.code != null
+  const hasCache = cache != null && cache.account != null && cache.storage != null
   const hasStateOps = state_reads != null && state_writes != null
 
   // Calculate overhead time (non-execution time)
@@ -223,10 +223,12 @@ export function BlockLogDetails({ blockLog, threshold = DEFAULT_THRESHOLD, slowM
   // Cache performance stacked bar chart
   const cacheBarOption = useMemo(() => {
     if (!hasCache) return null
-    const categories = ['Account', 'Storage', 'Code']
-    const hits = [cache.account.hits, cache.storage.hits, cache.code.hits]
-    const misses = [cache.account.misses, cache.storage.misses, cache.code.misses]
-    const hitRates = [cache.account.hit_rate, cache.storage.hit_rate, cache.code.hit_rate]
+    const entries: Array<[string, BlockLogCacheEntry]> = [['Account', cache.account], ['Storage', cache.storage]]
+    if (cache.code != null) entries.push(['Code', cache.code])
+    const categories = entries.map(([name]) => name)
+    const hits = entries.map(([, c]) => c.hits)
+    const misses = entries.map(([, c]) => c.misses)
+    const hitRates = entries.map(([, c]) => c.hit_rate)
 
     return {
       tooltip: {
@@ -305,9 +307,9 @@ export function BlockLogDetails({ blockLog, threshold = DEFAULT_THRESHOLD, slowM
   const stateOpsOption = useMemo(() => {
     if (!hasStateOps) return null
     const categories = ['Accounts', 'Storage', 'Code']
-    const reads = [state_reads.accounts, state_reads.storage_slots, state_reads.code]
-    const writes = [state_writes.accounts, state_writes.storage_slots, state_writes.code]
-    const deleted = [state_writes.accounts_deleted, state_writes.storage_slots_deleted, 0]
+    const reads = [state_reads.accounts, state_reads.storage_slots, state_reads.code ?? 0]
+    const writes = [state_writes.accounts, state_writes.storage_slots, state_writes.code ?? 0]
+    const deleted = [state_writes.accounts_deleted ?? 0, state_writes.storage_slots_deleted ?? 0, 0]
 
     return {
       tooltip: {

--- a/ui/src/components/run-detail/block-logs-dashboard/charts/CacheBarChart.tsx
+++ b/ui/src/components/run-detail/block-logs-dashboard/charts/CacheBarChart.tsx
@@ -22,26 +22,20 @@ const CACHE_TYPE_LABELS: Record<CacheType, string> = {
   code: 'Code Cache',
 }
 
-function getCacheData(item: ProcessedTestData, cacheType: CacheType) {
+type CacheCounts = { hitRate: number; hits: number; misses: number }
+
+function getCacheData(item: ProcessedTestData, cacheType: CacheType): CacheCounts | null {
   switch (cacheType) {
     case 'account':
-      return {
-        hitRate: item.accountCacheHitRate,
-        hits: item.accountCacheHits,
-        misses: item.accountCacheMisses,
-      }
+      return { hitRate: item.accountCacheHitRate, hits: item.accountCacheHits, misses: item.accountCacheMisses }
     case 'storage':
-      return {
-        hitRate: item.storageCacheHitRate,
-        hits: item.storageCacheHits,
-        misses: item.storageCacheMisses,
-      }
+      return { hitRate: item.storageCacheHitRate, hits: item.storageCacheHits, misses: item.storageCacheMisses }
     case 'code':
-      return {
-        hitRate: item.codeCacheHitRate,
-        hits: item.codeCacheHits,
-        misses: item.codeCacheMisses,
+      if (item.codeCacheHitRate == null || item.codeCacheHits == null || item.codeCacheMisses == null) {
+        return null
       }
+
+      return { hitRate: item.codeCacheHitRate, hits: item.codeCacheHits, misses: item.codeCacheMisses }
   }
 }
 
@@ -62,17 +56,19 @@ export function CacheBarChart({
   const tooltipBorder = isDark ? '#374151' : '#e5e7eb'
 
   const chartData = useMemo(() => {
-    return [...data].sort((a, b) => {
-      if (sortMode === 'order') {
-        return a.testOrder - b.testOrder
-      }
-      const aCache = getCacheData(a, cacheType)
-      const bCache = getCacheData(b, cacheType)
-      if (sortMode === 'total') {
-        return (aCache.hits + aCache.misses) - (bCache.hits + bCache.misses)
-      }
-      return aCache.hitRate - bCache.hitRate
-    })
+    return data
+      .filter((d) => getCacheData(d, cacheType) != null)
+      .sort((a, b) => {
+        if (sortMode === 'order') {
+          return a.testOrder - b.testOrder
+        }
+        const aCache = getCacheData(a, cacheType)!
+        const bCache = getCacheData(b, cacheType)!
+        if (sortMode === 'total') {
+          return (aCache.hits + aCache.misses) - (bCache.hits + bCache.misses)
+        }
+        return aCache.hitRate - bCache.hitRate
+      })
   }, [data, sortMode, cacheType])
 
   const option = useMemo(() => {
@@ -91,7 +87,7 @@ export function CacheBarChart({
         formatter: (params: { name: string; value: number; dataIndex: number }[]) => {
           const param = params[0]
           const item = chartData[param.dataIndex]
-          const cache = getCacheData(item, cacheType)
+          const cache = getCacheData(item, cacheType)!
           const testLabel = item.testOrder === Infinity ? '-' : `#${item.testOrder}`
           const total = cache.hits + cache.misses
           return `
@@ -203,10 +199,7 @@ export function CacheBarChart({
           type: 'bar' as const,
           stack: 'cache',
           yAxisIndex: 0,
-          data: chartData.map((d) => {
-            const cache = getCacheData(d, cacheType)
-            return cache.hits
-          }),
+          data: chartData.map((d) => getCacheData(d, cacheType)!.hits),
           itemStyle: { color: CACHE_COLORS.hit },
           barMaxWidth: 30,
         },
@@ -215,10 +208,7 @@ export function CacheBarChart({
           type: 'bar' as const,
           stack: 'cache',
           yAxisIndex: 0,
-          data: chartData.map((d) => {
-            const cache = getCacheData(d, cacheType)
-            return cache.misses
-          }),
+          data: chartData.map((d) => getCacheData(d, cacheType)!.misses),
           itemStyle: { color: CACHE_COLORS.miss },
           barMaxWidth: 30,
         },
@@ -226,10 +216,7 @@ export function CacheBarChart({
           name: 'Hit Rate %',
           type: 'line' as const,
           yAxisIndex: 1,
-          data: chartData.map((d) => {
-            const cache = getCacheData(d, cacheType)
-            return cache.hitRate
-          }),
+          data: chartData.map((d) => getCacheData(d, cacheType)!.hitRate),
           itemStyle: { color: '#3b82f6' },
           lineStyle: { color: '#3b82f6', width: 2 },
           symbol: 'circle',

--- a/ui/src/components/run-detail/block-logs-dashboard/components/BlockLogsTable.tsx
+++ b/ui/src/components/run-detail/block-logs-dashboard/components/BlockLogsTable.tsx
@@ -284,10 +284,12 @@ export function BlockLogsTable({ data, state, onUpdate, onTestClick }: BlockLogs
                   <td className="px-3 py-2 text-right font-mono text-sm">
                     <span
                       className={clsx(
-                        row.codeCacheHitRate >= 80 ? 'text-green-600 dark:text-green-400' : 'text-orange-600 dark:text-orange-400'
+                        row.codeCacheHitRate == null
+                          ? 'text-gray-400 dark:text-gray-500'
+                          : row.codeCacheHitRate >= 80 ? 'text-green-600 dark:text-green-400' : 'text-orange-600 dark:text-orange-400'
                       )}
                     >
-                      {formatPercent(row.codeCacheHitRate)}
+                      {row.codeCacheHitRate != null ? formatPercent(row.codeCacheHitRate) : '-'}
                     </span>
                   </td>
                 </tr>

--- a/ui/src/components/run-detail/block-logs-dashboard/components/CacheTab.tsx
+++ b/ui/src/components/run-detail/block-logs-dashboard/components/CacheTab.tsx
@@ -34,11 +34,11 @@ export function CacheTab({ data, isDark, useLogScale, onTestClick }: CacheTabPro
 
     const accountRates = data.map((d) => d.accountCacheHitRate)
     const storageRates = data.map((d) => d.storageCacheHitRate)
-    const codeRates = data.map((d) => d.codeCacheHitRate)
+    const codeRates = data.map((d) => d.codeCacheHitRate).filter((r): r is number => r != null)
 
     const avgAccount = accountRates.reduce((a, b) => a + b, 0) / accountRates.length
     const avgStorage = storageRates.reduce((a, b) => a + b, 0) / storageRates.length
-    const avgCode = codeRates.reduce((a, b) => a + b, 0) / codeRates.length
+    const avgCode = codeRates.length > 0 ? codeRates.reduce((a, b) => a + b, 0) / codeRates.length : null
 
     const poorAccountCount = accountRates.filter((r) => r < 80).length
     const poorStorageCount = storageRates.filter((r) => r < 80).length
@@ -79,8 +79,8 @@ export function CacheTab({ data, isDark, useLogScale, onTestClick }: CacheTabPro
         />
         <CacheStatCard
           label="Avg Code Cache"
-          value={`${cacheStats.avgCode.toFixed(1)}%`}
-          isGood={cacheStats.avgCode >= 80}
+          value={cacheStats.avgCode != null ? `${cacheStats.avgCode.toFixed(1)}%` : '-'}
+          isGood={cacheStats.avgCode != null && cacheStats.avgCode >= 80}
         />
         <CacheStatCard
           label="Poor Account (<80%)"

--- a/ui/src/components/run-detail/block-logs-dashboard/hooks/useProcessedData.test.ts
+++ b/ui/src/components/run-detail/block-logs-dashboard/hooks/useProcessedData.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { compareOptional } from './useProcessedData'
+
+describe('compareOptional', () => {
+  it('orders reported values by magnitude', () => {
+    expect(compareOptional(10, 20)).toBeLessThan(0)
+    expect(compareOptional(20, 10)).toBeGreaterThan(0)
+    expect(compareOptional(10, 10)).toBe(0)
+  })
+
+  it('groups unreported values instead of ranking them as zero', () => {
+    expect(compareOptional(undefined, undefined)).toBe(0)
+    expect(compareOptional(undefined, 0)).toBeGreaterThan(0)
+    expect(compareOptional(0, undefined)).toBeLessThan(0)
+  })
+})

--- a/ui/src/components/run-detail/block-logs-dashboard/hooks/useProcessedData.ts
+++ b/ui/src/components/run-detail/block-logs-dashboard/hooks/useProcessedData.ts
@@ -5,6 +5,13 @@ import { parseCategory } from '../utils/categoryParser'
 import { percentile, removeOutliers, countOutliers, normalizeValue, emptyCategoryBreakdown } from '../utils/statistics'
 import { compileQuery } from '@/utils/eestNameFilter'
 
+export function compareOptional(a: number | undefined, b: number | undefined): number {
+  if (a == null && b == null) return 0
+  if (a == null) return 1
+  if (b == null) return -1
+  return a - b
+}
+
 export function useProcessedData(
   blockLogs: BlockLogs | null | undefined,
   state: DashboardState,
@@ -40,13 +47,13 @@ export function useProcessedData(
         commitMs,
         accountCacheHitRate: entry.cache?.account?.hit_rate ?? 0,
         storageCacheHitRate: entry.cache?.storage?.hit_rate ?? 0,
-        codeCacheHitRate: entry.cache?.code?.hit_rate ?? 0,
+        codeCacheHitRate: entry.cache?.code?.hit_rate,
         accountCacheHits: entry.cache?.account?.hits ?? 0,
         accountCacheMisses: entry.cache?.account?.misses ?? 0,
         storageCacheHits: entry.cache?.storage?.hits ?? 0,
         storageCacheMisses: entry.cache?.storage?.misses ?? 0,
-        codeCacheHits: entry.cache?.code?.hits ?? 0,
-        codeCacheMisses: entry.cache?.code?.misses ?? 0,
+        codeCacheHits: entry.cache?.code?.hits,
+        codeCacheMisses: entry.cache?.code?.misses,
         gasUsed: entry.block.gas_used,
         txCount: entry.block.tx_count,
         // Normalized values will be calculated after filtering
@@ -98,7 +105,7 @@ export function useProcessedData(
       const executions = data.map((d) => d.executionMs)
       const overheads = data.map((d) => d.overheadMs)
       const accountCaches = data.map((d) => d.accountCacheHitRate)
-      const codeCaches = data.map((d) => d.codeCacheHitRate)
+      const codeCaches = data.map((d) => d.codeCacheHitRate).filter((v): v is number => v != null)
 
       const minThroughput = Math.min(...throughputs)
       const maxThroughput = Math.max(...throughputs)
@@ -108,8 +115,8 @@ export function useProcessedData(
       const maxOverhead = Math.max(...overheads)
       const minAccountCache = Math.min(...accountCaches)
       const maxAccountCache = Math.max(...accountCaches)
-      const minCodeCache = Math.min(...codeCaches)
-      const maxCodeCache = Math.max(...codeCaches)
+      const minCodeCache = codeCaches.length > 0 ? Math.min(...codeCaches) : 0
+      const maxCodeCache = codeCaches.length > 0 ? Math.max(...codeCaches) : 0
 
       // Update normalized values
       data = data.map((d) => ({
@@ -118,7 +125,7 @@ export function useProcessedData(
         normalizedSpeed: normalizeValue(d.executionMs, minExecution, maxExecution, true), // Lower is better
         normalizedLowOverhead: normalizeValue(d.overheadMs, minOverhead, maxOverhead, true), // Lower is better
         normalizedAccountCache: normalizeValue(d.accountCacheHitRate, minAccountCache, maxAccountCache),
-        normalizedCodeCache: normalizeValue(d.codeCacheHitRate, minCodeCache, maxCodeCache),
+        normalizedCodeCache: d.codeCacheHitRate != null ? normalizeValue(d.codeCacheHitRate, minCodeCache, maxCodeCache) : 0,
       }))
     }
 
@@ -151,7 +158,7 @@ export function useProcessedData(
           comparison = a.storageCacheHitRate - b.storageCacheHitRate
           break
         case 'codeCache':
-          comparison = a.codeCacheHitRate - b.codeCacheHitRate
+          comparison = compareOptional(a.codeCacheHitRate, b.codeCacheHitRate)
           break
         case 'gas':
           comparison = a.gasUsed - b.gasUsed

--- a/ui/src/components/run-detail/block-logs-dashboard/types.ts
+++ b/ui/src/components/run-detail/block-logs-dashboard/types.ts
@@ -29,13 +29,13 @@ export interface ProcessedTestData {
   commitMs: number
   accountCacheHitRate: number
   storageCacheHitRate: number
-  codeCacheHitRate: number
+  codeCacheHitRate: number | undefined
   accountCacheHits: number
   accountCacheMisses: number
   storageCacheHits: number
   storageCacheMisses: number
-  codeCacheHits: number
-  codeCacheMisses: number
+  codeCacheHits: number | undefined
+  codeCacheMisses: number | undefined
   gasUsed: number
   txCount: number
   // Normalized 0-100 for radar chart

--- a/ui/src/utils/format.test.ts
+++ b/ui/src/utils/format.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatBytes } from './format'
+
+describe('formatBytes', () => {
+  it('formats byte counts by magnitude', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(2048)).toBe('2.0 KB')
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB')
+    expect(formatBytes(3 * 1024 * 1024 * 1024)).toBe('3.0 GB')
+  })
+
+  it('renders a placeholder for a value the client never emitted', () => {
+    expect(formatBytes(undefined)).toBe('-')
+    expect(formatBytes(NaN)).toBe('-')
+  })
+})

--- a/ui/src/utils/format.test.ts
+++ b/ui/src/utils/format.test.ts
@@ -4,10 +4,7 @@ import { formatBytes } from './format'
 
 describe('formatBytes', () => {
   it('formats byte counts by magnitude', () => {
-    expect(formatBytes(512)).toBe('512 B')
     expect(formatBytes(2048)).toBe('2.0 KB')
-    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB')
-    expect(formatBytes(3 * 1024 * 1024 * 1024)).toBe('3.0 GB')
   })
 
   it('renders a placeholder for a value the client never emitted', () => {

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -31,7 +31,8 @@ export function formatNumber(num: number): string {
   return new Intl.NumberFormat().format(num)
 }
 
-export function formatBytes(bytes: number): string {
+export function formatBytes(bytes: number | undefined): string {
+  if (bytes == null || !Number.isFinite(bytes)) return '-'
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`


### PR DESCRIPTION
Erigon's parser was a stub, so its slow block records were captured and dropped. This implements it. Record from erigontech/erigon#23764.

The record is everything from the first `{` of a console line, or the escaped `msg` of a `--log.json` line; erigon's envelope test pins both extractions since erigontech/erigon#23913.

Erigon omits six documented fields instead of reporting an unmeasured zero. The UI scored a missing code cache as a real 0%, ranking Erigon worst on a number it never reported; absent now reads `-`.
