### PR TITLE
feat(config): merge instance resource_limits over the global limits

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -758,9 +758,9 @@ runner:
       #   enabled: true
       #   max_retries: 10
       #   backoff: 1s
-      # resource_limits:  # Instance-level override (optional)
-      #   cpuset_count: 2  # Override global with fewer CPUs
-      #   memory: "8g"     # Override global memory limit
+      # resource_limits:  # Instance-level override (optional, merged field by field with the global limits)
+      #   cpuset_count: 2  # Override global with fewer CPUs (replaces a global cpuset)
+      #   memory: "8g"     # Override global memory limit, keep the other global limits
       # post_test_rpc_calls:  # Instance-level override (optional, replaces global)
       #   - method: debug_traceBlockByNumber
       #     params: ["{{.BlockNumberHex}}"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1427,7 +1427,7 @@ runner:
 | `run_timeout` | string | No | From `runner.client.config` | Instance-specific run timeout duration |
 | `retry_new_payloads_syncing_state` | object | No | From `runner.client.config` | Instance-specific retry config for SYNCING responses |
 | `retry_new_payloads_failed_state` | object | No | From `runner.client.config` | Instance-specific retry config for non-SYNCING failures |
-| `resource_limits` | object | No | From `runner.client.config` | Instance-specific resource limits |
+| `resource_limits` | object | No | From `runner.client.config` | Instance-specific resource limits (merged field by field with the global limits) |
 | `post_test_rpc_calls` | []object | No | From `runner.client.config` | Instance-specific post-test RPC calls (replaces global) |
 | `post_test_sleep_duration` | string | No | From `runner.client.config` | Instance-specific post-test sleep duration |
 | `bootstrap_fcu` | bool/object | No | From `runner.client.config` | Instance-specific bootstrap FCU setting |
