### PR TITLE
runner: post-pre-run hook before schelk promote (BENCHMARKOOR_POST_PRERUN_CMD)

### DIFF
--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/client"
@@ -1221,6 +1222,31 @@ func (r *runner) promoteSchelkAfterPreRuns(
 		log.WithError(syncErr).Warn("Failed to sync before schelk promote")
 	}
 
+	// Optional operator hook between the pre-run and the promote: the client is
+	// stopped, logs are drained and the filesystem is synced, so the datadir is
+	// quiescent. Used for baseline surgery that must be baked into the promoted
+	// virgin - e.g. draining the pathdb journal into the disk layer so no test
+	// inherits journal-resident (RAM-served) state. Gated on an env var rather
+	// than a config key: like BENCHMARKOOR_COMPACT_BETWEEN_STEPS this is a
+	// deliberate methodology switch for the state-DB divergence work, not
+	// upstream behaviour. Failure aborts before the promote - a half-treated
+	// baseline must never replace the golden image.
+	if hookCmd := os.Getenv("BENCHMARKOOR_POST_PRERUN_CMD"); hookCmd != "" {
+		log.WithField("cmd", hookCmd).Warn("BENCHMARKOOR_POST_PRERUN_CMD is set; running it before schelk promote")
+
+		hookStart := time.Now()
+
+		out, hookErr := exec.CommandContext(ctx, "sh", "-c", hookCmd).CombinedOutput()
+		if hookErr != nil {
+			return "", false, fmt.Errorf("post-pre-run hook failed: %w (output: %s)", hookErr, string(out))
+		}
+
+		log.WithFields(logrus.Fields{
+			"elapsed": time.Since(hookStart).Round(time.Millisecond),
+			"output":  lastLines(string(out), 5),
+		}).Info("Post-pre-run hook completed; proceeding to schelk promote")
+	}
+
 	log.Info("Persisting the advanced datadir as the new schelk baseline (`schelk promote`)")
 
 	if err := datadir.SchelkPromote(ctx, r.log); err != nil {
@@ -1278,3 +1304,21 @@ func (r *runner) promoteSchelkAfterPreRuns(
 // with that test; a run of them means the client cannot start at all, and
 // continuing would spend a full RPC timeout per remaining test.
 const maxConsecutiveSetupFailures = 3
+
+// lastLines returns at most n trailing non-empty lines of s joined by " | ",
+// keeping hook output in the run log without flooding it.
+func lastLines(s string, n int) string {
+	var kept []string
+
+	for _, line := range strings.Split(s, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			kept = append(kept, trimmed)
+		}
+	}
+
+	if len(kept) > n {
+		kept = kept[len(kept)-n:]
+	}
+
+	return strings.Join(kept, " | ")
+}


### PR DESCRIPTION
Runs an operator command between "pre-run steps complete, client stopped, fs synced" and `schelk promote`, so baseline surgery gets baked into the promoted virgin. Hook failure aborts before the promote, so a half-treated baseline can never replace the golden image.

**Motivation.** A baseline built by replaying a pre-run bundle keeps the last ~4k blocks of geth trie state in the pathdb journal. `promote` bakes that journal into the golden image and every per-test `restore` hands it back, so geth loads it into memory on every boot. Accounts deployed in those final blocks are then served from RAM for the whole suite: in our runs one EEST account class read 23x faster than the same class on an identically-hosted generated-state baseline, purely from deploy recency. Draining the journal into the disk layer (and compacting) between pre-run and promote removes the bias.

**Usage**

```
BENCHMARKOOR_POST_PRERUN_CMD='drainjournal --datadir $DATADIR && geth db compact --datadir $DATADIR' \
  benchmarkoor run --config config.yaml
```

Unset (the default) the runner behaves exactly as before.

Write-up with the full investigation and before/after numbers: https://cperezz.github.io/articles/state-db-perf-divergence/state-db-perf-report.html