### PR TITLE
feat(erigon): support db_compaction

### DIFF
--- a/.github/workflows/ci.action.yaml
+++ b/.github/workflows/ci.action.yaml
@@ -284,7 +284,7 @@ jobs:
   # code.
   pre-runs:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -316,6 +316,7 @@ jobs:
                 images:
                   besu: ghcr.io/ethereum/state-actor-besu:main
                   geth: ghcr.io/ethereum/state-actor:main
+                  erigon: ghcr.io/ethereum/state-actor-erigon:main
                 pull_policy: always
                 config:
                   seed: 1234
@@ -356,11 +357,14 @@ jobs:
                 targets:
                   - client: besu
                     output_dir: /tmp/benchmarkoor/state-actor/besu
-                  # Same seed + spec, so geth's snapshot carries the same state as
-                  # besu's. The db-compaction step below boots geth on it and
-                  # replays besu's pre-run bundle to reach the same setup head.
+                  # Same seed + spec, so geth's and erigon's snapshots carry the
+                  # same state as besu's. The db-compaction steps below boot each
+                  # on its own snapshot and replay besu's pre-run bundle to reach
+                  # the same setup head.
                   - client: geth
                     output_dir: /tmp/benchmarkoor/state-actor/geth
+                  - client: erigon
+                    output_dir: /tmp/benchmarkoor/state-actor/erigon
               # Advance the snapshot: boot besu, run a tiny setup fill (with
               # fill-stateful --no-reset-between-tests, so the deployed contracts
               # persist), and record a replay bundle under the output_dir.
@@ -472,6 +476,85 @@ jobs:
                   # Same amsterdam schedule the fills used.
                   genesis_fork_override: { amsterdam: 1 }
                   extra_args: [--p2p-enabled=true]
+
+      # Same fixtures and the same pre-run bundle as the besu step above, on
+      # ERIGON with runner.client.config.db_compaction enabled. Erigon cannot
+      # boot besu's datadir, so it boots its OWN raw snapshot and replays besu's
+      # recorded bundle to reach the setup head.
+      #
+      # before_benchmarks is the phase worth testing: it lands after the
+      # pre-run bundle, which writes blocks that undo most of what an earlier
+      # compaction achieved, so it is the compacted database that the tests
+      # actually measure. On this datadir the compaction takes chaindata from
+      # 2.0GB to 32MB.
+      #
+      # It needs --exec.no-prune on the client (below). Erigon refuses to reopen
+      # a datadir whose receipt domain it pruned past the snapshot files, and a
+      # synthetic snapshot has no such files, so the client's own pruning during
+      # the replay is enough to leave a datadir that cannot be restarted:
+      #
+      #   [snapshots] gap between snapshot files and DB for domain receipt:
+      #   files end at txNum 0 but the DB was pruned up to 390625
+      #
+      - name: Run benchmarks with db compaction (erigon)
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          git-ref: ${{ github.event.pull_request.head.sha }}
+          git-repo: ${{ github.event.pull_request.head.repo.clone_url }}
+          mode: run
+          run-config-urls: >-
+            https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-cleanup.yaml,
+            https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.sha }}/.github/workflows/config/benchmarkoor-global-clientstdout.yaml
+          run-config: |
+            runner:
+              benchmark:
+                tests:
+                  source:
+                    eest_fixtures:
+                      local_fixtures_dir: /tmp/benchmarkoor/eest-fixtures/besu
+                      fixtures_subdir: blockchain_tests_stateful_engine
+                      # Replay besu's recorded pre-run bundle on erigon's raw
+                      # snapshot; fixtures_subdir defaults to "pre_run_bundle".
+                      pre_runs:
+                        local_fixtures_dir: /tmp/benchmarkoor/pre-runs/besu
+              client:
+                config:
+                  bootstrap_fcu:
+                    enabled: true
+                    max_retries: 10
+                    backoff: 1s
+                  # `erigon db compact`, with `erigon seg du` either side of
+                  # it. No persist: datadir_method is copy, so the compaction is
+                  # run-local, which is what CI wants.
+                  db_compaction:
+                    enabled: true
+                    when: [before_benchmarks]
+                    inspect: true
+                    timeout: 20m
+                # No genesis entry for erigon: state-actor bakes the genesis into
+                # the snapshot datadir it builds.
+                datadirs:
+                  erigon:
+                    source_dir: /tmp/benchmarkoor/state-actor/erigon
+                    method: copy
+              instances:
+                - id: erigon
+                  client: erigon
+                  image: ethpandaops/erigon:main
+                  extra_args:
+                    # Erigon reads the chain config from the datadir, so the
+                    # fork schedule comes from the flag rather than a genesis
+                    # override.
+                    - --override.amsterdam=1
+                    # Keep the datadir reopenable across the compaction's stop
+                    # and restart, by disabling the state-aggregator
+                    # (Domain/InvertedIndex) pruning that otherwise advances the
+                    # DB's prune marker past the snapshot files. Erigon documents
+                    # it for exactly this kind of use ("Diagnostic /
+                    # perf-comparison use only"), and a benchmark wants the
+                    # housekeeping off anyway.
+                    - --exec.no-prune
 
       # Same fixtures and the same pre-run bundle as the besu step above, on
       # geth with runner.client.config.db_compaction enabled. geth cannot boot

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -592,16 +592,24 @@ runner:
       #   timeout: 2m   # per-block trace timeout; default 2m
       # Optional: Compact the client database before the run measures anything.
       # The client is stopped for it (compaction needs the database lock), so the
-      # runner runs the client's own offline command in a one-shot container.
-      # Only geth ships one today (`geth db compact`). Per-instance override allowed.
+      # runner runs the client's own offline commands in one-shot containers.
+      # Supported on geth (`geth db compact`) and erigon (`erigon db compact`,
+      # which needs erigon >= 3.7.0-dev). On erigon, before_benchmarks also
+      # needs --exec.no-prune on the instance, so the client leaves a datadir it
+      # can reopen after the restart. Per-instance override allowed.
       # db_compaction:
       #   enabled: true
       #   # Both phases may be listed; they always run in lifecycle order.
       #   #   before_pre_runs   - before the client boots (needs a datadir)
       #   #   before_benchmarks - after the pre-run steps, before the first test
       #   when: [before_benchmarks]