@@ -1475,7 +1475,33 @@ Applying an override to the wrong genesis format is an error (a geth-format over
 
 ## Resource Limits
 
-Resource limits can be configured globally (`runner.client.config.resource_limits`) or per-instance (`runner.instances[].resource_limits`). Instance-level settings override global defaults.
+Resource limits can be configured globally (`runner.client.config.resource_limits`) or per-instance (`runner.instances[].resource_limits`). The two levels merge field by field: an instance keeps every global value that it does not set.
+
+```yaml
+runner:
+  client:
+    config:
+      resource_limits:
+        cpuset: [6, 7, 8, 9, 10, 11]
+        cpu_freq: "3600MHz"
+        cpu_turboboost: false
+        cpu_freq_governor: performance
+        memory: "32g"
+        swap_disabled: true
+  instances:
+    - id: geth-1
+      client: geth
+      resource_limits:
+        memory: "16g" # Only the memory limit changes. The CPU and swap
+                      # settings stay at the global values.
+```
+
+Merge rules:
+
+- A field that the instance omits keeps the global value.
+- `cpuset` and `cpuset_count` are one setting. An instance that sets either one replaces both global fields.
+- Each `blkio_config` device list is replaced as a whole. An instance `device_read_bps` list does not change the global `device_write_bps` list.
+- Set `swap_disabled: false` on the instance to turn swap on again when the global config disables it.
 
 ```yaml
 resource_limits:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1634,11 +1635,63 @@ type ResourceLimits struct {
 	CpusetCount   *int         `yaml:"cpuset_count,omitempty" mapstructure:"cpuset_count" json:"cpuset_count,omitempty"`
 	Cpuset        []int        `yaml:"cpuset,omitempty" mapstructure:"cpuset" json:"cpuset,omitempty"`
 	Memory        string       `yaml:"memory,omitempty" mapstructure:"memory" json:"memory,omitempty"`
-	SwapDisabled  bool         `yaml:"swap_disabled,omitempty" mapstructure:"swap_disabled" json:"swap_disabled,omitempty"`
+	SwapDisabled  *bool        `yaml:"swap_disabled,omitempty" mapstructure:"swap_disabled" json:"swap_disabled,omitempty"`
 	BlkioConfig   *BlkioConfig `yaml:"blkio_config,omitempty" mapstructure:"blkio_config" json:"blkio_config,omitempty"`
 	CPUFreq       string       `yaml:"cpu_freq,omitempty" mapstructure:"cpu_freq" json:"cpu_freq,omitempty"`
 	CPUTurboBoost *bool        `yaml:"cpu_turboboost,omitempty" mapstructure:"cpu_turboboost" json:"cpu_turboboost,omitempty"`
 	CPUGovernor   string       `yaml:"cpu_freq_governor,omitempty" mapstructure:"cpu_freq_governor" json:"cpu_freq_governor,omitempty"`
+}
+
+// Merge returns a copy of r with the set fields of override on top of it.
+// The merge is field by field, so an instance can change one limit and keep the
+// other global defaults. Both sides accept a nil value.
+func (r *ResourceLimits) Merge(override *ResourceLimits) *ResourceLimits {
+	if r == nil {
+		return override
+	}
+
+	if override == nil {
+		return r
+	}
+
+	merged := *r
+	merged.Cpuset = slices.Clone(r.Cpuset)
+
+	// cpuset_count and cpuset are mutually exclusive, so a CPU selection in the
+	// override replaces both fields of the base.
+	if override.CpusetCount != nil || len(override.Cpuset) > 0 {
+		merged.CpusetCount = override.CpusetCount
+		merged.Cpuset = slices.Clone(override.Cpuset)
+	}
+
+	if override.Memory != "" {
+		merged.Memory = override.Memory
+	}
+
+	if override.SwapDisabled != nil {
+		merged.SwapDisabled = override.SwapDisabled
+	}
+
+	if override.CPUFreq != "" {
+		merged.CPUFreq = override.CPUFreq
+	}
+
+	if override.CPUTurboBoost != nil {
+		merged.CPUTurboBoost = override.CPUTurboBoost
+	}
+
+	if override.CPUGovernor != "" {
+		merged.CPUGovernor = override.CPUGovernor
+	}
+
+	merged.BlkioConfig = r.BlkioConfig.Merge(override.BlkioConfig)
+
+	return &merged
+}
+
+// IsSwapDisabled reports if the limits disable swap.
+func (r *ResourceLimits) IsSwapDisabled() bool {
+	return r != nil && r.SwapDisabled != nil && *r.SwapDisabled
 }
 
 // BlkioConfig configures container block I/O limits.
@@ -1647,6 +1700,43 @@ type BlkioConfig struct {
 	DeviceReadIOps  []ThrottleDevice `yaml:"device_read_iops,omitempty" mapstructure:"device_read_iops" json:"device_read_iops,omitempty"`
 	DeviceWriteBps  []ThrottleDevice `yaml:"device_write_bps,omitempty" mapstructure:"device_write_bps" json:"device_write_bps,omitempty"`
 	DeviceWriteIOps []ThrottleDevice `yaml:"device_write_iops,omitempty" mapstructure:"device_write_iops" json:"device_write_iops,omitempty"`
+}
+
+// Merge returns a copy of b with the set device lists of override on top of it.
+// Each device list is replaced as a whole. Both sides accept a nil value.
+func (b *BlkioConfig) Merge(override *BlkioConfig) *BlkioConfig {
+	if b == nil {
+		return override
+	}
+
+	if override == nil {
+		return b
+	}
+
+	merged := &BlkioConfig{
+		DeviceReadBps:   slices.Clone(b.DeviceReadBps),
+		DeviceReadIOps:  slices.Clone(b.DeviceReadIOps),
+		DeviceWriteBps:  slices.Clone(b.DeviceWriteBps),
+		DeviceWriteIOps: slices.Clone(b.DeviceWriteIOps),
+	}
+
+	if len(override.DeviceReadBps) > 0 {
+		merged.DeviceReadBps = slices.Clone(override.DeviceReadBps)
+	}
+
+	if len(override.DeviceReadIOps) > 0 {
+		merged.DeviceReadIOps = slices.Clone(override.DeviceReadIOps)
+	}
+
+	if len(override.DeviceWriteBps) > 0 {
+		merged.DeviceWriteBps = slices.Clone(override.DeviceWriteBps)
+	}
+
+	if len(override.DeviceWriteIOps) > 0 {
+		merged.DeviceWriteIOps = slices.Clone(override.DeviceWriteIOps)
+	}
+
+	return merged
 }
 
 // ThrottleDevice defines a device throttle setting.
@@ -3221,14 +3311,11 @@ func (c *Config) GetCPUSysfsPath() string {
 }
 
 // GetResourceLimits returns the resource limits for an instance.
-// Instance-level limits take precedence over global defaults.
+// Instance-level limits merge over the global defaults field by field, so a
+// field that the instance does not set keeps the global value.
 // Returns nil if no limits are configured.
 func (c *Config) GetResourceLimits(instance *ClientInstance) *ResourceLimits {
-	if instance.ResourceLimits != nil {
-		return instance.ResourceLimits
-	}
-
-	return c.Runner.Client.Config.ResourceLimits
+	return c.Runner.Client.Config.ResourceLimits.Merge(instance.ResourceLimits)
 }
 
 // GetRetryNewPayloadsSyncingState returns the retry config for an instance.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5071,3 +5071,114 @@ func TestDataDirShouldPromotePostPreRuns(t *testing.T) {
 		})
 	}
 }
+
+func intCfg(v int) *int { return &v }
+
+func TestGetResourceLimits(t *testing.T) {
+	global := &ResourceLimits{
+		Cpuset:        []int{6, 7, 8},
+		CPUFreq:       "3600MHz",
+		CPUTurboBoost: boolCfg(false),
+		CPUGovernor:   "performance",
+		Memory:        "32g",
+		SwapDisabled:  boolCfg(true),
+		BlkioConfig: &BlkioConfig{
+			DeviceReadBps:  []ThrottleDevice{{Path: "/dev/sdb", Rate: "12mb"}},
+			DeviceWriteBps: []ThrottleDevice{{Path: "/dev/sdb", Rate: "1024k"}},
+		},
+	}
+
+	t.Run("instance memory keeps the global defaults", func(t *testing.T) {
+		cfg := &Config{Runner: RunnerConfig{
+			Client: ClientConfig{Config: ClientDefaults{ResourceLimits: global}},
+		}}
+
+		got := cfg.GetResourceLimits(&ClientInstance{
+			ID:             "geth-1",
+			ResourceLimits: &ResourceLimits{Memory: "16g"},
+		})
+
+		require.NotNil(t, got)
+		assert.Equal(t, "16g", got.Memory)
+		assert.Equal(t, []int{6, 7, 8}, got.Cpuset)
+		assert.Equal(t, "3600MHz", got.CPUFreq)
+		assert.Equal(t, "performance", got.CPUGovernor)
+		assert.Equal(t, boolCfg(false), got.CPUTurboBoost)
+		assert.True(t, got.IsSwapDisabled())
+		assert.Equal(t, global.BlkioConfig, got.BlkioConfig)
+
+		// The global limits stay untouched.
+		assert.Equal(t, "32g", global.Memory)
+	})
+
+	t.Run("instance cpuset_count replaces the global cpuset", func(t *testing.T) {
+		cfg := &Config{Runner: RunnerConfig{
+			Client: ClientConfig{Config: ClientDefaults{ResourceLimits: global}},
+		}}
+
+		got := cfg.GetResourceLimits(&ClientInstance{
+			ID:             "geth-1",
+			ResourceLimits: &ResourceLimits{CpusetCount: intCfg(4)},
+		})
+
+		require.NotNil(t, got)
+		assert.Equal(t, intCfg(4), got.CpusetCount)
+		assert.Empty(t, got.Cpuset)
+		assert.Equal(t, "32g", got.Memory)
+		require.NoError(t, got.Validate("merged"))
+	})
+
+	t.Run("instance can enable swap again", func(t *testing.T) {
+		cfg := &Config{Runner: RunnerConfig{
+			Client: ClientConfig{Config: ClientDefaults{ResourceLimits: global}},
+		}}
+
+		got := cfg.GetResourceLimits(&ClientInstance{
+			ID:             "geth-1",
+			ResourceLimits: &ResourceLimits{SwapDisabled: boolCfg(false)},
+		})
+
+		require.NotNil(t, got)
+		assert.False(t, got.IsSwapDisabled())
+	})
+
+	t.Run("no instance limits returns the global limits", func(t *testing.T) {
+		cfg := &Config{Runner: RunnerConfig{
+			Client: ClientConfig{Config: ClientDefaults{ResourceLimits: global}},
+		}}
+
+		assert.Equal(t, global, cfg.GetResourceLimits(&ClientInstance{ID: "geth-1"}))
+	})
+
+	t.Run("no global limits returns the instance limits", func(t *testing.T) {
+		cfg := &Config{}
+		instance := &ClientInstance{ID: "geth-1", ResourceLimits: &ResourceLimits{Memory: "16g"}}
+
+		assert.Equal(t, instance.ResourceLimits, cfg.GetResourceLimits(instance))
+	})
+
+	t.Run("no limits at all returns nil", func(t *testing.T) {
+		cfg := &Config{}
+
+		assert.Nil(t, cfg.GetResourceLimits(&ClientInstance{ID: "geth-1"}))
+	})
+}
+
+func TestBlkioConfigMerge(t *testing.T) {
+	base := &BlkioConfig{
+		DeviceReadBps:   []ThrottleDevice{{Path: "/dev/sdb", Rate: "12mb"}},
+		DeviceWriteIOps: []ThrottleDevice{{Path: "/dev/sdb", Rate: "30"}},
+	}
+
+	got := base.Merge(&BlkioConfig{
+		DeviceReadBps: []ThrottleDevice{{Path: "/dev/nvme0n1", Rate: "50mb"}},
+	})
+
+	require.NotNil(t, got)
+	assert.Equal(t, []ThrottleDevice{{Path: "/dev/nvme0n1", Rate: "50mb"}}, got.DeviceReadBps)
+	assert.Equal(t, []ThrottleDevice{{Path: "/dev/sdb", Rate: "30"}}, got.DeviceWriteIOps)
+	assert.Empty(t, got.DeviceWriteBps)
+
+	// The base stays untouched.
+	assert.Equal(t, []ThrottleDevice{{Path: "/dev/sdb", Rate: "12mb"}}, base.DeviceReadBps)
+}

--- a/pkg/runner/resources.go
+++ b/pkg/runner/resources.go
@@ -89,7 +89,7 @@ func buildContainerResourceLimits(cfg *config.ResourceLimits) (*docker.ResourceL
 		resolved.MemoryBytes = memBytes
 
 		// Handle swap.
-		if cfg.SwapDisabled {
+		if cfg.IsSwapDisabled() {
 			// Set memory-swap equal to memory to disable swap.
 			containerLimits.MemorySwapBytes = memBytes
 			// Set swappiness to 0.


### PR DESCRIPTION
## Summary

Instance `resource_limits` replaced the whole global block. An instance that set only `memory` lost the global `cpuset`, `cpu_freq`, `cpu_turboboost`, `cpu_freq_governor` and `swap_disabled`.

`GetResourceLimits` now merges the two levels field by field. An instance keeps every global value that it does not set.

```yaml
runner:
  client:
    config:
      # Limits as per: https://eips.ethereum.org/EIPS/eip-7870
      resource_limits:
        cpuset: [6, 7, 8, 9, 10, 11]
        cpu_freq: "3600MHz"
        cpu_turboboost: false
        cpu_freq_governor: performance
        memory: "32g"
        swap_disabled: true
  instances:
    - id: geth-1
      client: geth
      resource_limits:
        memory: "16g"   # Only the memory limit changes. The CPU and swap
                        # settings stay at the global values.
```

## Merge rules

- An omitted field keeps the global value.
- `cpuset` and `cpuset_count` are one setting. An instance that sets either one replaces both global fields, so the mutual-exclusivity rule holds.
- Each `blkio_config` device list is replaced as a whole. An instance `device_read_bps` list does not change the global `device_write_bps` list.
- Set `swap_disabled: false` on an instance to turn swap on again when the global config disables it.

## Notes

`ResourceLimits.SwapDisabled` changes from `bool` to `*bool`. Without a pointer, an unset instance field looks the same as `swap_disabled: false`, so the merge cannot keep a global `true`. The resolved `config.json` output and the UI type stay a plain bool.

## Test plan

- New `TestGetResourceLimits` and `TestBlkioConfigMerge` in `pkg/config`.
- `go build` and `golangci-lint` pass with the Makefile build tags.
- `pkg/config`, `pkg/runner` and `pkg/executor` tests pass, except the pre-existing schelk datadir tests that need `/proc/mounts` and cannot run on macOS.