### PR TITLE
feat(ui): hide the inactive suites by default

### DIFF
--- a/ui/src/components/suites/SuitesTable.tsx
+++ b/ui/src/components/suites/SuitesTable.tsx
@@ -21,7 +21,6 @@ interface SuitesTableProps {
   sortBy?: SuiteSortColumn
   sortDir?: SuiteSortDirection
   onSortChange?: (column: SuiteSortColumn, direction: SuiteSortDirection) => void
-  hideInactive?: boolean
   inactiveThresholdMs?: number
 }
 
@@ -74,11 +73,9 @@ function StaticHeader({ label }: { label: string }) {
   )
 }
 
-function SuiteRow({ suite, isInactive, hidden }: { suite: SuiteEntry; isInactive?: boolean; hidden?: boolean }) {
+function SuiteRow({ suite, isInactive }: { suite: SuiteEntry; isInactive?: boolean }) {
   const navigate = useNavigate()
   const { data: suiteInfo } = useSuite(suite.hash)
-
-  if (hidden) return null
 
   return (
     <tr
@@ -170,7 +167,6 @@ export function SuitesTable({
   sortBy = 'lastRun',
   sortDir = 'desc',
   onSortChange,
-  hideInactive,
   inactiveThresholdMs = DEFAULT_INACTIVE_THRESHOLD_MS,
 }: SuitesTableProps) {
   const now = useNow()
@@ -219,7 +215,6 @@ export function SuitesTable({
               key={suite.hash}
               suite={suite}
               isInactive={(now - suite.lastRun * 1000) > inactiveThresholdMs}
-              hidden={hideInactive && (now - suite.lastRun * 1000) > inactiveThresholdMs}
             />
           ))}
         </tbody>

--- a/ui/src/pages/SuitesPage.tsx
+++ b/ui/src/pages/SuitesPage.tsx
@@ -261,7 +261,7 @@ export function SuitesPage() {
     inactiveDays?: string
   }
   const { page = 1, sortBy = 'lastRun', sortDir = 'desc' } = search
-  const hideInactive = search.hideInactive === '1'
+  const hideInactive = search.hideInactive !== '0'
   const inactiveDays = Number(search.inactiveDays) || DEFAULT_INACTIVE_DAYS
   const inactiveThresholdMs = inactiveDays * DAY_MS
   const [now] = useState(() => Date.now())
@@ -354,12 +354,18 @@ export function SuitesPage() {
     })
   }, [suites, suiteInfoMap, labelFilters])
 
