### PR TITLE
feat(runner): record the compaction settings in the datadir marker

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1248,6 +1248,7 @@ A finished compaction writes `.benchmarkoor-db-compaction.json` at the root of t
       "image": "ethpandaops/erigon:main",
       "run_id": "20260827-101203-abcd",
       "prepare": ["seg-retire"],
+      "extra_args": ["--cache=16384"],
       "completed_at": "2026-08-27T10:12:03Z",
       "duration_ms": 812345,
       "datadir_bytes": { "before": 812000000000, "after": 640000000000 }
@@ -1256,7 +1257,9 @@ A finished compaction writes `.benchmarkoor-db-compaction.json` at the root of t
 }
 ```
 
-`prepare` names the steps that ran. Absent means none did — a marker written before `prepare` existed cannot have had one either, so the two cases coincide.
+`prepare` and `extra_args` record the settings that decided what the compaction did to the database, alongside the `image` that ran it. An absent list means the setting was empty — a marker written before these fields existed cannot have had a value either, so the two cases coincide.
+
+The rest of `db_compaction` is deliberately not recorded. `timeout`, `inspect`, `continue_on_error`, `when`, `persist` and `skip_if_marked` govern the run rather than the bytes the compaction leaves behind, so recording them would only produce mismatches that mean nothing.
 
 It holds only what is known the moment the compaction finishes, so it is written once and never patched. With `persist` enabled, `skip_if_marked` defaults to true and a later run skips a phase the marker already names — which is what stops every run paying the compaction cost again.
 
@@ -1265,19 +1268,20 @@ A skipped phase logs how the datadir was compacted, so a run that compacts nothi
 ```
 Datadir already carries a compaction marker for this phase; skipping
   compacted_at=2026-08-27T10:12:03Z run_id=20260827-101203-abcd
-  image=ethpandaops/erigon:main prepare=seg-retire
+  image=ethpandaops/erigon:main prepare=seg-retire extra_args=--cache=16384
 ```
 
-**Changing `prepare` on a persisted datadir does not recompact it.** The marker skips the whole phase, so new steps never run. That case logs a WARNING naming both lists, rather than passing silently:
+**`skip_if_marked` skips by phase, not by config.** Changing `prepare` or `extra_args` on a persisted datadir does not recompact it, so the new settings never take effect. That case logs a WARNING naming what differs, rather than passing silently:
 
 ```
-Datadir already carries a compaction marker for this phase, so it is skipped and the
-configured db_compaction.prepare steps do NOT run; the datadir keeps the preparation
-the marker names (set db_compaction.skip_if_marked: false to recompact)
-  prepare=none configured_prepare=seg-retire
+Datadir already carries a compaction marker for this phase, so it is skipped and this
+run's db_compaction settings do NOT take effect; the datadir keeps the compaction the
+marker describes (set db_compaction.skip_if_marked: false to recompact)
+  prepare=seg-retire extra_args=--cache=16384
+  changed=prepare: seg-retire -> none; extra_args: --cache=16384 -> --cache=32768
 ```
 
-The same is true of any other change to the compaction config, `extra_args` included: the marker records that a phase ran, and `skip_if_marked` takes it at its word.
+The `image` is reported but not compared. Client images change routinely, and the marker cannot tell whether a new one compacts differently, so warning on every bump would teach you to ignore the warning — the recorded image is in the line either way.
 
 The marker also cannot tell that a datadir advanced after it was written. If you point a longer pre-run bundle at a baseline persisted at `before_benchmarks`, set `skip_if_marked: false` to force the compaction.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1257,7 +1257,7 @@ A finished compaction writes `.benchmarkoor-db-compaction.json` at the root of t
 }
 ```
 
