### PR TITLE
feat(ui): show the bucket ranges and double the heatmap colors

### DIFF
--- a/ui/src/components/run-detail/TestHeatmap.tsx
+++ b/ui/src/components/run-detail/TestHeatmap.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx'
 import { Check, Copy, Download } from 'lucide-react'
 import type { TestEntry, SuiteTest, AggregatedStats, MethodsAggregated, StepResult, PostTestRPCCallConfig } from '@/api/types'
 import { fetchHead } from '@/api/client'
+import { ColorScaleLegend } from '@/components/shared/ColorScaleLegend'
 import { Modal } from '@/components/shared/Modal'
 import { TestName } from '@/components/shared/TestName'
 import { compileQuery, testNameMatches, toggleSearchTerm } from '@/utils/eestNameFilter'
@@ -22,10 +23,13 @@ import {
   DEFAULT_THRESHOLD,
   SLOW_COLOR,
   THRESHOLD_COLORS,
+  THRESHOLD_LIMIT_STEP,
+  durationStepRange,
   formatSlowMs,
   getColorByDuration,
   getColorByThreshold,
   isSlowPayload,
+  thresholdStepRange,
 } from '@/utils/perfThreshold'
 import { getPayloadTimes } from '@/utils/payloadTime'
 
@@ -961,15 +965,16 @@ export function TestHeatmap({
 
       {/* Legend */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs/5 text-gray-500 dark:text-gray-400">
-        <span className="flex items-center gap-1">
-          <span>{isDurationMode ? `<${formatSlowMs(slowMs / 2)}` : `>${threshold * 2}`}</span>
-          <span className="flex gap-0.5">
-            {THRESHOLD_COLORS.map((color, i) => (
-              <span key={i} className="size-3 rounded-xs" style={{ backgroundColor: color }} />
-            ))}
-          </span>
-          <span>{isDurationMode ? `>${formatSlowMs(slowMs * 2)}` : `<${threshold / 2}`}</span>
-        </span>
+        <ColorScaleLegend
+          colors={THRESHOLD_COLORS}
+          startLabel={isDurationMode ? `<${formatSlowMs(slowMs / 3)}` : `>${threshold * 3}`}
+          endLabel={isDurationMode ? `>${formatSlowMs(slowMs * 3)}` : `<${Math.round(threshold / 3)}`}
+          title={isDurationMode ? 'Payload time buckets' : 'MGas/s buckets'}
+          stepRange={(step) =>
+            isDurationMode ? durationStepRange(step, slowMs) : `${thresholdStepRange(step, threshold)} MGas/s`
+          }
+          note={`Each bucket is a multiple of the ${isDurationMode ? 'limit' : 'threshold'} (${limitLabel})`}
+        />
         <span className="text-gray-400 dark:text-gray-500">({limitLabel} = yellow)</span>
         <span>
           <span className="mr-1 inline-block size-3 rounded-xs" style={NO_DATA_STYLE} />
@@ -980,13 +985,13 @@ export function TestHeatmap({
           Not processed
         </span>
         <span>
-          <span className="mr-1 inline-block size-3 rounded-xs ring-1 ring-red-500" style={{ backgroundColor: THRESHOLD_COLORS[2] }} />
+          <span className="mr-1 inline-block size-3 rounded-xs ring-1 ring-red-500" style={{ backgroundColor: THRESHOLD_COLORS[THRESHOLD_LIMIT_STEP] }} />
           Has failures
         </span>
         <span title={`A single engine_newPayload call above ${formatSlowMs(slowMs)}`}>
           <span
             className="mr-1 inline-block size-3 rounded-xs"
-            style={{ backgroundColor: THRESHOLD_COLORS[2], outline: `2px solid ${SLOW_COLOR}`, outlineOffset: '-2px' }}
+            style={{ backgroundColor: THRESHOLD_COLORS[THRESHOLD_LIMIT_STEP], outline: `2px solid ${SLOW_COLOR}`, outlineOffset: '-2px' }}
           />
           Slow payload (&gt;{formatSlowMs(slowMs)})
         </span>

--- a/ui/src/components/shared/ColorScaleLegend.tsx
+++ b/ui/src/components/shared/ColorScaleLegend.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react'
+import clsx from 'clsx'
+
+interface ColorScaleLegendProps {
+  /** Scale colours, best first. */
+  colors: readonly string[]
+  /** Caption before the swatches — the best end of the scale. */
+  startLabel?: string
+  /** Caption after the swatches — the worst end of the scale. */
+  endLabel?: string
+  /** Heading of the hover panel. */
+  title?: string
+  /** Range of a step, one line in the hover panel. */
+  stepRange: (step: number) => string
+  /** Extra line under the ranges in the hover panel. */
+  note?: string
+}
+
+interface PanelPosition {
+  step: number
+  x: number
+  y: number
+}
+
+/**
+ * Legend for a discrete colour scale. Hover a swatch to open a panel
+ * with the range of every bucket, with the hovered one highlighted.
+ */
+export function ColorScaleLegend({ colors, startLabel, endLabel, title, stepRange, note }: ColorScaleLegendProps) {
+  const [panel, setPanel] = useState<PanelPosition | null>(null)
+
+  const handleMouseEnter = (step: number, event: React.MouseEvent) => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    setPanel({ step, x: rect.left + rect.width / 2, y: rect.top })
+  }
+
+  return (
+    <span className="flex items-center gap-1">
+      {startLabel && <span>{startLabel}</span>}
+      <span className="flex gap-0.5">
+        {colors.map((color, step) => (
+          <span
+            key={step}
+            className={clsx(
+              'size-3 cursor-help rounded-xs ring-inset transition-transform',
+              panel?.step === step && 'scale-125 ring-1 ring-gray-600 dark:ring-gray-200',
+            )}
+            style={{ backgroundColor: color }}
+            onMouseEnter={(event) => handleMouseEnter(step, event)}
+            onMouseLeave={() => setPanel(null)}
+          />
+        ))}
+      </span>
+      {endLabel && <span>{endLabel}</span>}
+
+      {panel && (
+        <div
+          className="pointer-events-none fixed z-50 rounded-sm bg-white px-3 py-2 text-xs/5 text-gray-900 shadow-lg ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-700"
+          style={{ left: panel.x, top: panel.y - 8, transform: 'translate(-50%, -100%)' }}
+        >
+          {title && <div className="mb-1 font-medium">{title}</div>}
+          <div className="flex flex-col gap-0.5">
+            {colors.map((color, step) => (
+              <div
+                key={step}
+                className={clsx(
+                  'flex items-center gap-2 whitespace-nowrap',
+                  step === panel.step ? 'font-medium' : 'text-gray-500 dark:text-gray-400',
+                )}
+              >
+                <span className="size-3 shrink-0 rounded-xs" style={{ backgroundColor: color }} />
+                <span>{stepRange(step)}</span>
+              </div>
+            ))}
+          </div>
+          {note && (
+            <div className="mt-1 border-t border-gray-200 pt-1 text-gray-400 dark:border-gray-700 dark:text-gray-500">{note}</div>
+          )}
+        </div>
+      )}
+    </span>
+  )
+}

--- a/ui/src/components/suite-detail/RunsHeatmap.tsx
+++ b/ui/src/components/suite-detail/RunsHeatmap.tsx
@@ -5,6 +5,8 @@ import { AlertTriangle, GitCompareArrows, Layers } from 'lucide-react'
 import { type IndexEntry, type IndexStepType, getIndexAggregatedStats, ALL_INDEX_STEP_TYPES } from '@/api/types'
 import { formatTimestamp } from '@/utils/date'
 import { ClientBadge } from '@/components/shared/ClientBadge'
+import { ColorScaleLegend } from '@/components/shared/ColorScaleLegend'
+import { THRESHOLD_COLORS } from '@/utils/perfThreshold'
 
 // Check if run completed successfully (no status = completed for backward compat)
 function isRunCompleted(run: IndexEntry): boolean {
@@ -18,23 +20,35 @@ function isRunLive(run: IndexEntry): boolean {
 
 const MAX_RUNS_PER_CLIENT = 30
 
-// 5-level discrete color scale (green to red for duration, reversed for MGas/s)
-const COLORS = [
-  '#22c55e', // green - best
-  '#84cc16', // lime
-  '#eab308', // yellow
-  '#f97316', // orange
-  '#ef4444', // red - worst
-]
+// Discrete color scale (green to red for duration, reversed for MGas/s).
+// Shared with the run-detail heatmaps so every heatmap reads the same way.
+const COLORS = THRESHOLD_COLORS
+const LEVELS = COLORS.length
+
+// Colour of a cell whose value is unknown — the middle of the scale.
+const NEUTRAL_COLOR = COLORS[Math.floor(LEVELS / 2)]
+
+// Observed value range of one colour step. null when no run fell in it.
+type ScaleBound = { lo: number; hi: number } | null
+
+interface ColorScale {
+  color: (value: number) => string
+  /** Value range of each step, best first. Empty when there is no data. */
+  bounds: ScaleBound[]
+}
 
 /**
- * Create a percentile-based color mapper. Values are split into equal-sized
- * quintiles so the color spread is balanced regardless of outliers.
+ * Create a percentile-based color mapper. Values are split into
+ * equal-sized bands so the color spread is balanced regardless of
+ * outliers. The bounds report the values each band actually holds, so
+ * the legend can name the ranges.
  */
-function createColorScale(values: number[], higherIsBetter: boolean): (value: number) => string {
-  if (values.length === 0) return () => COLORS[2]
+function createColorScale(values: number[], higherIsBetter: boolean): ColorScale {
+  const bounds: ScaleBound[] = Array(LEVELS).fill(null)
+  if (values.length === 0) return { color: () => NEUTRAL_COLOR, bounds }
+
   const sorted = [...values].sort((a, b) => a - b)
-  return (value: number) => {
+  const level = (value: number) => {
     // Binary search for rank position
     let lo = 0
     let hi = sorted.length
@@ -45,9 +59,17 @@ function createColorScale(values: number[], higherIsBetter: boolean): (value: nu
     }
     let percentile = lo / sorted.length
     if (higherIsBetter) percentile = 1 - percentile
-    const level = Math.min(4, Math.floor(percentile * 5))
-    return COLORS[level]
+    return Math.min(LEVELS - 1, Math.floor(percentile * LEVELS))
   }
+
+  for (const value of sorted) {
+    const step = level(value)
+    const bound = bounds[step]
+    if (bound === null) bounds[step] = { lo: value, hi: value }
+    else bounds[step] = { lo: Math.min(bound.lo, value), hi: Math.max(bound.hi, value) }
+  }
+
+  return { color: (value: number) => COLORS[level(value)], bounds }
 }
 
 function formatDurationMinSec(nanoseconds: number): string {
@@ -124,8 +146,8 @@ interface GroupSection {
   clientRuns: Record<string, IndexEntry[]>
   clientDurationStats: Record<string, ClientStats>
   clientMgasStats: Record<string, ClientStats>
-  clientDurationScales: Record<string, (v: number) => string>
-  clientMgasScales: Record<string, (v: number) => string>
+  clientDurationScales: Record<string, ColorScale>
+  clientMgasScales: Record<string, ColorScale>
 }
 
 interface TooltipData {
@@ -201,8 +223,8 @@ export function RunsHeatmap({
     const clientRuns: Record<string, IndexEntry[]> = {}
     const clientDurationStats: Record<string, ClientStats> = {}
     const clientMgasStats: Record<string, ClientStats> = {}
-    const clientDurationScales: Record<string, (v: number) => string> = {}
-    const clientMgasScales: Record<string, (v: number) => string> = {}
+    const clientDurationScales: Record<string, ColorScale> = {}
+    const clientMgasScales: Record<string, ColorScale> = {}
 
     const allDurations: number[] = []
     const allMgas: number[] = []
@@ -301,8 +323,8 @@ export function RunsHeatmap({
       const sectionClientRuns: Record<string, IndexEntry[]> = {}
       const sectionDurationStats: Record<string, ClientStats> = {}
       const sectionMgasStats: Record<string, ClientStats> = {}
-      const sectionDurationScales: Record<string, (v: number) => string> = {}
-      const sectionMgasScales: Record<string, (v: number) => string> = {}
+      const sectionDurationScales: Record<string, ColorScale> = {}
+      const sectionMgasScales: Record<string, ColorScale> = {}
 
       for (const [c, cRuns] of Object.entries(byClient)) {
         const sorted = [...cRuns].sort((a, b) => b.timestamp - a.timestamp)
@@ -355,26 +377,26 @@ export function RunsHeatmap({
   const getColorForRun = (
     run: IndexEntry,
     overrides?: {
-      mgasScales: Record<string, (v: number) => string>
-      durationScales: Record<string, (v: number) => string>
+      mgasScales: Record<string, ColorScale>
+      durationScales: Record<string, ColorScale>
     },
   ) => {
     const stats = getIndexAggregatedStats(run, stepFilter)
     if (metricMode === 'mgas') {
       const mgas = calculateMGasPerSec(stats.gasUsed, stats.gasUsedDuration)
-      if (mgas === undefined) return COLORS[2]
+      if (mgas === undefined) return NEUTRAL_COLOR
 
       if (colorNormalization === 'client') {
         const scales = overrides?.mgasScales ?? clientMgasScales
-        return scales[run.instance.client]?.(mgas) ?? COLORS[2]
+        return scales[run.instance.client]?.color(mgas) ?? NEUTRAL_COLOR
       }
-      return suiteMgasScale(mgas)
+      return suiteMgasScale.color(mgas)
     } else {
       if (colorNormalization === 'client') {
         const scales = overrides?.durationScales ?? clientDurationScales
-        return scales[run.instance.client]?.(stats.duration) ?? COLORS[2]
+        return scales[run.instance.client]?.color(stats.duration) ?? NEUTRAL_COLOR
       }
-      return suiteDurationScale(stats.duration)
+      return suiteDurationScale.color(stats.duration)
     }
   }
 
@@ -408,6 +430,31 @@ export function RunsHeatmap({
   const handleMouseLeave = () => {
     setTooltip(null)
   }
+
+  // Legend ranges. The suite scale colours every tile in 'suite' mode,
+  // so its bounds are the real ones. In 'client' mode each client has
+  // its own scale, so the legend names the percentile band instead.
+  const legendScale = metricMode === 'mgas' ? suiteMgasScale : suiteDurationScale
+  const bandLabel = (step: number) => {
+    const from = Math.round((step / LEVELS) * 100)
+    const to = Math.round(((step + 1) / LEVELS) * 100)
+    return `Fastest ${from}–${to}%`
+  }
+  const legendStepRange = (step: number) => {
+    const band = bandLabel(step)
+    if (colorNormalization === 'client') return band
+
+    const bound = legendScale.bounds[step]
+    if (!bound) return `${band} — no runs`
+
+    const fmt = (value: number) => (metricMode === 'mgas' ? value.toFixed(1) : formatDurationCompact(value))
+    const range = bound.lo === bound.hi ? fmt(bound.lo) : `${fmt(bound.lo)} – ${fmt(bound.hi)}`
+    return `${band}: ${range}${metricMode === 'mgas' ? ' MGas/s' : ''}`
+  }
+  const legendNote =
+    colorNormalization === 'client'
+      ? 'Each client is ranked against its own runs'
+      : 'All runs of the suite are ranked together'
 
   if (runs.length === 0) {
     return null
@@ -675,17 +722,16 @@ export function RunsHeatmap({
       {/* Legend */}
       <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs/5 text-gray-500 dark:text-gray-400">
         <span>Recent → Older</span>
-        <span className="flex items-center gap-1">
-          <span>Fast</span>
-          <span className="flex gap-0.5">
-            {COLORS.map((color, i) => (
-              <span key={i} className="size-3 rounded-xs" style={{ backgroundColor: color }} />
-            ))}
-          </span>
-          <span>Slow</span>
-        </span>
+        <ColorScaleLegend
+          colors={COLORS}
+          startLabel="Fast"
+          endLabel="Slow"
+          title={`${metricMode === 'mgas' ? 'MGas/s' : 'Duration'} buckets`}
+          stepRange={legendStepRange}
+          note={legendNote}
+        />
         <span>
-          <span className="relative mr-1 inline-block size-3 rounded-xs ring-2 ring-inset ring-orange-500" style={{ backgroundColor: COLORS[2] }}>
+          <span className="relative mr-1 inline-block size-3 rounded-xs ring-2 ring-inset ring-orange-500" style={{ backgroundColor: NEUTRAL_COLOR }}>
             <svg className="absolute inset-0 size-3" viewBox="0 0 12 12" fill="none">
               <text x="6" y="9.5" textAnchor="middle" fill="white" fontSize="9" fontWeight="bold" fontFamily="system-ui">!</text>
             </svg>

--- a/ui/src/components/suite-detail/TestHeatmap.tsx
+++ b/ui/src/components/suite-detail/TestHeatmap.tsx
@@ -10,6 +10,8 @@ import { Spinner } from '@/components/shared/Spinner'
 import { TestName } from '@/components/shared/TestName'
 import { testNameMatches, toggleSearchTerm } from '@/utils/eestNameFilter'
 import { formatTimestamp } from '@/utils/date'
+import { THRESHOLD_COLORS, THRESHOLD_LIMIT_STEP, getColorByThreshold, thresholdStepRange } from '@/utils/perfThreshold'
+import { ColorScaleLegend } from '@/components/shared/ColorScaleLegend'
 
 const DEFAULT_PAGE_SIZE = 20
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const
@@ -24,33 +26,18 @@ const MIN_THRESHOLD = 10
 const MAX_THRESHOLD = 1000
 const DEFAULT_THRESHOLD = 60
 
-// 5-level discrete color scale (green to red)
-const COLORS = [
-  '#22c55e', // green - fast (high MGas/s)
-  '#84cc16', // lime
-  '#eab308', // yellow
-  '#f97316', // orange
-  '#ef4444', // red - slow (low MGas/s)
-]
+// Discrete color scale (green to red), shared with the run-detail
+// heatmaps so every heatmap in the UI reads the same way.
+const COLORS = THRESHOLD_COLORS
+const LEVELS = COLORS.length
 
 // For per-test normalization (border color)
 function getColorByNormalizedValue(value: number, min: number, max: number): string {
-  if (max === min) return COLORS[2] // middle color if all same
+  if (max === min) return COLORS[THRESHOLD_LIMIT_STEP] // middle color if all same
   // Reverse: high values (fast) get green, low values (slow) get red
   const normalized = 1 - (value - min) / (max - min)
-  const level = Math.min(4, Math.floor(normalized * 5))
+  const level = Math.min(LEVELS - 1, Math.floor(normalized * LEVELS))
   return COLORS[level]
-}
-
-// For global threshold-based coloring (fill color)
-function getColorByThreshold(value: number, threshold: number): string {
-  // Scale: threshold = yellow, >threshold = green, <threshold = red
-  const ratio = value / threshold
-  if (ratio >= 2) return COLORS[0] // Very fast - green
-  if (ratio >= 1.5) return COLORS[1] // Fast - lime
-  if (ratio >= 1) return COLORS[2] // At threshold - yellow
-  if (ratio >= 0.5) return COLORS[3] // Slow - orange
-  return COLORS[4] // Very slow - red
 }
 
 function calculateMGasPerSec(gasUsed: number, timeNs: number): number | undefined {
@@ -925,13 +912,14 @@ export function TestHeatmap({ stats, testFiles, isDark, isLoading, suiteHash, su
       {/* Legend */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs/5 text-gray-500 dark:text-gray-400">
         <span className="flex items-center gap-1">
-          <span>&gt;{threshold * 2}</span>
-          <span className="flex gap-0.5">
-            {COLORS.map((color, i) => (
-              <span key={i} className="size-3 rounded-xs" style={{ backgroundColor: color }} />
-            ))}
-          </span>
-          <span>&lt;{threshold / 2}</span>
+          <ColorScaleLegend
+            colors={COLORS}
+            startLabel={`>${threshold * 3}`}
+            endLabel={`<${Math.round(threshold / 3)}`}
+            title="MGas/s buckets"
+            stepRange={(step) => `${thresholdStepRange(step, threshold)} MGas/s`}
+            note={`Each bucket is a multiple of the threshold (${threshold} MGas/s)`}
+          />
           <span className="text-gray-400 dark:text-gray-500">(fill: threshold, border: per-test)</span>
         </span>
         <span>

--- a/ui/src/utils/perfThreshold.ts
+++ b/ui/src/utils/perfThreshold.ts
@@ -2,42 +2,64 @@
 // for the run-detail page; the Performance Heatmap, the distribution
 // histogram, and the Dimension Breakdown bars all colour against it.
 
+import { formatDuration } from './format'
+
 export const MIN_THRESHOLD = 1
 export const MAX_THRESHOLD = 1000
 export const DEFAULT_THRESHOLD = 60
 
+// Ten-step scale, green (well above the limit) to red (well below it).
+// The same palette colours the percentile scales on the suite page, so
+// every heatmap in the UI reads the same way.
 export const THRESHOLD_COLORS = [
-  '#22c55e', // very fast — green
-  '#84cc16', // fast — lime
-  '#eab308', // at threshold — yellow
-  '#f97316', // slow — orange
-  '#ef4444', // very slow — red
+  '#047857', // deep green
+  '#16a34a', // green
+  '#32a71b', // green-lime
+  '#84cc16', // lime
+  '#eab308', // yellow — the limit itself
+  '#f59e0b', // amber
+  '#f97316', // orange
+  '#f2542c', // deep orange
+  '#ef4444', // red
+  '#b91c1c', // deep red
 ] as const
 
-// Text classes for the same five steps. The tile colours are fills and
-// are too light for small text, so a value rendered as text uses these.
+// Lower bound of each step, as a multiple of the limit. The steps are
+// symmetric around the limit: 1.25x pairs with 0.8x, 1.5x with 1/1.5x,
+// 2x with 0.5x and 3x with 1/3x.
+export const THRESHOLD_RATIOS = [3, 2, 1.5, 1.25, 1, 0.8, 1 / 1.5, 0.5, 1 / 3, 0] as const
+
+// Step of a value that sits exactly on the limit — the yellow one.
+export const THRESHOLD_LIMIT_STEP = 4
+
+// Text classes for the same scale. The tile colours are fills and are
+// too light for small text, so a value rendered as text uses these. Ten
+// fills map onto five text colours, at the boundaries the earlier
+// five-step scale used: >=2x green, >=1.5x lime, >=1x yellow, >=0.5x
+// orange, below that red.
 export const THRESHOLD_TEXT_CLASSES = [
+  'text-green-600 dark:text-green-400',
   'text-green-600 dark:text-green-400',
   'text-lime-600 dark:text-lime-400',
   'text-yellow-600 dark:text-yellow-400',
+  'text-yellow-600 dark:text-yellow-400',
   'text-orange-600 dark:text-orange-400',
+  'text-orange-600 dark:text-orange-400',
+  'text-orange-600 dark:text-orange-400',
+  'text-red-600 dark:text-red-400',
   'text-red-600 dark:text-red-400',
 ] as const
 
 /**
- * Step of the scale a "higher is better" ratio falls in:
- *   ratio >= 2     → 0  very fast
- *   ratio >= 1.5   → 1  fast
- *   ratio >= 1     → 2  at the limit
- *   ratio >= 0.5   → 3  slow
- *   ratio <  0.5   → 4  very slow
+ * Step of the scale a "higher is better" ratio falls in. Step 0 is the
+ * best (ratio >= 3) and step 9 the worst (ratio < 1/3).
  */
-function thresholdStep(ratio: number): number {
-  if (ratio >= 2) return 0
-  if (ratio >= 1.5) return 1
-  if (ratio >= 1) return 2
-  if (ratio >= 0.5) return 3
-  return 4
+export function thresholdStep(ratio: number): number {
+  for (let i = 0; i < THRESHOLD_RATIOS.length; i++) {
+    if (ratio >= THRESHOLD_RATIOS[i]) return i
+  }
+
+  return THRESHOLD_RATIOS.length - 1
 }
 
 // A duration is better when it is shorter, so the ratio inverts.
@@ -56,6 +78,37 @@ export function getTextClassByThreshold(value: number, threshold: number): strin
   return THRESHOLD_TEXT_CLASSES[thresholdStep(value / threshold)]
 }
 
+/**
+ * MGas/s range of a step, for the legend. The step holds every value
+ * from its own multiple of the threshold up to the next one, e.g.
+ * "90 - 120" for step 3 at a threshold of 60.
+ */
+export function thresholdStepRange(step: number, threshold: number): string {
+  const low = THRESHOLD_RATIOS[step] * threshold
+  const fmt = (value: number) => (value >= 10 ? value.toFixed(0) : value.toFixed(1))
+  if (step === 0) return `≥ ${fmt(low)}`
+
+  const high = THRESHOLD_RATIOS[step - 1] * threshold
+  if (low === 0) return `< ${fmt(high)}`
+
+  return `${fmt(low)} – ${fmt(high)}`
+}
+
+/**
+ * Payload-duration range of a step, for the legend. A long duration is a
+ * bad one, so the step bounds invert: step 0 is the shortest.
+ */
+export function durationStepRange(step: number, slowMs: number): string {
+  const limitNs = slowMs * 1_000_000
+  const high = THRESHOLD_RATIOS[step] === 0 ? undefined : limitNs / THRESHOLD_RATIOS[step]
+  if (step === 0) return `≤ ${formatDuration(high as number)}`
+
+  const low = limitNs / THRESHOLD_RATIOS[step - 1]
+  if (high === undefined) return `> ${formatDuration(low)}`
+
+  return `${formatDuration(low)} – ${formatDuration(high)}`
+}
+
 // Slow-payload model. The user picks a duration limit on the run-detail
 // page; the Performance Heatmap marks every test with an
 // engine_newPayload call above that limit.
@@ -69,14 +122,7 @@ export const DEFAULT_SLOW_MS = 3_000
 // (green → red) and from the red failure ring.
 export const SLOW_COLOR = '#d946ef' // fuchsia-500
 
-/**
- * Map a payload duration to a colour, scaled against the slow limit:
- *   duration <= limit/2   → green   (very fast)
- *   duration <= limit/1.5 → lime    (fast)
- *   duration <= limit     → yellow  (at the limit)
- *   duration <= limit*2   → orange  (slow)
- *   duration >  limit*2   → red     (very slow)
- */
+/** Map a payload duration to a colour, scaled against the slow limit. */
 export function getColorByDuration(nanoseconds: number, slowMs: number): string {
   return THRESHOLD_COLORS[thresholdStep(durationRatio(nanoseconds, slowMs))]
 }


### PR DESCRIPTION
## What

Two changes to the colored buckets in the heatmaps.

**1. The legend tells you the bucket ranges.** Hover a colour and a panel opens with the range of every bucket. The panel marks the bucket you hover.

**2. Twice the colours.** The scale goes from 5 steps to 10, so a small diff between two runs is easier to see.

## Where

- **Performance Heatmap** — run detail page. The panel shows MGas/s ranges, or real payload times in Duration mode (`≤ 1.00s`, `1.00s – 1.50s`, … `> 9.00s`).
- **Recent Runs by Client** — suite detail page.
- **Test Heatmap** — suite detail page. It kept its own copy of the 5-step palette, so it now shares the same one. Both heatmaps on that page match again.

## The new scale

The bucket edges are multiples of the limit, symmetric around it. The four old edges (2x, 1.5x, 1x, 0.5x) all stay, and a value on the threshold is still yellow.

| step | multiple | at threshold 60 | colour |
|---|---|---|---|
| 0 | ≥ 3x | ≥ 180 | `#047857` deep green |
| 1 | ≥ 2x | 120–180 | `#16a34a` green |
| 2 | ≥ 1.5x | 90–120 | `#32a71b` green-lime |
| 3 | ≥ 1.25x | 75–90 | `#84cc16` lime |
| 4 | ≥ 1x | 60–75 | `#eab308` yellow |
| 5 | ≥ 0.8x | 48–60 | `#f59e0b` amber |
| 6 | ≥ 1/1.5x | 40–48 | `#f97316` orange |
| 7 | ≥ 0.5x | 30–40 | `#f2542c` deep orange |
| 8 | ≥ 1/3x | 20–30 | `#ef4444` red |
| 9 | < 1/3x | < 20 | `#b91c1c` deep red |

## Recent Runs by Client

That heatmap ranks runs by percentile, not against a threshold. The scale now splits into 10 bands and reports the values each band holds, so the panel reads `Fastest 20–30%: 118.4 – 126.1 MGas/s`.

In `Colors: Client` mode each client has its own scale. The panel then shows the band alone, plus a note that each client is ranked against its own runs.

## Notes

- Text colours in the tables and breakdowns stay at 5 levels. Ten text colours are not readable at 12px, so the 10 steps map onto the 5 old text colours at the old boundaries.
- The inline legend end labels said 2x / 0.5x. They now say 3x / (1/3)x, to match the wider ramp.

## Test

- `tsc -b` clean
- `eslint` clean
- `npm test` — 12 tests pass