-  // Group filtered suites by the selected label keys
+  // Drop the inactive suites so empty groups and pages do not appear
+  const visibleSuites = useMemo(() => {
+    if (!hideInactive) return filteredSuites
+    return filteredSuites.filter((suite) => (now - suite.lastRun * 1000) <= inactiveThresholdMs)
+  }, [filteredSuites, hideInactive, now, inactiveThresholdMs])
+
+  // Group the visible suites by the selected label keys
   const groups = useMemo((): GroupEntry[] | null => {
     if (groupByKeys.length === 0) return null
 
     const grouped = new Map<string, GroupEntry>()
-    for (const suite of filteredSuites) {
+    for (const suite of visibleSuites) {
       const info = suiteInfoMap.get(suite.hash)
       const labels: Record<string, string> = {}
       for (const key of groupByKeys) {
@@ -392,7 +398,7 @@ export function SuitesPage() {
       }
       return 0
     })
-  }, [groupByKeys, filteredSuites, suiteInfoMap, now, inactiveThresholdMs])
+  }, [groupByKeys, visibleSuites, suiteInfoMap, now, inactiveThresholdMs])
 
   const updateSearch = useCallback(
     (patch: Record<string, string | number | undefined>) => {
@@ -442,14 +448,14 @@ export function SuitesPage() {
     return <EmptyState title="No suites found" message="No test suites have been used yet." />
   }
 
-  const totalPages = groups ? 0 : Math.ceil(filteredSuites.length / PAGE_SIZE)
-  const paginatedSuites = groups ? [] : filteredSuites.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+  const totalPages = groups ? 0 : Math.ceil(visibleSuites.length / PAGE_SIZE)
+  const paginatedSuites = groups ? [] : visibleSuites.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
 
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl/8 font-bold text-gray-900 dark:text-gray-100">
-          Test Suites ({filteredSuites.length}{labelFilters.size > 0 && ` / ${suites.length}`})
+          Test Suites ({visibleSuites.length}{visibleSuites.length !== suites.length && ` / ${suites.length}`})
         </h1>
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2 text-sm/6 text-gray-600 dark:text-gray-400">
@@ -458,7 +464,7 @@ export function SuitesPage() {
               {INACTIVE_OPTIONS.map((opt) => (
                 <button
                   key={opt.days}
-                  onClick={() => updateSearch({ inactiveDays: opt.days === DEFAULT_INACTIVE_DAYS ? undefined : String(opt.days) })}
+                  onClick={() => { updateSearch({ inactiveDays: opt.days === DEFAULT_INACTIVE_DAYS ? undefined : String(opt.days), page: 1 }); setCurrentPage(1) }}
                   className={clsx(
                     'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
                     inactiveDays === opt.days
@@ -471,7 +477,7 @@ export function SuitesPage() {
               ))}
             </div>
             <button
-              onClick={() => updateSearch({ hideInactive: hideInactive ? undefined : '1' })}
+              onClick={() => { updateSearch({ hideInactive: hideInactive ? '0' : undefined, page: 1 }); setCurrentPage(1) }}
               className={clsx(
                 'rounded-xs px-2 py-0.5 text-xs/5 font-medium transition-colors',
                 hideInactive
@@ -515,7 +521,12 @@ export function SuitesPage() {
         />
       )}
 
-      {groups ? (
+      {visibleSuites.length === 0 ? (
+        <EmptyState
+          title="No active suites"
+          message={`No suite ran in the last ${inactiveDays} days. Turn off "Hide" to see the inactive suites.`}
+        />
+      ) : groups ? (
         <div className="flex flex-col gap-8">
           {groups.map((group) => {
             const groupKey = groupByKeys.map((k) => `${k}=${group.labels[k]}`).join(', ')
@@ -535,14 +546,14 @@ export function SuitesPage() {
                     ({group.suites.length}{inactiveCount > 0 && `, ${inactiveCount} inactive`})
                   </span>
                 </h2>
-                <SuitesTable suites={group.suites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} hideInactive={hideInactive} inactiveThresholdMs={inactiveThresholdMs} />
+                <SuitesTable suites={group.suites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} inactiveThresholdMs={inactiveThresholdMs} />
               </div>
             )
           })}
         </div>
       ) : (
         <>
-          <SuitesTable suites={paginatedSuites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} hideInactive={hideInactive} inactiveThresholdMs={inactiveThresholdMs} />
+          <SuitesTable suites={paginatedSuites} sortBy={sortBy} sortDir={sortDir} onSortChange={handleSortChange} inactiveThresholdMs={inactiveThresholdMs} />
 
           {totalPages > 1 && (
             <div className="flex justify-center">


### PR DESCRIPTION
## Summary

The Suites page listed every suite, so the old suites made the list long. This PR enables the **Hide** option by default. The inactive window keeps the `7d` default.

A group with no visible suite no longer appears. Before, the page drew the group header and an empty table.

## Changes

`ui/src/pages/SuitesPage.tsx`
- `hideInactive` defaults to on. The URL param is inverted: `?hideInactive=0` shows the inactive suites. No param means the filter is active.
- A new `visibleSuites` memo drops the inactive suites before the grouping step. An empty group does not exist, so the page does not draw its header.
- The page title count and the pagination read from `visibleSuites`.
- The "Hide" button and the day buttons reset the page to 1.
- An empty state appears if the filter hides every suite. It tells the user to turn off "Hide".

`ui/src/components/suites/SuitesTable.tsx`
- Removed the `hideInactive` prop and the per-row `hidden` logic. The page filters the rows now. The table keeps `inactiveThresholdMs` to dim the inactive rows when the filter is off.

## Test

- `npx tsc --noEmit` passes.
- `npx eslint` passes on both files.