-      #   inspect: true        # `geth db inspect` before and after; default true
-      #   timeout: 3h          # per phase; default 3h
+      #   inspect: true        # client inspection before and after; default true
+      #   timeout: 3h          # per phase, covers every step; default 3h
+      #   # Optional client steps run before the compaction, so it reclaims more.
+      #   # None run unless named here. erigon offers "seg-retire"
+      #   # (`erigon seg retire`), which needs a datadir whose history spans
+      #   # whole steps (390625 blocks) — it RUINS a synthetic snapshot.
+      #   # prepare: [seg-retire]
       #   # extra_args: ["--cache=16384"]
       #   # Keep the compacted database for later runs. Only datadir methods
       #   # "schelk" and "zfs" support it, and both overwrite the baseline

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1244,9 +1244,10 @@ A finished compaction writes `.benchmarkoor-db-compaction.json` at the root of t
   "version": 1,
   "phases": {
     "before_pre_runs": {
-      "client": "geth",
-      "image": "ethereum/client-go:stable",
+      "client": "erigon",
+      "image": "ethpandaops/erigon:main",
       "run_id": "20260827-101203-abcd",
+      "prepare": ["seg-retire"],
       "completed_at": "2026-08-27T10:12:03Z",
       "duration_ms": 812345,
       "datadir_bytes": { "before": 812000000000, "after": 640000000000 }
@@ -1255,9 +1256,30 @@ A finished compaction writes `.benchmarkoor-db-compaction.json` at the root of t
 }
 ```
 
+`prepare` names the steps that ran. Absent means none did — a marker written before `prepare` existed cannot have had one either, so the two cases coincide.
+
 It holds only what is known the moment the compaction finishes, so it is written once and never patched. With `persist` enabled, `skip_if_marked` defaults to true and a later run skips a phase the marker already names — which is what stops every run paying the compaction cost again.
 
-The marker cannot tell that a datadir advanced after it was written. If you point a longer pre-run bundle at a baseline persisted at `before_benchmarks`, set `skip_if_marked: false` to force the compaction.
+A skipped phase logs how the datadir was compacted, so a run that compacts nothing itself can still say how its baseline got that way:
+
+```
+Datadir already carries a compaction marker for this phase; skipping
+  compacted_at=2026-08-27T10:12:03Z run_id=20260827-101203-abcd
+  image=ethpandaops/erigon:main prepare=seg-retire
+```
+
+**Changing `prepare` on a persisted datadir does not recompact it.** The marker skips the whole phase, so new steps never run. That case logs a WARNING naming both lists, rather than passing silently:
+
+```
+Datadir already carries a compaction marker for this phase, so it is skipped and the
+configured db_compaction.prepare steps do NOT run; the datadir keeps the preparation
+the marker names (set db_compaction.skip_if_marked: false to recompact)
+  prepare=none configured_prepare=seg-retire
+```
+
+The same is true of any other change to the compaction config, `extra_args` included: the marker records that a phase ran, and `skip_if_marked` takes it at its word.
+
+The marker also cannot tell that a datadir advanced after it was written. If you point a longer pre-run bundle at a baseline persisted at `before_benchmarks`, set `skip_if_marked: false` to force the compaction.
 
 ###### Rollback strategy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1123,7 +1123,34 @@ runner:
 
 The `db_compaction` option compacts the client database before the run measures anything. Compaction needs exclusive access to the database, so the client is never running while it happens: the runner runs the client's own offline command in a one-shot container against the datadir.
 
-Only clients that ship an offline compaction command support this. Today that is **geth** alone (`geth db compact`); every other client fails validation with a clear message.
+Only clients that ship an offline compaction command support this. Today that is **geth** and **erigon**; every other client fails validation with a clear message.
+
+| Client | Compaction | Inspection |
+|--------|------------|------------|
+| geth | `geth db compact` | `geth db inspect` |
+| erigon | `erigon db compact` | `erigon seg du --verbose` |
+
+`erigon db compact` rewrites every mdbx database of the datadir without its free pages. It needs **Erigon 3.7.0-dev or newer** (September 2026); an older binary, including every pinned glamsterdam-devnet image, fails the step with `command db not found`.
+
+> **On erigon, `before_benchmarks` needs `--exec.no-prune` on the instance.** That phase stops and restarts the client, and erigon refuses to reopen a datadir whose receipt domain it pruned past the snapshot files: `[snapshots] gap between snapshot files and DB for domain receipt: files end at txNum 0 but the DB was pruned up to 390625`. A synthetic snapshot has no snapshot files, so the client's own pruning is enough to create the gap. `--exec.no-prune` disables the state-aggregator pruning that advances the marker. Erigon documents the flag for diagnostic and perf-comparison use, which is what a benchmark is, and it removes housekeeping the benchmark does not want anyway. `before_pre_runs` needs no flag: it compacts before the client ever boots, so nothing restarts.
+
+###### Preparation steps (`prepare`)
+
+A client can offer steps that run before the compaction to make it reclaim more. None run unless `prepare` names them, because a step that helps one datadir can ruin another.
+
+| Client | Step | What it does | Needs |
+|--------|------|--------------|-------|
+| erigon | `seg-retire` | `erigon seg retire` — freezes block and history ranges into segment files under `<datadir>/snapshots` and prunes what it froze, which is what leaves free pages for the compaction | A datadir whose history spans whole steps (390,625 blocks) |
+
+```yaml
+db_compaction:
+  enabled: true
+  prepare: [seg-retire]   # erigon, real synced datadir only
+```
+
+On a **real synced erigon datadir** this is the pairing erigon documents, and it is where the compaction reclaims most of its space. A step you name is one you asked for, so its failure fails the phase unless `continue_on_error` is set. Naming a step the client does not offer fails validation, which lists the alternatives and what each one needs.
+
+> **Do not enable `seg-retire` for a state-actor or otherwise synthetic snapshot.** Its history is far shorter than one step, so the retire finds nothing to freeze but prunes anyway, and erigon then refuses to reopen its own datadir with the gap error above. Verified in CI on a snapshot advanced to block 39: `retiring blocks from=0 to=39`, `Build state history snapshots` (nothing to build), `Prune state history` (marker advances regardless). The compaction alone is worth running there — it took that datadir's `chaindata` from 2.0GB to 32MB.
 
 Besu was checked and cannot be supported yet: as of Besu 26.6.1, `besu storage` has no compaction subcommand. `trie-log prune` deletes trie logs below the retention limit instead of rewriting the database, which is a different operation and removes history the Bonsai rollback needs.
 
@@ -1134,7 +1161,7 @@ runner:
       db_compaction:
         enabled: true
         when: [before_benchmarks]   # or [before_pre_runs], or both
-        inspect: true               # `geth db inspect` before and after
+        inspect: true               # the client inspection before and after
         timeout: 3h
         extra_args: ["--cache=16384"]
 ```
@@ -1144,7 +1171,8 @@ runner:
 | `enabled` | bool | Yes | `false` | Enable the compaction |
 | `when` | []string | No | `[before_benchmarks]` | The lifecycle points at which to compact (see below). A plain string also works |
 | `inspect` | bool | No | `true` | Run the client database inspection before and after each compaction. A failed inspection is logged and never fails the run |
-| `timeout` | string | No | `3h` | Cap for one phase's work — the compaction and both inspections (Go duration). Applies per phase |
+| `prepare` | []string | No | - | Client preparation steps to run before each compaction, in order (see [Preparation steps](#preparation-steps-prepare)) |
+| `timeout` | string | No | `3h` | Cap for one phase's work — every preparation step, the compaction, and both inspections (Go duration). Applies per phase |
 | `image` | string | No | the instance image | Image of the compaction container. The default keeps the tool version and the client version identical |
 | `extra_args` | []string | No | - | Extra arguments for the compaction command, e.g. `--cache=16384` |
 | `continue_on_error` | bool | No | `false` | Downgrade a compaction failure to a warning. A failed compaction makes the results incomparable, so the run fails by default |
@@ -1249,13 +1277,14 @@ Each phase writes its reports to the run results directory:
 ```
 <run-results>/db-compaction/
   before_pre_runs/inspect-before.txt
+  before_pre_runs/seg-retire.log        # one per selected preparation step
   before_pre_runs/compact.log
   before_pre_runs/inspect-after.txt
   before_pre_runs/compaction.json
   before_benchmarks/...
 ```
 
-`compaction.json` records the command, the duration, the datadir size either side, and — at `before_benchmarks` only, where the runner reads it from the client it is about to stop — the datadir head.
+`compaction.json` records the command, the duration, the datadir size either side, and — at `before_benchmarks` only, where the runner reads it from the client it is about to stop — the datadir head. Each selected preparation step gets its own log, named after the step, and a `prepare[]` entry.
 
 The inspection is a report, so a failure is logged and the compaction still runs. geth 1.17.5 exits 1 on `db inspect` against a datadir whose freezer is empty, which a freshly-initialised datadir has.
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -38,17 +38,43 @@ type RPCRollbackSpec struct {
 	RPCMethod string // e.g. "debug_setHead", "debug_resetHead"
 }
 
-// DBMaintenanceCommands holds the client argv for offline database
-// maintenance, run in a one-shot container against the datadir.
+// DBMaintenanceStep is one named command a client can run before the
+// compaction, to make it reclaim more.
 //
-// The client must NOT be running: both commands need exclusive access to the
+// A step is never run unless db_compaction.prepare names it: a step that helps
+// one datadir can ruin another, so the choice belongs to whoever knows what the
+// datadir holds. See the erigon spec for the case that made this opt-in.
+type DBMaintenanceStep struct {
+	// Name is how db_compaction.prepare selects the step, and how the runner
+	// names its log file. Keep it lower-case with hyphens.
+	Name string
+
+	// Args is the client argv for the step.
+	Args []string
+
+	// Why explains, in one line, what the step buys and what it needs from the
+	// datadir. Validation prints it when it lists the available steps, so the
+	// user sees the trade-off at the point of choosing.
+	Why string
+}
+
+// DBMaintenanceCommands holds the client argv for offline database
+// maintenance, run in one-shot containers against the datadir.
+//
+// The client must NOT be running: every command needs exclusive access to the
 // database, and a second process holding the lock makes them fail.
 type DBMaintenanceCommands struct {
+	// Prepare holds the optional steps that can run before the compaction, in
+	// the order given. Each is opt-in through db_compaction.prepare.
+	Prepare []DBMaintenanceStep
+
 	// Compact rewrites the database to reclaim space and restore key locality.
+	// It is the command db_compaction.extra_args are appended to.
 	Compact []string
 
-	// Inspect prints a report of the database contents. Optional: a client
-	// that can compact but not inspect leaves it nil.
+	// Inspect prints a report of the database contents, before and after the
+	// compaction. Optional: a client that can compact but not inspect leaves
+	// it nil.
 	Inspect []string
 }
 
@@ -155,6 +181,22 @@ func SupportsDBCompaction(clientType ClientType) bool {
 	cmds := spec.DBMaintenanceCommands("/data")
 
 	return cmds != nil && len(cmds.Compact) > 0
+}
+
+// DBMaintenancePrepareSteps returns the optional preparation steps the client
+// offers for db_compaction.prepare, or nil when it offers none.
+func DBMaintenancePrepareSteps(clientType ClientType) []DBMaintenanceStep {
+	spec, err := NewRegistry().Get(clientType)
+	if err != nil {
+		return nil
+	}
+
+	cmds := spec.DBMaintenanceCommands("/data")
+	if cmds == nil {
+		return nil
+	}
+
+	return cmds.Prepare
 }
 
 // Ensure interface compliance.

--- a/pkg/client/erigon.go
+++ b/pkg/client/erigon.go
@@ -115,8 +115,58 @@ func (s *erigonSpec) SnapshotPrepareArgs() []string {
 	return nil
 }
 
-// DBMaintenanceCommands returns nil; benchmarkoor has no offline
-// compaction command for Erigon yet.
-func (s *erigonSpec) DBMaintenanceCommands(_ string) *DBMaintenanceCommands {
-	return nil
+// DBMaintenanceCommands returns Erigon's offline database commands.
+//
+// `erigon db compact` rewrites every mdbx database of the datadir without its
+// free pages. On a state-actor snapshot it takes chaindata from 2.0GB to 32MB.
+//
+// `erigon seg du` is the inspection: it reports the datadir disk usage by
+// category.
+//
+// `erigon seg retire` is offered as an OPT-IN preparation step, named
+// "seg-retire". It freezes the block and history ranges out of the mdbx
+// databases into segment files under <datadir>/snapshots and prunes what it
+// froze, which is what leaves free pages for the compaction to reclaim. On a
+// real synced datadir that is the pairing erigon documents, and it is where the
+// compaction earns most of its space.
+//
+// It is opt-in because it needs a datadir whose history spans whole steps. On a
+// short synthetic chain it finds nothing to freeze but prunes anyway, and erigon
+// then refuses to reopen its own datadir. Verified in CI on a state-actor
+// snapshot advanced to block 39:
+//
+//	retiring blocks from=0 to=39
+//	Build state history snapshots      <- nothing to build, a step is 390625
+//	Prune state history                <- advances the DB prune marker anyway
+//
+// and the next boot fails with
+//
+//	[snapshots] gap between snapshot files and DB for domain receipt:
+//	files end at txNum 0 but the DB was pruned up to 390625
+//
+// So do not enable it for a state-actor or otherwise synthetic snapshot. The
+// compaction alone is worth running there.
+//
+// Every command runs against a STOPPED client: `db compact` takes the datadir
+// lock and opens each database exclusively, so a running node makes it fail.
+// They take --datadir rather than inheriting the one in DefaultCommand, since a
+// datadir config may mount the data somewhere other than /data.
+//
+// `erigon db compact` landed in Erigon 3.7.0-dev (erigon PR #23677, September
+// 2026). An older binary fails the step with "command db not found".
+func (s *erigonSpec) DBMaintenanceCommands(dataDir string) *DBMaintenanceCommands {
+	return &DBMaintenanceCommands{
+		Prepare: []DBMaintenanceStep{
+			{
+				Name: "seg-retire",
+				Args: []string{"seg", "retire", "--datadir=" + dataDir},
+				Why: "freezes block and history ranges into segment files so the" +
+					" compaction can reclaim the pages they used; needs a datadir" +
+					" whose history spans whole steps (390625 blocks), and RUINS a" +
+					" synthetic snapshot that has less",
+			},
+		},
+		Compact: []string{"db", "compact", "--datadir=" + dataDir},
+		Inspect: []string{"seg", "du", "--datadir=" + dataDir, "--verbose"},
+	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1393,7 +1393,7 @@ const (
 // the global one; it does not merge field by field.
 //
 // Only clients whose spec returns compaction commands support this. Today
-// that is geth alone.
+// that is geth and erigon.
 type DBCompactionConfig struct {
 	Enabled bool `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
 
@@ -1411,6 +1411,19 @@ type DBCompactionConfig struct {
 	// Inspect runs the client database inspection before and after each
 	// compaction and writes both reports to the run results. Default: true.
 	Inspect *bool `yaml:"inspect,omitempty" mapstructure:"inspect" json:"inspect,omitempty"`
+
+	// Prepare names the client's optional preparation steps to run, in the
+	// order given, before each compaction. Empty runs none, which is the safe
+	// default: a step that reclaims more on one datadir can ruin another.
+	//
+	// Erigon offers "seg-retire" (`erigon seg retire`). Enable it for a datadir
+	// whose history spans whole steps, where it is what leaves free pages for
+	// the compaction. Do NOT enable it for a state-actor or otherwise synthetic
+	// snapshot: it prunes without freezing there and leaves a datadir erigon
+	// refuses to reopen.
+	//
+	// Validation lists the steps a client offers, with what each one needs.
+	Prepare []string `yaml:"prepare,omitempty" mapstructure:"prepare" json:"prepare,omitempty"`
 
 	// Timeout caps one phase's compaction work as a Go duration string: the
 	// compaction and both inspections around it. It applies per phase, not to
@@ -4197,6 +4210,10 @@ func (c *Config) validateDBCompaction(opt ValidateOpts) error {
 			return err
 		}
 
+		if err := validateDBCompactionPrepare(instance.ID, instance.Client, cfg); err != nil {
+			return err
+		}
+
 		if cfg.Timeout != "" {
 			d, err := time.ParseDuration(cfg.Timeout)
 			if err != nil {
@@ -4286,6 +4303,60 @@ func validateDBCompactionPhases(id string, cfg *DBCompactionConfig) error {
 				id, phase,
 			)
 		}
+	}
+
+	return nil
+}
+
+// validateDBCompactionPrepare checks that every name in db_compaction.prepare
+// is a step the client actually offers, and reports the alternatives when it is
+// not. The message carries each step's trade-off, since choosing one wrongly can
+// leave a datadir the client cannot reopen.
+func validateDBCompactionPrepare(id, clientName string, cfg *DBCompactionConfig) error {
+	if len(cfg.Prepare) == 0 {
+		return nil
+	}
+
+	steps := client.DBMaintenancePrepareSteps(client.ClientType(clientName))
+
+	available := make(map[string]string, len(steps))
+	for _, step := range steps {
+		available[step.Name] = step.Why
+	}
+
+	seen := make(map[string]struct{}, len(cfg.Prepare))
+
+	for _, name := range cfg.Prepare {
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf(
+				"instance %q: duplicate db_compaction.prepare step %q", id, name,
+			)
+		}
+
+		seen[name] = struct{}{}
+
+		if _, ok := available[name]; ok {
+			continue
+		}
+
+		if len(steps) == 0 {
+			return fmt.Errorf(
+				"instance %q: db_compaction.prepare names %q, but client %q offers"+
+					" no preparation steps",
+				id, name, clientName,
+			)
+		}
+
+		offered := make([]string, 0, len(steps))
+		for _, step := range steps {
+			offered = append(offered, fmt.Sprintf("%q (%s)", step.Name, step.Why))
+		}
+
+		return fmt.Errorf(
+			"instance %q: unknown db_compaction.prepare step %q for client %q;"+
+				" available: %s",
+			id, name, clientName, strings.Join(offered, ", "),
+		)
 	}
 
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1587,6 +1587,16 @@ func (c *DBCompactionConfig) InspectEnabled() bool {
 	return *c.Inspect
 }
 
+// PrepareSteps returns the preparation steps to run before each compaction, in
+// the configured order. Nil means none, which is the default.
+func (c *DBCompactionConfig) PrepareSteps() []string {
+	if c == nil || len(c.Prepare) == 0 {
+		return nil
+	}
+
+	return c.Prepare
+}
+
 // SkipIfMarkedEnabled reports whether a phase the datadir marker already names
 // is skipped. Defaults to true when the compaction persists, since only a
 // persisted marker can describe the datadir in front of us.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3728,6 +3728,39 @@ func TestValidateDBCompaction(t *testing.T) {
 			cfg:    &DBCompactionConfig{Enabled: true},
 		},
 		{
+			name:   "enabled on erigon with defaults",
+			client: "erigon",
+			cfg:    &DBCompactionConfig{Enabled: true},
+		},
+		{
+			name:   "erigon with the opt-in seg-retire step",
+			client: "erigon",
+			cfg:    &DBCompactionConfig{Enabled: true, Prepare: []string{"seg-retire"}},
+		},
+		{
+			name:      "unknown prepare step names the alternatives",
+			client:    "erigon",
+			cfg:       &DBCompactionConfig{Enabled: true, Prepare: []string{"retire"}},
+			wantErr:   true,
+			errSubstr: "unknown db_compaction.prepare step",
+		},
+		{
+			name:   "duplicate prepare step",
+			client: "erigon",
+			cfg: &DBCompactionConfig{
+				Enabled: true, Prepare: []string{"seg-retire", "seg-retire"},
+			},
+			wantErr:   true,
+			errSubstr: "duplicate db_compaction.prepare step",
+		},
+		{
+			name:      "prepare step on a client that offers none",
+			client:    "geth",
+			cfg:       &DBCompactionConfig{Enabled: true, Prepare: []string{"seg-retire"}},
+			wantErr:   true,
+			errSubstr: "offers no preparation steps",
+		},
+		{
 			name:      "unsupported client",
 			client:    "besu",
 			cfg:       &DBCompactionConfig{Enabled: true},

--- a/pkg/runner/db_compaction.go
+++ b/pkg/runner/db_compaction.go
@@ -24,8 +24,8 @@ import (
 const dbCompactionMarkerVersion = 1
 
 // dbCompactionRequest describes one compaction phase against a datadir whose
-// client is NOT running. The caller owns the client lifecycle: `geth db
-// compact` takes the database lock, so a live node makes it fail.
+// client is NOT running. The caller owns the client lifecycle: the client's
+// compaction command takes the database lock, so a live node makes it fail.
 type dbCompactionRequest struct {
 	Instance  *config.ClientInstance
 	Spec      client.Spec
@@ -74,6 +74,13 @@ type dbCompactionSizes struct {
 	After  int64 `json:"after"`
 }
 
+// dbCompactionStep is one preparation command of a compaction phase, as the run
+// report records it.
+type dbCompactionStep struct {
+	Name    string   `json:"name"`
+	Command []string `json:"command"`
+}
+
 // dbCompactionReport is the per-run record of one compaction phase, written to
 // <results>/db-compaction/<phase>/compaction.json.
 type dbCompactionReport struct {
@@ -85,6 +92,7 @@ type dbCompactionReport struct {
 	CompletedAt  string             `json:"completed_at,omitempty"`
 	DurationMS   int64              `json:"duration_ms"`
 	Persisted    bool               `json:"persisted"`
+	Prepare      []dbCompactionStep `json:"prepare,omitempty"`
 	Command      []string           `json:"command"`
 	DatadirBytes *dbCompactionSizes `json:"datadir_bytes,omitempty"`
 	Head         *dbCompactionHead  `json:"head,omitempty"`
@@ -150,6 +158,11 @@ func (r *runner) runDBCompaction(
 		)
 	}
 
+	steps, err := dbCompactionSelectedSteps(cmds, req.Cfg)
+	if err != nil {
+		return false, err
+	}
+
 	hostPath := req.hostPath()
 
 	if entry := r.dbCompactionSkipEntry(req.Instance, req.Phase, req.Mount); entry != nil {
@@ -172,7 +185,8 @@ func (r *runner) runDBCompaction(
 		RunID:     req.RunID,
 		StartedAt: started.UTC().Format(time.RFC3339),
 		Persisted: req.Persisting,
-		Command:   append(append([]string{}, cmds.Compact...), req.Cfg.ExtraArgs...),
+		Prepare:   dbCompactionPrepareReport(steps),
+		Command:   dbCompactionCommand(cmds, req.Cfg),
 		Head:      req.Head,
 	}
 
@@ -180,7 +194,7 @@ func (r *runner) runDBCompaction(
 		report.DatadirBytes = &dbCompactionSizes{Before: dirSize(hostPath)}
 	}
 
-	runErr := r.runDBCompactionContainers(ctx, req, cmds, phaseDir, log)
+	runErr := r.runDBCompactionContainers(ctx, req, cmds, steps, phaseDir, log)
 
 	if hostPath != "" {
 		report.DatadirBytes.After = dirSize(hostPath)
@@ -225,8 +239,70 @@ func (r *runner) runDBCompaction(
 	return true, nil
 }
 
-// runDBCompactionContainers runs the inspection either side of the compaction
-// and the compaction itself, each in its own one-shot container.
+// dbCompactionSelectedSteps resolves db_compaction.prepare against the steps
+// the client offers, in the order the config names them.
+//
+// Validation already rejects an unknown name, so reaching one here means the
+// config was never validated. Refusing beats silently skipping the step the
+// user asked for.
+func dbCompactionSelectedSteps(
+	cmds *client.DBMaintenanceCommands, cfg *config.DBCompactionConfig,
+) ([]client.DBMaintenanceStep, error) {
+	if len(cfg.Prepare) == 0 {
+		return nil, nil
+	}
+
+	byName := make(map[string]client.DBMaintenanceStep, len(cmds.Prepare))
+	for _, step := range cmds.Prepare {
+		byName[step.Name] = step
+	}
+
+	steps := make([]client.DBMaintenanceStep, 0, len(cfg.Prepare))
+
+	for _, name := range cfg.Prepare {
+		step, ok := byName[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown db_compaction.prepare step %q", name)
+		}
+
+		steps = append(steps, step)
+	}
+
+	return steps, nil
+}
+
+// dbCompactionPrepareReport records the steps that run, for the run report.
+func dbCompactionPrepareReport(steps []client.DBMaintenanceStep) []dbCompactionStep {
+	if len(steps) == 0 {
+		return nil
+	}
+
+	out := make([]dbCompactionStep, 0, len(steps))
+	for _, step := range steps {
+		out = append(out, dbCompactionStep{
+			Name:    step.Name,
+			Command: append([]string{}, step.Args...),
+		})
+	}
+
+	return out
+}
+
+// dbCompactionCommand returns the compaction argv with the configured extra
+// arguments appended, without mutating the client's own slice.
+func dbCompactionCommand(
+	cmds *client.DBMaintenanceCommands, cfg *config.DBCompactionConfig,
+) []string {
+	return append(append([]string{}, cmds.Compact...), cfg.ExtraArgs...)
+}
+
+// runDBCompactionContainers runs the inspection either side of the compaction,
+// the selected preparation steps, and the compaction itself, each in its own
+// one-shot container.
+//
+// A preparation step is one the user asked for by name, so its failure fails the
+// phase: the compaction that follows would not be the operation they configured.
+// continue_on_error still downgrades it.
 //
 // An inspection failure is never fatal: it is a report, and losing it must not
 // cost the run its compaction. geth 1.17.5 exits 1 on `db inspect` against a
@@ -236,6 +312,7 @@ func (r *runner) runDBCompactionContainers(
 	ctx context.Context,
 	req *dbCompactionRequest,
 	cmds *client.DBMaintenanceCommands,
+	steps []client.DBMaintenanceStep,
 	phaseDir string,
 	log logrus.FieldLogger,
 ) error {
@@ -253,12 +330,30 @@ func (r *runner) runDBCompactionContainers(
 		}
 	}
 
-	log.WithField("timeout", req.Cfg.EffectiveTimeout()).Info("Compacting the database")
+	// The timeout covers the whole sequence, so every step logs it: a step the
+	// timeout kills names the budget it ran out of.
+	timeout := req.Cfg.EffectiveTimeout()
 
-	compactCmd := append(append([]string{}, cmds.Compact...), req.Cfg.ExtraArgs...)
+	for i, step := range steps {
+		log.WithFields(logrus.Fields{
+			"step":    step.Name,
+			"index":   fmt.Sprintf("%d/%d", i+1, len(steps)),
+			"timeout": timeout,
+		}).Info("Preparing the database for compaction")
+
+		if err := r.runDBMaintenanceContainer(
+			ctx, req, step.Name, step.Args,
+			filepath.Join(phaseDir, step.Name+".log"),
+		); err != nil {
+			return fmt.Errorf("preparation step %q: %w", step.Name, err)
+		}
+	}
+
+	log.WithField("timeout", timeout).Info("Compacting the database")
 
 	if err := r.runDBMaintenanceContainer(
-		ctx, req, "compact", compactCmd, filepath.Join(phaseDir, "compact.log"),
+		ctx, req, "compact", dbCompactionCommand(cmds, req.Cfg),
+		filepath.Join(phaseDir, "compact.log"),
 	); err != nil {
 		return err
 	}

--- a/pkg/runner/db_compaction.go
+++ b/pkg/runner/db_compaction.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/client"
@@ -114,12 +116,30 @@ type dbCompactionMarker struct {
 
 // dbCompactionMarkerEntry is one phase's entry in the marker file.
 type dbCompactionMarkerEntry struct {
-	Client       string             `json:"client"`
-	Image        string             `json:"image"`
-	RunID        string             `json:"run_id"`
+	Client string `json:"client"`
+	Image  string `json:"image"`
+	RunID  string `json:"run_id"`
+
+	// Prepare names the db_compaction.prepare steps that ran, so a later run
+	// that skips this phase can say HOW it was compacted, and notice that its
+	// own prepare config would have done something else.
+	//
+	// Absent means no step ran: a marker written before prepare existed cannot
+	// have had one either, so the two cases coincide.
+	Prepare []string `json:"prepare,omitempty"`
+
 	CompletedAt  string             `json:"completed_at"`
 	DurationMS   int64              `json:"duration_ms"`
 	DatadirBytes *dbCompactionSizes `json:"datadir_bytes,omitempty"`
+}
+
+// prepareSummary renders the entry's steps for a log line.
+func (e *dbCompactionMarkerEntry) prepareSummary() string {
+	if len(e.Prepare) == 0 {
+		return "none"
+	}
+
+	return strings.Join(e.Prepare, ",")
 }
 
 // hostPath returns the host path of the datadir mount, or "" when
@@ -166,7 +186,7 @@ func (r *runner) runDBCompaction(
 	hostPath := req.hostPath()
 
 	if entry := r.dbCompactionSkipEntry(req.Instance, req.Phase, req.Mount); entry != nil {
-		logDBCompactionSkip(log, entry)
+		logDBCompactionSkip(log, entry, req.Cfg)
 
 		return false, nil
 	}
@@ -269,6 +289,21 @@ func dbCompactionSelectedSteps(
 	}
 
 	return steps, nil
+}
+
+// dbCompactionStepNames returns the step names of a report's prepare list, in
+// order, for the datadir marker.
+func dbCompactionStepNames(steps []dbCompactionStep) []string {
+	if len(steps) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(steps))
+	for _, step := range steps {
+		names = append(names, step.Name)
+	}
+
+	return names
 }
 
 // dbCompactionPrepareReport records the steps that run, for the run report.
@@ -489,6 +524,7 @@ func (r *runner) writeDBCompactionMarker(
 		Client:       req.Instance.Client,
 		Image:        report.Image,
 		RunID:        req.RunID,
+		Prepare:      dbCompactionStepNames(report.Prepare),
 		CompletedAt:  report.CompletedAt,
 		DurationMS:   report.DurationMS,
 		DatadirBytes: report.DatadirBytes,
@@ -600,15 +636,55 @@ func (r *runner) dbCompactionSkipEntry(
 	return &entry
 }
 
-// logDBCompactionSkip reports a phase the datadir marker already covers.
-func logDBCompactionSkip(log logrus.FieldLogger, entry *dbCompactionMarkerEntry) {
-	log.WithFields(logrus.Fields{
+// logDBCompactionSkip reports a phase the datadir marker already covers, and
+// says how that earlier compaction ran.
+//
+// The marker is the only record of what the persisted baseline had done to it,
+// so the skip line carries the earlier run's id, image and prepare steps: a run
+// that compacts nothing itself should still be able to say how its datadir got
+// that way.
+//
+// When the current prepare config would do something else, the line is a
+// WARNING instead. That is the case the marker used to hide: the whole point of
+// prepare is to change what the compaction does, so a changed setting that is
+// being ignored has to say so.
+func logDBCompactionSkip(
+	log logrus.FieldLogger, entry *dbCompactionMarkerEntry, cfg *config.DBCompactionConfig,
+) {
+	fields := logrus.Fields{
 		"compacted_at": entry.CompletedAt,
 		"run_id":       entry.RunID,
-	}).Info(
+		"image":        entry.Image,
+		"prepare":      entry.prepareSummary(),
+	}
+
+	wanted := cfg.PrepareSteps()
+	if !slices.Equal(wanted, entry.Prepare) {
+		fields["configured_prepare"] = dbCompactionPrepareSummary(wanted)
+
+		log.WithFields(fields).Warn(
+			"Datadir already carries a compaction marker for this phase, so it is" +
+				" skipped and the configured db_compaction.prepare steps do NOT" +
+				" run; the datadir keeps the preparation the marker names" +
+				" (set db_compaction.skip_if_marked: false to recompact)",
+		)
+
+		return
+	}
+
+	log.WithFields(fields).Info(
 		"Datadir already carries a compaction marker for this phase; skipping" +
 			" (set db_compaction.skip_if_marked: false to force)",
 	)
+}
+
+// dbCompactionPrepareSummary renders a configured step list for a log line.
+func dbCompactionPrepareSummary(steps []string) string {
+	if len(steps) == 0 {
+		return "none"
+	}
+
+	return strings.Join(steps, ",")
 }
 
 // dbCompactionPersistsAt reports whether the instance writes the result of the

--- a/pkg/runner/db_compaction_test.go
+++ b/pkg/runner/db_compaction_test.go
@@ -34,6 +34,7 @@ func TestDBCompactionMarker_RoundTrip(t *testing.T) {
 		CompletedAt:  "2026-08-27T10:12:03Z",
 		DurationMS:   4200,
 		DatadirBytes: &dbCompactionSizes{Before: 200, After: 100},
+		Prepare:      []dbCompactionStep{{Name: "seg-retire"}},
 	}
 
 	r.writeDBCompactionMarker(dir, req, report, log)
@@ -50,6 +51,10 @@ func TestDBCompactionMarker_RoundTrip(t *testing.T) {
 	assert.Equal(t, int64(4200), entry.DurationMS)
 	require.NotNil(t, entry.DatadirBytes)
 	assert.Equal(t, int64(100), entry.DatadirBytes.After)
+
+	// The steps that ran are recorded, so a later run that skips this phase can
+	// say how the datadir was compacted.
+	assert.Equal(t, []string{"seg-retire"}, entry.Prepare)
 
 	// A second phase is added, never replacing the first.
 	req.Phase = config.DBCompactionBeforeBenchmarks
@@ -542,4 +547,82 @@ func TestDBCompactionPrepareReport(t *testing.T) {
 	assert.Equal(t, []dbCompactionStep{
 		{Name: "seg-retire", Command: []string{"seg", "retire"}},
 	}, got)
+}
+
+// TestLogDBCompactionSkip covers the two shapes of the skip line: an INFO that
+// says how the datadir was compacted, and a WARNING when the configured prepare
+// steps differ from the ones the marker names and are therefore not going to run.
+func TestLogDBCompactionSkip(t *testing.T) {
+	entry := &dbCompactionMarkerEntry{
+		Client:      "erigon",
+		Image:       "ethpandaops/erigon:main",
+		RunID:       "run-1",
+		CompletedAt: "2026-09-09T20:21:21Z",
+		Prepare:     []string{"seg-retire"},
+	}
+
+	capture := func(cfg *config.DBCompactionConfig) *logrus.Entry {
+		log := logrus.New()
+		log.SetOutput(io.Discard)
+
+		hook := &captureHook{}
+		log.AddHook(hook)
+
+		logDBCompactionSkip(logrus.NewEntry(log), entry, cfg)
+
+		require.Len(t, hook.entries, 1)
+
+		return hook.entries[0]
+	}
+
+	t.Run("same prepare config reports how it ran", func(t *testing.T) {
+		got := capture(&config.DBCompactionConfig{Prepare: []string{"seg-retire"}})
+
+		assert.Equal(t, logrus.InfoLevel, got.Level)
+		assert.Equal(t, "seg-retire", got.Data["prepare"])
+		assert.Equal(t, "run-1", got.Data["run_id"])
+		assert.Equal(t, "ethpandaops/erigon:main", got.Data["image"])
+		assert.NotContains(t, got.Data, "configured_prepare")
+	})
+
+	t.Run("a changed prepare config warns that it is ignored", func(t *testing.T) {
+		got := capture(&config.DBCompactionConfig{})
+
+		assert.Equal(t, logrus.WarnLevel, got.Level)
+		assert.Equal(t, "seg-retire", got.Data["prepare"], "what the datadir had")
+		assert.Equal(t, "none", got.Data["configured_prepare"], "what this run wanted")
+		assert.Contains(t, got.Message, "do NOT")
+	})
+
+	t.Run("a marker with no steps reads as none", func(t *testing.T) {
+		entry = &dbCompactionMarkerEntry{RunID: "run-0", CompletedAt: "2026-09-09T00:00:00Z"}
+
+		got := capture(&config.DBCompactionConfig{})
+
+		assert.Equal(t, logrus.InfoLevel, got.Level)
+		assert.Equal(t, "none", got.Data["prepare"])
+	})
+}
+
+// captureHook collects the entries a logrus logger emits, so a test can assert
+// on the level and fields of a single log line.
+type captureHook struct {
+	entries []*logrus.Entry
+}
+
+func (h *captureHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *captureHook) Fire(e *logrus.Entry) error {
+	h.entries = append(h.entries, e)
+
+	return nil
+}
+
+func TestDBCompactionStepNames(t *testing.T) {
+	assert.Nil(t, dbCompactionStepNames(nil))
+	assert.Equal(t, []string{"a", "b"}, dbCompactionStepNames([]dbCompactionStep{
+		{Name: "a"}, {Name: "b"},
+	}))
 }

--- a/pkg/runner/db_compaction_test.go
+++ b/pkg/runner/db_compaction_test.go
@@ -1,9 +1,13 @@
 package runner
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ethpandaops/benchmarkoor/pkg/client"
@@ -145,17 +149,63 @@ func TestGethDBMaintenanceCommands(t *testing.T) {
 
 	cmds := spec.DBMaintenanceCommands("/var/lib/geth")
 	require.NotNil(t, cmds)
+	assert.Empty(t, cmds.Prepare, "geth compacts in one command")
 	assert.Equal(t, []string{"db", "compact", "--datadir=/var/lib/geth"}, cmds.Compact)
 	assert.Equal(t, []string{"db", "inspect", "--datadir=/var/lib/geth"}, cmds.Inspect)
 
 	assert.True(t, client.SupportsDBCompaction(client.ClientGeth))
+}
 
+// TestErigonDBMaintenanceCommands pins the exact argv verified against
+// erigon 3.7.0-dev, and that the retire is offered but not part of the
+// compaction unless the config selects it.
+func TestErigonDBMaintenanceCommands(t *testing.T) {
+	spec, err := client.NewRegistry().Get(client.ClientErigon)
+	require.NoError(t, err)
+
+	cmds := spec.DBMaintenanceCommands("/var/lib/erigon")
+	require.NotNil(t, cmds)
+
+	assert.Equal(t, []string{"db", "compact", "--datadir=/var/lib/erigon"}, cmds.Compact)
+	assert.Equal(
+		t, []string{"seg", "du", "--datadir=/var/lib/erigon", "--verbose"}, cmds.Inspect,
+	)
+
+	// `seg retire` is offered, never run unless db_compaction.prepare says so.
+	require.Len(t, cmds.Prepare, 1)
+	assert.Equal(t, "seg-retire", cmds.Prepare[0].Name)
+	assert.Equal(
+		t, []string{"seg", "retire", "--datadir=/var/lib/erigon"}, cmds.Prepare[0].Args,
+	)
+	assert.NotEmpty(t, cmds.Prepare[0].Why, "validation prints this to the user")
+
+	assert.True(t, client.SupportsDBCompaction(client.ClientErigon))
+}
+
+func TestSupportsDBCompaction_UnsupportedClients(t *testing.T) {
 	for _, other := range []client.ClientType{
-		client.ClientBesu, client.ClientNethermind, client.ClientErigon,
+		client.ClientBesu, client.ClientNethermind,
 		client.ClientReth, client.ClientNimbus, client.ClientEthrex,
 	} {
 		assert.False(t, client.SupportsDBCompaction(other), string(other))
 	}
+}
+
+// TestDBCompactionCommand checks that extra_args land on the compaction and
+// that the client's own slice is not mutated.
+func TestDBCompactionCommand(t *testing.T) {
+	cmds := &client.DBMaintenanceCommands{
+		Compact: []string{"db", "compact", "--datadir=/data"},
+	}
+
+	got := dbCompactionCommand(cmds, &config.DBCompactionConfig{
+		ExtraArgs: []string{"--cache=16384"},
+	})
+
+	assert.Equal(
+		t, []string{"db", "compact", "--datadir=/data", "--cache=16384"}, got,
+	)
+	assert.Equal(t, []string{"db", "compact", "--datadir=/data"}, cmds.Compact)
 }
 
 func TestDirSize(t *testing.T) {
@@ -290,4 +340,206 @@ func TestDBCompactionSkipEntry(t *testing.T) {
 			t, r.dbCompactionSkipEntry(instance, config.DBCompactionBeforePreRuns, mount),
 		)
 	})
+}
+
+// fakeDBMaintenanceMgr is a docker.ContainerManager that only implements the
+// one call the compaction makes. The embedded interface is nil on purpose: a
+// call to anything else panics, which is what makes the test tell us if the
+// compaction path grows a dependency it should not have.
+type fakeDBMaintenanceMgr struct {
+	docker.ContainerManager
+
+	// failCommand fails any container whose command starts with this word.
+	failCommand string
+
+	ran []string
+}
+
+func (f *fakeDBMaintenanceMgr) RunInitContainer(
+	_ context.Context, spec *docker.ContainerSpec, stdout, _ io.Writer,
+) error {
+	f.ran = append(f.ran, strings.Join(spec.Command, " "))
+
+	_, _ = fmt.Fprintln(stdout, "fake container output")
+
+	if f.failCommand != "" && len(spec.Command) > 0 && spec.Command[0] == f.failCommand {
+		return fmt.Errorf("exit status 1")
+	}
+
+	return nil
+}
+
+// dbCompactionTestRunner wires a runner with a fake container manager and a
+// temporary results dir, for the phases that only need the command sequence.
+func dbCompactionTestRunner(
+	t *testing.T, mgr docker.ContainerManager,
+) (*runner, string) {
+	t.Helper()
+
+	resultsDir := t.TempDir()
+
+	return &runner{
+		log:          logrus.New(),
+		cfg:          &Config{ResultsDir: resultsDir},
+		containerMgr: mgr,
+	}, resultsDir
+}
+
+func dbCompactionTestRequest(resultsDir string) *dbCompactionRequest {
+	return &dbCompactionRequest{
+		Instance:   &config.ClientInstance{ID: "erigon", Client: "erigon"},
+		Cfg:        &config.DBCompactionConfig{Enabled: true, Timeout: "1m"},
+		Phase:      config.DBCompactionBeforeBenchmarks,
+		ImageName:  "erigontech/erigon:main-latest",
+		RunID:      "run-1",
+		Mount:      docker.Mount{Type: "bind", Source: resultsDir, Target: "/data"},
+		ResultsDir: resultsDir,
+	}
+}
+
+// TestRunDBCompactionContainers_Sequence pins the order of a whole phase, that
+// extra_args reach only the compaction, and that each step writes its own log.
+func TestRunDBCompactionContainers_Sequence(t *testing.T) {
+	mgr := &fakeDBMaintenanceMgr{}
+	r, resultsDir := dbCompactionTestRunner(t, mgr)
+
+	cmds := &client.DBMaintenanceCommands{
+		Compact: []string{"db", "compact"},
+		Inspect: []string{"seg", "du"},
+	}
+
+	req := dbCompactionTestRequest(resultsDir)
+	req.Cfg.ExtraArgs = []string{"--cache=16384"}
+
+	require.NoError(t, r.runDBCompactionContainers(
+		context.Background(), req, cmds, nil, resultsDir, r.log,
+	))
+
+	assert.Equal(t, []string{
+		"seg du", "db compact --cache=16384", "seg du",
+	}, mgr.ran)
+
+	for _, name := range []string{
+		"inspect-before.txt", "compact.log", "inspect-after.txt",
+	} {
+		assert.FileExists(t, filepath.Join(resultsDir, name))
+	}
+}
+
+// TestRunDBCompactionContainers_CompactionFails checks that a failed compaction
+// fails the phase, while a failed inspection does not.
+func TestRunDBCompactionContainers_CompactionFails(t *testing.T) {
+	t.Run("compaction failure fails the phase", func(t *testing.T) {
+		mgr := &fakeDBMaintenanceMgr{failCommand: "db"}
+		r, resultsDir := dbCompactionTestRunner(t, mgr)
+
+		err := r.runDBCompactionContainers(
+			context.Background(), dbCompactionTestRequest(resultsDir),
+			&client.DBMaintenanceCommands{Compact: []string{"db", "compact"}},
+			nil, resultsDir, r.log,
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("inspection failure does not", func(t *testing.T) {
+		mgr := &fakeDBMaintenanceMgr{failCommand: "seg"}
+		r, resultsDir := dbCompactionTestRunner(t, mgr)
+
+		err := r.runDBCompactionContainers(
+			context.Background(), dbCompactionTestRequest(resultsDir),
+			&client.DBMaintenanceCommands{
+				Compact: []string{"db", "compact"},
+				Inspect: []string{"seg", "du"},
+			},
+			nil, resultsDir, r.log,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"seg du", "db compact", "seg du"}, mgr.ran)
+	})
+}
+
+// TestDBCompactionSelectedSteps covers the opt-in: nothing runs unless
+// db_compaction.prepare names it, and the config's order wins.
+func TestDBCompactionSelectedSteps(t *testing.T) {
+	cmds := &client.DBMaintenanceCommands{
+		Prepare: []client.DBMaintenanceStep{
+			{Name: "seg-retire", Args: []string{"seg", "retire"}},
+			{Name: "other", Args: []string{"other"}},
+		},
+		Compact: []string{"db", "compact"},
+	}
+
+	t.Run("no prepare selects nothing", func(t *testing.T) {
+		steps, err := dbCompactionSelectedSteps(cmds, &config.DBCompactionConfig{})
+		require.NoError(t, err)
+		assert.Empty(t, steps)
+	})
+
+	t.Run("selects in the configured order", func(t *testing.T) {
+		steps, err := dbCompactionSelectedSteps(cmds, &config.DBCompactionConfig{
+			Prepare: []string{"other", "seg-retire"},
+		})
+		require.NoError(t, err)
+		require.Len(t, steps, 2)
+		assert.Equal(t, "other", steps[0].Name)
+		assert.Equal(t, "seg-retire", steps[1].Name)
+	})
+
+	t.Run("an unknown name is refused", func(t *testing.T) {
+		_, err := dbCompactionSelectedSteps(cmds, &config.DBCompactionConfig{
+			Prepare: []string{"nope"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nope")
+	})
+}
+
+// TestRunDBCompactionContainers_PrepareStep runs a selected step and checks the
+// order, its own log, and that its failure fails the phase — the user asked for
+// it by name, so the compaction alone is not what they configured.
+func TestRunDBCompactionContainers_PrepareStep(t *testing.T) {
+	cmds := &client.DBMaintenanceCommands{
+		Prepare: []client.DBMaintenanceStep{
+			{Name: "seg-retire", Args: []string{"seg", "retire"}},
+		},
+		Compact: []string{"db", "compact"},
+	}
+	steps := cmds.Prepare
+
+	t.Run("runs before the compaction", func(t *testing.T) {
+		mgr := &fakeDBMaintenanceMgr{}
+		r, resultsDir := dbCompactionTestRunner(t, mgr)
+
+		require.NoError(t, r.runDBCompactionContainers(
+			context.Background(), dbCompactionTestRequest(resultsDir),
+			cmds, steps, resultsDir, r.log,
+		))
+
+		assert.Equal(t, []string{"seg retire", "db compact"}, mgr.ran)
+		assert.FileExists(t, filepath.Join(resultsDir, "seg-retire.log"))
+	})
+
+	t.Run("its failure fails the phase", func(t *testing.T) {
+		mgr := &fakeDBMaintenanceMgr{failCommand: "seg"}
+		r, resultsDir := dbCompactionTestRunner(t, mgr)
+
+		err := r.runDBCompactionContainers(
+			context.Background(), dbCompactionTestRequest(resultsDir),
+			cmds, steps, resultsDir, r.log,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `preparation step "seg-retire"`)
+		assert.Equal(t, []string{"seg retire"}, mgr.ran, "the compaction must not run")
+	})
+}
+
+func TestDBCompactionPrepareReport(t *testing.T) {
+	assert.Nil(t, dbCompactionPrepareReport(nil))
+
+	got := dbCompactionPrepareReport([]client.DBMaintenanceStep{
+		{Name: "seg-retire", Args: []string{"seg", "retire"}},
+	})
+	assert.Equal(t, []dbCompactionStep{
+		{Name: "seg-retire", Command: []string{"seg", "retire"}},
+	}, got)
 }

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -1907,8 +1907,8 @@ type preBenchmarkDatadirParams struct {
 // database compaction, a schelk promote, or both.
 //
 // It serves the strategies that keep one client for the whole run (none,
-// rpc-debug-setHead). Both steps need the client stopped — `geth db compact`
-// takes the database lock, and `schelk promote` unmounts the volume — so they
+// rpc-debug-setHead). Both steps need the client stopped — the compaction takes
+// the database lock, and `schelk promote` unmounts the volume — so they
 // share a single stop and restart: settle, graceful stop, drain the logs,
 // sync, work, start the SAME container again (restarting re-binds the mount
 // from the host path, which now resolves to the promoted volume). The

--- a/pkg/runner/lifecycle.go
+++ b/pkg/runner/lifecycle.go
@@ -1942,7 +1942,7 @@ func (r *runner) prepareDatadirBeforeBenchmarks(
 		if entry := r.dbCompactionSkipEntry(
 			instance, config.DBCompactionBeforeBenchmarks, p.DataMount,
 		); entry != nil {
-			logDBCompactionSkip(log, entry)
+			logDBCompactionSkip(log, entry, compaction)
 
 			compaction = nil
 		}

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -216,8 +216,8 @@ func (r *runner) runTestsWithCheckpointRestore(
 	}
 
 	// 2a. Compact the database before the checkpoint, so every restored
-	//     container resumes on the compacted datadir. `geth db compact` takes
-	//     the database lock, so the client is stopped for it and started again
+	//     container resumes on the compacted datadir. The compaction takes the
+	//     database lock, so the client is stopped for it and started again
 	//     before the checkpoint is taken — a checkpoint of a client that is not
 	//     running on this datadir would restore onto a database it never opened.
 	compactionMount := docker.Mount{

--- a/pkg/runner/strategy_checkpoint.go
+++ b/pkg/runner/strategy_checkpoint.go
@@ -231,7 +231,10 @@ func (r *runner) runTestsWithCheckpointRestore(
 		params.Instance, config.DBCompactionBeforeBenchmarks, compactionMount,
 	)
 	if compactionSkip != nil {
-		logDBCompactionSkip(log, compactionSkip)
+		logDBCompactionSkip(
+			log, compactionSkip,
+			r.dbCompactionFor(params.Instance, config.DBCompactionBeforeBenchmarks),
+		)
 	}
 
 	if compactionSkip == nil &&

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -329,6 +329,7 @@ export interface DBCompactionConfig {
   enabled: boolean
   when?: string[]
   inspect?: boolean
+  prepare?: string[]
   timeout?: string
   image?: string
   extra_args?: string[]

--- a/ui/src/components/run-detail/RunConfiguration.tsx
+++ b/ui/src/components/run-detail/RunConfiguration.tsx
@@ -371,6 +371,12 @@ export function RunConfiguration({ instance, system, startBlock, metadata, bench
                         <span className="text-gray-500 dark:text-gray-400">timeout: </span>
                         {instance.db_compaction.timeout || '3h'}
                       </div>
+                      {instance.db_compaction.prepare?.length ? (
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">prepare: </span>
+                          {instance.db_compaction.prepare.join(', ')}
+                        </div>
+                      ) : null}
                       {instance.db_compaction.persist?.enabled && (
                         <div>
                           <span className="text-gray-500 dark:text-gray-400">persist: </span>


### PR DESCRIPTION
## Summary

Adds erigon to the clients `runner.client.config.db_compaction` supports. #309 added the mechanism and geth; this adds the client.

| Client | Compaction | Inspection |
|---|---|---|
| geth | `geth db compact` | `geth db inspect` |
| erigon | `erigon db compact` | `erigon seg du --verbose` |

`erigon db compact` rewrites every mdbx database of the datadir without its free pages. On the CI datadir it takes `chaindata` from **2.0GB to 32MB**.

**No new config.** `client.SupportsDBCompaction` already reads the spec, so `db_compaction` simply becomes available for erigon and every existing option keeps its meaning:

```yaml
runner:
  client:
    config:
      db_compaction:
        enabled: true
        when: [before_benchmarks]
        inspect: true
        timeout: 3h
```

## Two erigon caveats, both documented

**1. It needs Erigon 3.7.0-dev or newer.** `erigon db compact` landed in erigontech/erigon#23677 on 2026-09-01, so it is in no tagged release and in none of the pinned devnet images — `ethpandaops/erigon:glamsterdam-devnet-7` answers `Command 'db' not found`.

**2. `before_benchmarks` needs `--exec.no-prune` on the instance.** That phase stops and restarts the client, and erigon refuses to reopen a datadir whose receipt domain it pruned past the snapshot files:

```
[snapshots] gap between snapshot files and DB for domain receipt:
files end at txNum 0 but the DB was pruned up to 390625
```

A synthetic snapshot has no snapshot files, so the client's own pruning during the replay is enough to create the gap. `--exec.no-prune` disables the state-aggregator pruning that advances the marker; erigon documents it for diagnostic and perf-comparison use, which is what a benchmark is, and it removes housekeeping a benchmark does not want anyway.

It is **documented rather than added to erigon's `DefaultCommand`**, because it changes what a run measures — existing erigon benchmarks keep their current behaviour and stay comparable with past results. Happy to make it the default instead if you would rather.

## `erigon seg retire` as an opt-in step

`db_compaction` gains `prepare`, a list of client steps that run before the compaction so it reclaims more. Nothing runs unless it is named — a step that helps one datadir can ruin another, so the choice belongs to whoever knows what the datadir holds.

```yaml
db_compaction:
  enabled: true
  prepare: [seg-retire]   # erigon, real synced datadir
```

| Client | Step | What it does | Needs |
|---|---|---|---|
| erigon | `seg-retire` | `erigon seg retire` — freezes block and history ranges into segment files and prunes what it froze, leaving the free pages `db compact` reclaims | A datadir whose history spans whole steps (390,625 blocks) |

On a **real synced datadir** this is the pairing erigon documents, and it is where the compaction earns most of its space. A step you name is one you asked for, so its failure fails the phase (`continue_on_error` still downgrades it). Naming a step a client does not offer fails validation, which lists the alternatives *and what each one needs*, so the trade-off is visible at the point of choosing.

**Why it is opt-in rather than automatic.** On a short synthetic chain the retire finds nothing to freeze but prunes anyway, and erigon then refuses to reopen its own datadir. From CI, on a state-actor snapshot advanced to block 39:

```
retiring blocks from=0 to=39
Build state history snapshots      <- nothing to build, a step is 390,625 blocks
Prune state history                <- advances the DB prune marker anyway
```

Two CI runs separated the two ways to reach that gap:

| Run | `--exec.no-prune` | Client prunes? | `seg retire` | Restart |
|---|---|---|---|---|
| 1 | no | yes, creates the gap | fails at open (gap already there) | fails |
| 2 | yes | no | succeeds, and its own pruning creates the gap | fails |

Hence both the opt-in and the `--exec.no-prune` note above. The hazard is documented at the config field, in `pkg/client/erigon.go`, and in the docs.

## The datadir marker records the steps (review follow-up)

The marker used to record only *that* a phase ran. On a persisted baseline (`schelk`/`zfs`) `skip_if_marked` then skipped the whole phase forever, so changing `prepare` did nothing and nothing said why — bad for any setting, worst for a knob whose entire purpose is to change what the compaction does.

The marker entry now carries the step names:

```json
"before_pre_runs": {
  "client": "erigon",
  "image": "ethpandaops/erigon:main",
  "run_id": "20260827-101203-abcd",
  "prepare": ["seg-retire"],
  "completed_at": "2026-08-27T10:12:03Z",
  "duration_ms": 812345,
  "datadir_bytes": { "before": 812000000000, "after": 640000000000 }
}
```

so a skipped phase can say how the datadir got that way:

```
Datadir already carries a compaction marker for this phase; skipping
  compacted_at=... run_id=... image=ethpandaops/erigon:main prepare=seg-retire
```

and a `prepare` config that will **not** run is a WARNING naming both lists, rather than a routine INFO:

```
... so it is skipped and the configured db_compaction.prepare steps do NOT run;
the datadir keeps the preparation the marker names
(set db_compaction.skip_if_marked: false to recompact)
  prepare=none configured_prepare=seg-retire
```

An absent list means no step ran — a marker written before `prepare` existed cannot have had one either — so the two cases coincide and no schema version bump is needed. The docs also now state that the same staleness applies to every other compaction setting, `extra_args` included.

## Files

- `pkg/client/erigon.go` — the two commands plus the `seg-retire` step, with the hazard recorded.
- `pkg/client/client.go` — `DBMaintenanceStep` (name, argv, and a one-line `Why` that validation prints) and `Prepare` on `DBMaintenanceCommands`.
- `pkg/config/config.go` — the `prepare` field and `validateDBCompactionPrepare`.
- `pkg/runner/db_compaction.go` — resolve the named steps, run them in order, record them in `compaction.json`.
- `.github/workflows/ci.action.yaml` — the erigon leg in `pre-runs`.
- `docs/configuration.md`, `config.example.yaml`, `ui/` (the compaction card shows `prepare`), tests.

Four comments that named `geth db compact` for a client-agnostic fact now say "the compaction".

## CI

An erigon leg sits in `pre-runs` next to the geth one: same fixtures, same recorded pre-run bundle, compaction at `before_benchmarks`, with `--exec.no-prune`. state-actor grows an erigon target, since erigon cannot boot besu's or geth's datadir.

The image is `ethpandaops/erigon:main` — the only tag carrying `db compact`, and it also carries amsterdam and the devnet-7/8 EIP-8282 predeploys this job's fixtures need (verified: the `0x0000bFF4…8282` predeploy address and `BuilderDeposit` appear in the `main` binary at the same counts as `glamsterdam-devnet-7`). A floating tag also catches an erigon-side regression in the command, which is what this leg is for.

It deliberately does **not** enable `prepare`: this datadir is a synthetic snapshot, so the default of running no preparation step is exactly what CI should exercise here.

Job timeout goes 60 → 75 minutes for the third snapshot and the third run step. `actionlint` is clean.

## Test plan

- [x] `go build ./...`, `go test -race ./pkg/...`, `golangci-lint run --new-from-rev=origin/master` → 0 issues. The only failures are the 6 pre-existing `TestValidateDataDirMethods_SchelkBinary` cases that need `/proc/mounts` (macOS only; they pass on Linux CI).
- [x] New tests: the erigon argv and its offered step, geth offering none, the unsupported clients, `extra_args` reaching the compaction without mutating the client's slice, step selection (none by default, config order honoured, unknown name refused), the report mapping, four validation cases (valid step, unknown name, duplicate, client that offers none), and — through a partial `docker.ContainerManager` fake — the inspect/compact/inspect order with per-step logs, a selected step running before the compaction, its failure failing the phase, a failed compaction failing the phase, and a failed inspection not failing it.
- [x] `tsc -b` clean for the UI.
- [x] Verified the argv against `erigontech/erigon:main-latest` and `ethpandaops/erigon:main` (both 3.7.0-dev): `db compact` exits 0, `seg du --verbose` exits 0, and erigon reboots cleanly on the compacted datadir.
- [x] Full local run with `when: [before_benchmarks]`: settle → stop → inspect → compact → inspect → restart → RPC ready → 7/7 tests passed, with `db-compaction/before_benchmarks/{compact.log,compaction.json,inspect-*.txt}` written and the head recorded.
- [x] The CI erigon leg green on run 34399717509: inspect → compact (chaindata 2.0GB → 32MB) → inspect → restart → `Client back up on the prepared datadir` → 4/4 tests passed. All five jobs green.
- [x] Re-run green on run 34401582356 after the `prepare` addition — all five jobs, with the CI leg's own config unchanged.
