### PR TITLE
fix(runner): compact a schelk datadir that needs no promote

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1232,6 +1232,7 @@ Two rules follow from the mechanisms:
 
 - **ZFS persists only at `before_pre_runs`.** The clone is a child of its source dataset, so no promote or rename puts the compacted clone back at the source path. Compacting the source first also keeps the clone small, since a compaction inside a copy-on-write clone rewrites the whole database into it.
 - **A schelk persist at `before_benchmarks` needs `promote_post_pre_runs: true`.** Persisting there moves the baseline head past the pre-run bundle, which is exactly what that option does. Requiring it keeps the decision explicit, and lets the runner persist both with a single promote.
+- **A baseline that already carries the pre-run state is still compacted.** The promote has nothing of its own left to do there, so the runner does the stop, the compaction and the promote for the compaction alone. It happens once: the marker the compaction writes goes into the promoted baseline, and every later run skips both.
 
 > **A persist is destructive and irreversible.** It overwrites the golden image. On ZFS, `safety_snapshot` leaves a `<dataset>@benchmarkoor-precompaction-<run-id>` snapshot that a `zfs rollback` restores exactly.
 

--- a/pkg/runner/strategy_container.go
+++ b/pkg/runner/strategy_container.go
@@ -1141,7 +1141,9 @@ func (r *runner) runInitForRecreate(
 // promote captures whatever is on disk, so stopping too eagerly persists a
 // datadir the client had not finished writing, and a client restored from that
 // comes up syncing.
-const schelkSettleBeforeStop = 20 * time.Second
+//
+// var (not const) so tests can shorten it.
+var schelkSettleBeforeStop = 20 * time.Second
 
 // promoteSchelkAfterPreRuns applies the suite's pre-run steps, then persists the
 // resulting datadir as the new schelk baseline so every per-test container
@@ -1156,6 +1158,13 @@ const schelkSettleBeforeStop = 20 * time.Second
 // The promote is skipped unless every pre-run step succeeded: promote overwrites
 // the virgin volume irreversibly, and a baseline built from a half-applied bundle
 // is worse than no baseline at all.
+//
+// It also owns the ONLY before_benchmarks compaction this strategy has, so a
+// datadir that needs no promote still comes through here to be compacted. The
+// two share one stop, one promote and one restart: `schelk promote` is what
+// writes the compacted database into the baseline, and every per-test recreate
+// runs `schelk restore`, so a compaction the baseline does not carry is
+// discarded at the first test.
 func (r *runner) promoteSchelkAfterPreRuns(
 	ctx context.Context,
 	params *containerRunParams,
@@ -1170,66 +1179,144 @@ func (r *runner) promoteSchelkAfterPreRuns(
 	logDone *chan struct{},
 	log logrus.FieldLogger,
 ) (newIP string, baked bool, err error) {
+	// Whether the compaction has anything to do is settled FIRST, before the
+	// head check that can return early. The compaction used to hang off the
+	// promote, so a datadir whose baseline already carried the pre-run state
+	// returned early and took a configured compaction with it — silently, since
+	// the code that logs a skip had not run either.
+	//
+	// The marker question is settled here too, as prepareDatadirBeforeBenchmarks
+	// does it: a persisted baseline carries the marker into every later run, and
+	// stopping and restarting the client to skip the work costs a settle, a
+	// graceful shutdown and a boot, every run, for nothing.
+	compaction := r.dbCompactionFor(params.Instance, config.DBCompactionBeforeBenchmarks)
+
+	var compactionMount docker.Mount
+
+	if compaction != nil {
+		// A missing datadir mount is an error rather than a skip: the container
+		// spec and the datadir config that name the same target are built
+		// together, so a miss means they disagree — and silently dropping a
+		// configured compaction would promote a baseline the operator believes
+		// is compacted.
+		mount, ok := datadirMountFor(params.ContainerSpec, spec, params.DataDirCfg)
+		if !ok {
+			return "", false, fmt.Errorf(
+				"db_compaction is configured at %s but the container spec has no"+
+					" datadir mount to compact",
+				config.DBCompactionBeforeBenchmarks,
+			)
+		}
+
+		compactionMount = mount
+
+		if entry := r.dbCompactionSkipEntry(
+			params.Instance, config.DBCompactionBeforeBenchmarks, mount,
+		); entry != nil {
+			logDBCompactionSkip(log, entry, compaction)
+
+			compaction = nil
+		}
+	}
+
 	// Where the datadir already sits decides how much of the bundle to replay. A
 	// promoted baseline is already AT the bundle's end, so replaying from its
 	// first block re-imports thousands of known blocks — minutes of wasted work
 	// that lands on the head it started from.
+	preRunsApplied := false
+
 	headNumber, headHash, _, blkErr := r.getLatestBlock(ctx, containerIP, spec.RPCPort())
 	if blkErr != nil {
 		log.WithError(blkErr).Warn("Could not read the datadir head; replaying the whole bundle")
 	} else {
-		applied, err := r.verifyPreRunBundleHead(log, headNumber, headHash)
-		if err != nil {
-			return "", false, err
+		applied, verifyErr := r.verifyPreRunBundleHead(log, headNumber, headHash)
+		if verifyErr != nil {
+			return "", false, verifyErr
 		}
 
-		if applied {
-			// The datadir was restored from the schelk baseline moments ago, so a
-			// head already at the bundle's end means the BASELINE carries the
-			// pre-run state — every per-test restore will land here too, and
-			// replaying per test would be pure waste.
-			log.Info(
-				"Pre-run bundle already applied to this datadir; nothing to promote",
+		preRunsApplied = applied
+	}
+
+	if preRunsApplied {
+		// The datadir was restored from the schelk baseline moments ago, so a
+		// head already at the bundle's end means the BASELINE carries the
+		// pre-run state — every per-test restore will land here too, and
+		// replaying per test would be pure waste.
+		log.Info(
+			"Pre-run bundle already applied to this datadir; nothing to promote",
+		)
+
+		if compaction == nil {
+			return "", true, nil
+		}
+
+		// The promote has nothing of its own left to persist, but the compaction
+		// does, and this is the only place that can persist it. The marker the
+		// compaction leaves in the promoted baseline makes every later run skip
+		// both again.
+		if !compaction.PersistsAt(config.DBCompactionBeforeBenchmarks) {
+			log.Warn(
+				"db_compaction runs at " + config.DBCompactionBeforeBenchmarks +
+					" without persist, and the datadir needs no promote; skipping" +
+					" the compaction (every per-test `schelk restore` would" +
+					" discard it before the second test)",
 			)
 
 			return "", true, nil
 		}
-	}
 
-	preRunOpts := &executor.ExecuteOptions{
-		EngineEndpoint: fmt.Sprintf(
-			"http://%s:%d", containerIP, spec.EnginePort(),
-		),
-		JWT:                           r.cfg.JWT,
-		ResultsDir:                    resultsDir,
-		FailFast:                      true,
-		PreRunStepSleep:               r.cfg.PreRunStepSleep,
-		SkipUntilBlockNumber:          headNumber,
-		RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(params.Instance),
-		RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(params.Instance),
-	}
-
-	n, err := r.executor.RunPreRunSteps(ctx, preRunOpts)
-	if err != nil {
-		return "", false, fmt.Errorf("running pre-run steps before schelk promote: %w", err)
-	}
-
-	if n == 0 {
-		log.Warn(
-			"promote_post_pre_runs is set but the suite has no pre-run steps; " +
-				"refusing to promote (the baseline would be the raw snapshot)",
+		log.Info(
+			"Compacting the datadir anyway, and promoting the compacted result " +
+				"to the schelk baseline",
 		)
+	} else {
+		preRunOpts := &executor.ExecuteOptions{
+			EngineEndpoint: fmt.Sprintf(
+				"http://%s:%d", containerIP, spec.EnginePort(),
+			),
+			JWT:                           r.cfg.JWT,
+			ResultsDir:                    resultsDir,
+			FailFast:                      true,
+			PreRunStepSleep:               r.cfg.PreRunStepSleep,
+			SkipUntilBlockNumber:          headNumber,
+			RetryNewPayloadsSyncingConfig: r.cfg.FullConfig.GetRetryNewPayloadsSyncingState(params.Instance),
+			RetryNewPayloadsFailedConfig:  r.cfg.FullConfig.GetRetryNewPayloadsFailedState(params.Instance),
+		}
 
-		return "", false, nil
+		n, runErr := r.executor.RunPreRunSteps(ctx, preRunOpts)
+		if runErr != nil {
+			return "", false, fmt.Errorf("running pre-run steps before schelk promote: %w", runErr)
+		}
+
+		if n == 0 {
+			log.Warn(
+				"promote_post_pre_runs is set but the suite has no pre-run steps; " +
+					"refusing to promote (the baseline would be the raw snapshot)",
+			)
+
+			// The compaction goes with the promote here. Without a promote the
+			// baseline keeps the uncompacted database, and the first per-test
+			// `schelk restore` throws the compacted one away.
+			if compaction != nil {
+				log.Warn(
+					"db_compaction at " + config.DBCompactionBeforeBenchmarks +
+						" is skipped with the promote (a compaction the baseline" +
+						" does not carry would not survive the first per-test" +
+						" `schelk restore`)",
+				)
+			}
+
+			return "", false, nil
+		}
+
+		log.WithField("steps", n).Info("Pre-run steps completed; promoting datadir to the schelk baseline")
 	}
-
-	log.WithField("steps", n).Info("Pre-run steps completed; promoting datadir to the schelk baseline")
 
 	// The head is exact here and free: the client is still up, and this is the
 	// last moment before it stops. Only the compaction report uses it.
 	var compactionHead *dbCompactionHead
 
-	if r.dbCompactionFor(params.Instance, config.DBCompactionBeforeBenchmarks) != nil {
+	if compaction != nil {
 		compactionHead = r.dbCompactionHeadFromRPC(ctx, containerIP, spec.RPCPort(), log)
 	}
 
@@ -1253,25 +1340,10 @@ func (r *runner) promoteSchelkAfterPreRuns(
 
 	// Compact before the promote, so the baseline every per-test recreate
 	// restores from carries the compacted database. One stop, one promote.
-	//
-	// A missing datadir mount is an error rather than a skip, matching the ZFS
-	// ready-snapshot path above: the container spec and the datadir config that
-	// name the same target are built together, so a miss means they disagree —
-	// and silently dropping a configured compaction would promote a baseline
-	// the operator believes is compacted.
-	if r.dbCompactionFor(params.Instance, config.DBCompactionBeforeBenchmarks) != nil {
-		mount, ok := datadirMountFor(params.ContainerSpec, spec, params.DataDirCfg)
-		if !ok {
-			return "", false, fmt.Errorf(
-				"db_compaction is configured at %s but the container spec has no"+
-					" datadir mount to compact",
-				config.DBCompactionBeforeBenchmarks,
-			)
-		}
-
+	if compaction != nil {
 		if _, err := r.compactDatadirForPhase(
 			ctx, params.Instance, spec, config.DBCompactionBeforeBenchmarks,
-			params.RunID, params.ImageName, resultsDir, mount,
+			params.RunID, params.ImageName, resultsDir, compactionMount,
 			benchmarkoorLog, compactionHead,
 		); err != nil {
 			return "", false, err

--- a/pkg/runner/strategy_container_compaction_test.go
+++ b/pkg/runner/strategy_container_compaction_test.go
@@ -1,0 +1,302 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/benchmarkoor/pkg/client"
+	"github.com/ethpandaops/benchmarkoor/pkg/config"
+	"github.com/ethpandaops/benchmarkoor/pkg/datadir"
+	"github.com/ethpandaops/benchmarkoor/pkg/docker"
+)
+
+// fakeSchelkPromoteMgr is a docker.ContainerManager for the promote path: it
+// answers the container lifecycle calls and runs the compaction container the
+// way fakeDBMaintenanceMgr does. The embedded interface is nil on purpose, so a
+// call to anything else panics and the test says the path grew a dependency.
+type fakeSchelkPromoteMgr struct {
+	docker.ContainerManager
+
+	// compacted holds the maintenance commands, lifecycle the stop/start calls.
+	compacted []string
+	lifecycle []string
+}
+
+func (f *fakeSchelkPromoteMgr) RunInitContainer(
+	_ context.Context, spec *docker.ContainerSpec, stdout, _ io.Writer,
+) error {
+	f.compacted = append(f.compacted, strings.Join(spec.Command, " "))
+
+	_, _ = fmt.Fprintln(stdout, "fake container output")
+
+	return nil
+}
+
+func (f *fakeSchelkPromoteMgr) StopContainer(
+	_ context.Context, containerID string, _ *int,
+) error {
+	f.lifecycle = append(f.lifecycle, "stop "+containerID)
+
+	return nil
+}
+
+func (f *fakeSchelkPromoteMgr) StartContainer(
+	_ context.Context, containerID string,
+) error {
+	f.lifecycle = append(f.lifecycle, "start "+containerID)
+
+	return nil
+}
+
+// stubRPCSpec is a real client spec with the RPC port pointed at a test server,
+// so getLatestBlock reads a head the test chooses. Everything else — the
+// datadir, the maintenance commands — stays the client's own.
+type stubRPCSpec struct {
+	client.Spec
+
+	rpcPort int
+}
+
+func (s stubRPCSpec) RPCPort() int { return s.rpcPort }
+
+// headServer answers eth_getBlockByNumber with one fixed block.
+func headServer(t *testing.T, number uint64, hash string) (host string, port int) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":1,"result":{`+
+				`"number":"%#x","hash":%q,"stateRoot":"0xstate"}}`, number, hash)
+		},
+	))
+	t.Cleanup(srv.Close)
+
+	hostPart, portPart, err := splitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+
+	return hostPart, portPart
+}
+
+func splitHostPort(addr string) (string, int, error) {
+	idx := strings.LastIndex(addr, ":")
+	if idx < 0 {
+		return "", 0, fmt.Errorf("no port in %q", addr)
+	}
+
+	port, err := strconv.Atoi(addr[idx+1:])
+	if err != nil {
+		return "", 0, err
+	}
+
+	return addr[:idx], port, nil
+}
+
+// schelkStub points the schelk binary at a script that records its arguments
+// and fails. Nothing in these tests may run the real `schelk promote`, and the
+// failure ends the function at a known point, just past the work under test.
+func schelkStub(t *testing.T) *string {
+	t.Helper()
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "calls.txt")
+	script := filepath.Join(dir, "schelk")
+
+	require.NoError(t, os.WriteFile(script, []byte(
+		"#!/bin/sh\necho \"$@\" >> \""+record+"\"\nexit 1\n",
+	), 0o755))
+
+	t.Setenv(datadir.SchelkBinaryEnv, script)
+
+	return &record
+}
+
+// promoteTestRunner wires a runner whose datadir sits at the pre-run bundle's
+// end, so promoteSchelkAfterPreRuns takes the "nothing to promote" branch.
+func promoteTestRunner(
+	t *testing.T, mgr docker.ContainerManager, compaction *config.DBCompactionConfig,
+) (*runner, *containerRunParams, client.Spec, string, string) {
+	t.Helper()
+
+	bundleDir := bundleAt(t)
+	dataDir := t.TempDir()
+
+	host, port := headServer(t, 181, "0xend")
+
+	erigon, err := client.NewRegistry().Get(client.ClientErigon)
+	require.NoError(t, err)
+
+	spec := stubRPCSpec{Spec: erigon, rpcPort: port}
+
+	r := runnerWithBundle(bundleDir)
+	r.log = logrus.New()
+	r.containerMgr = mgr
+	r.cfg.FullConfig.Runner.Client.Config.DBCompaction = compaction
+
+	instance := &config.ClientInstance{ID: "erigon-bal-full", Client: "erigon"}
+
+	params := &containerRunParams{
+		Instance:  instance,
+		RunID:     "run-1",
+		ImageName: "ethpandaops/erigon:main",
+		ContainerSpec: &docker.ContainerSpec{
+			Name: "benchmarkoor-erigon",
+			Mounts: []docker.Mount{
+				{Type: "bind", Source: dataDir, Target: "/data"},
+			},
+		},
+		DataDirCfg: &config.DataDirConfig{
+			Method:        "schelk",
+			ContainerDir:  "/data",
+			SchelkOptions: &config.SchelkOptions{PromotePostPreRuns: true},
+		},
+	}
+
+	return r, params, spec, dataDir, host
+}
+
+// callPromoteSchelk runs the function under test with the log plumbing a real
+// run would pass it.
+func callPromoteSchelk(
+	t *testing.T, r *runner, params *containerRunParams, spec client.Spec,
+	containerIP, resultsDir string,
+) (string, bool, error) {
+	t.Helper()
+
+	logDone := make(chan struct{})
+	close(logDone)
+
+	cancel := context.CancelFunc(func() {})
+	cleanupFuncs := []func(){}
+
+	return r.promoteSchelkAfterPreRuns(
+		context.Background(), params, spec, "container-1", containerIP,
+		resultsDir, nil, &cleanupFuncs, make(chan struct{}),
+		&cancel, &logDone, r.log,
+	)
+}
+
+// The regression behind the erigon run that compacted nothing: the compaction
+// hung off the promote, so a datadir whose baseline already carried the pre-run
+// state returned at "nothing to promote" and skipped a configured compaction —
+// with no log line at all, because nothing that logs a skip had run.
+func TestPromoteSchelkAfterPreRuns_CompactsWhenThereIsNothingToPromote(t *testing.T) {
+	schelkSettleBeforeStop = 0
+	t.Cleanup(func() { schelkSettleBeforeStop = 20 * time.Second })
+
+	calls := schelkStub(t)
+
+	mgr := &fakeSchelkPromoteMgr{}
+	r, params, spec, dataDir, host := promoteTestRunner(t, mgr, &config.DBCompactionConfig{
+		Enabled: true,
+		When:    []string{config.DBCompactionBeforeBenchmarks},
+		Timeout: "1m",
+		Persist: &config.DBCompactionPersistConfig{Enabled: true},
+	})
+
+	resultsDir := t.TempDir()
+
+	_, _, err := callPromoteSchelk(t, r, params, spec, host, resultsDir)
+
+	// The stub schelk fails, which ends the function right after the work under
+	// test. Everything below is what ran before it.
+	require.ErrorContains(t, err, "schelk promote")
+
+	assert.Equal(
+		t, []string{
+			"seg du --datadir=/data --verbose",
+			"db compact --datadir=/data",
+			"seg du --datadir=/data --verbose",
+		}, mgr.compacted,
+		"the datadir needs no promote, but the configured compaction must still run",
+	)
+	assert.Equal(t, []string{"stop container-1"}, mgr.lifecycle)
+
+	// The promote is what writes the compacted database into the baseline; every
+	// per-test `schelk restore` would otherwise discard it.
+	recorded, readErr := os.ReadFile(*calls)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(recorded), "promote")
+
+	// The compaction reports where the run collects them.
+	assert.FileExists(t, filepath.Join(
+		resultsDir, config.DBCompactionResultsDir,
+		config.DBCompactionBeforeBenchmarks, "compaction.json",
+	))
+	assert.FileExists(t, filepath.Join(dataDir, config.DBCompactionMarkerFile))
+}
+
+// A datadir the marker already covers must not cost a client recycle: the skip
+// is decided before the stop, and the function returns as it always did.
+func TestPromoteSchelkAfterPreRuns_MarkedDatadirNeitherCompactsNorStops(t *testing.T) {
+	mgr := &fakeSchelkPromoteMgr{}
+	r, params, spec, dataDir, host := promoteTestRunner(t, mgr, &config.DBCompactionConfig{
+		Enabled: true,
+		When:    []string{config.DBCompactionBeforeBenchmarks},
+		Timeout: "1m",
+		Persist: &config.DBCompactionPersistConfig{Enabled: true},
+	})
+
+	writeMarkerFor(t, dataDir, config.DBCompactionBeforeBenchmarks)
+
+	newIP, baked, err := callPromoteSchelk(t, r, params, spec, host, t.TempDir())
+
+	require.NoError(t, err)
+	assert.Empty(t, newIP)
+	assert.True(t, baked, "the baseline still carries the pre-run state")
+	assert.Empty(t, mgr.compacted)
+	assert.Empty(t, mgr.lifecycle, "the client is left running")
+}
+
+// Without persist the compaction cannot reach the baseline, and the first
+// per-test `schelk restore` would discard it. Skip it rather than spend the
+// stop, the compaction and the restart on work nothing keeps.
+func TestPromoteSchelkAfterPreRuns_UnpersistedCompactionIsSkipped(t *testing.T) {
+	mgr := &fakeSchelkPromoteMgr{}
+	r, params, spec, _, host := promoteTestRunner(t, mgr, &config.DBCompactionConfig{
+		Enabled: true,
+		When:    []string{config.DBCompactionBeforeBenchmarks},
+		Timeout: "1m",
+	})
+
+	newIP, baked, err := callPromoteSchelk(t, r, params, spec, host, t.TempDir())
+
+	require.NoError(t, err)
+	assert.Empty(t, newIP)
+	assert.True(t, baked)
+	assert.Empty(t, mgr.compacted)
+	assert.Empty(t, mgr.lifecycle)
+}
+
+// A configured compaction with no datadir mount to compact is an error, not a
+// silent skip: the promote would otherwise publish a baseline the operator
+// believes is compacted.
+func TestPromoteSchelkAfterPreRuns_MissingDatadirMountFails(t *testing.T) {
+	mgr := &fakeSchelkPromoteMgr{}
+	r, params, spec, _, host := promoteTestRunner(t, mgr, &config.DBCompactionConfig{
+		Enabled: true,
+		When:    []string{config.DBCompactionBeforeBenchmarks},
+		Timeout: "1m",
+		Persist: &config.DBCompactionPersistConfig{Enabled: true},
+	})
+
+	params.ContainerSpec.Mounts = nil
+
+	_, _, err := callPromoteSchelk(t, r, params, spec, host, t.TempDir())
+
+	require.ErrorContains(t, err, "no datadir mount to compact")
+	assert.Empty(t, mgr.lifecycle)
+}


### PR DESCRIPTION
## The bug

`promoteSchelkAfterPreRuns` owns the only `before_benchmarks` compaction the `container-recreate` strategy has. The compaction sat at the end of the function, behind the promote. Two early returns stood in front of it:

- "Pre-run bundle already applied to this datadir; nothing to promote"
- "refusing to promote (the baseline would be the raw snapshot)"

A datadir whose schelk baseline already carried the pre-run state took the first one and lost a configured compaction. Nothing said so: the code that logs a skip had not run either.

An erigon run on `jochemnet/v1/glamsterdam-devnet-8` with `db_compaction` at `before_benchmarks` showed it. The log goes straight from the promote skip to the first test:

```
Datadir head matches the pre-run bundle ... pre_runs_applied=true
Pre-run bundle already applied to this datadir; nothing to promote
Executing test index=1/692 ...
```

The baseline stays promoted, so every later run repeated the skip. The other two strategies were always correct: `prepareDatadirBeforeBenchmarks` (single-client) and `strategy_checkpoint` both check the marker first and compact whether or not the pre-runs replay.

## The fix

Settle the compaction FIRST, before the head check that can return early:

1. Resolve the datadir mount. A configured compaction with no mount is still an error, not a skip.
2. Resolve the marker, as `prepareDatadirBeforeBenchmarks` does, so a datadir that is already compacted does not cost a client recycle.
3. Replay the pre-runs only when they are not applied yet.
4. Stop, compact, promote, restart — one stop, one promote, whichever branch got here.

A datadir that needs no promote now still gets the compaction, and the promote that persists it. Every per-test `schelk restore` would otherwise discard the compacted database. The marker goes into the promoted baseline, so the work happens once.

Two cases refuse the work instead, and say so in the log:

- The compaction does not persist at this phase. The first per-test restore would discard it.
- The suite has no pre-run steps, so the promote is refused. The compaction goes with it.

## Tests

`pkg/runner/strategy_container_compaction_test.go` drives the function with a fake container manager, a stub RPC head at the bundle's end, and a stub `schelk` binary that records its arguments and fails:

- A datadir that needs no promote is compacted, then promoted (the regression).
- A marked datadir neither compacts nor stops the client.
- An unpersisted compaction is skipped.
- A missing datadir mount fails the run.

`schelkSettleBeforeStop` becomes a `var` so the tests can shorten it, matching `SchelkGracePeriod`.

## Verified

- `go test -race ./pkg/runner/` passes.
- `make lint-core` reports 0 issues.
- The `pkg/config` failures on this machine are pre-existing and macOS-only (`/proc/mounts`). They fail on `master` too.
