### PR TITLE
feat(ui): find slow payloads on the run detail page

### DIFF
--- a/ui/src/components/run-detail/BlockLogDetails.tsx
+++ b/ui/src/components/run-detail/BlockLogDetails.tsx
@@ -2,6 +2,13 @@ import { useEffect, useMemo, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { BlockLogEntry } from '@/api/types'
 import { formatBytes } from '@/utils/format'
+import {
+  DEFAULT_SLOW_MS,
+  DEFAULT_THRESHOLD,
+  formatSlowMs,
+  getTextClassByDuration,
+  getTextClassByThreshold,
+} from '@/utils/perfThreshold'
 
 function useDarkMode() {
   const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'))
@@ -33,12 +40,15 @@ interface MetricCardProps {
   label: string
   value: string
   subValue?: string
+  /** Colour class for the value. Defaults to the plain text colour. */
+  valueClassName?: string
+  title?: string
 }
 
-function MetricCard({ label, value, subValue }: MetricCardProps) {
+function MetricCard({ label, value, subValue, valueClassName, title }: MetricCardProps) {
   return (
-    <div className="flex flex-col rounded-xs bg-gray-50 px-3 py-2 dark:bg-gray-700/50">
-      <span className="text-lg font-semibold text-gray-900 dark:text-gray-100">{value}</span>
+    <div className="flex flex-col rounded-xs bg-gray-50 px-3 py-2 dark:bg-gray-700/50" title={title}>
+      <span className={valueClassName ?? 'text-lg font-semibold text-gray-900 dark:text-gray-100'}>{value}</span>
       <span className="text-xs text-gray-500 dark:text-gray-400">{label}</span>
       {subValue && <span className="text-xs text-gray-400 dark:text-gray-500">{subValue}</span>}
     </div>
@@ -71,9 +81,13 @@ function pct(value: number | undefined, total: number | undefined): number {
 
 interface BlockLogDetailsProps {
   blockLog: BlockLogEntry
+  /** Slow-threshold MGas/s the throughput card colours against. */
+  threshold?: number
+  /** Slow-payload limit in milliseconds the total-time card colours against. */
+  slowMs?: number
 }
 
-export function BlockLogDetails({ blockLog }: BlockLogDetailsProps) {
+export function BlockLogDetails({ blockLog, threshold = DEFAULT_THRESHOLD, slowMs = DEFAULT_SLOW_MS }: BlockLogDetailsProps) {
   const isDark = useDarkMode()
 
   const textColor = isDark ? '#e5e7eb' : '#374151'
@@ -391,10 +405,18 @@ export function BlockLogDetails({ blockLog }: BlockLogDetailsProps) {
         <MetricCard
           label="MGas/s"
           value={fmt(throughput?.mgas_per_sec, 1)}
+          valueClassName={throughput?.mgas_per_sec != null
+            ? `text-lg font-semibold ${getTextClassByThreshold(throughput.mgas_per_sec, threshold)}`
+            : undefined}
+          title={throughput?.mgas_per_sec != null ? `Threshold ${threshold} MGas/s` : undefined}
         />
         <MetricCard
           label="Total Time"
           value={timing?.total_ms != null ? `${timing.total_ms.toFixed(1)}ms` : 'N/A'}
+          valueClassName={timing?.total_ms != null
+            ? `text-lg font-semibold ${getTextClassByDuration(timing.total_ms * 1_000_000, slowMs)}`
+            : undefined}
+          title={timing?.total_ms != null ? `Slow-payload limit ${formatSlowMs(slowMs)}` : undefined}
         />
         <MetricCard
           label="Gas Used"

--- a/ui/src/components/run-detail/DimensionInsights.tsx
+++ b/ui/src/components/run-detail/DimensionInsights.tsx
@@ -6,7 +6,9 @@ import { parseEESTName } from '@/utils/eestName'
 import { compileQuery, queryTermDimension, searchQueryContains, splitQuery } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES, getAggregatedStats } from '@/pages/RunDetailPage'
 import { percentile } from './block-logs-dashboard/utils/statistics'
-import { DEFAULT_THRESHOLD, getColorByThreshold } from '@/utils/perfThreshold'
+import { DEFAULT_SLOW_MS, DEFAULT_THRESHOLD, getColorByDuration, getColorByThreshold } from '@/utils/perfThreshold'
+import { getPayloadTimes } from '@/utils/payloadTime'
+import { formatDuration } from '@/utils/format'
 
 interface DimensionInsightsProps {
   tests: Record<string, TestEntry>
@@ -19,6 +21,8 @@ interface DimensionInsightsProps {
   query: string
   /** Slow-threshold MGas/s (shared with the Performance Heatmap). */
   threshold?: number
+  /** Slow-payload limit in milliseconds (shared with the Performance Heatmap). */
+  slowMs?: number
   /**
    * Open the test detail modal for a specific test. When provided and the
    * user clicks a not-yet-active value with only one matching test, the
@@ -46,13 +50,24 @@ const TRAILING_DIMENSIONS: DimensionDef[] = [
 // they're filtering by.
 const BARS_PREVIEW_KEYS = new Set(['file', 'benchmark'])
 
-interface ValueAgg {
-  value: string
-  count: number
+// Metric selects the number behind the bars and the table: throughput,
+// or the duration of the slowest payload of a test.
+type Metric = 'mgas' | 'duration'
+
+interface MetricAgg {
   mean: number
   p50: number
   p95: number
   p99: number
+}
+
+interface ValueAgg {
+  value: string
+  count: number
+  /** MGas/s stats. */
+  mgas: MetricAgg
+  /** Slowest-payload stats, in nanoseconds. */
+  duration: MetricAgg
   /** When count === 1, the single test's name. Used for "click to open". */
   singleTestName?: string
 }
@@ -67,6 +82,17 @@ function calculateMGasPerSec(gas: number, timeNs: number): number | undefined {
   return (gas * 1000) / timeNs
 }
 
+// aggregate rolls one metric's samples into mean and percentiles.
+function aggregate(samples: number[]): MetricAgg {
+  const sorted = [...samples].sort((a, b) => a - b)
+  return {
+    mean: sorted.reduce((sum, v) => sum + v, 0) / sorted.length,
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+  }
+}
+
 function compareNumeric(a: string, b: string): number {
   const na = parseInt(a, 10)
   const nb = parseInt(b, 10)
@@ -76,7 +102,7 @@ function compareNumeric(a: string, b: string): number {
   return a.localeCompare(b)
 }
 
-type SortColumn = 'value' | 'count' | 'mean' | 'p50' | 'p95' | 'p99'
+type SortColumn = 'value' | 'count' | keyof MetricAgg
 
 export function DimensionInsights({
   tests,
@@ -86,18 +112,22 @@ export function DimensionInsights({
   onToggle,
   query,
   threshold = DEFAULT_THRESHOLD,
+  slowMs = DEFAULT_SLOW_MS,
   onTestClick,
 }: DimensionInsightsProps) {
   const [view, setView] = useState<'bars' | 'table'>('bars')
+  const [metric, setMetric] = useState<Metric>('mgas')
   const [barsDir, setBarsDir] = useState<'desc' | 'asc'>('asc')
   const [showAllBars, setShowAllBars] = useState(false)
   const [groupByKey, setGroupByKey] = useState<string | null>(null)
   const [tableSort, setTableSort] = useState<{ col: SortColumn; dir: 'asc' | 'desc' }>({ col: 'mean', dir: 'desc' })
 
   const dimensions = useMemo<DimensionAgg[]>(() => {
-    // 1. Compute mgas per test, applying the same filter as the heatmap.
+    // 1. Compute the metrics per test, applying the same filter as the
+    //    heatmap. Both are collected in one pass, so the metric toggle
+    //    only picks which set of numbers to render.
     const matchesQuery = searchQuery ? compileQuery(searchQuery) : null
-    const samples: { name: string; mgas: number }[] = []
+    const samples: { name: string; mgas: number; durationNs: number }[] = []
     for (const [name, entry] of Object.entries(tests)) {
       if (matchesQuery && !matchesQuery(name)) continue
       const stats = getAggregatedStats(entry, stepFilter)
@@ -110,15 +140,15 @@ export function DimensionInsights({
       }
       const mgas = calculateMGasPerSec(stats.gas_used_total, stats.gas_used_time_total)
       if (mgas === undefined) continue
-      samples.push({ name, mgas })
+      samples.push({ name, mgas, durationNs: getPayloadTimes(entry, stepFilter).maxNs })
     }
 
-    // 2. Bucket samples by (dimension, value), keeping both the mgas array
+    // 2. Bucket samples by (dimension, value), keeping both metric arrays
     //    and the source test names so a 1-test bucket can deep-link to the
     //    test detail modal on click.
-    type Bucket = { mgas: number[]; names: string[] }
+    type Bucket = { mgas: number[]; durationNs: number[]; names: string[] }
     const byDim = new Map<string, Map<string, Bucket>>()
-    const bump = (dim: string, value: string | undefined, name: string, mgas: number) => {
+    const bump = (dim: string, value: string | undefined, sample: (typeof samples)[number]) => {
       if (!value) return
       let inner = byDim.get(dim)
       if (!inner) {
@@ -127,22 +157,23 @@ export function DimensionInsights({
       }
       let bucket = inner.get(value)
       if (!bucket) {
-        bucket = { mgas: [], names: [] }
+        bucket = { mgas: [], durationNs: [], names: [] }
         inner.set(value, bucket)
       }
-      bucket.mgas.push(mgas)
-      bucket.names.push(name)
+      bucket.mgas.push(sample.mgas)
+      bucket.durationNs.push(sample.durationNs)
+      bucket.names.push(sample.name)
     }
     for (const s of samples) {
       const p = parseEESTName(s.name)
       if (!p.isEEST) continue
-      bump('file', p.file, s.name, s.mgas)
-      bump('fn', p.fn, s.name, s.mgas)
-      bump('benchmark', p.benchmark, s.name, s.mgas)
-      bump('opcode', p.opcode, s.name, s.mgas)
-      bump('fork', p.fork, s.name, s.mgas)
-      for (const { key, value } of p.params) bump(key, value, s.name, s.mgas)
-      for (const label of p.labels) bump('label', label, s.name, s.mgas)
+      bump('file', p.file, s)
+      bump('fn', p.fn, s)
+      bump('benchmark', p.benchmark, s)
+      bump('opcode', p.opcode, s)
+      bump('fork', p.fork, s)
+      for (const { key, value } of p.params) bump(key, value, s)
+      for (const label of p.labels) bump('label', label, s)
     }
 
     // 3. Order dimensions: canonical primary + discovered params (alpha) + trailing.
@@ -166,15 +197,11 @@ export function DimensionInsights({
 
       const values: ValueAgg[] = []
       for (const [value, bucket] of inner) {
-        const sorted = [...bucket.mgas].sort((a, b) => a - b)
-        const mean = sorted.reduce((s, v) => s + v, 0) / sorted.length
         values.push({
           value,
-          count: sorted.length,
-          mean,
-          p50: percentile(sorted, 50),
-          p95: percentile(sorted, 95),
-          p99: percentile(sorted, 99),
+          count: bucket.names.length,
+          mgas: aggregate(bucket.mgas),
+          duration: aggregate(bucket.durationNs),
           singleTestName: bucket.names.length === 1 ? bucket.names[0] : undefined,
         })
       }
@@ -194,9 +221,10 @@ export function DimensionInsights({
     const sign = dir === 'asc' ? 1 : -1
     return [...tableDim.values].sort((a, b) => {
       if (col === 'value') return sign * compareNumeric(a.value, b.value)
-      return sign * (a[col] - b[col])
+      if (col === 'count') return sign * (a.count - b.count)
+      return sign * (a[metric][col] - b[metric][col])
     })
-  }, [tableDim, tableSort])
+  }, [tableDim, tableSort, metric])
 
   const handleSort = (col: SortColumn) => {
     setTableSort((prev) => {
@@ -208,6 +236,13 @@ export function DimensionInsights({
   // The page filter terms feeding this breakdown. Free-text terms (no `:`
   // or `=`) are kept too — they also affect what's counted.
   const activeTerms = splitQuery(query)
+
+  const isDuration = metric === 'duration'
+  // Render one metric value: a duration carries its own unit, MGas/s
+  // does not, so the unit goes in the labels around it.
+  const formatValue = (v: number) => (isDuration ? formatDuration(v) : v.toFixed(1))
+  const metricColor = (v: number) => (isDuration ? getColorByDuration(v, slowMs) : getColorByThreshold(v, threshold))
+  const unitSuffix = isDuration ? '' : ' MGas/s'
 
   return (
     <div className="overflow-hidden rounded-sm border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
@@ -261,16 +296,38 @@ export function DimensionInsights({
                   </button>
                 ))}
               </div>
+              <div className="flex items-center gap-1 rounded-xs bg-gray-100 p-0.5 dark:bg-gray-700">
+                {(['mgas', 'duration'] as const).map((m) => (
+                  <button
+                    key={m}
+                    type="button"
+                    onClick={() => setMetric(m)}
+                    title={
+                      m === 'mgas'
+                        ? 'Break down the MGas/s of each test'
+                        : 'Break down the duration of the slowest payload of each test'
+                    }
+                    className={clsx(
+                      'cursor-pointer rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
+                      metric === m
+                        ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
+                        : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
+                    )}
+                  >
+                    {m === 'mgas' ? 'MGas/s' : 'Duration'}
+                  </button>
+                ))}
+              </div>
               {view === 'bars' && (
                 <button
                   type="button"
                   onClick={() => setBarsDir(barsDir === 'desc' ? 'asc' : 'desc')}
-                  title={barsDir === 'desc' ? 'Click to sort slowest first' : 'Click to sort fastest first'}
+                  title={`Click to sort ${barsDir === 'desc' ? (isDuration ? 'fastest' : 'slowest') : (isDuration ? 'slowest' : 'fastest')} first`}
                   className="flex cursor-pointer items-center gap-1 rounded-xs border border-gray-300 bg-white px-2 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:hover:text-gray-100"
                 >
                   {barsDir === 'desc'
-                    ? <><ChevronDown className="size-3.5" /> Fastest first</>
-                    : <><ChevronUp className="size-3.5" /> Slowest first</>}
+                    ? <><ChevronDown className="size-3.5" /> {isDuration ? 'Slowest first' : 'Fastest first'}</>
+                    : <><ChevronUp className="size-3.5" /> {isDuration ? 'Fastest first' : 'Slowest first'}</>}
                 </button>
               )}
             </div>
@@ -317,9 +374,9 @@ export function DimensionInsights({
             const visibleDims = showAllBars ? dimensions : previewDims
 
             const renderDim = ({ def, values }: DimensionAgg) => {
-              const max = Math.max(...values.map((v) => v.mean))
+              const max = Math.max(...values.map((v) => v[metric].mean))
               const sign = barsDir === 'desc' ? -1 : 1
-              const sorted = [...values].sort((a, b) => sign * (a.mean - b.mean))
+              const sorted = [...values].sort((a, b) => sign * (a[metric].mean - b[metric].mean))
               return (
                 <div key={def.key} className="flex flex-col gap-1">
                   <div className="text-[10px]/4 font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
@@ -330,7 +387,8 @@ export function DimensionInsights({
                     {sorted.map((v) => {
                       const term = `${def.emitKey}=${v.value}`
                       const active = searchQueryContains(query, term)
-                      const widthPct = max > 0 ? (v.mean / max) * 100 : 0
+                      const mean = v[metric].mean
+                      const widthPct = max > 0 ? (mean / max) * 100 : 0
                       return (
                         <button
                           key={v.value}
@@ -349,8 +407,8 @@ export function DimensionInsights({
                           }}
                           title={
                             !active && v.singleTestName
-                              ? `${def.label}: ${v.value} — open the only matching test (${v.mean.toFixed(1)} MGas/s)`
-                              : `${def.label}: ${v.value} — mean ${v.mean.toFixed(1)} MGas/s, ${v.count} test${v.count === 1 ? '' : 's'}`
+                              ? `${def.label}: ${v.value} — open the only matching test (${formatValue(mean)}${unitSuffix})`
+                              : `${def.label}: ${v.value} — mean ${formatValue(mean)}${unitSuffix}, ${v.count} test${v.count === 1 ? '' : 's'}`
                           }
                           className={clsx(
                             'group grid cursor-pointer grid-cols-[minmax(7rem,12rem)_1fr_auto] items-center gap-2 rounded-xs px-1 py-0.5 text-left text-xs/5 transition-colors',
@@ -365,14 +423,14 @@ export function DimensionInsights({
                               className="absolute inset-y-0 left-0 rounded-xs"
                               style={{
                                 width: `${widthPct}%`,
-                                backgroundColor: getColorByThreshold(v.mean, threshold),
+                                backgroundColor: metricColor(mean),
                                 outline: active ? '1.5px solid #3b82f6' : 'none',
                                 outlineOffset: '0px',
                               }}
                             />
                           </span>
                           <span className="flex shrink-0 items-baseline gap-1.5 font-mono tabular-nums text-gray-600 dark:text-gray-300">
-                            <span>{v.mean.toFixed(1)}</span>
+                            <span>{formatValue(mean)}</span>
                             <span className="text-[10px]/4 text-gray-400 dark:text-gray-500">×{v.count}</span>
                           </span>
                         </button>
@@ -440,10 +498,10 @@ export function DimensionInsights({
                       >
                         <td className="px-2 py-1 font-mono text-gray-700 dark:text-gray-200">{v.value}</td>
                         <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{v.count}</td>
-                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-700 dark:text-gray-200">{v.mean.toFixed(1)}</td>
-                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{v.p50.toFixed(1)}</td>
-                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{v.p95.toFixed(1)}</td>
-                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{v.p99.toFixed(1)}</td>
+                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-700 dark:text-gray-200">{formatValue(v[metric].mean)}</td>
+                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{formatValue(v[metric].p50)}</td>
+                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{formatValue(v[metric].p95)}</td>
+                        <td className="px-2 py-1 text-right font-mono tabular-nums text-gray-500 dark:text-gray-400">{formatValue(v[metric].p99)}</td>
                       </tr>
                     )
                   })}

--- a/ui/src/components/run-detail/ExecutionsList.tsx
+++ b/ui/src/components/run-detail/ExecutionsList.tsx
@@ -7,6 +7,13 @@ import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/pris
 import { useTestRequests, useTestResponses, useTestResultDetails, useTestRequestSummaries, useTestResponseSummaries, type StepType } from '@/api/hooks/useTestDetails'
 import { fetchPartialText } from '@/api/client'
 import { Duration } from '@/components/shared/Duration'
+import {
+  DEFAULT_SLOW_MS,
+  DEFAULT_THRESHOLD,
+  formatSlowMs,
+  getTextClassByDuration,
+  getTextClassByThreshold,
+} from '@/utils/perfThreshold'
 
 function useDarkMode() {
   const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'))
@@ -75,6 +82,10 @@ interface ExecutionsListProps {
    * row position — non-newPayload methods consume no slot.
    */
   txCounts?: number[]
+  /** Slow-threshold MGas/s the per-call values colour against. */
+  threshold?: number
+  /** Slow-payload limit in milliseconds the payload times colour against. */
+  slowMs?: number
 }
 
 function parseMethod(request: string): string {
@@ -129,6 +140,10 @@ interface ExecutionRowProps {
   responseViewerUrl?: string
   /** File viewer link for the request file at this line. */
   requestViewerUrl?: string
+  /** Slow-threshold MGas/s the call's MGas/s colours against. */
+  threshold: number
+  /** Slow-payload limit in milliseconds the call's time colours against. */
+  slowMs: number
 }
 
 function StatusIndicator({ status }: { status?: number }) {
@@ -152,7 +167,7 @@ function StatusIndicator({ status }: { status?: number }) {
 
 const MAX_LAZY_LINE_SIZE = 1_000_000 // 1MB — lazy-load lines up to this size
 
-function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo, response, responseSize, time, status, mgasPerSec, gasUsed, txCount, responseViewerUrl, requestViewerUrl, expanded: expandedProp, onExpandedChange }: ExecutionRowProps & { expanded?: boolean; onExpandedChange?: (index: number, expanded: boolean) => void }) {
+function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo, response, responseSize, time, status, mgasPerSec, gasUsed, txCount, responseViewerUrl, requestViewerUrl, threshold, slowMs, expanded: expandedProp, onExpandedChange }: ExecutionRowProps & { expanded?: boolean; onExpandedChange?: (index: number, expanded: boolean) => void }) {
   const [expandedLocal, setExpandedLocal] = useState(false)
   const expanded = expandedProp ?? expandedLocal
   const setExpanded = (v: boolean) => {
@@ -178,6 +193,8 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
   const effectiveResponseSize = responseSize ?? (response ? new Blob([response]).size : undefined)
   const canExpand = !!effectiveRequest || !!response || !!responseViewerUrl || !!requestViewerUrl || canLazyLoad
   const isFail = status !== undefined && status !== 0
+  // A call that reports gas is a payload submission.
+  const isPayload = mgasPerSec !== undefined
 
   return (
     <div className={clsx(
@@ -217,7 +234,13 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
             </span>
           )}
         </span>
-        <span className="w-44 shrink-0 text-right text-sm/6 font-medium text-blue-600 dark:text-blue-400">
+        <span
+          className={clsx(
+            'w-44 shrink-0 text-right text-sm/6 font-medium',
+            mgasPerSec !== undefined ? getTextClassByThreshold(mgasPerSec, threshold) : '',
+          )}
+          title={mgasPerSec !== undefined ? `Threshold ${threshold} MGas/s` : undefined}
+        >
           {mgasPerSec !== undefined ? (
             <>
               {mgasPerSec.toFixed(2)} MGas/s
@@ -229,7 +252,17 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
             </>
           ) : ''}
         </span>
-        <span className="w-16 shrink-0 text-right text-sm/6 text-gray-500 dark:text-gray-400">
+        <span
+          className={clsx(
+            'w-16 shrink-0 text-right text-sm/6',
+            // Only a call that executed gas is a payload, so only it
+            // colours against the slow-payload limit.
+            time !== undefined && isPayload
+              ? getTextClassByDuration(time, slowMs)
+              : 'text-gray-500 dark:text-gray-400',
+          )}
+          title={time !== undefined && isPayload ? `Slow-payload limit ${formatSlowMs(slowMs)}` : undefined}
+        >
           {time !== undefined ? <Duration nanoseconds={time} /> : ''}
         </span>
         <span className="w-28 shrink-0 text-right text-xs text-gray-400 dark:text-gray-500">
@@ -339,7 +372,7 @@ function ExecutionRow({ index, request, requestSize, methodName, requestLineInfo
 
 const EXECUTIONS_PAGE_SIZE = 100
 
-export function ExecutionsList({ runId, suiteHash, testName, stepType, expandedRows, onExpandedRowsChange, txCounts }: ExecutionsListProps) {
+export function ExecutionsList({ runId, suiteHash, testName, stepType, expandedRows, onExpandedRowsChange, txCounts, threshold = DEFAULT_THRESHOLD, slowMs = DEFAULT_SLOW_MS }: ExecutionsListProps) {
   const { data: requests, isLoading: requestsLoading, error: requestsError } = useTestRequests(suiteHash, testName, stepType)
   const { data: responses, error: responsesError } = useTestResponses(runId, testName, stepType)
   const { data: resultDetails, isLoading: detailsLoading, error: detailsError } = useTestResultDetails(runId, testName, stepType)
@@ -456,6 +489,8 @@ export function ExecutionsList({ runId, suiteHash, testName, stepType, expandedR
               mgasPerSec={safeDetails?.mgas_s[String(index)]}
               gasUsed={safeDetails?.gas_used[String(index)]}
               txCount={txCountByRow.get(index)}
+              threshold={threshold}
+              slowMs={slowMs}
               responseViewerUrl={!safeResponses?.[index] && responseSummaries?.[index] && responseSummaries[index].size > 1_000_000
                 ? `/runs/${runId}/fileviewer?file=${encodeURIComponent(`${testName}/${stepType}.response`)}&lines=${index + 1}`
                 : undefined}

--- a/ui/src/components/run-detail/LiveRunDetailView.tsx
+++ b/ui/src/components/run-detail/LiveRunDetailView.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Flame, Loader } from 'lucide-react'
-import { DEFAULT_THRESHOLD, MAX_THRESHOLD, MIN_THRESHOLD } from '@/utils/perfThreshold'
+import {
+  DEFAULT_SLOW_MS,
+  DEFAULT_THRESHOLD,
+  MAX_SLOW_MS,
+  MAX_THRESHOLD,
+  MIN_SLOW_MS,
+  MIN_THRESHOLD,
+  SLOW_STEP_MS,
+} from '@/utils/perfThreshold'
 import type { LiveRun, LiveTestStats, TestEntry, AggregatedStats } from '@/api/types'
 import { ClientStat } from '@/components/shared/ClientStat'
 import { JDenticon } from '@/components/shared/JDenticon'
@@ -9,7 +17,7 @@ import { RunConfiguration } from '@/components/run-detail/RunConfiguration'
 import { MetadataLabels } from '@/components/run-detail/MetadataLabels'
 import { GitHubSection } from '@/components/run-detail/GitHubSection'
 import { ClientRunsStrip } from '@/components/run-detail/ClientRunsStrip'
-import { TestHeatmap, type SortMode, type GroupMode } from '@/components/run-detail/TestHeatmap'
+import { TestHeatmap, type SortMode, type GroupMode, type ColorMode } from '@/components/run-detail/TestHeatmap'
 import { LiveRunLogPanel } from '@/components/run-detail/LiveRunLogPanel'
 import { useSuite } from '@/api/hooks/useSuite'
 import { useIndex } from '@/api/hooks/useIndex'
@@ -98,6 +106,8 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
   const [heatmapSort, setHeatmapSort] = useState<SortMode>('order')
   const [heatmapGroup, setHeatmapGroup] = useState<GroupMode>('none')
   const [heatmapThreshold, setHeatmapThreshold] = useState<number | undefined>(undefined)
+  const [heatmapColor, setHeatmapColor] = useState<ColorMode>('mgas')
+  const [slowMs, setSlowMs] = useState<number | undefined>(undefined)
 
   // Smoothly tween the live counters between snapshots so users see
   // numbers ticking up rather than jumping. Integer counters are
@@ -326,6 +336,39 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
                 </button>
               )}
             </div>
+            <div className="flex items-center gap-2 text-xs/5 text-gray-500 dark:text-gray-400">
+              <span>Slow payload:</span>
+              <input
+                type="range"
+                min={MIN_SLOW_MS}
+                max={MAX_SLOW_MS}
+                step={SLOW_STEP_MS}
+                value={slowMs ?? DEFAULT_SLOW_MS}
+                onChange={(e) => setSlowMs(Number(e.target.value))}
+                className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-gray-200 accent-fuchsia-500 dark:bg-gray-700"
+              />
+              <input
+                type="number"
+                min={MIN_SLOW_MS / 1000}
+                max={MAX_SLOW_MS / 1000}
+                step={SLOW_STEP_MS / 1000}
+                value={(slowMs ?? DEFAULT_SLOW_MS) / 1000}
+                onChange={(e) => {
+                  const ms = Number(e.target.value) * 1000
+                  if (Number.isFinite(ms) && ms > 0) setSlowMs(Math.min(MAX_SLOW_MS, Math.round(ms)))
+                }}
+                className="w-16 rounded-sm border border-gray-300 bg-white px-1.5 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <span>s</span>
+              {(slowMs ?? DEFAULT_SLOW_MS) !== DEFAULT_SLOW_MS && (
+                <button
+                  onClick={() => setSlowMs(DEFAULT_SLOW_MS)}
+                  className="text-xs/5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  Reset
+                </button>
+              )}
+            </div>
           </div>
           <div className="p-4">
             <TestHeatmap
@@ -336,10 +379,13 @@ export function LiveRunDetailView({ run }: LiveRunDetailViewProps) {
               stepFilter={DEFAULT_INDEX_STEP_FILTER}
               sortMode={heatmapSort}
               groupMode={heatmapGroup}
+              colorMode={heatmapColor}
               threshold={heatmapThreshold}
+              slowMs={slowMs}
               inProgressTestKey={inProgressKey}
               onSortModeChange={setHeatmapSort}
               onGroupModeChange={setHeatmapGroup}
+              onColorModeChange={setHeatmapColor}
             />
           </div>
         </div>

--- a/ui/src/components/run-detail/MGasBreakdown.tsx
+++ b/ui/src/components/run-detail/MGasBreakdown.tsx
@@ -1,25 +1,45 @@
+import clsx from 'clsx'
 import type { MethodStatsFloat } from '@/api/types'
 import { formatNumber } from '@/utils/format'
+import { DEFAULT_THRESHOLD, getTextClassByThreshold } from '@/utils/perfThreshold'
 
 interface MGasBreakdownProps {
   methods: Record<string, MethodStatsFloat>
+  /** Slow-threshold MGas/s the values colour against. */
+  threshold?: number
 }
 
 function formatMGas(value: number): string {
   return value.toFixed(2)
 }
 
-export function MGasBreakdown({ methods }: MGasBreakdownProps) {
+export function MGasBreakdown({ methods, threshold = DEFAULT_THRESHOLD }: MGasBreakdownProps) {
   const methodEntries = Object.entries(methods).sort(([a], [b]) => a.localeCompare(b))
 
   if (methodEntries.length === 0) {
     return null
   }
 
+  // Each value carries the colour of the step it falls in, so a slow
+  // call stands out without reading the number.
+  const cell = (value: number) => (
+    <td
+      className={clsx('whitespace-nowrap px-3 py-2 text-right text-sm/6', getTextClassByThreshold(value, threshold))}
+      title={`${formatMGas(value)} MGas/s — threshold ${threshold} MGas/s`}
+    >
+      {formatMGas(value)}
+    </td>
+  )
+
   return (
     <div className="overflow-hidden rounded-sm border border-gray-200 dark:border-gray-700">
       <div className="border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-700 dark:bg-gray-800/50">
-        <h4 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">MGas/s Breakdown</h4>
+        <h4 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+          MGas/s Breakdown
+          <span className="ml-2 text-xs/5 font-normal text-gray-500 dark:text-gray-400">
+            coloured against {threshold} MGas/s
+          </span>
+        </h4>
       </div>
       <div className="overflow-x-auto">
         <table className="min-w-full">
@@ -71,33 +91,19 @@ export function MGasBreakdown({ methods }: MGasBreakdownProps) {
                 <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 dark:text-gray-400">
                   {formatNumber(stats.count)}
                 </td>
-                <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-blue-600 dark:text-blue-400">
-                  {formatMGas(stats.last)}
-                </td>
+                {cell(stats.last)}
                 {stats.min !== undefined && (
                   <>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-blue-600 dark:text-blue-400">
-                      {formatMGas(stats.min)}
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-blue-600 dark:text-blue-400">
-                      {formatMGas(stats.max!)}
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-blue-600 dark:text-blue-400">
-                      {formatMGas(stats.mean!)}
-                    </td>
+                    {cell(stats.min)}
+                    {cell(stats.max!)}
+                    {cell(stats.mean!)}
                   </>
                 )}
                 {stats.p50 !== undefined && (
                   <>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-blue-600 dark:text-blue-400">
-                      {formatMGas(stats.p50)}
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-blue-600 dark:text-blue-400">
-                      {formatMGas(stats.p95!)}
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-blue-600 dark:text-blue-400">
-                      {formatMGas(stats.p99!)}
-                    </td>
+                    {cell(stats.p50)}
+                    {cell(stats.p95!)}
+                    {cell(stats.p99!)}
                   </>
                 )}
               </tr>

--- a/ui/src/components/run-detail/PreRunStepsTable.tsx
+++ b/ui/src/components/run-detail/PreRunStepsTable.tsx
@@ -8,6 +8,7 @@ import { Modal } from '@/components/shared/Modal'
 import { TimeBreakdown } from './TimeBreakdown'
 import { MGasBreakdown } from './MGasBreakdown'
 import { ExecutionsList } from './ExecutionsList'
+import { DEFAULT_SLOW_MS, DEFAULT_THRESHOLD } from '@/utils/perfThreshold'
 
 export type PreRunSortColumn = 'order' | 'name' | 'time' | 'passed' | 'failed'
 export type PreRunSortDirection = 'asc' | 'desc'
@@ -19,6 +20,10 @@ interface PreRunStepsTableProps {
   suiteHash?: string
   selectedStep?: string
   onSelectedStepChange?: (stepName: string | undefined) => void
+  /** Slow-threshold MGas/s (shared with the Performance Heatmap). */
+  threshold?: number
+  /** Slow-payload limit in milliseconds (shared with the Performance Heatmap). */
+  slowMs?: number
 }
 
 function SortIcon({ direction, active }: { direction: PreRunSortDirection; active: boolean }) {
@@ -90,6 +95,8 @@ export function PreRunStepsTable({
   suiteHash,
   selectedStep,
   onSelectedStepChange,
+  threshold = DEFAULT_THRESHOLD,
+  slowMs = DEFAULT_SLOW_MS,
 }: PreRunStepsTableProps) {
   const [sortBy, setSortBy] = useState<PreRunSortColumn>('order')
   const [sortDir, setSortDir] = useState<PreRunSortDirection>('asc')
@@ -219,8 +226,8 @@ export function PreRunStepsTable({
 
             {selectedStepData.aggregated && (
               <>
-                <TimeBreakdown methods={selectedStepData.aggregated.method_stats.times} />
-                <MGasBreakdown methods={selectedStepData.aggregated.method_stats.mgas_s} />
+                <TimeBreakdown methods={selectedStepData.aggregated.method_stats.times} slowMs={slowMs} />
+                <MGasBreakdown methods={selectedStepData.aggregated.method_stats.mgas_s} threshold={threshold} />
               </>
             )}
 
@@ -232,6 +239,8 @@ export function PreRunStepsTable({
                   suiteHash={suiteHash}
                   testName={selectedStep}
                   stepType="pre_run"
+                  threshold={threshold}
+                  slowMs={slowMs}
                 />
               </div>
             )}

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -17,7 +17,17 @@ import { formatDuration, formatBytes } from '@/utils/format'
 import { EESTInfoContent, type OpcodeSortMode } from '@/components/suite-detail/TestFilesList'
 import { OpcodeDiffPanel, type OpcodeDiffRow } from './OpcodeDiffPanel'
 import { useBlockLogs } from '@/api/hooks/useBlockLogs'
-import { DEFAULT_THRESHOLD, THRESHOLD_COLORS, getColorByThreshold } from '@/utils/perfThreshold'
+import {
+  DEFAULT_SLOW_MS,
+  DEFAULT_THRESHOLD,
+  SLOW_COLOR,
+  THRESHOLD_COLORS,
+  formatSlowMs,
+  getColorByDuration,
+  getColorByThreshold,
+  isSlowPayload,
+} from '@/utils/perfThreshold'
+import { getPayloadTimes } from '@/utils/payloadTime'
 
 // Aggregate stats from selected steps of a test entry
 function getAggregatedStats(entry: TestEntry, stepFilter: StepTypeOption[] = ALL_STEP_TYPES): AggregatedStats | undefined {
@@ -88,8 +98,18 @@ function getAggregatedStats(entry: TestEntry, stepFilter: StepTypeOption[] = ALL
   }
 }
 
-export type SortMode = 'order' | 'mgas' | 'gas'
+export type SortMode = 'order' | 'mgas' | 'gas' | 'duration'
 export type GroupMode = 'none' | 'gas'
+// ColorMode selects the metric behind the tile colours and the
+// distribution histogram: throughput or payload duration.
+export type ColorMode = 'mgas' | 'duration'
+
+const SORT_CAPTIONS: Record<SortMode, string> = {
+  order: '(by execution order)',
+  mgas: '(by MGas/s, slowest first)',
+  gas: '(by gas used, most first)',
+  duration: '(by slowest payload, longest first)',
+}
 
 const GAS_GROUP_STEP = 30_000_000 // 30M gas per group
 
@@ -118,7 +138,10 @@ interface TestHeatmapProps {
   searchQuery?: string
   sortMode?: SortMode
   groupMode?: GroupMode
+  colorMode?: ColorMode
   threshold?: number
+  /** Slow-payload limit in milliseconds. Marks the tiles above it. */
+  slowMs?: number
   stepFilter?: StepTypeOption[]
   postTestRPCCalls?: PostTestRPCCallConfig[]
   // inProgressTestKey, when set, marks one tile to pulse blue
@@ -129,6 +152,7 @@ interface TestHeatmapProps {
   onSelectedTestChange?: (testName: string | undefined) => void
   onSortModeChange?: (mode: SortMode) => void
   onGroupModeChange?: (mode: GroupMode) => void
+  onColorModeChange?: (mode: ColorMode) => void
   onSearchChange?: (query: string) => void
   activeStepTab?: 'test' | 'setup' | 'cleanup'
   onActiveStepTabChange?: (tab: 'test' | 'setup' | 'cleanup') => void
@@ -168,6 +192,13 @@ interface TestData {
   mgasPerSec: number
   gasUsedTotal: number
   gasUsedTimeTotal: number
+  // Duration of the slowest engine_newPayload call of the test, and the
+  // number of payloads it aggregates. maxPayloadNs equals
+  // gasUsedTimeTotal when the test has a single payload.
+  maxPayloadNs: number
+  payloadCount: number
+  // isSlow is true when maxPayloadNs is above the slow-payload limit.
+  isSlow: boolean
   hasFail: boolean
   noData: boolean
   // notProcessed is true when the test is part of the suite but no
@@ -256,6 +287,8 @@ function PostTestDumps({ runId, testName, calls }: { runId: string; testName: st
 function HeatmapCell({
   test,
   threshold,
+  slowMs,
+  colorMode,
   statusFilter,
   searchQuery,
   popDelayMs,
@@ -266,6 +299,8 @@ function HeatmapCell({
 }: {
   test: TestData
   threshold: number
+  slowMs: number
+  colorMode: ColorMode
   statusFilter: TestStatusFilter
   searchQuery: string
   // popDelayMs is set when this tile just transitioned from
@@ -296,6 +331,8 @@ function HeatmapCell({
     baseStyle = NOT_PROCESSED_STYLE
   } else if (test.noData) {
     baseStyle = NO_DATA_STYLE
+  } else if (colorMode === 'duration') {
+    baseStyle = { backgroundColor: getColorByDuration(test.maxPayloadNs, slowMs) }
   } else {
     baseStyle = { backgroundColor: getColorByThreshold(test.mgasPerSec, threshold) }
   }
@@ -303,6 +340,13 @@ function HeatmapCell({
     ...baseStyle,
     transition: 'background-color 0.4s ease-out',
     ...(matchesFilter ? {} : { opacity: 0.2 }),
+  }
+
+  // Slow payloads get an inset outline. It sits inside the tile, so it
+  // stays readable next to the red failure ring on a failed test.
+  if (test.isSlow) {
+    style.outline = `2px solid ${SLOW_COLOR}`
+    style.outlineOffset = '-2px'
   }
 
   // Animation precedence: a freshly-popping tile takes priority over
@@ -330,6 +374,43 @@ function HeatmapCell({
   )
 }
 
+// ModeGroup is one labelled pill group of the heatmap controls (sort by,
+// color by, group by).
+function ModeGroup<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: T
+  options: { value: T; label: string; title?: string }[]
+  onChange: (value: T) => void
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs/5 text-gray-500 dark:text-gray-400">{label}</span>
+      <div className="flex items-center gap-1 rounded-sm bg-gray-100 p-0.5 dark:bg-gray-700">
+        {options.map((option) => (
+          <button
+            key={option.value}
+            onClick={() => onChange(option.value)}
+            title={option.title}
+            className={clsx(
+              'rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
+              value === option.value
+                ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
+                : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function TooltipFilename({ name }: { name: string }) {
   return (
     <div className="w-96 max-w-[80vw]">
@@ -349,7 +430,9 @@ export function TestHeatmap({
   searchQuery = '',
   sortMode: sortModeProp,
   groupMode: groupModeProp,
+  colorMode: colorModeProp,
   threshold: thresholdProp,
+  slowMs: slowMsProp,
   stepFilter = ALL_STEP_TYPES,
   postTestRPCCalls,
   inProgressTestKey,
@@ -357,6 +440,7 @@ export function TestHeatmap({
   onSearchChange,
   onSortModeChange,
   onGroupModeChange,
+  onColorModeChange,
   activeStepTab: activeStepTabProp,
   onActiveStepTabChange,
   expandedExecRows,
@@ -364,7 +448,9 @@ export function TestHeatmap({
 }: TestHeatmapProps) {
   const sortMode = sortModeProp ?? 'order'
   const groupMode = groupModeProp ?? 'none'
+  const colorMode = colorModeProp ?? 'mgas'
   const threshold = thresholdProp ?? DEFAULT_THRESHOLD
+  const slowMs = slowMsProp ?? DEFAULT_SLOW_MS
   const [tooltip, setTooltip] = useState<{ test: TestData; x: number; y: number } | null>(null)
   const [opcodeSort, setOpcodeSort] = useState<OpcodeSortMode>('name')
   const [activeStepTabLocal, setActiveStepTabLocal] = useState<'test' | 'setup' | 'cleanup'>('test')
@@ -390,6 +476,10 @@ export function TestHeatmap({
     onGroupModeChange?.(mode)
   }
 
+  const handleColorModeChange = (mode: ColorMode) => {
+    onColorModeChange?.(mode)
+  }
+
   const executionOrder = useMemo(() => {
     if (!suiteTests) return new Map<string, number>()
     return new Map(suiteTests.map((test, index) => [test.name, index + 1]))
@@ -404,10 +494,13 @@ export function TestHeatmap({
     return m
   }, [suiteTests])
 
-  const { testData, minMgas, maxMgas } = useMemo(() => {
+  const { testData, minMgas, maxMgas, minPayloadNs, maxPayloadNs, slowTestCount } = useMemo(() => {
     const data: TestData[] = []
     let minMgas = Infinity
     let maxMgas = -Infinity
+    let minPayloadNs = Infinity
+    let maxPayloadNs = -Infinity
+    let slowTestCount = 0
 
     // Union of suite tests and tests with results, so the heatmap always
     // shows a tile for every planned test in the suite — even if the run
@@ -432,6 +525,9 @@ export function TestHeatmap({
           mgasPerSec: 0,
           gasUsedTotal: 0,
           gasUsedTimeTotal: 0,
+          maxPayloadNs: 0,
+          payloadCount: 0,
+          isSlow: false,
           hasFail: false,
           noData: true,
           notProcessed: true,
@@ -446,10 +542,18 @@ export function TestHeatmap({
       const statsAll = getAggregatedStats(entry, ALL_STEP_TYPES)
       const mgasPerSec = statsFiltered ? calculateMGasPerSec(statsFiltered.gas_used_total, statsFiltered.gas_used_time_total) : undefined
       const noData = mgasPerSec === undefined
+      // Per-payload durations, so a test with several blocks is marked
+      // slow only when a single block is above the limit.
+      const payloads = getPayloadTimes(entry, stepFilter)
+
+      const isSlow = !noData && isSlowPayload(payloads.maxNs, slowMs)
 
       if (!noData) {
         minMgas = Math.min(minMgas, mgasPerSec)
         maxMgas = Math.max(maxMgas, mgasPerSec)
+        minPayloadNs = Math.min(minPayloadNs, payloads.maxNs)
+        maxPayloadNs = Math.max(maxPayloadNs, payloads.maxNs)
+        if (isSlow) slowTestCount++
       }
 
       data.push({
@@ -459,6 +563,9 @@ export function TestHeatmap({
         mgasPerSec: mgasPerSec ?? 0,
         gasUsedTotal: statsFiltered?.gas_used_total ?? 0,
         gasUsedTimeTotal: statsFiltered?.gas_used_time_total ?? 0,
+        maxPayloadNs: payloads.maxNs,
+        payloadCount: payloads.count,
+        isSlow,
         hasFail: statsAll ? statsAll.fail > 0 : false,
         noData,
         notProcessed: false,
@@ -467,9 +574,11 @@ export function TestHeatmap({
 
     if (minMgas === Infinity) minMgas = 0
     if (maxMgas === -Infinity) maxMgas = 0
+    if (minPayloadNs === Infinity) minPayloadNs = 0
+    if (maxPayloadNs === -Infinity) maxPayloadNs = 0
 
-    return { testData: data, minMgas, maxMgas }
-  }, [tests, suiteTests, executionOrder, stepFilter])
+    return { testData: data, minMgas, maxMgas, minPayloadNs, maxPayloadNs, slowTestCount }
+  }, [tests, suiteTests, executionOrder, stepFilter, slowMs])
 
   // Animate tiles that just transitioned from "not processed" to having
   // a result by giving each one a staggered pop-in. We diff against the
@@ -529,6 +638,8 @@ export function TestHeatmap({
       sorted.sort((a, b) => a.order - b.order)
     } else if (sortMode === 'gas') {
       sorted.sort((a, b) => b.gasUsedTotal - a.gasUsedTotal) // most gas first
+    } else if (sortMode === 'duration') {
+      sorted.sort((a, b) => b.maxPayloadNs - a.maxPayloadNs) // slowest payload first
     } else {
       sorted.sort((a, b) => a.mgasPerSec - b.mgasPerSec) // slowest first
     }
@@ -575,16 +686,22 @@ export function TestHeatmap({
     })
   }, [testData, statusFilter, searchQuery])
 
+  // Distribution bins for the active colour mode. Both metrics use the
+  // same multiples of their limit, so the chart keeps its shape: in
+  // MGas/s mode the slow tests sit on the left, in Duration mode on the
+  // right, because a long payload is a bad one.
   const histogramData = useMemo(() => {
     const testsWithData = filteredTestData.filter((t) => !t.noData)
     if (testsWithData.length === 0) return []
 
-    // Create bins based on threshold: 0, 0.25x, 0.5x, 0.75x, 1x, 1.25x, 1.5x, 1.75x, 2x, 2.5x, 3x+
+    // Create bins based on the limit: 0, 0.25x, 0.5x, 0.75x, 1x, 1.25x, 1.5x, 1.75x, 2x, 2.5x, 3x+
     const binMultipliers = [0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3]
     const bins = Array(binMultipliers.length).fill(0)
+    const limit = colorMode === 'duration' ? slowMs * 1_000_000 : threshold
 
     for (const test of testsWithData) {
-      const ratio = test.mgasPerSec / threshold
+      const value = colorMode === 'duration' ? test.maxPayloadNs : test.mgasPerSec
+      const ratio = value / limit
       let binIndex = binMultipliers.findIndex((_, i) => {
         const next = binMultipliers[i + 1]
         return next === undefined ? true : ratio < next
@@ -596,23 +713,35 @@ export function TestHeatmap({
     const maxCount = Math.max(...bins)
     const logMax = Math.log10(maxCount + 1)
     return bins.map((count, i) => {
-      const rangeStart = binMultipliers[i] * threshold
-      const rangeEnd = binMultipliers[i + 1] !== undefined ? binMultipliers[i + 1] * threshold : Infinity
+      const rangeStart = binMultipliers[i] * limit
+      const rangeEnd = binMultipliers[i + 1] !== undefined ? binMultipliers[i + 1] * limit : Infinity
       const midpoint = binMultipliers[i + 1] !== undefined
-        ? (binMultipliers[i] + binMultipliers[i + 1]) / 2 * threshold
-        : binMultipliers[i] * 1.25 * threshold
+        ? (binMultipliers[i] + binMultipliers[i + 1]) / 2 * limit
+        : binMultipliers[i] * 1.25 * limit
+      const isLast = binMultipliers[i + 1] === undefined
+      const format = (v: number) => (colorMode === 'duration' ? formatDuration(v) : v.toFixed(0))
       return {
         count,
         height: maxCount > 0 ? (Math.log10(count + 1) / logMax) * 100 : 0,
         rangeStart,
         rangeEnd,
-        label: binMultipliers[i + 1] !== undefined
-          ? `${rangeStart.toFixed(0)}-${rangeEnd.toFixed(0)}`
-          : `${rangeStart.toFixed(0)}+`,
-        color: getColorByThreshold(midpoint, threshold),
+        label: isLast ? `${format(rangeStart)}+` : `${format(rangeStart)}-${format(rangeEnd)}`,
+        color: colorMode === 'duration'
+          ? getColorByDuration(midpoint, slowMs)
+          : getColorByThreshold(midpoint, threshold),
       }
     })
-  }, [filteredTestData, threshold])
+  }, [filteredTestData, threshold, colorMode, slowMs])
+
+  // Slow / fast split for the counters next to the histogram, in the
+  // unit of the active colour mode.
+  const { slowCount, fastCount } = useMemo(() => {
+    const withData = filteredTestData.filter((t) => !t.noData)
+    const slow = colorMode === 'duration'
+      ? withData.filter((t) => t.isSlow).length
+      : withData.filter((t) => t.mgasPerSec < threshold).length
+    return { slowCount: slow, fastCount: withData.length - slow }
+  }, [filteredTestData, colorMode, threshold])
 
   const handleMouseEnter = (test: TestData, event: React.MouseEvent) => {
     const rect = event.currentTarget.getBoundingClientRect()
@@ -643,6 +772,10 @@ export function TestHeatmap({
     onSelectedTestChange?.(testKey)
   }
 
+  const isDurationMode = colorMode === 'duration'
+  // Label of the limit the colours and the histogram scale against.
+  const limitLabel = isDurationMode ? formatSlowMs(slowMs) : `${threshold} MGas/s`
+
   if (testData.length === 0) {
     return (
       <div className="flex h-32 items-center justify-center text-sm/6 text-gray-500 dark:text-gray-400">
@@ -656,87 +789,65 @@ export function TestHeatmap({
       {/* Controls */}
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex flex-wrap items-center gap-4">
-          <div className="flex items-center gap-2">
-            <span className="text-xs/5 text-gray-500 dark:text-gray-400">Sort by:</span>
-            <div className="flex items-center gap-1 rounded-sm bg-gray-100 p-0.5 dark:bg-gray-700">
-              <button
-                onClick={() => handleSortModeChange('order')}
-                className={clsx(
-                  'rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
-                  sortMode === 'order'
-                    ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
-                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
-                )}
-              >
-                Test #
-              </button>
-              <button
-                onClick={() => handleSortModeChange('mgas')}
-                className={clsx(
-                  'rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
-                  sortMode === 'mgas'
-                    ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
-                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
-                )}
-              >
-                MGas/s
-              </button>
-              <button
-                onClick={() => handleSortModeChange('gas')}
-                className={clsx(
-                  'rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
-                  sortMode === 'gas'
-                    ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
-                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
-                )}
-              >
-                Gas Used
-              </button>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="text-xs/5 text-gray-500 dark:text-gray-400">Group by:</span>
-            <div className="flex items-center gap-1 rounded-sm bg-gray-100 p-0.5 dark:bg-gray-700">
-              <button
-                onClick={() => handleGroupModeChange('none')}
-                className={clsx(
-                  'rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
-                  groupMode === 'none'
-                    ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
-                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
-                )}
-              >
-                None
-              </button>
-              <button
-                onClick={() => handleGroupModeChange('gas')}
-                className={clsx(
-                  'rounded-xs px-2 py-1 text-xs/5 font-medium transition-colors',
-                  groupMode === 'gas'
-                    ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-600 dark:text-gray-100'
-                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
-                )}
-              >
-                Gas Used
-              </button>
-            </div>
-          </div>
+          <ModeGroup
+            label="Sort by:"
+            value={sortMode}
+            onChange={handleSortModeChange}
+            options={[
+              { value: 'order', label: 'Test #' },
+              { value: 'mgas', label: 'MGas/s' },
+              { value: 'gas', label: 'Gas Used' },
+              { value: 'duration', label: 'Duration', title: 'Slowest engine_newPayload call of the test' },
+            ]}
+          />
+          <ModeGroup
+            label="Color by:"
+            value={colorMode}
+            onChange={handleColorModeChange}
+            options={[
+              { value: 'mgas', label: 'MGas/s', title: `Color against the ${threshold} MGas/s threshold` },
+              { value: 'duration', label: 'Duration', title: `Color against the ${formatSlowMs(slowMs)} slow-payload limit` },
+            ]}
+          />
+          <ModeGroup
+            label="Group by:"
+            value={groupMode}
+            onChange={handleGroupModeChange}
+            options={[
+              { value: 'none', label: 'None' },
+              { value: 'gas', label: 'Gas Used' },
+            ]}
+          />
         </div>
-        <div className="text-xs/5 text-gray-500 dark:text-gray-400">
-          {(() => {
-            const notProcessed = testData.filter((t) => t.notProcessed).length
-            if (notProcessed > 0) {
-              return `${testData.length - notProcessed}/${testData.length} tests processed | ${minMgas.toFixed(1)} - ${maxMgas.toFixed(1)} MGas/s`
-            }
-            return `${testData.length} tests | ${minMgas.toFixed(1)} - ${maxMgas.toFixed(1)} MGas/s`
-          })()}
+        <div className="flex flex-wrap items-center gap-2 text-xs/5 text-gray-500 dark:text-gray-400">
+          <span>
+            {(() => {
+              const notProcessed = testData.filter((t) => t.notProcessed).length
+              const counts = notProcessed > 0
+                ? `${testData.length - notProcessed}/${testData.length} tests processed`
+                : `${testData.length} tests`
+              const range = colorMode === 'duration'
+                ? `${formatDuration(minPayloadNs)} - ${formatDuration(maxPayloadNs)} per payload`
+                : `${minMgas.toFixed(1)} - ${maxMgas.toFixed(1)} MGas/s`
+              return `${counts} | ${range}`
+            })()}
+          </span>
+          {slowTestCount > 0 && (
+            <span
+              className="rounded-xs px-1.5 py-0.5 font-medium"
+              style={{ backgroundColor: `${SLOW_COLOR}26`, color: SLOW_COLOR }}
+              title={`Tests with an engine_newPayload call above ${formatSlowMs(slowMs)}`}
+            >
+              {slowTestCount} slow
+            </span>
+          )}
         </div>
       </div>
 
       {/* Heatmap Grid */}
       <div className="flex flex-col gap-1">
         <div className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">
-          Tests {sortMode === 'order' ? '(by execution order)' : sortMode === 'gas' ? '(by gas used, most first)' : '(by MGas/s, slowest first)'}
+          Tests {SORT_CAPTIONS[sortMode]}
           {groupMode !== 'none' && ' — grouped by gas used (30M steps)'}
         </div>
         {groupedData ? (
@@ -753,6 +864,8 @@ export function TestHeatmap({
                       key={test.testKey}
                       test={test}
                       threshold={threshold}
+                      slowMs={slowMs}
+                      colorMode={colorMode}
                       statusFilter={statusFilter}
                       searchQuery={searchQuery}
                       popDelayMs={popDelays.get(test.testKey)}
@@ -773,6 +886,8 @@ export function TestHeatmap({
                 key={test.testKey}
                 test={test}
                 threshold={threshold}
+                slowMs={slowMs}
+                colorMode={colorMode}
                 statusFilter={statusFilter}
                 searchQuery={searchQuery}
                 popDelayMs={popDelays.get(test.testKey)}
@@ -788,13 +903,20 @@ export function TestHeatmap({
 
       {/* Histogram */}
       <div className="flex flex-col gap-1">
-        <div className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">Distribution (by threshold multiples)</div>
+        <div className="text-xs/5 font-medium text-gray-500 dark:text-gray-400">
+          Distribution (by {isDurationMode ? 'slow-limit' : 'threshold'} multiples)
+        </div>
         <div className="flex items-end gap-1">
           <div className="flex h-16 w-8 shrink-0 flex-col items-center justify-end">
-            <span className="text-xs/5 font-medium text-red-600 dark:text-red-400">
-              {filteredTestData.filter((t) => !t.noData && t.mgasPerSec < threshold).length}
+            <span
+              className={clsx(
+                'text-xs/5 font-medium',
+                isDurationMode ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400',
+              )}
+            >
+              {isDurationMode ? fastCount : slowCount}
             </span>
-            <span className="text-xs/5 text-gray-400 dark:text-gray-500">slow</span>
+            <span className="text-xs/5 text-gray-400 dark:text-gray-500">{isDurationMode ? 'fast' : 'slow'}</span>
           </div>
           <div className="relative flex h-16 flex-1 items-end gap-1">
             {histogramData.map((bin, i) => (
@@ -806,42 +928,49 @@ export function TestHeatmap({
                   backgroundColor: bin.color,
                   minHeight: bin.count > 0 ? '2px' : '0',
                 }}
-                title={`${bin.label} MGas/s: ${bin.count} tests`}
+                title={`${bin.label}${isDurationMode ? '' : ' MGas/s'}: ${bin.count} tests`}
               />
             ))}
-            {/* Threshold line - positioned at bin index 4 (1x threshold) */}
+            {/* Limit line - positioned at bin index 4 (1x the limit) */}
             <div
               className="absolute bottom-0 top-0 w-0.5 bg-black dark:bg-white"
               style={{ left: `${(4 / 11) * 100}%` }}
-              title={`Threshold: ${threshold} MGas/s`}
+              title={`${isDurationMode ? 'Slow payload limit' : 'Threshold'}: ${limitLabel}`}
             />
           </div>
           <div className="flex h-16 w-8 shrink-0 flex-col items-center justify-end">
-            <span className="text-xs/5 font-medium text-green-600 dark:text-green-400">
-              {filteredTestData.filter((t) => !t.noData && t.mgasPerSec >= threshold).length}
+            <span
+              className={clsx(
+                'text-xs/5 font-medium',
+                isDurationMode ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400',
+              )}
+            >
+              {isDurationMode ? slowCount : fastCount}
             </span>
-            <span className="text-xs/5 text-gray-400 dark:text-gray-500">fast</span>
+            <span className="text-xs/5 text-gray-400 dark:text-gray-500">{isDurationMode ? 'slow' : 'fast'}</span>
           </div>
         </div>
         <div className="flex justify-between px-9 text-xs/5 text-gray-400 dark:text-gray-500">
           <span>0</span>
-          <span className="font-medium text-yellow-600 dark:text-yellow-400">{threshold} MGas/s (threshold)</span>
-          <span>{threshold * 3}+</span>
+          <span className="font-medium text-yellow-600 dark:text-yellow-400">
+            {limitLabel} ({isDurationMode ? 'limit' : 'threshold'})
+          </span>
+          <span>{isDurationMode ? `${formatSlowMs(slowMs * 3)}+` : `${threshold * 3}+`}</span>
         </div>
       </div>
 
       {/* Legend */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs/5 text-gray-500 dark:text-gray-400">
         <span className="flex items-center gap-1">
-          <span>&gt;{threshold * 2}</span>
+          <span>{isDurationMode ? `<${formatSlowMs(slowMs / 2)}` : `>${threshold * 2}`}</span>
           <span className="flex gap-0.5">
             {THRESHOLD_COLORS.map((color, i) => (
               <span key={i} className="size-3 rounded-xs" style={{ backgroundColor: color }} />
             ))}
           </span>
-          <span>&lt;{threshold / 2}</span>
+          <span>{isDurationMode ? `>${formatSlowMs(slowMs * 2)}` : `<${threshold / 2}`}</span>
         </span>
-        <span className="text-gray-400 dark:text-gray-500">({threshold} MGas/s = yellow)</span>
+        <span className="text-gray-400 dark:text-gray-500">({limitLabel} = yellow)</span>
         <span>
           <span className="mr-1 inline-block size-3 rounded-xs" style={NO_DATA_STYLE} />
           No data
@@ -853,6 +982,13 @@ export function TestHeatmap({
         <span>
           <span className="mr-1 inline-block size-3 rounded-xs ring-1 ring-red-500" style={{ backgroundColor: THRESHOLD_COLORS[2] }} />
           Has failures
+        </span>
+        <span title={`A single engine_newPayload call above ${formatSlowMs(slowMs)}`}>
+          <span
+            className="mr-1 inline-block size-3 rounded-xs"
+            style={{ backgroundColor: THRESHOLD_COLORS[2], outline: `2px solid ${SLOW_COLOR}`, outlineOffset: '-2px' }}
+          />
+          Slow payload (&gt;{formatSlowMs(slowMs)})
         </span>
       </div>
 
@@ -882,8 +1018,19 @@ export function TestHeatmap({
             {!tooltip.test.noData && (
               <>
                 <div>Gas used: {(tooltip.test.gasUsedTotal / 1_000_000).toFixed(2)} MGas</div>
-                <div>Gas time: {formatDuration(tooltip.test.gasUsedTimeTotal)}</div>
+                <div>
+                  Gas time: {formatDuration(tooltip.test.gasUsedTimeTotal)}
+                  {tooltip.test.payloadCount > 1 && ` (${tooltip.test.payloadCount} payloads)`}
+                </div>
+                {tooltip.test.payloadCount > 1 && (
+                  <div>Slowest payload: {formatDuration(tooltip.test.maxPayloadNs)}</div>
+                )}
               </>
+            )}
+            {tooltip.test.isSlow && (
+              <div className="font-medium" style={{ color: SLOW_COLOR }}>
+                Slow payload (&gt;{formatSlowMs(slowMs)})
+              </div>
             )}
             <div className="text-gray-500 dark:text-gray-400">Based on steps: {stepFilter.join(', ')}</div>
             <TooltipFilename name={tooltip.test.filename} />

--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -1117,7 +1117,7 @@ export function TestHeatmap({
                 )
               })()}
               {blockLogs?.[selectedTest] && (
-                <BlockLogDetails blockLog={blockLogs[selectedTest]} />
+                <BlockLogDetails blockLog={blockLogs[selectedTest]} threshold={threshold} slowMs={slowMs} />
               )}
               {suiteHash && entry.steps && (() => {
                 const steps = [
@@ -1171,8 +1171,8 @@ export function TestHeatmap({
                       <div>
                         {activeStep.step?.aggregated && (
                           <div className="flex flex-col gap-4">
-                            <TimeBreakdown methods={activeStep.step.aggregated.method_stats.times} />
-                            <MGasBreakdown methods={activeStep.step.aggregated.method_stats.mgas_s} />
+                            <TimeBreakdown methods={activeStep.step.aggregated.method_stats.times} slowMs={slowMs} />
+                            <MGasBreakdown methods={activeStep.step.aggregated.method_stats.mgas_s} threshold={threshold} />
                           </div>
                         )}
                         <ExecutionsList
@@ -1183,6 +1183,8 @@ export function TestHeatmap({
                           expandedRows={expandedExecRows}
                           onExpandedRowsChange={onExpandedExecRowsChange}
                           txCounts={matchingSuiteTest?.tx_counts?.[activeStep.key]}
+                          threshold={threshold}
+                          slowMs={slowMs}
                         />
                       </div>
                     )}

--- a/ui/src/components/run-detail/TestsTable.tsx
+++ b/ui/src/components/run-detail/TestsTable.tsx
@@ -8,6 +8,16 @@ import { Pagination } from '@/components/shared/Pagination'
 import { TestName } from '@/components/shared/TestName'
 import { compileQuery, toggleSearchTerm } from '@/utils/eestNameFilter'
 import { type StepTypeOption, ALL_STEP_TYPES } from '@/pages/RunDetailPage'
+import { getPayloadTimes } from '@/utils/payloadTime'
+import { formatDuration } from '@/utils/format'
+import {
+  DEFAULT_SLOW_MS,
+  DEFAULT_THRESHOLD,
+  formatSlowMs,
+  getTextClassByDuration,
+  getTextClassByThreshold,
+  isSlowPayload,
+} from '@/utils/perfThreshold'
 
 export type TestSortColumn = 'order' | 'name' | 'genesis' | 'time' | 'mgas' | 'passed' | 'failed'
 export type TestSortDirection = 'asc' | 'desc'
@@ -71,6 +81,10 @@ interface TestsTableProps {
   searchQuery?: string
   statusFilter?: TestStatusFilter
   stepFilter?: StepTypeOption[]
+  /** Slow-threshold MGas/s (shared with the Performance Heatmap). */
+  threshold?: number
+  /** Slow-payload limit in milliseconds (shared with the Performance Heatmap). */
+  slowMs?: number
   onPageChange?: (page: number) => void
   onPageSizeChange?: (size: number) => void
   onSortChange?: (column: TestSortColumn, direction: TestSortDirection) => void
@@ -138,6 +152,8 @@ export function TestsTable({
   searchQuery = '',
   statusFilter = 'all',
   stepFilter = ALL_STEP_TYPES,
+  threshold = DEFAULT_THRESHOLD,
+  slowMs = DEFAULT_SLOW_MS,
   onPageChange,
   onPageSizeChange,
   onSortChange,
@@ -234,6 +250,13 @@ export function TestsTable({
     })
   }, [tests, searchQuery, statusFilter, genesisFilter, stepFilter, executionOrder, genesisMap, sortBy, sortDir])
 
+  // Tests with a payload above the limit, over the filtered set — the
+  // count explains the tinted rows.
+  const slowCount = useMemo(
+    () => sortedTests.filter(([, entry]) => isSlowPayload(getPayloadTimes(entry, stepFilter).maxNs, slowMs)).length,
+    [sortedTests, stepFilter, slowMs],
+  )
+
   const totalPages = Math.ceil(sortedTests.length / pageSize)
   const paginatedTests = sortedTests.slice((currentPage - 1) * pageSize, currentPage * pageSize)
 
@@ -270,6 +293,14 @@ export function TestsTable({
         <h2 className="flex items-center gap-2 text-lg/7 font-semibold text-gray-900 dark:text-gray-100">
           <FlaskConical className="size-5 text-gray-400 dark:text-gray-500" />
           Tests ({sortedTests.length})
+          {slowCount > 0 && (
+            <span
+              className="rounded-xs bg-fuchsia-100 px-1.5 py-0.5 text-xs/5 font-medium text-fuchsia-700 dark:bg-fuchsia-950/50 dark:text-fuchsia-300"
+              title={`Tests with an engine_newPayload call above ${formatSlowMs(slowMs)}`}
+            >
+              {slowCount} slow
+            </span>
+          )}
         </h2>
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-1 rounded-sm bg-gray-100 p-0.5 dark:bg-gray-700">
@@ -335,12 +366,22 @@ export function TestsTable({
               const statsFiltered = getAggregatedStats(entry, stepFilter)
               // Use all steps for passed/failed columns
               const statsAll = getAggregatedStats(entry, ALL_STEP_TYPES)
+              // Payload times drive the slow marker. The Total Time
+              // column sums every RPC call of the step, so the colour
+              // is a magnitude read and the marker is the exact fact.
+              const payloads = getPayloadTimes(entry, stepFilter)
+              const isSlow = !!statsFiltered && isSlowPayload(payloads.maxNs, slowMs)
 
               return (
                 <tr
                   key={testName}
                   onClick={() => onTestClick?.(testName)}
-                  className="cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                  className={clsx(
+                    'cursor-pointer transition-colors',
+                    isSlow
+                      ? 'bg-fuchsia-50 hover:bg-fuchsia-100 dark:bg-fuchsia-950/30 dark:hover:bg-fuchsia-950/50'
+                      : 'hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                  )}
                 >
                   <td className="whitespace-nowrap px-4 py-3 text-sm/6 font-medium text-gray-500 dark:text-gray-400">
                     {executionOrder.get(testName) ?? '-'}
@@ -367,21 +408,38 @@ export function TestsTable({
                     </td>
                   )}
                   <td
-                    className="whitespace-nowrap px-4 py-3 text-right text-sm/6 text-gray-500 dark:text-gray-400"
-                    title={`Based on steps: ${stepFilter.join(', ')}`}
+                    className={clsx(
+                      'whitespace-nowrap px-4 py-3 text-right text-sm/6',
+                      statsFiltered
+                        ? getTextClassByDuration(statsFiltered.time_total, slowMs)
+                        : 'text-gray-500 dark:text-gray-400',
+                    )}
+                    title={statsFiltered
+                      ? `Every RPC call of steps: ${stepFilter.join(', ')} — coloured against the ${formatSlowMs(slowMs)} limit. Slowest payload: ${formatDuration(payloads.maxNs)}${payloads.count > 1 ? ` of ${payloads.count}` : ''}`
+                      : `Based on steps: ${stepFilter.join(', ')}`}
                   >
                     {statsFiltered ? <Duration nanoseconds={statsFiltered.time_total} /> : '-'}
                   </td>
-                  <td
-                    className="whitespace-nowrap px-4 py-3 text-right text-sm/6 text-gray-500 dark:text-gray-400"
-                    title={`Based on steps: ${stepFilter.join(', ')}`}
-                  >
-                    {(() => {
-                      if (!statsFiltered) return '-'
-                      const mgas = calculateMGasPerSec(statsFiltered.gas_used_total, statsFiltered.gas_used_time_total)
-                      return mgas !== undefined ? mgas.toFixed(2) : '-'
-                    })()}
-                  </td>
+                  {(() => {
+                    const mgas = statsFiltered
+                      ? calculateMGasPerSec(statsFiltered.gas_used_total, statsFiltered.gas_used_time_total)
+                      : undefined
+                    return (
+                      <td
+                        className={clsx(
+                          'whitespace-nowrap px-4 py-3 text-right text-sm/6',
+                          mgas !== undefined
+                            ? getTextClassByThreshold(mgas, threshold)
+                            : 'text-gray-500 dark:text-gray-400',
+                        )}
+                        title={mgas !== undefined
+                          ? `Based on steps: ${stepFilter.join(', ')} — coloured against ${threshold} MGas/s`
+                          : `Based on steps: ${stepFilter.join(', ')}`}
+                      >
+                        {mgas !== undefined ? mgas.toFixed(2) : '-'}
+                      </td>
+                    )
+                  })()}
                   <td className="whitespace-nowrap px-4 py-3 text-center">
                     {statsAll && statsAll.fail > 0 && <Badge variant="error">{statsAll.fail}</Badge>}
                   </td>

--- a/ui/src/components/run-detail/TimeBreakdown.tsx
+++ b/ui/src/components/run-detail/TimeBreakdown.tsx
@@ -1,22 +1,54 @@
+import clsx from 'clsx'
 import type { MethodStats } from '@/api/types'
 import { Duration } from '@/components/shared/Duration'
-import { formatNumber } from '@/utils/format'
+import { formatDuration, formatNumber } from '@/utils/format'
+import { DEFAULT_SLOW_MS, formatSlowMs, getTextClassByDuration } from '@/utils/perfThreshold'
 
 interface TimeBreakdownProps {
   methods: Record<string, MethodStats>
+  /** Slow-payload limit in milliseconds the payload times colour against. */
+  slowMs?: number
 }
 
-export function TimeBreakdown({ methods }: TimeBreakdownProps) {
+// Engine API method that submits a block. Only its times mean anything
+// against the slow-payload limit, so only they carry a colour.
+const PAYLOAD_METHOD = 'newPayload'
+
+export function TimeBreakdown({ methods, slowMs = DEFAULT_SLOW_MS }: TimeBreakdownProps) {
   const methodEntries = Object.entries(methods).sort(([a], [b]) => a.localeCompare(b))
 
   if (methodEntries.length === 0) {
     return <p className="text-sm/6 text-gray-500 dark:text-gray-400">No method data available</p>
   }
 
+  const hasPayload = methodEntries.some(([method]) => method.includes(PAYLOAD_METHOD))
+
+  // A payload time carries the colour of the step it falls in. Every
+  // other method stays grey — a forkchoice call has nothing to do with
+  // the slow-payload limit.
+  const cell = (nanoseconds: number, isPayload: boolean) => (
+    <td
+      className={clsx(
+        'whitespace-nowrap px-3 py-2 text-right text-sm/6',
+        isPayload ? getTextClassByDuration(nanoseconds, slowMs) : 'text-gray-500 dark:text-gray-400',
+      )}
+      title={isPayload ? `${formatDuration(nanoseconds)} — slow-payload limit ${formatSlowMs(slowMs)}` : undefined}
+    >
+      <Duration nanoseconds={nanoseconds} />
+    </td>
+  )
+
   return (
     <div className="overflow-hidden rounded-sm border border-gray-200 dark:border-gray-700">
       <div className="border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-700 dark:bg-gray-800/50">
-        <h4 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">RPC Calls Time Breakdown</h4>
+        <h4 className="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+          RPC Calls Time Breakdown
+          {hasPayload && (
+            <span className="ml-2 text-xs/5 font-normal text-gray-500 dark:text-gray-400">
+              payload times coloured against {formatSlowMs(slowMs)}
+            </span>
+          )}
+        </h4>
       </div>
       <div className="overflow-x-auto">
         <table className="min-w-full">
@@ -60,45 +92,34 @@ export function TimeBreakdown({ methods }: TimeBreakdownProps) {
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100 bg-white dark:divide-gray-800 dark:bg-gray-900/20">
-            {methodEntries.map(([method, stats]) => (
-              <tr key={method}>
-                <td className="whitespace-nowrap px-3 py-2 font-mono text-sm/6 text-gray-900 dark:text-gray-100">
-                  {method}
-                </td>
-                <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 dark:text-gray-400">
-                  {formatNumber(stats.count)}
-                </td>
-                <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 dark:text-gray-400">
-                  <Duration nanoseconds={stats.last} />
-                </td>
-                {stats.min !== undefined && (
-                  <>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 dark:text-gray-400">
-                      <Duration nanoseconds={stats.min} />
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 dark:text-gray-400">
-                      <Duration nanoseconds={stats.max!} />
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 dark:text-gray-400">
-                      <Duration nanoseconds={stats.mean!} />
-                    </td>
-                  </>
-                )}
-                {stats.p50 !== undefined && (
-                  <>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 dark:text-gray-400">
-                      <Duration nanoseconds={stats.p50} />
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 dark:text-gray-400">
-                      <Duration nanoseconds={stats.p95!} />
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 dark:text-gray-400">
-                      <Duration nanoseconds={stats.p99!} />
-                    </td>
-                  </>
-                )}
-              </tr>
-            ))}
+            {methodEntries.map(([method, stats]) => {
+              const isPayload = method.includes(PAYLOAD_METHOD)
+              return (
+                <tr key={method}>
+                  <td className="whitespace-nowrap px-3 py-2 font-mono text-sm/6 text-gray-900 dark:text-gray-100">
+                    {method}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2 text-right text-sm/6 text-gray-500 dark:text-gray-400">
+                    {formatNumber(stats.count)}
+                  </td>
+                  {cell(stats.last, isPayload)}
+                  {stats.min !== undefined && (
+                    <>
+                      {cell(stats.min, isPayload)}
+                      {cell(stats.max!, isPayload)}
+                      {cell(stats.mean!, isPayload)}
+                    </>
+                  )}
+                  {stats.p50 !== undefined && (
+                    <>
+                      {cell(stats.p50, isPayload)}
+                      {cell(stats.p95!, isPayload)}
+                      {cell(stats.p99!, isPayload)}
+                    </>
+                  )}
+                </tr>
+              )
+            })}
           </tbody>
         </table>
       </div>

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -896,6 +896,7 @@ export function RunDetailPage() {
             onToggle={(term) => handleSearchChange(toggleSearchTerm(q, term))}
             onTestClick={handleTestModalChange}
             threshold={heatmapThreshold}
+            slowMs={slowMs}
           />
 
           {mergedSuiteTests && mergedSuiteTests.length > 0 && (

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -980,6 +980,8 @@ export function RunDetailPage() {
               suiteHash={config.suite_hash}
               selectedStep={preRunModal}
               onSelectedStepChange={handlePreRunModalChange}
+              threshold={heatmapThreshold}
+              slowMs={slowMs}
             />
           )}
 

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -995,6 +995,8 @@ export function RunDetailPage() {
             searchQuery={q}
             statusFilter={status}
             stepFilter={stepFilter}
+            threshold={heatmapThreshold}
+            slowMs={slowMs}
             onPageChange={handlePageChange}
             onPageSizeChange={handlePageSizeChange}
             onSortChange={handleSortChange}

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -16,7 +16,7 @@ import { FilesPanel } from '@/components/run-detail/FilesPanel'
 import { ResourceUsageCharts } from '@/components/run-detail/ResourceUsageCharts'
 import { TestsTable, type TestSortColumn, type TestSortDirection, type TestStatusFilter } from '@/components/run-detail/TestsTable'
 import { PreRunStepsTable } from '@/components/run-detail/PreRunStepsTable'
-import { TestHeatmap, type SortMode, type GroupMode } from '@/components/run-detail/TestHeatmap'
+import { TestHeatmap, type SortMode, type GroupMode, type ColorMode } from '@/components/run-detail/TestHeatmap'
 import { OpcodeHeatmap } from '@/components/suite-detail/OpcodeHeatmap'
 import { OpcodeDiffPanel, type OpcodeDiffRow } from '@/components/run-detail/OpcodeDiffPanel'
 import { LoadingState } from '@/components/shared/Spinner'
@@ -29,7 +29,16 @@ import { FilterInput } from '@/components/shared/FilterInput'
 import { FacetPanel } from '@/components/shared/FacetPanel'
 import { DimensionInsights } from '@/components/run-detail/DimensionInsights'
 import { TEST_FILTER_HINT, toggleSearchTerm } from '@/utils/eestNameFilter'
-import { DEFAULT_THRESHOLD, MAX_THRESHOLD, MIN_THRESHOLD } from '@/utils/perfThreshold'
+import {
+  DEFAULT_SLOW_MS,
+  DEFAULT_THRESHOLD,
+  MAX_SLOW_MS,
+  MAX_THRESHOLD,
+  MIN_SLOW_MS,
+  MIN_THRESHOLD,
+  SLOW_STEP_MS,
+  formatSlowMs,
+} from '@/utils/perfThreshold'
 import { formatTimestamp, formatDurationSeconds } from '@/utils/date'
 import { formatNumber, formatBytes } from '@/utils/format'
 import { useIndex, useLiveRuns } from '@/api/hooks/useIndex'
@@ -146,7 +155,9 @@ export function RunDetailPage() {
     preRunModal?: string
     heatmapSort?: SortMode
     heatmapGroup?: GroupMode
+    heatmapColor?: ColorMode
     heatmapThreshold?: number
+    slowMs?: number
     steps?: string
     ohFs?: boolean // Opcode Heatmap fullscreen
     blFs?: boolean // Block Logs fullscreen
@@ -158,8 +169,9 @@ export function RunDetailPage() {
   const page = Number(search.page) || 1
   const pageSize = Number(search.pageSize) || 20
   const heatmapThreshold = search.heatmapThreshold ? Number(search.heatmapThreshold) : undefined
+  const slowMs = search.slowMs ? Number(search.slowMs) : undefined
   const stepFilter = parseStepFilter(search.steps)
-  const { sortBy = 'order', sortDir = 'asc', q = '', status = 'all', testModal, preRunModal, heatmapGroup, heatmapSort, ohFs = false, blFs = false, dlModal = false, dlFmt, testStep, testExec } = search
+  const { sortBy = 'order', sortDir = 'asc', q = '', status = 'all', testModal, preRunModal, heatmapGroup, heatmapSort, heatmapColor, ohFs = false, blFs = false, dlModal = false, dlFmt, testStep, testExec } = search
   const activeStepTab = (testStep === 'setup' || testStep === 'cleanup') ? testStep : testStep === 'test' ? testStep : undefined
   const expandedExecRows = testExec ? new Set(testExec.split(',').map(Number).filter(n => !isNaN(n))) : undefined
 
@@ -310,7 +322,9 @@ export function RunDetailPage() {
         testModal,
         preRunModal,
         heatmapSort,
+        heatmapColor,
         heatmapThreshold,
+        slowMs,
         steps: serializeStepFilter(stepFilter),
         ohFs: ohFs || undefined,
         blFs: blFs || undefined,
@@ -368,7 +382,18 @@ export function RunDetailPage() {
   }
 
   const handleHeatmapThresholdChange = (threshold: number) => {
-    updateSearch({ heatmapThreshold: threshold !== 60 ? threshold : undefined })
+    updateSearch({ heatmapThreshold: threshold !== DEFAULT_THRESHOLD ? threshold : undefined })
+  }
+
+  const handleHeatmapColorModeChange = (mode: ColorMode) => {
+    updateSearch({ heatmapColor: mode !== 'mgas' ? mode : undefined })
+  }
+
+  const handleSlowMsChange = (ms: number) => {
+    // Ignore an empty or invalid entry so the control keeps a usable value.
+    if (!Number.isFinite(ms) || ms <= 0) return
+    const rounded = Math.min(MAX_SLOW_MS, Math.round(ms))
+    updateSearch({ slowMs: rounded !== DEFAULT_SLOW_MS ? rounded : undefined })
   }
 
   const handleStepFilterChange = (steps: StepTypeOption[]) => {
@@ -788,6 +813,38 @@ export function RunDetailPage() {
                 </button>
               )}
             </div>
+            <div className="flex shrink-0 items-center gap-2 text-xs/5 text-gray-500 dark:text-gray-400">
+              <span title={`Mark every test with an engine_newPayload call above ${formatSlowMs(slowMs ?? DEFAULT_SLOW_MS)}`}>
+                Slow payload:
+              </span>
+              <input
+                type="range"
+                min={MIN_SLOW_MS}
+                max={MAX_SLOW_MS}
+                step={SLOW_STEP_MS}
+                value={slowMs ?? DEFAULT_SLOW_MS}
+                onChange={(e) => handleSlowMsChange(Number(e.target.value))}
+                className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-gray-200 accent-fuchsia-500 dark:bg-gray-700"
+              />
+              <input
+                type="number"
+                min={MIN_SLOW_MS / 1000}
+                max={MAX_SLOW_MS / 1000}
+                step={SLOW_STEP_MS / 1000}
+                value={(slowMs ?? DEFAULT_SLOW_MS) / 1000}
+                onChange={(e) => handleSlowMsChange(Number(e.target.value) * 1000)}
+                className="w-16 rounded-sm border border-gray-300 bg-white px-1.5 py-0.5 text-center text-xs/5 focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <span>s</span>
+              {(slowMs ?? DEFAULT_SLOW_MS) !== DEFAULT_SLOW_MS && (
+                <button
+                  onClick={() => handleSlowMsChange(DEFAULT_SLOW_MS)}
+                  className="text-xs/5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  Reset
+                </button>
+              )}
+            </div>
           </div>
           <div className="overflow-hidden rounded-sm bg-white shadow-xs dark:bg-gray-800">
             <div className="flex items-center gap-2 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
@@ -807,13 +864,16 @@ export function RunDetailPage() {
               statusFilter={status}
               searchQuery={q}
               sortMode={heatmapSort}
+              colorMode={heatmapColor}
               threshold={heatmapThreshold}
+              slowMs={slowMs}
               stepFilter={stepFilter}
               postTestRPCCalls={config.instance.post_test_rpc_calls}
               onSelectedTestChange={handleTestModalChange}
               onSortModeChange={handleHeatmapSortChange}
               groupMode={heatmapGroup}
               onGroupModeChange={handleHeatmapGroupChange}
+              onColorModeChange={handleHeatmapColorModeChange}
               onSearchChange={handleSearchChange}
               activeStepTab={activeStepTab}
               onActiveStepTabChange={handleStepTabChange}

--- a/ui/src/utils/payloadTime.test.ts
+++ b/ui/src/utils/payloadTime.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import type { AggregatedStats, MethodStats, TestEntry } from '@/api/types'
+import { getPayloadTimes } from './payloadTime'
+
+// step builds one aggregated step with a single payload method.
+function step(gasTimeNs: number, payload?: Partial<MethodStats>): { aggregated: AggregatedStats } {
+  return {
+    aggregated: {
+      time_total: gasTimeNs,
+      gas_used_total: 1_000_000,
+      gas_used_time_total: gasTimeNs,
+      success: 1,
+      fail: 0,
+      msg_count: 1,
+      method_stats: {
+        times: {
+          engine_forkchoiceUpdatedV4: { count: 1, last: 500 },
+          ...(payload ? { engine_newPayloadV5: { count: 1, last: gasTimeNs, ...payload } as MethodStats } : {}),
+        },
+        mgas_s: {},
+      },
+    },
+  }
+}
+
+describe('getPayloadTimes', () => {
+  it('returns zeroes for a test without steps', () => {
+    expect(getPayloadTimes({ dir: '' }, ['test'])).toEqual({ totalNs: 0, maxNs: 0, count: 0 })
+  })
+
+  it('reads a single payload from the last value', () => {
+    const entry: TestEntry = { dir: '', steps: { test: step(4_000_000_000, {}) } }
+    expect(getPayloadTimes(entry, ['test'])).toEqual({
+      totalNs: 4_000_000_000,
+      maxNs: 4_000_000_000,
+      count: 1,
+    })
+  })
+
+  it('takes the slowest call when a step has several payloads', () => {
+    const entry: TestEntry = {
+      dir: '',
+      steps: { test: step(9_000_000_000, { count: 3, max: 5_000_000_000, last: 1_000_000_000 }) },
+    }
+    expect(getPayloadTimes(entry, ['test'])).toEqual({
+      totalNs: 9_000_000_000,
+      maxNs: 5_000_000_000,
+      count: 3,
+    })
+  })
+
+  it('takes the slowest call across the selected steps only', () => {
+    const entry: TestEntry = {
+      dir: '',
+      steps: {
+        setup: step(7_000_000_000, {}),
+        test: step(2_000_000_000, {}),
+      },
+    }
+    expect(getPayloadTimes(entry, ['test'])).toEqual({
+      totalNs: 2_000_000_000,
+      maxNs: 2_000_000_000,
+      count: 1,
+    })
+    expect(getPayloadTimes(entry, ['setup', 'test'])).toEqual({
+      totalNs: 9_000_000_000,
+      maxNs: 7_000_000_000,
+      count: 2,
+    })
+  })
+
+  it('falls back to the step total when no payload method is present', () => {
+    const entry: TestEntry = { dir: '', steps: { test: step(3_000_000_000) } }
+    expect(getPayloadTimes(entry, ['test'])).toEqual({
+      totalNs: 3_000_000_000,
+      maxNs: 3_000_000_000,
+      count: 1,
+    })
+  })
+})

--- a/ui/src/utils/payloadTime.ts
+++ b/ui/src/utils/payloadTime.ts
@@ -1,0 +1,60 @@
+import type { StepResult, TestEntry } from '@/api/types'
+
+// Step types a test result can carry. Same union as StepTypeOption on the
+// run detail page, declared here so this helper stays free of page imports.
+export type PayloadStepType = 'setup' | 'test' | 'cleanup'
+
+// Engine API method that submits a block. The version suffix changes with
+// the fork, so the match is on the stable part of the name.
+const PAYLOAD_METHOD = 'newPayload'
+
+export interface PayloadTimes {
+  /** Sum of the payload durations of the selected steps, in nanoseconds. */
+  totalNs: number
+  /** Duration of the slowest single payload, in nanoseconds. */
+  maxNs: number
+  /** Number of payload calls in the selected steps. */
+  count: number
+}
+
+/**
+ * Collect the engine_newPayload durations of a test.
+ *
+ * `gas_used_time_total` gives the sum directly, because the executor only
+ * adds the calls that report gas. The per-payload maximum comes from the
+ * method stats, which carry `max` when a step has more than one call and
+ * only `last` when it has one.
+ */
+export function getPayloadTimes(entry: TestEntry, stepFilter: PayloadStepType[]): PayloadTimes {
+  const empty: PayloadTimes = { totalNs: 0, maxNs: 0, count: 0 }
+  if (!entry.steps) return empty
+
+  const stepMap: Record<PayloadStepType, StepResult | undefined> = {
+    setup: entry.steps.setup,
+    test: entry.steps.test,
+    cleanup: entry.steps.cleanup,
+  }
+
+  let totalNs = 0
+  let maxNs = 0
+  let count = 0
+
+  for (const type of stepFilter) {
+    const aggregated = stepMap[type]?.aggregated
+    if (!aggregated) continue
+
+    totalNs += aggregated.gas_used_time_total
+
+    for (const [method, stats] of Object.entries(aggregated.method_stats?.times ?? {})) {
+      if (!method.includes(PAYLOAD_METHOD)) continue
+      count += stats.count
+      maxNs = Math.max(maxNs, stats.max ?? stats.last)
+    }
+  }
+
+  // Fall back to the total when a step reports gas time but no payload
+  // method stats. One payload then covers the whole step time.
+  if (count === 0) return { totalNs, maxNs: totalNs, count: totalNs > 0 ? 1 : 0 }
+
+  return { totalNs, maxNs, count }
+}

--- a/ui/src/utils/perfThreshold.ts
+++ b/ui/src/utils/perfThreshold.ts
@@ -30,3 +30,42 @@ export function getColorByThreshold(value: number, threshold: number): string {
   if (ratio >= 0.5) return THRESHOLD_COLORS[3]
   return THRESHOLD_COLORS[4]
 }
+
+// Slow-payload model. The user picks a duration limit on the run-detail
+// page; the Performance Heatmap marks every test with an
+// engine_newPayload call above that limit.
+
+export const MIN_SLOW_MS = 100
+export const MAX_SLOW_MS = 20_000
+export const SLOW_STEP_MS = 100
+export const DEFAULT_SLOW_MS = 3_000
+
+// Marker colour for a slow payload. Distinct from the MGas/s scale
+// (green → red) and from the red failure ring.
+export const SLOW_COLOR = '#d946ef' // fuchsia-500
+
+/**
+ * Map a payload duration to a colour, scaled against the slow limit.
+ * Short is good, so the ratio is inverted before it goes through the
+ * same five steps as the MGas/s scale:
+ *   duration <= limit/2   → green   (very fast)
+ *   duration <= limit/1.5 → lime    (fast)
+ *   duration <= limit     → yellow  (at the limit)
+ *   duration <= limit*2   → orange  (slow)
+ *   duration >  limit*2   → red     (very slow)
+ */
+export function getColorByDuration(nanoseconds: number, slowMs: number): string {
+  if (nanoseconds <= 0) return THRESHOLD_COLORS[0]
+  return getColorByThreshold((slowMs * 1_000_000) / nanoseconds, 1)
+}
+
+/** Report if a payload duration in nanoseconds is above the limit. */
+export function isSlowPayload(nanoseconds: number, slowMs: number): boolean {
+  return nanoseconds > slowMs * 1_000_000
+}
+
+/** Render a slow limit in milliseconds as seconds, e.g. 3000 -> "3s". */
+export function formatSlowMs(slowMs: number): string {
+  const seconds = slowMs / 1000
+  return `${Number.isInteger(seconds) ? seconds : seconds.toFixed(1)}s`
+}

--- a/ui/src/utils/perfThreshold.ts
+++ b/ui/src/utils/perfThreshold.ts
@@ -14,21 +14,46 @@ export const THRESHOLD_COLORS = [
   '#ef4444', // very slow — red
 ] as const
 
+// Text classes for the same five steps. The tile colours are fills and
+// are too light for small text, so a value rendered as text uses these.
+export const THRESHOLD_TEXT_CLASSES = [
+  'text-green-600 dark:text-green-400',
+  'text-lime-600 dark:text-lime-400',
+  'text-yellow-600 dark:text-yellow-400',
+  'text-orange-600 dark:text-orange-400',
+  'text-red-600 dark:text-red-400',
+] as const
+
 /**
- * Map a MGas/s value to a colour, scaled relative to the threshold:
- *   ratio >= 2     → green   (very fast)
- *   ratio >= 1.5   → lime    (fast)
- *   ratio >= 1     → yellow  (at threshold)
- *   ratio >= 0.5   → orange  (slow)
- *   ratio <  0.5   → red     (very slow)
+ * Step of the scale a "higher is better" ratio falls in:
+ *   ratio >= 2     → 0  very fast
+ *   ratio >= 1.5   → 1  fast
+ *   ratio >= 1     → 2  at the limit
+ *   ratio >= 0.5   → 3  slow
+ *   ratio <  0.5   → 4  very slow
  */
+function thresholdStep(ratio: number): number {
+  if (ratio >= 2) return 0
+  if (ratio >= 1.5) return 1
+  if (ratio >= 1) return 2
+  if (ratio >= 0.5) return 3
+  return 4
+}
+
+// A duration is better when it is shorter, so the ratio inverts.
+function durationRatio(nanoseconds: number, slowMs: number): number {
+  if (nanoseconds <= 0) return Infinity
+  return (slowMs * 1_000_000) / nanoseconds
+}
+
+/** Map a MGas/s value to a colour, scaled relative to the threshold. */
 export function getColorByThreshold(value: number, threshold: number): string {
-  const ratio = value / threshold
-  if (ratio >= 2) return THRESHOLD_COLORS[0]
-  if (ratio >= 1.5) return THRESHOLD_COLORS[1]
-  if (ratio >= 1) return THRESHOLD_COLORS[2]
-  if (ratio >= 0.5) return THRESHOLD_COLORS[3]
-  return THRESHOLD_COLORS[4]
+  return THRESHOLD_COLORS[thresholdStep(value / threshold)]
+}
+
+/** Map a MGas/s value to a text class, scaled relative to the threshold. */
+export function getTextClassByThreshold(value: number, threshold: number): string {
+  return THRESHOLD_TEXT_CLASSES[thresholdStep(value / threshold)]
 }
 
 // Slow-payload model. The user picks a duration limit on the run-detail
@@ -45,9 +70,7 @@ export const DEFAULT_SLOW_MS = 3_000
 export const SLOW_COLOR = '#d946ef' // fuchsia-500
 
 /**
- * Map a payload duration to a colour, scaled against the slow limit.
- * Short is good, so the ratio is inverted before it goes through the
- * same five steps as the MGas/s scale:
+ * Map a payload duration to a colour, scaled against the slow limit:
  *   duration <= limit/2   → green   (very fast)
  *   duration <= limit/1.5 → lime    (fast)
  *   duration <= limit     → yellow  (at the limit)
@@ -55,8 +78,12 @@ export const SLOW_COLOR = '#d946ef' // fuchsia-500
  *   duration >  limit*2   → red     (very slow)
  */
 export function getColorByDuration(nanoseconds: number, slowMs: number): string {
-  if (nanoseconds <= 0) return THRESHOLD_COLORS[0]
-  return getColorByThreshold((slowMs * 1_000_000) / nanoseconds, 1)
+  return THRESHOLD_COLORS[thresholdStep(durationRatio(nanoseconds, slowMs))]
+}
+
+/** Map a payload duration to a text class, scaled against the slow limit. */
+export function getTextClassByDuration(nanoseconds: number, slowMs: number): string {
+  return THRESHOLD_TEXT_CLASSES[thresholdStep(durationRatio(nanoseconds, slowMs))]
 }
 
 /** Report if a payload duration in nanoseconds is above the limit. */


### PR DESCRIPTION
## Summary

The run detail page ranked and coloured everything by MGas/s. A block that takes seconds to execute was hard to find, because a low MGas/s tile and a slow tile are not the same thing: a 300M-gas test at 50 MGas/s takes 6 seconds, a 1M-gas test at 5 MGas/s takes 200ms.

This adds payload duration as a first-class metric next to throughput, and one limit that says what "slow" means.

## Slow-payload limit

A slider next to the MGas/s threshold, from 0.1s to 20s, default **3s**. It persists in the URL as `slowMs`, like the other heatmap controls, and every panel on the page colours against it.

A test counts as slow when a **single** `engine_newPayload` call is above the limit — not when its calls add up to it. `gas_used_time_total` gives the sum directly, because the executor only adds the calls that report gas; the per-payload maximum comes from the method stats, which carry `max` when a step has more than one call and only `last` when it has one.

## Performance Heatmap

- **Sort by: Duration** — orders the tiles by the slowest payload of each test.
- **Color by: MGas/s | Duration** — Duration reuses the five-step green-to-red scale, inverted: green at half the limit or better, yellow at the limit, red above twice the limit.
- **Distribution** follows the colour mode. In Duration mode it bins on multiples of the limit, the fast and slow counters swap sides because a long payload is a bad one, and the axis reads in seconds.
- Slow tiles get a fuchsia inset outline, a legend entry, a tooltip line and a count in the header. The outline sits inside the tile, so it stays readable next to the red failure ring of a failed test, and it shows in both colour modes.

The live-run heatmap gets the same slider and toggle.

## Dimension breakdown

A `MGas/s | Duration` toggle drives both the bars and the table. The bars colour, size and label against the active metric; the table renders Mean, P50, P95 and P99 as durations and sorts on the metric. The "Fastest first" and "Slowest first" labels swap in Duration mode.

Both metrics are aggregated in one pass over the tests, so the toggle only picks which set of numbers to render.

## Test modal and Tests table

Every MGas/s and every duration now carries the colour of the step it falls in.

| Where | Coloured value | Against |
|---|---|---|
| MGas/s Breakdown | Last, Min, Max, Mean, P50, P95, P99 | the MGas/s threshold |
| RPC Calls Time Breakdown | the same columns, `engine_newPayload` rows only | the slow-payload limit |
| Executions | the per-call MGas/s, and the time of a call that reports gas | both |
| Block Logs | the MGas/s and Total Time cards | both |
| Tests table | MGas/s, Total Time, plus a tinted row and a count | both |

Two rules keep the colours honest:

- Only a payload time colours against the slow-payload limit. A forkchoice call has nothing to do with that limit, so it stays grey.
- The Tests table **Total Time** column sums every RPC call of the selected steps, not one payload, so its colour is a magnitude read — "this test took a long time". The tinted row is the exact fact — "this test has one slow block". A test can be red without a tint (several payloads that add up) or tinted without being red (one slow block in a short test), and the tooltip names the slowest payload and the payload count either way.

The pre-run step modal reuses the same three tables, so it takes the limits too.

## Notes

The tile colours are fills and are too light for small text, so `THRESHOLD_TEXT_CLASSES` holds a readable text class per step, one pair per theme. The step logic lives in one `thresholdStep` helper that the colour and the class functions share.

Each panel says which limit it colours against, and every coloured value repeats it in a tooltip — the sliders scroll out of view, the colours should not become unexplained.

## Files

- `ui/src/utils/payloadTime.ts` (new) — the per-payload durations of a test entry, plus `payloadTime.test.ts`.
- `ui/src/utils/perfThreshold.ts` — the slow-limit constants, `getColorByDuration`, `getTextClassBy*`, `isSlowPayload`, `formatSlowMs`.
- `ui/src/components/run-detail/TestHeatmap.tsx` — sort mode, colour mode, slow marker, histogram, legend, tooltip. The three repeated pill groups fold into one `ModeGroup` component.
- `ui/src/components/run-detail/DimensionInsights.tsx` — the metric toggle and the dual aggregation.
- `TimeBreakdown`, `MGasBreakdown`, `ExecutionsList`, `BlockLogDetails`, `TestsTable`, `PreRunStepsTable` — the colouring.
- `ui/src/pages/RunDetailPage.tsx`, `LiveRunDetailView.tsx` — the slider and the state wiring.

## Test plan

- [x] `tsc --noEmit`, `eslint .`, `vitest run` and `npm run build` pass. The two eslint warnings are pre-existing (`react-hooks/incompatible-library` on the virtualiser).
- [x] Five new cases cover `getPayloadTimes`: no steps, one payload, several payloads in one step, the step filter, and the fallback with no payload method.
- [ ] Reviewed on a run with genuinely slow payloads. The local sample runs top out near 110ms per payload, so the marker and the Duration colours were checked with the limit dragged down to 0.1s.
