### PR TITLE
fix(ui): color the run heatmap by shortfall, not by percentile rank

### DIFF
--- a/ui/src/components/suite-detail/RunsHeatmap.tsx
+++ b/ui/src/components/suite-detail/RunsHeatmap.tsx
@@ -6,7 +6,16 @@ import { type IndexEntry, type IndexStepType, getIndexAggregatedStats, ALL_INDEX
 import { formatTimestamp } from '@/utils/date'
 import { ClientBadge } from '@/components/shared/ClientBadge'
 import { ColorScaleLegend } from '@/components/shared/ColorScaleLegend'
-import { THRESHOLD_COLORS } from '@/utils/perfThreshold'
+import {
+  COLORS,
+  LEVELS,
+  MIN_DROP,
+  NEUTRAL_COLOR,
+  type ColorScale,
+  calculatePercentile,
+  createColorScale,
+  formatShortfall,
+} from '@/utils/runColorScale'
 
 // Check if run completed successfully (no status = completed for backward compat)
 function isRunCompleted(run: IndexEntry): boolean {
@@ -19,58 +28,6 @@ function isRunLive(run: IndexEntry): boolean {
 }
 
 const MAX_RUNS_PER_CLIENT = 30
-
-// Discrete color scale (green to red for duration, reversed for MGas/s).
-// Shared with the run-detail heatmaps so every heatmap reads the same way.
-const COLORS = THRESHOLD_COLORS
-const LEVELS = COLORS.length
-
-// Colour of a cell whose value is unknown — the middle of the scale.
-const NEUTRAL_COLOR = COLORS[Math.floor(LEVELS / 2)]
-
-// Observed value range of one colour step. null when no run fell in it.
-type ScaleBound = { lo: number; hi: number } | null
-
-interface ColorScale {
-  color: (value: number) => string
-  /** Value range of each step, best first. Empty when there is no data. */
-  bounds: ScaleBound[]
-}
-
-/**
- * Create a percentile-based color mapper. Values are split into
- * equal-sized bands so the color spread is balanced regardless of
- * outliers. The bounds report the values each band actually holds, so
- * the legend can name the ranges.
- */
-function createColorScale(values: number[], higherIsBetter: boolean): ColorScale {
-  const bounds: ScaleBound[] = Array(LEVELS).fill(null)
-  if (values.length === 0) return { color: () => NEUTRAL_COLOR, bounds }
-
-  const sorted = [...values].sort((a, b) => a - b)
-  const level = (value: number) => {
-    // Binary search for rank position
-    let lo = 0
-    let hi = sorted.length
-    while (lo < hi) {
-      const mid = (lo + hi) >>> 1
-      if (sorted[mid] < value) lo = mid + 1
-      else hi = mid
-    }
-    let percentile = lo / sorted.length
-    if (higherIsBetter) percentile = 1 - percentile
-    return Math.min(LEVELS - 1, Math.floor(percentile * LEVELS))
-  }
-
-  for (const value of sorted) {
-    const step = level(value)
-    const bound = bounds[step]
-    if (bound === null) bounds[step] = { lo: value, hi: value }
-    else bounds[step] = { lo: Math.min(bound.lo, value), hi: Math.max(bound.hi, value) }
-  }
-
-  return { color: (value: number) => COLORS[level(value)], bounds }
-}
 
 function formatDurationMinSec(nanoseconds: number): string {
   const seconds = nanoseconds / 1_000_000_000
@@ -91,15 +48,6 @@ function formatDurationCompact(nanoseconds: number): string {
 function calculateMGasPerSec(gasUsed: number, gasUsedDuration: number): number | undefined {
   if (gasUsedDuration <= 0 || gasUsed <= 0) return undefined
   return (gasUsed * 1000) / gasUsedDuration
-}
-
-function calculatePercentile(sortedValues: number[], percentile: number): number {
-  if (sortedValues.length === 0) return 0
-  const index = (percentile / 100) * (sortedValues.length - 1)
-  const lower = Math.floor(index)
-  const upper = Math.ceil(index)
-  if (lower === upper) return sortedValues[lower]
-  return sortedValues[lower] + (sortedValues[upper] - sortedValues[lower]) * (index - lower)
 }
 
 interface ClientStats {
@@ -431,30 +379,44 @@ export function RunsHeatmap({
     setTooltip(null)
   }
 
-  // Legend ranges. The suite scale colours every tile in 'suite' mode,
-  // so its bounds are the real ones. In 'client' mode each client has
-  // its own scale, so the legend names the percentile band instead.
+  // Legend ranges. In 'suite' mode one scale colours every tile, so the
+  // legend can name the real values. In 'client' mode each client has
+  // its own scale, so it names the shortfall band alone.
   const legendScale = metricMode === 'mgas' ? suiteMgasScale : suiteDurationScale
-  const bandLabel = (step: number) => {
-    const from = Math.round((step / LEVELS) * 100)
-    const to = Math.round(((step + 1) / LEVELS) * 100)
-    return `Fastest ${from}–${to}%`
-  }
+  const showValues = colorNormalization === 'suite' && legendScale.hasData
+  const stepWidth = showValues ? legendScale.step : MIN_DROP / LEVELS
+
   const legendStepRange = (step: number) => {
-    const band = bandLabel(step)
-    if (colorNormalization === 'client') return band
+    const from = step * stepWidth
+    const to = (step + 1) * stepWidth
+    const band =
+      step === 0
+        ? `within ${formatShortfall(to)} of best`
+        : step === LEVELS - 1
+          ? `over ${formatShortfall(from)} off`
+          : `${formatShortfall(from)} – ${formatShortfall(to)} off`
+    if (!showValues) return band
 
-    const bound = legendScale.bounds[step]
-    if (!bound) return `${band} — no runs`
+    const { top } = legendScale
+    if (metricMode === 'mgas') {
+      const fmt = (value: number) => value.toFixed(1)
+      if (step === 0) return `≥ ${fmt(top * (1 - to))} MGas/s · ${band}`
+      if (step === LEVELS - 1) return `< ${fmt(Math.max(0, top * (1 - from)))} MGas/s · ${band}`
 
-    const fmt = (value: number) => (metricMode === 'mgas' ? value.toFixed(1) : formatDurationCompact(value))
-    const range = bound.lo === bound.hi ? fmt(bound.lo) : `${fmt(bound.lo)} – ${fmt(bound.hi)}`
-    return `${band}: ${range}${metricMode === 'mgas' ? ' MGas/s' : ''}`
+      return `${fmt(Math.max(0, top * (1 - to)))} – ${fmt(top * (1 - from))} MGas/s · ${band}`
+    }
+
+    const fmt = formatDurationCompact
+    if (step === 0) return `≤ ${fmt(top * (1 + to))} · ${band}`
+    if (step === LEVELS - 1) return `> ${fmt(top * (1 + from))} · ${band}`
+
+    return `${fmt(top * (1 + from))} – ${fmt(top * (1 + to))} · ${band}`
   }
+
   const legendNote =
     colorNormalization === 'client'
-      ? 'Each client is ranked against its own runs'
-      : 'All runs of the suite are ranked together'
+      ? 'Each client is measured against its own best run. A client whose runs spread wider than 15% gets a wider scale.'
+      : 'Every run of the suite is measured against the best one.'
 
   if (runs.length === 0) {
     return null

--- a/ui/src/components/suite-detail/RunsHeatmap.tsx
+++ b/ui/src/components/suite-detail/RunsHeatmap.tsx
@@ -50,6 +50,14 @@ function calculateMGasPerSec(gasUsed: number, gasUsedDuration: number): number |
   return (gasUsed * 1000) / gasUsedDuration
 }
 
+// A run that has not finished reports no steps, so its duration is 0.
+// Such a run must stay out of the scale and out of the stats, the same
+// way calculateMGasPerSec keeps it out of the MGas/s ones.
+function calculateDuration(duration: number): number | undefined {
+  if (duration <= 0) return undefined
+  return duration
+}
+
 interface ClientStats {
   min?: number
   max?: number
@@ -182,18 +190,25 @@ export function RunsHeatmap({
       clientRuns[client] = sorted.slice(0, MAX_RUNS_PER_CLIENT)
 
       // Calculate duration stats
-      const durations = clientRuns[client].map((r) => getIndexAggregatedStats(r, stepFilter).duration)
-      const sortedDurations = [...durations].sort((a, b) => a - b)
-      const durationSum = durations.reduce((acc, d) => acc + d, 0)
+      const durations = clientRuns[client]
+        .map((r) => calculateDuration(getIndexAggregatedStats(r, stepFilter).duration))
+        .filter((v): v is number => v !== undefined)
       allDurations.push(...durations)
 
-      clientDurationStats[client] = {
-        min: sortedDurations[0],
-        max: sortedDurations[sortedDurations.length - 1],
-        mean: durationSum / durations.length,
-        p95: calculatePercentile(sortedDurations, 95),
-        p99: calculatePercentile(sortedDurations, 99),
-        last: durations[0],
+      if (durations.length > 0) {
+        const sortedDurations = [...durations].sort((a, b) => a - b)
+        const durationSum = durations.reduce((acc, d) => acc + d, 0)
+
+        clientDurationStats[client] = {
+          min: sortedDurations[0],
+          max: sortedDurations[sortedDurations.length - 1],
+          mean: durationSum / durations.length,
+          p95: calculatePercentile(sortedDurations, 95),
+          p99: calculatePercentile(sortedDurations, 99),
+          last: durations[0],
+        }
+      } else {
+        clientDurationStats[client] = {}
       }
 
       clientDurationScales[client] = createColorScale(durations, false)
@@ -278,14 +293,20 @@ export function RunsHeatmap({
         const sorted = [...cRuns].sort((a, b) => b.timestamp - a.timestamp)
         sectionClientRuns[c] = sorted.slice(0, MAX_RUNS_PER_CLIENT)
 
-        const durations = sectionClientRuns[c].map((r) => getIndexAggregatedStats(r, stepFilter).duration)
-        const sortedD = [...durations].sort((a, b) => a - b)
-        const dSum = durations.reduce((acc, d) => acc + d, 0)
-        sectionDurationStats[c] = {
-          min: sortedD[0], max: sortedD[sortedD.length - 1],
-          mean: dSum / durations.length,
-          p95: calculatePercentile(sortedD, 95), p99: calculatePercentile(sortedD, 99),
-          last: durations[0],
+        const durations = sectionClientRuns[c]
+          .map((r) => calculateDuration(getIndexAggregatedStats(r, stepFilter).duration))
+          .filter((v): v is number => v !== undefined)
+        if (durations.length > 0) {
+          const sortedD = [...durations].sort((a, b) => a - b)
+          const dSum = durations.reduce((acc, d) => acc + d, 0)
+          sectionDurationStats[c] = {
+            min: sortedD[0], max: sortedD[sortedD.length - 1],
+            mean: dSum / durations.length,
+            p95: calculatePercentile(sortedD, 95), p99: calculatePercentile(sortedD, 99),
+            last: durations[0],
+          }
+        } else {
+          sectionDurationStats[c] = {}
         }
         sectionDurationScales[c] = createColorScale(durations, false)
 

--- a/ui/src/utils/runColorScale.test.ts
+++ b/ui/src/utils/runColorScale.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { COLORS, LEVELS, createColorScale, formatShortfall } from './runColorScale'
+
+const BEST = COLORS[0]
+const WORST = COLORS[LEVELS - 1]
+
+// Evenly spaced values between lo and hi.
+function spread(lo: number, hi: number, count: number): number[] {
+  return Array.from({ length: count }, (_, i) => lo + (hi - lo) * (i / (count - 1)))
+}
+
+// Distinct colours a set takes, so a "flat" row is easy to assert.
+function usedColors(values: number[], higherIsBetter = true): number[] {
+  const scale = createColorScale(values, higherIsBetter)
+
+  const palette: readonly string[] = COLORS
+
+  return [...new Set(values.map((v) => palette.indexOf(scale.color(v))))].sort((a, b) => a - b)
+}
+
+describe('createColorScale', () => {
+  it('paints identical runs one colour', () => {
+    expect(usedColors(Array(20).fill(500))).toEqual([0])
+  })
+
+  it('keeps a set within 1% near the best colour', () => {
+    // Ethrex in a real suite: 559.1 - 563.6 MGas/s.
+    expect(usedColors(spread(559.1, 563.6, 24))).toEqual([0])
+  })
+
+  it('keeps a set within 3% in the green half', () => {
+    // Reth in a real suite: 370.7 - 383.9 MGas/s.
+    expect(Math.max(...usedColors(spread(370.7, 383.9, 26)))).toBeLessThanOrEqual(2)
+  })
+
+  it('never sends a run 8% off the best to the worst colour', () => {
+    const values = spread(1100, 1200, 20)
+    const scale = createColorScale(values, true)
+    expect(scale.color(1100)).not.toBe(WORST)
+    expect(scale.color(1200)).toBe(BEST)
+  })
+
+  it('spends the whole ramp on a set that genuinely spreads', () => {
+    const values = [...spread(295, 312.6, 22), 228.9, 240, 255, 262, 270, 280]
+    const used = usedColors(values)
+    expect(used[0]).toBe(0)
+    expect(used[used.length - 1]).toBe(LEVELS - 1)
+  })
+
+  it('marks a lone slow run without recolouring the stable ones', () => {
+    const values = [...spread(1100, 1200, 29), 50]
+    const scale = createColorScale(values, true)
+    expect(scale.color(50)).toBe(WORST)
+    // The 29 normal runs keep the colours they had without the outlier.
+    expect(scale.color(1200)).toBe(BEST)
+    expect(scale.color(1100)).not.toBe(WORST)
+  })
+
+  it('ignores a lone fast run when setting the reference', () => {
+    // 29 runs at 1100 and one flukey 1400 must not paint the rest red.
+    const scale = createColorScale([...Array(29).fill(1100), 1400], true)
+    expect(scale.color(1100)).toBe(BEST)
+  })
+
+  it('grades a duration set the other way round', () => {
+    const scale = createColorScale(spread(10, 30, 20), false)
+    expect(scale.color(10)).toBe(BEST)
+    expect(scale.color(30)).toBe(WORST)
+  })
+
+  it('falls back to the neutral colour with no data', () => {
+    const scale = createColorScale([], true)
+    expect(scale.hasData).toBe(false)
+    expect(scale.color(1)).toBe(COLORS[Math.floor(LEVELS / 2)])
+  })
+})
+
+describe('formatShortfall', () => {
+  it('keeps one decimal below 10% and drops it above', () => {
+    expect(formatShortfall(0.015)).toBe('1.5%')
+    expect(formatShortfall(0.0796)).toBe('8.0%')
+    expect(formatShortfall(0.24)).toBe('24%')
+  })
+})

--- a/ui/src/utils/runColorScale.test.ts
+++ b/ui/src/utils/runColorScale.test.ts
@@ -68,6 +68,22 @@ describe('createColorScale', () => {
     expect(scale.color(30)).toBe(WORST)
   })
 
+  it('ignores in-flight runs that report a zero duration', () => {
+    // A live run is merged in with `steps: {}`, so its duration is 0. It
+    // sorts to the fast end, where it used to drag the reference down:
+    // three of them sent every finished run to the red half.
+    const finished = Array.from({ length: 27 }, (_, i) => 100 + (i % 5))
+    const clean = createColorScale(finished, false)
+    const polluted = createColorScale([0, 0, 0, ...finished], false)
+    expect(polluted.top).toBe(clean.top)
+    expect(finished.map((v) => polluted.color(v))).toEqual(finished.map((v) => clean.color(v)))
+  })
+
+  it('survives a set of nothing but in-flight runs', () => {
+    const scale = createColorScale([0, 0, 0, 0], false)
+    expect(scale.hasData).toBe(false)
+  })
+
   it('falls back to the neutral colour with no data', () => {
     const scale = createColorScale([], true)
     expect(scale.hasData).toBe(false)

--- a/ui/src/utils/runColorScale.ts
+++ b/ui/src/utils/runColorScale.ts
@@ -1,0 +1,83 @@
+// Colour scale for the run heatmaps on the suite page.
+//
+// The colour of a run says how far it sits below the best run it is
+// compared against. A percentile rank cannot say that — it spends the
+// whole green-to-red ramp on any set, so twenty runs within 1% of each
+// other read as a full rainbow.
+//
+// The scale saturates at MIN_DROP below the best. A set that genuinely
+// spreads further widens the scale to fit, so a suite that mixes clients
+// of very different speed still uses every colour.
+
+import { THRESHOLD_COLORS } from './perfThreshold'
+
+// Green to red, shared with the run-detail heatmaps so every heatmap
+// in the UI reads the same way.
+export const COLORS = THRESHOLD_COLORS
+export const LEVELS = COLORS.length
+
+// Colour of a cell whose value is unknown — the middle of the scale.
+export const NEUTRAL_COLOR = COLORS[Math.floor(LEVELS / 2)]
+
+// Shortfall that reaches the end of the scale, unless the runs spread
+// wider than this on their own.
+export const MIN_DROP = 0.15
+
+export interface ColorScale {
+  color: (value: number) => string
+  // Reference value the scale measures from — the robust best of the
+  // set. Every run at or above it takes the first colour.
+  top: number
+  // Width of one colour step, as a fraction of `top`.
+  step: number
+  hasData: boolean
+}
+
+const EMPTY_SCALE: ColorScale = {
+  color: () => NEUTRAL_COLOR,
+  top: 0,
+  step: MIN_DROP / LEVELS,
+  hasData: false,
+}
+
+/** Percentile of an already sorted list. */
+export function calculatePercentile(sortedValues: number[], percentile: number): number {
+  if (sortedValues.length === 0) return 0
+  const index = (percentile / 100) * (sortedValues.length - 1)
+  const lower = Math.floor(index)
+  const upper = Math.ceil(index)
+  if (lower === upper) return sortedValues[lower]
+
+  return sortedValues[lower] + (sortedValues[upper] - sortedValues[lower]) * (index - lower)
+}
+
+/**
+ * Create a colour mapper that grades runs by their shortfall against the
+ * best of the set. The ends are percentiles, not the raw min and max, so
+ * one flukey run cannot compress the scale for every other run.
+ */
+export function createColorScale(values: number[], higherIsBetter: boolean): ColorScale {
+  if (values.length === 0) return EMPTY_SCALE
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const top = calculatePercentile(sorted, higherIsBetter ? 90 : 10)
+  const low = calculatePercentile(sorted, higherIsBetter ? 10 : 90)
+  if (top <= 0) return EMPTY_SCALE
+
+  const step = Math.max(MIN_DROP, Math.abs(low - top) / top) / LEVELS
+
+  const color = (value: number) => {
+    const shortfall = higherIsBetter ? (top - value) / top : (value - top) / top
+    if (shortfall <= 0) return COLORS[0]
+
+    return COLORS[Math.min(LEVELS - 1, Math.floor(shortfall / step))]
+  }
+
+  return { color, top, step, hasData: true }
+}
+
+/** Render a shortfall fraction as a percentage, e.g. 0.015 -> "1.5%". */
+export function formatShortfall(fraction: number): string {
+  const percent = fraction * 100
+  return `${percent < 10 ? percent.toFixed(1) : percent.toFixed(0)}%`
+}

--- a/ui/src/utils/runColorScale.ts
+++ b/ui/src/utils/runColorScale.ts
@@ -57,9 +57,14 @@ export function calculatePercentile(sortedValues: number[], percentile: number):
  * one flukey run cannot compress the scale for every other run.
  */
 export function createColorScale(values: number[], higherIsBetter: boolean): ColorScale {
-  if (values.length === 0) return EMPTY_SCALE
+  // A run that has not finished carries no throughput and no duration.
+  // Callers filter those out, but drop them here too: a placeholder zero
+  // at the good end of the scale drags the reference towards it and
+  // paints every finished run red.
+  const usable = values.filter((value) => value > 0)
+  if (usable.length === 0) return EMPTY_SCALE
 
-  const sorted = [...values].sort((a, b) => a - b)
+  const sorted = [...usable].sort((a, b) => a - b)
   const top = calculatePercentile(sorted, higherIsBetter ? 90 : 10)
   const low = calculatePercentile(sorted, higherIsBetter ? 10 : 90)
   if (top <= 0) return EMPTY_SCALE


### PR DESCRIPTION
## The problem

"Recent Runs by Client" colours a run by its percentile rank inside the compared set. A rank ignores magnitude, so the scale spends the whole green-to-red ramp on **any** set, however tight.

In a real suite:

| client | range | spread | how it looked |
|---|---|---|---|
| Ethrex | 559.1 – 563.6 | 0.8% | full rainbow |
| Geth | 314.6 – 318.3 | 1.2% | full rainbow |
| Erigon | 113.3 – 115.6 | 2.0% | full rainbow |
| Reth | 370.7 – 383.9 | 3.5% | full rainbow |
| Nethermind | 228.9 – 312.6 | 27% | full rainbow |

Nethermind is the only client with real run-to-run variance, and it looked the same as the four stable ones. A run 1% off its neighbour was painted deep red.

## The fix

A run's colour is now its **shortfall against the best run it is compared against**. The scale saturates at 15% below that best. A set that genuinely spreads further widens the scale to fit, so suite mode still uses every colour across clients that differ by 5x.

Same suite, after:

| client | spread | after |
|---|---|---|
| Ethrex | 0.8% | flat deep green |
| Geth | 1.2% | flat deep green |
| Erigon | 2.0% | two greens |
| Reth | 3.5% | three greens |
| Nethermind | 27% | green cluster + 6 hot tiles |

Nethermind is now the only row that shouts, which is the correct reading.

### Outliers

Both ends of the scale are p90 and p10, not the raw min and max, so one flukey run cannot compress the scale for every other run.

- 29 runs at 1100–1200 plus one at 50 — the outlier goes deep red, the other 29 keep the colours they had without it.
- 29 runs at 1100 plus one flukey 1400 — the reference stays at 1100, so the 29 stay green instead of turning red.

This is why the scale does not rank within a compressed band. An outlier widens the measured spread, the palette un-compresses, and the 29 tight runs get rank-mapped across nine buckets again. The rainbow comes straight back on noise. Using a robust spread instead just hides the outlier. Rank is the root cause: it ignores magnitude inside the band too.

## Changes

- `ui/src/utils/runColorScale.ts` (new) — the scale, moved out of the component, because it is now the part that has to be right.
- `ui/src/utils/runColorScale.test.ts` (new) — 10 tests, one per case above, including both outlier directions.
- `ui/src/components/suite-detail/RunsHeatmap.tsx` — uses the util. The legend reads `≥ 519.4 MGas/s · within 8% of best` instead of `Fastest 20–30%`.

Suite mode prints real values in the legend. Per-client mode prints the shortfall bands only, because each client has its own scale.

## Tuning

`MIN_DROP = 0.15` is the one knob. At 15% a bucket is 1.5%, so a 5% regression moves three buckets. Lower it to make regressions louder, raise it to make noise calmer.

## Test

- `tsc -b` clean
- `eslint` clean
- `npm test` — 22 tests pass (10 new)