-`prepare` and `extra_args` record the settings that decided what the compaction did to the database, alongside the `image` that ran it. An absent list means the setting was empty — a marker written before these fields existed cannot have had a value either, so the two cases coincide.
+`prepare` and `extra_args` record the settings that decided what the compaction did to the database, alongside the `image` that ran it — the compaction container's image, which is `db_compaction.image` when set and the instance image otherwise. An absent list means the setting was empty — a marker written before these fields existed cannot have had a value either, so the two cases coincide.
 
 The rest of `db_compaction` is deliberately not recorded. `timeout`, `inspect`, `continue_on_error`, `when`, `persist` and `skip_if_marked` govern the run rather than the bytes the compaction leaves behind, so recording them would only produce mismatches that mean nothing.
 
@@ -1281,7 +1281,7 @@ marker describes (set db_compaction.skip_if_marked: false to recompact)
   changed=prepare: seg-retire -> none; extra_args: --cache=16384 -> --cache=32768
 ```
 
-The `image` is reported but not compared. Client images change routinely, and the marker cannot tell whether a new one compacts differently, so warning on every bump would teach you to ignore the warning — the recorded image is in the line either way.
+The `image` is reported but not compared. Client images change routinely, and the marker cannot tell whether a new one compacts differently, so warning on every bump would teach you to ignore the warning — the recorded image is in the line either way, so a datadir compacted by an older build stays visible.
 
 The marker also cannot tell that a datadir advanced after it was written. If you point a longer pre-run bundle at a baseline persisted at `before_benchmarks`, set `skip_if_marked: false` to force the compaction.
 

--- a/pkg/runner/db_compaction.go
+++ b/pkg/runner/db_compaction.go
@@ -120,26 +120,37 @@ type dbCompactionMarkerEntry struct {
 	Image  string `json:"image"`
 	RunID  string `json:"run_id"`
 
-	// Prepare names the db_compaction.prepare steps that ran, so a later run
-	// that skips this phase can say HOW it was compacted, and notice that its
-	// own prepare config would have done something else.
+	// Prepare names the db_compaction.prepare steps that ran, and ExtraArgs the
+	// arguments the compaction command carried. They are what a later run
+	// compares against its own config, so a phase it skips can say HOW the
+	// datadir was compacted and whether that is what this run asks for. Image is
+	// recorded and reported beside them, but not compared: see
+	// dbCompactionMarkerDiff.
 	//
-	// Absent means no step ran: a marker written before prepare existed cannot
-	// have had one either, so the two cases coincide.
-	Prepare []string `json:"prepare,omitempty"`
+	// The rest of db_compaction is deliberately absent. timeout, inspect,
+	// continue_on_error, when, persist and skip_if_marked govern the run, not
+	// the bytes the compaction leaves behind, so recording them would only
+	// produce mismatches that mean nothing.
+	//
+	// An absent list means the setting was empty. A marker written before these
+	// fields existed cannot have had a value either, so the two cases coincide
+	// and no schema version bump is needed.
+	Prepare   []string `json:"prepare,omitempty"`
+	ExtraArgs []string `json:"extra_args,omitempty"`
 
 	CompletedAt  string             `json:"completed_at"`
 	DurationMS   int64              `json:"duration_ms"`
 	DatadirBytes *dbCompactionSizes `json:"datadir_bytes,omitempty"`
 }
 
-// prepareSummary renders the entry's steps for a log line.
-func (e *dbCompactionMarkerEntry) prepareSummary() string {
-	if len(e.Prepare) == 0 {
+// dbCompactionListSummary renders a setting's value for a log line, so an empty
+// one reads as a deliberate "none" rather than a blank field.
+func dbCompactionListSummary(values []string) string {
+	if len(values) == 0 {
 		return "none"
 	}
 
-	return strings.Join(e.Prepare, ",")
+	return strings.Join(values, ",")
 }
 
 // hostPath returns the host path of the datadir mount, or "" when
@@ -525,6 +536,7 @@ func (r *runner) writeDBCompactionMarker(
 		Image:        report.Image,
 		RunID:        req.RunID,
 		Prepare:      dbCompactionStepNames(report.Prepare),
+		ExtraArgs:    append([]string{}, dbCompactionConfiguredExtraArgs(req.Cfg)...),
 		CompletedAt:  report.CompletedAt,
 		DurationMS:   report.DurationMS,
 		DatadirBytes: report.DatadirBytes,
@@ -640,14 +652,14 @@ func (r *runner) dbCompactionSkipEntry(
 // says how that earlier compaction ran.
 //
 // The marker is the only record of what the persisted baseline had done to it,
-// so the skip line carries the earlier run's id, image and prepare steps: a run
-// that compacts nothing itself should still be able to say how its datadir got
-// that way.
+// so the skip line carries the earlier run's id, image and settings: a run that
+// compacts nothing itself should still be able to say how its datadir got that
+// way.
 //
-// When the current prepare config would do something else, the line is a
-// WARNING instead. That is the case the marker used to hide: the whole point of
-// prepare is to change what the compaction does, so a changed setting that is
-// being ignored has to say so.
+// When this run's settings would do something else, the line is a WARNING
+// naming what differs. `skip_if_marked` skips by PHASE, not by config, so a
+// changed setting is silently without effect on a persisted baseline unless the
+// skip says so.
 func logDBCompactionSkip(
 	log logrus.FieldLogger, entry *dbCompactionMarkerEntry, cfg *config.DBCompactionConfig,
 ) {
@@ -655,17 +667,17 @@ func logDBCompactionSkip(
 		"compacted_at": entry.CompletedAt,
 		"run_id":       entry.RunID,
 		"image":        entry.Image,
-		"prepare":      entry.prepareSummary(),
+		"prepare":      dbCompactionListSummary(entry.Prepare),
+		"extra_args":   dbCompactionListSummary(entry.ExtraArgs),
 	}
 
-	wanted := cfg.PrepareSteps()
-	if !slices.Equal(wanted, entry.Prepare) {
-		fields["configured_prepare"] = dbCompactionPrepareSummary(wanted)
+	if diff := dbCompactionMarkerDiff(entry, cfg); len(diff) > 0 {
+		fields["changed"] = strings.Join(diff, "; ")
 
 		log.WithFields(fields).Warn(
 			"Datadir already carries a compaction marker for this phase, so it is" +
-				" skipped and the configured db_compaction.prepare steps do NOT" +
-				" run; the datadir keeps the preparation the marker names" +
+				" skipped and this run's db_compaction settings do NOT take effect;" +
+				" the datadir keeps the compaction the marker describes" +
 				" (set db_compaction.skip_if_marked: false to recompact)",
 		)
 
@@ -678,13 +690,47 @@ func logDBCompactionSkip(
 	)
 }
 
-// dbCompactionPrepareSummary renders a configured step list for a log line.
-func dbCompactionPrepareSummary(steps []string) string {
-	if len(steps) == 0 {
-		return "none"
+// dbCompactionMarkerDiff lists the recorded settings that differ from the ones
+// this run is configured with, each as "name: recorded -> configured".
+//
+// Only the settings that decide what the compaction does to the database are
+// compared. timeout, inspect, continue_on_error, when, persist and
+// skip_if_marked govern the run rather than the bytes, so a change there is not
+// a reason to tell anyone their datadir is stale.
+//
+// The image is reported but NOT compared. Client images change routinely here,
+// and the marker cannot tell whether a new one compacts differently, so warning
+// on every bump would teach people to ignore the warning.
+func dbCompactionMarkerDiff(
+	entry *dbCompactionMarkerEntry, cfg *config.DBCompactionConfig,
+) []string {
+	var diff []string
+
+	if want := cfg.PrepareSteps(); !slices.Equal(want, entry.Prepare) {
+		diff = append(diff, fmt.Sprintf(
+			"prepare: %s -> %s",
+			dbCompactionListSummary(entry.Prepare), dbCompactionListSummary(want),
+		))
 	}
 
-	return strings.Join(steps, ",")
+	if want := dbCompactionConfiguredExtraArgs(cfg); !slices.Equal(want, entry.ExtraArgs) {
+		diff = append(diff, fmt.Sprintf(
+			"extra_args: %s -> %s",
+			dbCompactionListSummary(entry.ExtraArgs), dbCompactionListSummary(want),
+		))
+	}
+
+	return diff
+}
+
+// dbCompactionConfiguredExtraArgs returns the configured compaction arguments,
+// tolerating a nil config the way the config's own accessors do.
+func dbCompactionConfiguredExtraArgs(cfg *config.DBCompactionConfig) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	return cfg.ExtraArgs
 }
 
 // dbCompactionPersistsAt reports whether the instance writes the result of the

--- a/pkg/runner/db_compaction.go
+++ b/pkg/runner/db_compaction.go
@@ -153,6 +153,21 @@ func dbCompactionListSummary(values []string) string {
 	return strings.Join(values, ",")
 }
 
+// image returns the image the maintenance containers actually run: the
+// compaction's own image when db_compaction.image is set, and the instance
+// image otherwise.
+//
+// The run report and the datadir marker record this rather than the instance
+// image, so "which build compacted this datadir" stays answerable when the two
+// differ — which is the whole reason db_compaction.image exists.
+func (req *dbCompactionRequest) image() string {
+	if req.Cfg != nil && req.Cfg.Image != "" {
+		return req.Cfg.Image
+	}
+
+	return req.ImageName
+}
+
 // hostPath returns the host path of the datadir mount, or "" when
 // the datadir is a container volume. The marker and the size measurements need
 // a path the runner can read.
@@ -212,7 +227,7 @@ func (r *runner) runDBCompaction(
 	report := &dbCompactionReport{
 		Phase:     req.Phase,
 		Client:    req.Instance.Client,
-		Image:     req.ImageName,
+		Image:     req.image(),
 		RunID:     req.RunID,
 		StartedAt: started.UTC().Format(time.RFC3339),
 		Persisted: req.Persisting,
@@ -434,14 +449,9 @@ func (r *runner) runDBMaintenanceContainer(
 		"benchmarkoor-%s-%s-dbc-%s-%s", req.RunID, req.Instance.ID, req.Phase, step,
 	)
 
-	image := req.ImageName
-	if req.Cfg.Image != "" {
-		image = req.Cfg.Image
-	}
-
 	spec := &docker.ContainerSpec{
 		Name:        name,
-		Image:       image,
+		Image:       req.image(),
 		Entrypoint:  req.Instance.Entrypoint,
 		Command:     command,
 		Mounts:      []docker.Mount{req.Mount},
@@ -466,7 +476,7 @@ func (r *runner) runDBMaintenanceContainer(
 	}()
 
 	_, _ = fmt.Fprintf(
-		out, "# %s %s\n# %v\n\n", image, step, command,
+		out, "# %s %s\n# %v\n\n", req.image(), step, command,
 	)
 
 	var stdout, stderr io.Writer = out, out

--- a/pkg/runner/db_compaction_test.go
+++ b/pkg/runner/db_compaction_test.go
@@ -670,3 +670,46 @@ func TestDBCompactionStepNames(t *testing.T) {
 		{Name: "a"}, {Name: "b"},
 	}))
 }
+
+// TestDBCompactionRequestImage pins what the report and the marker record: the
+// image that actually ran the compaction, which db_compaction.image overrides.
+// Recording the instance image there would name a build that never ran.
+func TestDBCompactionRequestImage(t *testing.T) {
+	req := &dbCompactionRequest{
+		ImageName: "ethpandaops/erigon:main",
+		Cfg:       &config.DBCompactionConfig{},
+	}
+	assert.Equal(t, "ethpandaops/erigon:main", req.image())
+
+	req.Cfg.Image = "erigontech/erigon:v3.7.0"
+	assert.Equal(t, "erigontech/erigon:v3.7.0", req.image())
+
+	req.Cfg = nil
+	assert.Equal(t, "ethpandaops/erigon:main", req.image())
+}
+
+// TestDBCompactionMarkerRecordsTheOverriddenImage is the same fact end to end:
+// the datadir marker names the image that compacted it.
+func TestDBCompactionMarkerRecordsTheOverriddenImage(t *testing.T) {
+	dir := t.TempDir()
+
+	r := &runner{log: logrus.New(), cfg: &Config{}}
+
+	req := &dbCompactionRequest{
+		Instance:  &config.ClientInstance{ID: "erigon", Client: "erigon"},
+		ImageName: "ethpandaops/erigon:main",
+		Cfg:       &config.DBCompactionConfig{Image: "erigontech/erigon:v3.7.0"},
+		Phase:     config.DBCompactionBeforePreRuns,
+		RunID:     "run-1",
+	}
+
+	r.writeDBCompactionMarker(
+		dir, req, &dbCompactionReport{Image: req.image()}, r.log,
+	)
+
+	marker := readDBCompactionMarker(dir)
+	require.NotNil(t, marker)
+
+	entry := marker.Phases[config.DBCompactionBeforePreRuns]
+	assert.Equal(t, "erigontech/erigon:v3.7.0", entry.Image)
+}

--- a/pkg/runner/db_compaction_test.go
+++ b/pkg/runner/db_compaction_test.go
@@ -26,6 +26,7 @@ func TestDBCompactionMarker_RoundTrip(t *testing.T) {
 
 	req := &dbCompactionRequest{
 		Instance: &config.ClientInstance{ID: "geth", Client: "geth"},
+		Cfg:      &config.DBCompactionConfig{ExtraArgs: []string{"--cache=16384"}},
 		Phase:    config.DBCompactionBeforePreRuns,
 		RunID:    "run-1",
 	}
@@ -52,9 +53,10 @@ func TestDBCompactionMarker_RoundTrip(t *testing.T) {
 	require.NotNil(t, entry.DatadirBytes)
 	assert.Equal(t, int64(100), entry.DatadirBytes.After)
 
-	// The steps that ran are recorded, so a later run that skips this phase can
-	// say how the datadir was compacted.
+	// The settings that decided what the compaction did are recorded, so a later
+	// run that skips this phase can say how the datadir was compacted.
 	assert.Equal(t, []string{"seg-retire"}, entry.Prepare)
+	assert.Equal(t, []string{"--cache=16384"}, entry.ExtraArgs)
 
 	// A second phase is added, never replacing the first.
 	req.Phase = config.DBCompactionBeforeBenchmarks
@@ -550,8 +552,8 @@ func TestDBCompactionPrepareReport(t *testing.T) {
 }
 
 // TestLogDBCompactionSkip covers the two shapes of the skip line: an INFO that
-// says how the datadir was compacted, and a WARNING when the configured prepare
-// steps differ from the ones the marker names and are therefore not going to run.
+// says how the datadir was compacted, and a WARNING naming the settings this run
+// configured that are therefore not going to take effect.
 func TestLogDBCompactionSkip(t *testing.T) {
 	entry := &dbCompactionMarkerEntry{
 		Client:      "erigon",
@@ -559,48 +561,90 @@ func TestLogDBCompactionSkip(t *testing.T) {
 		RunID:       "run-1",
 		CompletedAt: "2026-09-09T20:21:21Z",
 		Prepare:     []string{"seg-retire"},
+		ExtraArgs:   []string{"--cache=16384"},
 	}
 
-	capture := func(cfg *config.DBCompactionConfig) *logrus.Entry {
+	capture := func(e *dbCompactionMarkerEntry, cfg *config.DBCompactionConfig) *logrus.Entry {
 		log := logrus.New()
 		log.SetOutput(io.Discard)
 
 		hook := &captureHook{}
 		log.AddHook(hook)
 
-		logDBCompactionSkip(logrus.NewEntry(log), entry, cfg)
+		logDBCompactionSkip(logrus.NewEntry(log), e, cfg)
 
 		require.Len(t, hook.entries, 1)
 
 		return hook.entries[0]
 	}
 
-	t.Run("same prepare config reports how it ran", func(t *testing.T) {
-		got := capture(&config.DBCompactionConfig{Prepare: []string{"seg-retire"}})
+	t.Run("matching config reports how it ran", func(t *testing.T) {
+		got := capture(entry, &config.DBCompactionConfig{
+			Prepare:   []string{"seg-retire"},
+			ExtraArgs: []string{"--cache=16384"},
+		})
 
 		assert.Equal(t, logrus.InfoLevel, got.Level)
 		assert.Equal(t, "seg-retire", got.Data["prepare"])
+		assert.Equal(t, "--cache=16384", got.Data["extra_args"])
 		assert.Equal(t, "run-1", got.Data["run_id"])
 		assert.Equal(t, "ethpandaops/erigon:main", got.Data["image"])
-		assert.NotContains(t, got.Data, "configured_prepare")
+		assert.NotContains(t, got.Data, "changed")
 	})
 
-	t.Run("a changed prepare config warns that it is ignored", func(t *testing.T) {
-		got := capture(&config.DBCompactionConfig{})
+	t.Run("a changed prepare warns", func(t *testing.T) {
+		got := capture(entry, &config.DBCompactionConfig{
+			ExtraArgs: []string{"--cache=16384"},
+		})
 
 		assert.Equal(t, logrus.WarnLevel, got.Level)
-		assert.Equal(t, "seg-retire", got.Data["prepare"], "what the datadir had")
-		assert.Equal(t, "none", got.Data["configured_prepare"], "what this run wanted")
-		assert.Contains(t, got.Message, "do NOT")
+		assert.Equal(t, "prepare: seg-retire -> none", got.Data["changed"])
+		assert.Contains(t, got.Message, "do NOT take effect")
 	})
 
-	t.Run("a marker with no steps reads as none", func(t *testing.T) {
-		entry = &dbCompactionMarkerEntry{RunID: "run-0", CompletedAt: "2026-09-09T00:00:00Z"}
+	t.Run("changed extra_args warn", func(t *testing.T) {
+		got := capture(entry, &config.DBCompactionConfig{
+			Prepare:   []string{"seg-retire"},
+			ExtraArgs: []string{"--cache=32768"},
+		})
 
-		got := capture(&config.DBCompactionConfig{})
+		assert.Equal(t, logrus.WarnLevel, got.Level)
+		assert.Equal(t, "extra_args: --cache=16384 -> --cache=32768", got.Data["changed"])
+	})
+
+	t.Run("both changed are reported together", func(t *testing.T) {
+		got := capture(entry, &config.DBCompactionConfig{})
+
+		assert.Equal(t, logrus.WarnLevel, got.Level)
+		assert.Equal(
+			t,
+			"prepare: seg-retire -> none; extra_args: --cache=16384 -> none",
+			got.Data["changed"],
+		)
+	})
+
+	t.Run("a settings-only change does not warn", func(t *testing.T) {
+		// timeout, inspect, continue_on_error and friends govern the run, not
+		// the bytes, so they must not read as a stale datadir.
+		got := capture(entry, &config.DBCompactionConfig{
+			Prepare:         []string{"seg-retire"},
+			ExtraArgs:       []string{"--cache=16384"},
+			Timeout:         "9h",
+			ContinueOnError: true,
+		})
+
+		assert.Equal(t, logrus.InfoLevel, got.Level)
+	})
+
+	t.Run("an older marker with no settings reads as none", func(t *testing.T) {
+		got := capture(
+			&dbCompactionMarkerEntry{RunID: "run-0", CompletedAt: "2026-09-09T00:00:00Z"},
+			&config.DBCompactionConfig{},
+		)
 
 		assert.Equal(t, logrus.InfoLevel, got.Level)
 		assert.Equal(t, "none", got.Data["prepare"])
+		assert.Equal(t, "none", got.Data["extra_args"])
 	})
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #319, from its review: the datadir marker recorded *that* a phase ran, so `skip_if_marked` skipped it forever on a persisted baseline and a changed compaction setting silently had no effect.

#319 fixed half of it by recording `prepare`. This records the rest of the settings that decide what the compaction does, and generalises the skip line to compare them.

## The marker entry

```json
"before_pre_runs": {
  "client": "erigon",
  "image": "ethpandaops/erigon:main",
  "run_id": "20260827-101203-abcd",
  "prepare": ["seg-retire"],
  "extra_args": ["--cache=16384"],
  "completed_at": "2026-08-27T10:12:03Z",
  "duration_ms": 812345,
  "datadir_bytes": { "before": 812000000000, "after": 640000000000 }
}
```

A skipped phase now says how the datadir was compacted:

```
Datadir already carries a compaction marker for this phase; skipping
  compacted_at=2026-08-27T10:12:03Z run_id=20260827-101203-abcd
  image=ethpandaops/erigon:main prepare=seg-retire extra_args=--cache=16384
```

and a run whose settings will **not** take effect gets a WARNING naming exactly what differs:

```
Datadir already carries a compaction marker for this phase, so it is skipped and this
run's db_compaction settings do NOT take effect; the datadir keeps the compaction the
marker describes (set db_compaction.skip_if_marked: false to recompact)
  changed=prepare: seg-retire -> none; extra_args: --cache=16384 -> --cache=32768
```

## What is recorded, and what is not

Only the settings that decide what the compaction does **to the database**:

| Setting | Recorded | Compared | Why |
|---|---|---|---|
| `prepare` | yes | yes | changes what runs against the datadir |
| `extra_args` | yes | yes | changes the compaction command |
| `image` | yes | **no** | see below |
| `timeout`, `inspect`, `continue_on_error`, `when`, `persist`, `skip_if_marked` | no | no | govern the run, not the bytes it leaves behind |

Recording the literal full `db_compaction` block was the obvious reading of the ask, but it would warn on a `timeout` bump — a mismatch that means nothing about the datadir — and noise trains the warning away. So the marker records the inputs that determine the result. Happy to widen it if you disagree.

**The image is recorded and reported but not compared.** Client images change routinely here (`devnet-7` → `devnet-8`), and the marker cannot tell whether a new one compacts differently, so warning on every bump would make the warning worthless. The recorded image is in the line either way, so a datadir compacted by an older build is still visible.

Review follow-up: that claim was not true when written. The marker recorded `req.ImageName`, the **instance** image, while the container that compacts uses `db_compaction.image` when it is set — so with an override, the marker and the run report both named a build that never ran. The override is exactly the case where the recorded image matters, since its whole purpose is to decouple the tool version from the client version, so the second commit fixes the data rather than softening the docs. One accessor now answers "which image runs" for the container, the run report, the marker and the per-step log header, so the four cannot drift again. The docs also name which image it is.

## Behaviour is unchanged

`skip_if_marked` still skips by phase. This PR makes that legible, it does not make a config mismatch force a recompaction — that would turn a routine `extra_args` edit into hours of unexpected work on a persisted baseline. If you want the stricter semantics, it wants its own knob and its own decision.

## Compatibility

No schema version bump. An absent list still means the setting was empty, so a marker written by #319 (or before it) reads correctly.

## Test plan

- [x] `go build ./...`, `go test -race ./pkg/...`, `golangci-lint run --new-from-rev=origin/master` → 0 issues. The only failures are the 6 pre-existing `TestValidateDataDirMethods_SchelkBinary` cases that need `/proc/mounts` (macOS only; they pass on Linux CI).
- [x] Six new cases on the skip line: matching config → INFO reporting both settings; changed `prepare` → WARN; changed `extra_args` → WARN; both changed → one combined diff; a `timeout`/`continue_on_error`-only change → still INFO; an older marker with neither field → reads as `none`.
- [x] The marker round-trip asserts both recorded settings.
- [x] A nil compaction config no longer panics in `writeDBCompactionMarker` — the existing round-trip test caught this while writing the change.
- [x] Two cases on the effective image: `db_compaction.image` overrides the instance image, an unset one falls back, a nil config falls back; and end to end, the marker records the overriding image.
